### PR TITLE
chore: add release workflow and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cdehaan
+* @chrisdhaan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for npm provenance attestation
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — triggers on GitHub Release published, builds and publishes `@newrelic/preflight` to npm with provenance attestation. Requires `NPM_TOKEN` secret in repo settings.
- Updates `.github/CODEOWNERS` to `@chrisdhaan` (public GitHub username)

## Test plan

- [ ] Set `NPM_TOKEN` secret in repo Settings → Secrets and variables → Actions
- [ ] Merge this PR
- [ ] Create a GitHub Release to verify the workflow triggers