### PR TITLE
Fix: disable husky pre-push hook in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      HUSKY: 0 # disable git hooks in CI
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Adds `HUSKY: 0` to the publish job environment so the pre-push git hook
doesn't run during `git push --tags`. The hook runs `npm test`, which
includes two integration tests that require a configured environment
(license key, git repo) and always fail in a clean CI runner.

## Test plan

- [ ] Merge and re-trigger the Release workflow — publish step should proceed past the tag push without running tests