### PR TITLE
Fix: use string-literal '/' in path-containment guard to resolve CodeQL alert

### DIFF
--- a/src/dashboard/routes/static-handler.ts
+++ b/src/dashboard/routes/static-handler.ts
@@ -61,7 +61,11 @@ export function createStaticHandler(
     }
 
     const target = resolve(join(root, filename));
-    if (!target.startsWith(root + sep) && target !== root) {
+    // Use a literal '/' so static analysis tools (CodeQL js/path-injection)
+    // can recognise this as the standard path-containment sanitizer pattern.
+    // The runtime sep from node:path would be equivalent on POSIX, but CodeQL
+    // cannot statically prove that sep === '/' and therefore misses the guard.
+    if (!target.startsWith(root + '/')) {
       res.writeHead(403);
       res.end();
       return;


### PR DESCRIPTION
## Summary

- Rewrites the path-containment guard in `static-handler.ts` from `root + sep`
  to `root + '/'` (string literal).
- CodeQL's `js/path-injection` sanitizer pattern-matches on `startsWith(root + '/')`;
  it cannot statically prove that the runtime `path.sep` variable equals `'/'`,
  so the previous guard was not being recognised and both the `stat()` and
  `readFile()` calls were flagged (alerts #3 and #4).
- Removes the dead `&& target !== root` branch — empty-filename URLs (e.g. `//`)
  now correctly return 403 instead of falling through to a directory `stat`.

## Test plan

- [ ] `npm test` — all tests pass
- [ ] CodeQL scan shows alerts #3 and #4 (`js/path-injection` in `static-handler.ts`) closed