### PR TITLE
Fix: local dashboard auto-starts without manual intervention (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-06-23
+
+### Added
+
+- Always-on background dashboard daemon for macOS (`local` and `both` modes). The setup wizard now offers to install a launchd agent (`com.preflight.dashboard`) that keeps the local dashboard running at `http://127.0.0.1:7777` even when Claude Code is closed. `preflight uninstall` removes it.
+
+### Fixed
+
+- Local dashboard now starts immediately when `--stdio` mode launches with `mode: local` or `mode: both` — no longer requires manually running `preflight --local` after a Claude Code session starts
+- Background dashboard daemon correctly survives port contention with active Claude Code sessions and reclaims the dashboard port when sessions end (previously exited immediately on EADDRINUSE)
+- Setup wizard daemon upgrade is now atomic — installing over an existing daemon no longer risks leaving the user with no daemon if the reinstall fails
+- Session resolution polling loop is now correctly aborted when the MCP server shuts down, preventing orphaned breadcrumb poll timers
+- OTel session spans no longer emit a zero-call ghost span with a placeholder session ID to OTLP backends when session ID resolution takes the async path
+- `isSyntheticSessionId` now covers the provisional `pending-` prefix, preventing provisional session IDs from appearing in audit records, dashboard live-session lists, or the session history
+
 ## [1.0.1] - 2026-06-23
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/live-event-bus.ts
+++ b/src/dashboard/live-event-bus.ts
@@ -1,12 +1,11 @@
 import { EventEmitter } from 'node:events';
 
-// Task #17 (D3): events that can be attributed to a single Claude Code
-// session_id carry it explicitly so dashboard clients can subscribe with a
-// `?sessionId=` filter and so the Today view can render a per-session pill on
-// each anti-pattern row. `AlertEvent.sessionId` stays optional because some
-// alerts (system-level) don't originate from a specific session. The
-// `HeartbeatEvent` deliberately stays global — it's a connection keepalive,
-// not a data event.
+// Events that can be attributed to a single Claude Code session_id carry it
+// explicitly so dashboard clients can subscribe with a `?sessionId=` filter
+// and so the Today view can render a per-session pill on each anti-pattern row.
+// `AlertEvent.sessionId` stays optional because some alerts (system-level)
+// don't originate from a specific session. The `HeartbeatEvent` deliberately
+// stays global — it's a connection keepalive, not a data event.
 export interface ToolCallEvent {
   readonly id: string;
   readonly sessionId: string;

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -229,8 +229,8 @@ export interface ApiHandlerDeps {
   readonly contextTracker?: { getMetrics: (sessionId?: string) => unknown };
   readonly config?: McpServerConfig;
   readonly configFilePath?: string;
-  // Task #17 (D3): the dashboard owner reads every per-session buffer file
-  // in read-only mode for the cross-session aggregate endpoint.
+  // The dashboard owner reads every per-session buffer file in read-only
+  // mode for the cross-session aggregate endpoint.
   // `peekAllBuffers()` does NOT drain — only the owning MCP's own
   // `drainBuffer()` consumes events for ingestion.
   readonly localStore?: { peekAllBuffers: () => readonly { readonly [key: string]: unknown }[] };
@@ -716,11 +716,10 @@ export function createApiHandler(
     jsonOk(res, slimmed.length > limit ? slimmed.slice(-limit) : slimmed);
   });
 
-  // Task #17 (D3): currently-live session list with metadata. Sourced from
-  // LiveSessionRegistry (touch-based liveness within a 3-minute window) so
-  // the Today selector can default to the most-recently-active session even
-  // when nothing has been persisted to disk yet. The dashboard owner sees
-  // every live session — Fix 3 partitioned per-session buffer files but the
+  // Currently-live session list with metadata. Sourced from LiveSessionRegistry
+  // (touch-based liveness within a 3-minute window) so the Today selector can
+  // default to the most-recently-active session even when nothing has been
+  // persisted to disk yet. The dashboard owner sees every live session — the
   // registry is in-memory and shared via this MCP, so the data is one
   // authoritative read.
   //
@@ -771,9 +770,9 @@ export function createApiHandler(
     jsonOk(res, sessions);
   });
 
-  // Task #17 (D3): cross-session aggregate KPIs for the Today view. Reads:
-  //   1. every per-session buffer-*.jsonl in read-only mode (post-Fix-3
-  //      each MCP only drains its own; the dashboard owner needs the union)
+  // Cross-session aggregate KPIs for the Today view. Reads:
+  //   1. every per-session buffer-*.jsonl in read-only mode (each MCP only
+  //      drains its own; the dashboard owner needs the union)
   //   2. completed session JSONs at ~/.newrelic-preflight/sessions/ (loaded via
   //      sessionStore.loadTodaySessions())
   //   3. the in-memory tool call buffer (events from this MCP that have

--- a/src/dashboard/routes/sse-handler.ts
+++ b/src/dashboard/routes/sse-handler.ts
@@ -3,10 +3,10 @@ import { IncomingMessage, ServerResponse } from 'node:http';
 import { LiveEventBus, LiveEventMap, LiveEventName, SeqEntry } from '../live-event-bus.js';
 
 const HEARTBEAT_MS = 30_000;
-// Task #17 (D3): only validate the same character class the rest of the
-// codebase uses for session_id (collector-script.ts, local-store.ts).
-// A bad input is silently ignored — the filter falls open to "all events"
-// rather than 400ing, since SSE clients can't easily react to a 4xx.
+// Only validate the same character class the rest of the codebase uses for
+// session_id (collector-script.ts, local-store.ts). A bad input is silently
+// ignored — the filter falls open to "all events" rather than 400ing, since
+// SSE clients can't easily react to a 4xx.
 const SESSION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
 
 // Narrow a payload to its sessionId field if present. ToolCall, AntiPattern,
@@ -42,13 +42,13 @@ export function createSseHandler(
     });
     res.write(': stream-open\n\n');
 
-    // Task #17 (D3): optional `?sessionId=` query parameter scopes the stream
-    // to events emitted from a single Claude Code session. Events without a
-    // `sessionId` field (heartbeat) and AlertEvents whose sessionId is unset
-    // are always delivered — heartbeat is a connection keepalive and
-    // unscoped alerts are system-level. An invalid sessionId is treated as
-    // "no filter" so a typo in the query string degrades to the existing
-    // global stream behavior rather than a permanently silent connection.
+    // Optional `?sessionId=` query parameter scopes the stream to events
+    // emitted from a single Claude Code session. Events without a `sessionId`
+    // field (heartbeat) and AlertEvents whose sessionId is unset are always
+    // delivered — heartbeat is a connection keepalive and unscoped alerts are
+    // system-level. An invalid sessionId is treated as "no filter" so a typo
+    // in the query string degrades to the existing global stream behavior
+    // rather than a permanently silent connection.
     const url = new URL(req.url ?? '/', 'http://localhost');
     const rawSessionId = url.searchParams.get('sessionId');
     const filterSessionId =

--- a/src/hooks/event-processor.ts
+++ b/src/hooks/event-processor.ts
@@ -41,10 +41,10 @@ const DEFAULT_ORPHAN_TIMEOUT_MS = 60_000;
 const DEFAULT_MAX_PENDING = 2_000;
 
 export class HookEventProcessor {
-  private readonly store: LocalStore;
+  private store: LocalStore;
   private readonly pollIntervalMs: number;
   private readonly orphanTimeoutMs: number;
-  private readonly drainAllSessions: boolean;
+  private drainAllSessions: boolean;
   private readonly onRecord: (record: ToolCallRecord) => void;
   private readonly onTokenEvent: ((event: TokenEvent) => void) | null;
 
@@ -124,6 +124,19 @@ export class HookEventProcessor {
     // or when stop() is called without start(). A second call on an already-empty
     // pending map is a no-op.
     this.flushPending();
+  }
+
+  /**
+   * Hot-swap the underlying LocalStore and session-drain mode without
+   * recreating the processor or its callbacks. Used when the provisional
+   * unscoped store is replaced by the real session-scoped store once the
+   * Claude Code session ID is resolved asynchronously.
+   */
+  replaceStore(newStore: LocalStore, drainAllSessions: boolean): void {
+    this.stop();
+    this.store = newStore;
+    this.drainAllSessions = drainAllSessions;
+    this.start();
   }
 
   /**

--- a/src/hooks/session-resolver.ts
+++ b/src/hooks/session-resolver.ts
@@ -211,5 +211,5 @@ export async function resolveSessionId(
  */
 export function isSyntheticSessionId(id: string | null | undefined): boolean {
   if (!id) return false;
-  return id.startsWith('local-') || id.startsWith('proxy-');
+  return id.startsWith('local-') || id.startsWith('proxy-') || id.startsWith('pending-');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ import {
   resolveSessionId,
   resolveFromJobDir,
   resolveFromBreadcrumb,
+  isSyntheticSessionId,
 } from './hooks/session-resolver.js';
 import { initMcpTracer } from './tracing/mcp-tracer.js';
 import { SessionSpan } from './tracing/session-span.js';
@@ -158,7 +159,7 @@ export function classifyDashboardStartError(
 
 /**
  * Default interval (ms) between dashboard re-bind attempts when this MCP
- * started in headless mode (Fix 1 EADDRINUSE skip path). Overridable via
+ * started in headless mode (EADDRINUSE skip). Overridable via
  * NR_AI_DASHBOARD_REPOLL_MS — kept simple to avoid threading a new config
  * field through the loader for what is essentially a knob for tests.
  */
@@ -193,10 +194,10 @@ export function setupDashboardPostBind(
   const log = createLogger('mcp-cli');
   log.info(`Dashboard ready at http://${addr.address}:${addr.port}`);
 
-  // Task #18: only the dashboard owner runs orphan-buffer/breadcrumb GC —
-  // running it from every MCP would race with itself and re-archive files
-  // repeatedly. Run once at startup, then every 5 minutes. The interval is
-  // unref'd so it doesn't keep the event loop alive.
+  // Only the dashboard owner runs orphan-buffer/breadcrumb GC — running it
+  // from every MCP would race with itself and re-archive files repeatedly.
+  // Run once at startup, then every 5 minutes. The interval is unref'd so
+  // it doesn't keep the event loop alive.
   const { localStore, liveSessionRegistry } = deps;
   const runGc = (): void => {
     try {
@@ -228,12 +229,12 @@ export function setupDashboardPostBind(
 }
 
 /**
- * Schedule periodic re-bind attempts after a headless start (Fix 1 path).
+ * Schedule periodic re-bind attempts after a headless start (EADDRINUSE skip).
  *
- * After Fix 1 the first MCP to launch wins port 7777 and serves the
- * dashboard; the rest run headless. If the owner exits while the headless
- * MCPs are still alive, the port is freed and nobody picks it up — the
- * dashboard goes dead. This re-poll closes that gap: every
+ * The first MCP to launch wins port 7777 and serves the dashboard; the rest
+ * run headless. If the owner exits while the headless MCPs are still alive,
+ * the port is freed and nobody picks it up — the dashboard goes dead. This
+ * re-poll closes that gap: every
  * `intervalMs` (default 30s) the headless MCP retries `start()`, and the
  * first one to succeed promotes itself to dashboard owner and runs the
  * post-bind setup (GC interval, etc.).
@@ -504,15 +505,21 @@ async function main(): Promise<void> {
   let alertRulesWatchTimer: NodeJS.Timeout | undefined;
   let localStoreForShutdown: LocalStore | undefined;
   let gcInterval: NodeJS.Timeout | undefined;
-  // Task #13: when this MCP starts headless (Fix 1 EADDRINUSE skip), this
-  // interval retries dashboardServer.start() periodically so we can take
-  // over if the current owner exits. Cleared in the shutdown handler.
+  // When this MCP starts headless (EADDRINUSE skip), this interval retries
+  // dashboardServer.start() periodically so we can take over if the current
+  // owner exits. Cleared in the shutdown handler.
   let dashboardRepollInterval: NodeJS.Timeout | undefined;
+  // Aborts the async resolveSessionId polling loop when shutdown fires so
+  // the breadcrumb poll does not outlive the process.
+  let sessionResolutionAbort: AbortController | undefined;
 
   let shuttingDown = false;
   const shutdown = async () => {
     if (shuttingDown) return;
     shuttingDown = true;
+    // Abort any in-progress session resolution so its polling loop exits
+    // cleanly rather than continuing after process.exit() is called.
+    sessionResolutionAbort?.abort();
     logger.info('Shutting down...');
     try {
       persistSession?.();
@@ -525,8 +532,8 @@ async function main(): Promise<void> {
       if (alertEvaluationInterval) clearInterval(alertEvaluationInterval);
       if (gcInterval) clearInterval(gcInterval);
       if (dashboardRepollInterval) clearInterval(dashboardRepollInterval);
-      // Task #18: remove this MCP's heartbeat so the next dashboard-owner GC
-      // pass doesn't have to mtime-archive our buffer file.
+      // Remove this MCP's heartbeat so the next dashboard-owner GC pass
+      // doesn't have to mtime-archive our buffer file.
       localStoreForShutdown?.removeHeartbeat();
       if (alertRulesWatchTimer) clearTimeout(alertRulesWatchTimer);
       if (alertRulesWatcher) {
@@ -596,25 +603,6 @@ async function main(): Promise<void> {
         process.exit(0);
       }
 
-      // Fix 3 / D2: resolve the Claude Code session_id BEFORE constructing
-      // anything that takes sessionTraceId as input. We try the cheap
-      // synchronous paths first (CLAUDE_JOB_DIR, then a one-shot breadcrumb
-      // probe). If both miss, register a "pending" tool handler so the MCP
-      // can answer health/config requests while we poll for the breadcrumb,
-      // then await full resolution.
-      const configFilePathEarly = options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
-      const configSummaryEarly: ConfigSummary = {
-        mode: config.mode,
-        developer: config.developer,
-        accountId: config.accountId ?? null,
-        licenseKeyMasked: config.licenseKey ? maskCredential(config.licenseKey) : null,
-        nrApiKeyMasked: config.nrApiKey ? maskCredential(config.nrApiKey) : null,
-        region: config.collectorHost ?? 'us',
-        storagePath: config.storagePath,
-        dashboardUrl: `http://${config.dashboard.host}:${config.dashboard.port}`,
-        configFilePath: configFilePathEarly,
-      };
-
       const synchronouslyResolved =
         resolveFromJobDir(process.env.CLAUDE_JOB_DIR ?? null) ??
         resolveFromBreadcrumb(config.storagePath, process.ppid);
@@ -622,31 +610,28 @@ async function main(): Promise<void> {
         sessionTraceId = synchronouslyResolved;
         logger.info('Session ID resolved synchronously', { sessionTraceId });
       } else {
-        // Tools must respond with a structured error during the resolution
-        // window — registerPendingTools wires that up. Once resolved we
-        // overwrite the handlers via registerTools().
-        registerPendingTools(mcpServer.server, {
-          sessionStartMs: Date.now(),
-          developer: config.developer,
-          configSummary: configSummaryEarly,
-        });
-        logger.info('Awaiting session_id resolution (breadcrumb poll)');
-        try {
-          sessionTraceId = await resolveSessionId({ storagePath: config.storagePath });
-        } catch (err) {
-          logger.error('Session ID resolution failed; shutting down', { error: String(err) });
-          await shutdown();
-          return;
-        }
+        // Use a provisional ID so the shared section (including dashboard) can
+        // start immediately. The real session ID is resolved asynchronously in
+        // the tail section below after all shared infrastructure is ready.
+        sessionTraceId = `pending-${Date.now()}`;
+        logger.info(
+          'Session ID not yet available; using provisional ID, dashboard will start early',
+        );
       }
 
+      // Create the span objects in Phase A so shutdown always has a valid
+      // sessionSpan reference. For the provisional case (pending-{ts}), defer
+      // start() to Phase B when the real session ID is known — starting here
+      // would emit a ghost span with a placeholder ID to the OTLP backend.
+      // SessionSpan.end() guards on started=false, so an unstarted provisional
+      // span is a safe no-op on shutdown.
       if (config.transport !== 'nr-events-api') {
         initMcpTracer();
-      }
-      sessionSpan = new SessionSpan(sessionTraceId, config.developer);
-      taskSpanTracker = new TaskSpanTracker();
-      if (config.transport !== 'nr-events-api') {
-        sessionSpan.start();
+        sessionSpan = new SessionSpan(sessionTraceId, config.developer);
+        taskSpanTracker = new TaskSpanTracker();
+        if (!sessionTraceId.startsWith('pending-')) {
+          sessionSpan.start();
+        }
       }
     } else {
       // --local: force local mode so config validation skips cloud credentials.
@@ -666,18 +651,20 @@ async function main(): Promise<void> {
 
     // Per-session buffer scoping: in --stdio mode the LocalStore is bound to
     // this MCP's resolved session_id so drainBuffer() only sees this session's
-    // events. In --local mode no single session owns the buffer; we drain all
-    // buffer-*.jsonl files via drainAllBuffers() instead.
-    const localStore = options.stdio
-      ? new LocalStore(config.storagePath, sessionTraceId)
-      : new LocalStore(config.storagePath);
+    // events. In --local mode (or the provisional window before session ID
+    // resolution) we use an unscoped store that drains all session buffers.
+    const isProvisional = options.stdio && sessionTraceId.startsWith('pending-');
+    const localStore =
+      options.stdio && !isProvisional
+        ? new LocalStore(config.storagePath, sessionTraceId)
+        : new LocalStore(config.storagePath);
     localStore.initialize();
 
-    // Task #18: every MCP writes its heartbeat once it has bound a session_id
-    // so the dashboard owner's GC pass can tell which buffer files still have
-    // a live owner. Removed in the shutdown handler below. No-op in --local
-    // mode (no sessionId).
-    if (options.stdio) localStore.writeHeartbeat();
+    // Every MCP writes its heartbeat once it has bound a session_id so the
+    // dashboard owner's GC pass can tell which buffer files still have a live
+    // owner. Removed in the shutdown handler below. Skipped during the
+    // provisional window — the real heartbeat is written after resolution.
+    if (options.stdio && !isProvisional) localStore.writeHeartbeat();
     localStoreForShutdown = localStore;
 
     // Migrate any pre-Fix-3 events from the legacy shared `buffer.jsonl` into
@@ -1023,8 +1010,8 @@ async function main(): Promise<void> {
           contextTracker,
           config,
           configFilePath: options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json'),
-          // Task #17 (D3): the dashboard owner reads every per-session
-          // buffer file in read-only mode for the Today aggregate endpoint.
+          // The dashboard owner reads every per-session buffer file in
+          // read-only mode for the Today aggregate endpoint.
           // peekAllBuffers() returns HookEvent[] — widen at the boundary
           // so the dashboard tree stays decoupled from storage internals.
           localStore: {
@@ -1053,16 +1040,11 @@ async function main(): Promise<void> {
         if (decision.kind === 'rethrow') {
           throw decision.error;
         }
-        // In --local mode the HTTP server IS the process — without it there is
-        // nothing to keep the event loop alive. Treat EADDRINUSE as fatal so
-        // the user gets an actionable error instead of a silent exit.
-        if (options.local) {
-          logger.error(
-            `Dashboard port ${config.dashboard.port} is already in use. ` +
-              `Stop the existing --local instance before starting another.`,
-          );
-          process.exit(1);
-        }
+        // In --local mode (e.g. a launchd daemon) EADDRINUSE means the port is
+        // owned by a --stdio MCP instance. Instead of exiting fatally, poll
+        // until the port is free and take over — same as the --stdio repoll
+        // path. This lets the daemon coexist with active Claude Code sessions
+        // and seamlessly reclaim the dashboard when sessions end.
         logger.info(decision.message);
         addr = undefined;
       }
@@ -1070,7 +1052,7 @@ async function main(): Promise<void> {
       // Capture deps for the post-bind helper. Both the initial-bind path
       // and the re-poll takeover path call this; keeping the closure small
       // ensures the two paths produce identical side effects (GC interval,
-      // openOnStart warning, etc. — Task #18 + #13).
+      // openOnStart warning, etc.).
       const postBindDeps: DashboardPostBindDeps = {
         localStore,
         liveSessionRegistry,
@@ -1082,9 +1064,9 @@ async function main(): Promise<void> {
       if (addr) {
         gcInterval = runPostBind(addr);
       } else {
-        // Task #13: this MCP is headless. Schedule periodic re-bind attempts
-        // so it can take over if the current dashboard owner exits. The
-        // interval is unref'd and cleared by the shutdown handler.
+        // This MCP is headless. Schedule periodic re-bind attempts so it can
+        // take over if the current dashboard owner exits. The interval is
+        // unref'd and cleared by the shutdown handler.
         dashboardRepollInterval = startDashboardRepoll({
           dashboardServer,
           host: config.dashboard.host,
@@ -1095,11 +1077,19 @@ async function main(): Promise<void> {
           },
           logger,
         });
+        // In --local mode the dashboard IS the process — the HTTP listener is
+        // the only thing that keeps the event loop alive. When EADDRINUSE fires
+        // the listener is never bound, so the repoll interval must be ref'd or
+        // Node exits immediately before it ever fires. In --stdio mode stdin
+        // acts as the keepalive, so leaving the interval unref'd is correct.
+        if (options.local) {
+          dashboardRepollInterval.ref?.();
+        }
       }
     }
 
     let capturedNrIngest: NrIngestManager | undefined;
-    if (config.mode !== 'local') {
+    if (config.mode !== 'local' && !isProvisional) {
       if (!config.licenseKey || !config.accountId) {
         throw new Error(
           'licenseKey and accountId must be defined. ' +
@@ -1166,9 +1156,11 @@ async function main(): Promise<void> {
     });
     eventProcessor = new HookEventProcessor({
       store: localStore,
-      // --local mode owns no specific Claude Code session, so drain every
-      // per-session buffer so the dashboard sees all live sessions' events.
-      drainAllSessions: !options.stdio,
+      // --local mode and the provisional --stdio window own no specific Claude
+      // Code session; drain every per-session buffer so the dashboard sees all
+      // live sessions' events. After real session ID resolution the processor
+      // is hot-swapped to the scoped store via replaceStore().
+      drainAllSessions: !options.stdio || isProvisional,
       onRecord: (record) => {
         if (!config || !sessionTracker || !taskDetector) {
           logger.warn('onRecord called before full initialization; skipping');
@@ -1222,12 +1214,12 @@ async function main(): Promise<void> {
         const auditRecord = auditTrail.recordToolCall(record);
         capturedNrIngest?.ingestToolCall(record, auditRecord);
 
-        // Task #17 (D3): SSE consumers filter by sessionId for the per-
-        // session live tail. Records without a sessionId are pre-Fix-3
-        // legacy buffer leaks during the migrateLegacyBuffer() window on
-        // first boot — skip the live emit rather than fabricate a session
-        // by falling back to the MCP's resolved sessionTraceId, which would
-        // re-introduce the fictional-session-ID bug Fix 3 removed.
+        // SSE consumers filter by sessionId for the per-session live tail.
+        // Records without a sessionId are legacy buffer entries that surfaced
+        // during the migrateLegacyBuffer() window on first boot — skip the
+        // live emit rather than fabricate a session by falling back to the
+        // MCP's resolved sessionTraceId, which would re-introduce the
+        // fictional-session-ID bug the session-ID resolver removed.
         if (record.sessionId) {
           liveBus.emit('tool-call', {
             id: record.id,
@@ -1280,8 +1272,8 @@ async function main(): Promise<void> {
             dailyFirstActivityMs,
           });
           liveBus.emit('cost-update', {
-            // Task #17 (D3): MCP-owned cost totals — sessionId is always the
-            // resolved Claude Code session_id for this MCP instance.
+            // sessionId is always the resolved Claude Code session_id for
+            // this MCP instance so cost totals can be attributed per-session.
             sessionId: sessionTraceId,
             sessionTotalUsd: costMetrics.sessionTotalCostUsd,
             todayTotalUsd,
@@ -1302,9 +1294,9 @@ async function main(): Promise<void> {
             taskSpanTracker.closeTask(task.taskId, task.toolCallCount);
           }
           const firstRecord = task.toolCalls[0];
-          // Fix 3: sessionTraceId is the resolved Claude Code session_id and is
+          // sessionTraceId is the resolved Claude Code session_id and is
           // shared across the whole MCP, so we use it directly rather than
-          // peeking at the first record's sessionId (which may now be null).
+          // peeking at the first record's sessionId (which may be null).
           const context = {
             sessionId: sessionTraceId,
             platform: typeof firstRecord?.platform === 'string' ? firstRecord.platform : undefined,
@@ -1315,8 +1307,8 @@ async function main(): Promise<void> {
           for (const pattern of patterns) {
             capturedNrIngest?.ingestAntiPattern(pattern, context);
             liveBus.emit('anti-pattern', {
-              // Task #17 (D3): tag with the originating session so the Today
-              // view can render a "Session: <name>" pill on each alert row.
+              // Tag with the originating session so the Today view can render
+              // a "Session: <name>" pill on each alert row.
               sessionId: sessionTraceId,
               type: pattern.type,
               target: pattern.file ?? pattern.command ?? 'unknown',
@@ -1402,8 +1394,8 @@ async function main(): Promise<void> {
             dailyFirstActivityMs,
           });
           liveBus.emit('cost-update', {
-            // Task #17 (D3): same as the per-tool-call cost-update emission —
-            // tag with the MCP's owning session_id.
+            // Same as the per-tool-call cost-update emission — tag with the
+            // MCP's owning session_id for per-session attribution.
             sessionId: sessionTraceId,
             sessionTotalUsd: costMetrics.sessionTotalCostUsd,
             todayTotalUsd,
@@ -1433,8 +1425,7 @@ async function main(): Promise<void> {
         // bookkeeping; they don't correspond to a real Claude Code session
         // and produce confusing `local-...` rows in the dashboard's history
         // view that have no useful content to show.
-        const isSyntheticId =
-          summary.sessionId.startsWith('local-') || summary.sessionId.startsWith('proxy-');
+        const isSyntheticId = isSyntheticSessionId(summary.sessionId);
         if (isSyntheticId) {
           logger.info('Skipping synthetic session JSON persistence', {
             sessionId: summary.sessionId,
@@ -1456,67 +1447,236 @@ async function main(): Promise<void> {
       // three see the same audit log.
       mcpServer!.auditTrailManager = auditTrail;
 
-      // Re-register tools with full dependencies (replaces empty handlers)
-      const configFilePath = options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
-      const configSummary: ConfigSummary = {
-        mode: config.mode,
-        developer: config.developer,
-        accountId: config.accountId ?? null,
-        licenseKeyMasked: config.licenseKey ? maskCredential(config.licenseKey) : null,
-        nrApiKeyMasked: config.nrApiKey ? maskCredential(config.nrApiKey) : null,
-        region: config.collectorHost ?? 'us',
-        storagePath: config.storagePath,
-        dashboardUrl: `http://${config.dashboard.host}:${config.dashboard.port}`,
-        configFilePath,
-      };
-      registerTools(mcpServer!.server, {
-        sessionTracker,
-        costTracker,
-        budgetTracker,
-        taskDetector,
-        antiPatternDetector,
-        efficiencyScorer,
-        feedbackCollector,
-        sessionStore,
-        weeklySummaryGenerator,
-        trendAnalyzer,
-        collaborationProfiler,
-        claudeMdTracker,
-        costPerOutcomeAnalyzer,
-        recommendationEngine,
-        contextWindowTracker,
-        contextTracker,
-        latencyTracker,
-        taskCompletionTracker,
-        modelUsageTracker,
-        retryDetector,
-        contextCompositionTracker,
-        latencyDecompositionTracker,
-        decisionTracker,
-        instructionDriftTracker,
-        toolSelectionScorer,
-        toolCallBuffer: toolCallBufferAccessor,
-        qualityProxyTracker,
-        apiFailureTracker,
-        turnCostAttributor,
-        turnTracker,
-        gitEfficiencyTracker,
-        sessionTraceId,
-        sessionStartMs,
-        accountId: config.accountId,
-        teamId: config.teamId,
-        projectId: config.projectId,
-        developer: config.developer,
-        nrApiKey: config.nrApiKey,
-        collectorHost: config.collectorHost,
-        configFilePath,
-        configSummary,
-      });
+      if (isProvisional) {
+        // Dashboard is already live. Register pending tools so the MCP can
+        // respond to health/config requests while the real session ID resolves.
+        const pendingConfigFilePath =
+          options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
+        registerPendingTools(mcpServer!.server, {
+          sessionStartMs: Date.now(),
+          developer: config.developer,
+          configSummary: {
+            mode: config.mode,
+            developer: config.developer,
+            accountId: config.accountId ?? null,
+            licenseKeyMasked: config.licenseKey ? maskCredential(config.licenseKey) : null,
+            nrApiKeyMasked: config.nrApiKey ? maskCredential(config.nrApiKey) : null,
+            region: config.collectorHost ?? 'us',
+            storagePath: config.storagePath,
+            dashboardUrl: `http://${config.dashboard.host}:${config.dashboard.port}`,
+            configFilePath: pendingConfigFilePath,
+          },
+        });
+        logger.info('Dashboard started early; awaiting session_id resolution (breadcrumb poll)');
 
-      nrIngest?.start();
-      logger.info('Server running on stdio transport');
-      // stdin 'end' and 'error' handlers are registered immediately after
-      // connectStdio() above so shutdown fires even during session-ID resolution.
+        sessionResolutionAbort = new AbortController();
+        void (async () => {
+          try {
+            const realId = await resolveSessionId({
+              storagePath: config!.storagePath,
+              signal: sessionResolutionAbort!.signal,
+            });
+
+            // Adopt the real session ID without clearing accumulated metrics.
+            sessionTraceId = realId;
+            sessionTracker!.adoptSessionId(realId);
+
+            // Replace the provisional unscoped LocalStore with the session-scoped one.
+            const realLocalStore = new LocalStore(config!.storagePath, realId);
+            realLocalStore.initialize();
+            realLocalStore.writeHeartbeat();
+            localStoreForShutdown = realLocalStore;
+            try {
+              realLocalStore.migrateLegacyBuffer();
+            } catch (err) {
+              logger.warn('Legacy buffer migration failed (continuing)', { error: String(err) });
+            }
+
+            // Hot-swap the event processor to the scoped store so it only
+            // drains this session's events going forward.
+            eventProcessor!.replaceStore(realLocalStore, false);
+
+            // Replace the provisional span with a real-ID span. End the
+            // provisional one first (end() is a no-op if never started).
+            // initMcpTracer() was already called in Phase A — skip it here.
+            if (config!.transport !== 'nr-events-api') {
+              sessionSpan?.end(0, 0);
+              // Close any task spans opened against the provisional tracker
+              // (cross-session events can open them during Phase A) before
+              // replacing it with a clean real-session instance.
+              taskSpanTracker?.closeAll();
+              sessionSpan = new SessionSpan(realId, config!.developer);
+              taskSpanTracker = new TaskSpanTracker();
+              sessionSpan.start();
+            }
+
+            // Complete NrIngest setup.
+            if (config!.mode !== 'local') {
+              if (!config!.licenseKey || !config!.accountId) {
+                throw new Error(
+                  'licenseKey and accountId must be defined for non-local mode. ' +
+                    'This should have been caught by config validation.',
+                );
+              }
+              nrIngest = new NrIngestManager({
+                licenseKey: config!.licenseKey,
+                transportOptions: {
+                  accountId: config!.accountId,
+                  collectorHost: config!.collectorHost,
+                },
+                developer: config!.developer,
+                appName: config!.appName,
+                teamId: config!.teamId,
+                projectId: config!.projectId,
+                orgId: config!.orgId,
+                sessionTracker: sessionTracker!,
+                localStore: realLocalStore,
+                auditTrail,
+                eventHarvestIntervalMs: config!.harvestIntervalMs.events,
+                metricHarvestIntervalMs: config!.harvestIntervalMs.metrics,
+                costTracker,
+                efficiencyScorer,
+                turnCostAttributor,
+                sessionTraceId: realId,
+              });
+              capturedNrIngest = nrIngest;
+              nrIngest.start();
+            }
+
+            // Register full tools, replacing the pending handlers.
+            const configFilePath = options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
+            const configSummary: ConfigSummary = {
+              mode: config!.mode,
+              developer: config!.developer,
+              accountId: config!.accountId ?? null,
+              licenseKeyMasked: config!.licenseKey ? maskCredential(config!.licenseKey) : null,
+              nrApiKeyMasked: config!.nrApiKey ? maskCredential(config!.nrApiKey) : null,
+              region: config!.collectorHost ?? 'us',
+              storagePath: config!.storagePath,
+              dashboardUrl: `http://${config!.dashboard.host}:${config!.dashboard.port}`,
+              configFilePath,
+            };
+            registerTools(mcpServer!.server, {
+              sessionTracker: sessionTracker!,
+              costTracker,
+              budgetTracker,
+              taskDetector: taskDetector!,
+              antiPatternDetector,
+              efficiencyScorer,
+              feedbackCollector,
+              sessionStore,
+              weeklySummaryGenerator,
+              trendAnalyzer,
+              collaborationProfiler,
+              claudeMdTracker,
+              costPerOutcomeAnalyzer,
+              recommendationEngine,
+              contextWindowTracker,
+              contextTracker,
+              latencyTracker,
+              taskCompletionTracker,
+              modelUsageTracker,
+              retryDetector,
+              contextCompositionTracker,
+              latencyDecompositionTracker,
+              decisionTracker,
+              instructionDriftTracker,
+              toolSelectionScorer,
+              toolCallBuffer: toolCallBufferAccessor,
+              qualityProxyTracker,
+              apiFailureTracker,
+              turnCostAttributor,
+              turnTracker,
+              gitEfficiencyTracker,
+              sessionTraceId: realId,
+              sessionStartMs,
+              accountId: config!.accountId,
+              teamId: config!.teamId,
+              projectId: config!.projectId,
+              developer: config!.developer,
+              nrApiKey: config!.nrApiKey,
+              collectorHost: config!.collectorHost,
+              configFilePath,
+              configSummary,
+            });
+
+            logger.info('Session ID resolved, full initialization complete', {
+              sessionTraceId: realId,
+            });
+          } catch (err) {
+            // Use the signal's own aborted flag rather than matching the error
+            // message string — robust against future changes to the throw site.
+            if (sessionResolutionAbort?.signal.aborted) {
+              logger.info('Session ID resolution aborted by shutdown');
+              return;
+            }
+            logger.error('Session ID resolution failed; shutting down', { error: String(err) });
+            await shutdown();
+          }
+        })();
+      } else {
+        // Session ID resolved synchronously — proceed as normal.
+        const configFilePath = options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
+        const configSummary: ConfigSummary = {
+          mode: config.mode,
+          developer: config.developer,
+          accountId: config.accountId ?? null,
+          licenseKeyMasked: config.licenseKey ? maskCredential(config.licenseKey) : null,
+          nrApiKeyMasked: config.nrApiKey ? maskCredential(config.nrApiKey) : null,
+          region: config.collectorHost ?? 'us',
+          storagePath: config.storagePath,
+          dashboardUrl: `http://${config.dashboard.host}:${config.dashboard.port}`,
+          configFilePath,
+        };
+        registerTools(mcpServer!.server, {
+          sessionTracker,
+          costTracker,
+          budgetTracker,
+          taskDetector,
+          antiPatternDetector,
+          efficiencyScorer,
+          feedbackCollector,
+          sessionStore,
+          weeklySummaryGenerator,
+          trendAnalyzer,
+          collaborationProfiler,
+          claudeMdTracker,
+          costPerOutcomeAnalyzer,
+          recommendationEngine,
+          contextWindowTracker,
+          contextTracker,
+          latencyTracker,
+          taskCompletionTracker,
+          modelUsageTracker,
+          retryDetector,
+          contextCompositionTracker,
+          latencyDecompositionTracker,
+          decisionTracker,
+          instructionDriftTracker,
+          toolSelectionScorer,
+          toolCallBuffer: toolCallBufferAccessor,
+          qualityProxyTracker,
+          apiFailureTracker,
+          turnCostAttributor,
+          turnTracker,
+          gitEfficiencyTracker,
+          sessionTraceId,
+          sessionStartMs,
+          accountId: config.accountId,
+          teamId: config.teamId,
+          projectId: config.projectId,
+          developer: config.developer,
+          nrApiKey: config.nrApiKey,
+          collectorHost: config.collectorHost,
+          configFilePath,
+          configSummary,
+        });
+
+        nrIngest?.start();
+        logger.info('Server running on stdio transport');
+        // stdin 'end' and 'error' handlers are registered immediately after
+        // connectStdio() above so shutdown fires even during session-ID resolution.
+      }
     } else {
       logger.info('Server running in local dashboard mode (Ctrl+C to stop)');
       // DashboardServer HTTP listener keeps the process alive.
@@ -1541,7 +1701,7 @@ async function main(): Promise<void> {
 
     // Proxy mode has no Claude Code session to resolve; use a deterministic
     // identifier instead of randomUUID so we don't fabricate something that
-    // looks like a real session id (Fix 3).
+    // looks like a real session id.
     const sessionTraceId = `proxy-${Date.now()}`;
 
     proxyManager = new ProxyManager({

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -18,6 +18,9 @@ jest.mock('./schedule.js', () => ({
   installSchedule: jest.fn(),
   removeSchedule: jest.fn(),
   getScheduleStatus: jest.fn(() => ({ installed: false })),
+  installDashboardDaemon: jest.fn(),
+  removeDashboardDaemon: jest.fn(),
+  getDashboardDaemonStatus: jest.fn(() => ({ installed: false })),
   resolveBinaryPath: jest.fn(() => '/usr/local/bin/preflight'),
 }));
 jest.mock('./install-helper.js', () => ({

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -34,6 +34,8 @@ import {
   installSchedule,
   removeSchedule,
   getScheduleStatus,
+  removeDashboardDaemon,
+  getDashboardDaemonStatus,
   resolveBinaryPath,
 } from './schedule.js';
 
@@ -325,6 +327,10 @@ function handleUninstall(options: { project?: boolean }): void {
   const scheduleWasInstalled = getScheduleStatus().installed;
   removeSchedule();
   if (scheduleWasInstalled) print('✓ Auto-update schedule removed');
+
+  const daemonWasInstalled = getDashboardDaemonStatus().installed;
+  removeDashboardDaemon();
+  if (daemonWasInstalled) print('✓ Background dashboard daemon removed');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/install/schedule.test.ts
+++ b/src/install/schedule.test.ts
@@ -18,11 +18,20 @@ import {
   removeSchedule,
   getScheduleStatus,
   resolveBinaryPath,
+  installDashboardDaemon,
+  removeDashboardDaemon,
+  getDashboardDaemonStatus,
 } from './schedule.js';
 
 const mockedExecFileSync = childProcess.execFileSync as jest.Mock;
 
 const PLIST_PATH = join(TEST_HOME, 'Library', 'LaunchAgents', 'com.preflight.update.plist');
+const DASHBOARD_PLIST_PATH = join(
+  TEST_HOME,
+  'Library',
+  'LaunchAgents',
+  'com.preflight.dashboard.plist',
+);
 
 beforeAll(() => {
   mkdirSync(join(TEST_HOME, 'Library', 'LaunchAgents'), { recursive: true });
@@ -34,11 +43,12 @@ afterAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // Remove plist between tests.
-  try {
-    rmSync(PLIST_PATH);
-  } catch {
-    /* ok */
+  for (const p of [PLIST_PATH, DASHBOARD_PLIST_PATH]) {
+    try {
+      rmSync(p);
+    } catch {
+      /* ok */
+    }
   }
 });
 
@@ -176,5 +186,74 @@ describe('resolveBinaryPath', () => {
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('installDashboardDaemon', () => {
+  it('writes a plist file to the LaunchAgents directory', () => {
+    installDashboardDaemon('/usr/local/bin/preflight');
+    expect(existsSync(DASHBOARD_PLIST_PATH)).toBe(true);
+  });
+
+  it('plist contains --local arg, KeepAlive true, and RunAtLoad true', () => {
+    installDashboardDaemon('/usr/local/bin/preflight');
+    const content = readFileSync(DASHBOARD_PLIST_PATH, 'utf-8');
+    expect(content).toContain('<string>--local</string>');
+    expect(content).toContain('<key>KeepAlive</key>');
+    expect(content).toMatch(/<key>KeepAlive<\/key>\s*<true\/>/);
+    expect(content).toMatch(/<key>RunAtLoad<\/key>\s*<true\/>/);
+  });
+
+  it('embeds the binary path and redirects to dashboard.log', () => {
+    installDashboardDaemon('/opt/homebrew/bin/preflight');
+    const content = readFileSync(DASHBOARD_PLIST_PATH, 'utf-8');
+    expect(content).toContain('<string>/opt/homebrew/bin/preflight</string>');
+    expect(content).toContain('.newrelic-preflight/dashboard.log');
+  });
+
+  it('calls launchctl unload then load', () => {
+    mockedExecFileSync.mockImplementation(() => Buffer.from(''));
+    installDashboardDaemon('/usr/local/bin/preflight');
+    const calls = mockedExecFileSync.mock.calls.map((c) => (c as unknown[])[1] as string[]);
+    expect(calls.some((args) => args[0] === 'unload')).toBe(true);
+    expect(calls.some((args) => args[0] === 'load')).toBe(true);
+  });
+
+  it('does not throw when launchctl unload fails (not yet loaded)', () => {
+    mockedExecFileSync
+      .mockImplementationOnce(() => {
+        throw new Error('not loaded');
+      })
+      .mockImplementation(() => Buffer.from('') as unknown as string);
+    expect(() => installDashboardDaemon('/usr/local/bin/preflight')).not.toThrow();
+  });
+});
+
+describe('removeDashboardDaemon', () => {
+  it('is a no-op when plist does not exist', () => {
+    expect(() => removeDashboardDaemon()).not.toThrow();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('calls launchctl unload and deletes the plist', () => {
+    installDashboardDaemon('/usr/local/bin/preflight');
+    mockedExecFileSync.mockClear();
+    removeDashboardDaemon();
+    const calls = mockedExecFileSync.mock.calls.map((c) => (c as unknown[])[1] as string[]);
+    expect(calls.some((args) => args[0] === 'unload')).toBe(true);
+    expect(existsSync(DASHBOARD_PLIST_PATH)).toBe(false);
+  });
+});
+
+describe('getDashboardDaemonStatus', () => {
+  it('returns installed:false when plist is absent', () => {
+    expect(getDashboardDaemonStatus()).toEqual({ installed: false });
+  });
+
+  it('returns installed:true with binaryPath after install', () => {
+    installDashboardDaemon('/usr/local/bin/preflight');
+    const status = getDashboardDaemonStatus();
+    expect(status.installed).toBe(true);
+    expect(status.binaryPath).toBe('/usr/local/bin/preflight');
   });
 });

--- a/src/install/schedule.ts
+++ b/src/install/schedule.ts
@@ -21,13 +21,22 @@ function escapeXml(s: string): string {
 }
 
 const PLIST_LABEL = 'com.preflight.update';
+const DASHBOARD_PLIST_LABEL = 'com.preflight.dashboard';
 
 function plistPath(): string {
   return resolve(homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.plist`);
 }
 
+function dashboardPlistPath(): string {
+  return resolve(homedir(), 'Library', 'LaunchAgents', `${DASHBOARD_PLIST_LABEL}.plist`);
+}
+
 function updateLogPath(): string {
   return resolve(homedir(), '.newrelic-preflight', 'update.log');
+}
+
+function dashboardLogPath(): string {
+  return resolve(homedir(), '.newrelic-preflight', 'dashboard.log');
 }
 
 function buildPlist(binaryPath: string, hour: number, minute: number): string {
@@ -107,6 +116,79 @@ export function getScheduleStatus(): ScheduleStatus {
       installed: true,
       hour: hourMatch ? parseInt(hourMatch[1], 10) : undefined,
       minute: minuteMatch ? parseInt(minuteMatch[1], 10) : undefined,
+      binaryPath: binaryMatch ? binaryMatch[1] : undefined,
+    };
+  } catch {
+    return { installed: false };
+  }
+}
+
+function buildDashboardPlist(binaryPath: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${DASHBOARD_PLIST_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${escapeXml(binaryPath)}</string>
+    <string>--local</string>
+  </array>
+  <key>KeepAlive</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(dashboardLogPath())}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(dashboardLogPath())}</string>
+</dict>
+</plist>`;
+}
+
+export interface DashboardDaemonStatus {
+  readonly installed: boolean;
+  readonly binaryPath?: string;
+}
+
+export function installDashboardDaemon(binaryPath: string): void {
+  const path = dashboardPlistPath();
+  mkdirSync(resolve(homedir(), 'Library', 'LaunchAgents'), { recursive: true, mode: 0o755 });
+  writeFileSync(path, buildDashboardPlist(binaryPath), { mode: 0o600 });
+  try {
+    execFileSync('launchctl', ['unload', path], { stdio: 'pipe' });
+  } catch {
+    // Not yet loaded — that's fine.
+  }
+  try {
+    execFileSync('launchctl', ['load', path], { stdio: 'pipe' });
+  } catch (err) {
+    throw new Error(`launchctl load failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export function removeDashboardDaemon(): void {
+  const path = dashboardPlistPath();
+  if (!existsSync(path)) return;
+  try {
+    execFileSync('launchctl', ['unload', path], { stdio: 'pipe' });
+  } catch {
+    // Already unloaded.
+  }
+  unlinkSync(path);
+}
+
+export function getDashboardDaemonStatus(): DashboardDaemonStatus {
+  const path = dashboardPlistPath();
+  if (!existsSync(path)) return { installed: false };
+  try {
+    const content = readFileSync(path, 'utf-8');
+    const binaryMatch = content.match(
+      /<key>ProgramArguments<\/key>\s*<array>\s*<string>([^<]+)<\/string>/,
+    );
+    return {
+      installed: true,
       binaryPath: binaryMatch ? binaryMatch[1] : undefined,
     };
   } catch {

--- a/src/install/setup-wizard.ts
+++ b/src/install/setup-wizard.ts
@@ -14,7 +14,7 @@ import { homedir } from 'node:os';
 import { normalizeDeveloperName, ConfigFileSchema } from '../config.js';
 import { migrateStoragePath } from './migrate.js';
 import { runInstallCli, verifyBinaryOnPath } from './cli.js';
-import { installSchedule, resolveBinaryPath } from './schedule.js';
+import { installSchedule, installDashboardDaemon, resolveBinaryPath } from './schedule.js';
 import { validateLicenseKey, validateApiKey } from './key-validator.js';
 
 const DEFAULT_STORAGE_PATH = resolve(homedir(), '.newrelic-preflight');
@@ -513,6 +513,45 @@ export async function runSetupWizard(): Promise<void> {
         print('  Claude Code hooks will fail with "command not found" until this is resolved.');
         print('  Fix: run `npm link` in the project directory, or install globally:');
         print('    npm install -g @newrelic/preflight');
+      }
+    }
+
+    // Step 6b: Always-on background dashboard daemon (local/both mode, macOS only)
+    if ((mode === 'local' || mode === 'both') && process.platform === 'darwin') {
+      const binaryPath = resolveBinaryPath();
+      const daemonAnswer = (
+        await rl.question(
+          '\nInstall always-on background dashboard? Keeps the local dashboard running even when Claude Code is closed [Y/n]: ',
+        )
+      )
+        .trim()
+        .toLowerCase();
+      if (daemonAnswer !== 'n' && daemonAnswer !== 'no') {
+        if (binaryPath) {
+          try {
+            // installDashboardDaemon calls launchctl unload before load, so
+            // it handles the upgrade case atomically — no need to remove first.
+            // Removing before installing would leave the user with no daemon if
+            // the install step fails.
+            installDashboardDaemon(binaryPath);
+            print(
+              `✓ Background dashboard daemon installed — dashboard will be available at http://127.0.0.1:${dashboardPort ?? 7777} after login.`,
+            );
+            print(
+              '  To stop: preflight uninstall  (or: launchctl unload ~/Library/LaunchAgents/com.preflight.dashboard.plist)',
+            );
+          } catch (err) {
+            print(
+              `⚠ Could not install dashboard daemon: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            print('  You can start the dashboard manually at any time with: preflight --local');
+          }
+        } else {
+          print('\n⚠ Cannot install dashboard daemon — preflight not found on PATH.');
+          print(
+            '  Fix PATH first, then run: preflight setup  (or start manually: preflight --local)',
+          );
+        }
       }
     }
 

--- a/src/metrics/live-session-registry.ts
+++ b/src/metrics/live-session-registry.ts
@@ -44,10 +44,10 @@ export class LiveSessionRegistry {
     return this.sessionNames.get(sessionId) ?? null;
   }
 
-  // Task #17 (D3): the dashboard's `/api/sessions/live` endpoint surfaces
-  // last-activity per live session so the Today selector can default to the
-  // most-recently-active live session. Returns null when the session is not
-  // tracked (e.g. already gc'd as stale).
+  // The dashboard's `/api/sessions/live` endpoint surfaces last-activity per
+  // live session so the Today selector can default to the most-recently-active
+  // live session. Returns null when the session is not tracked (e.g. already
+  // gc'd as stale).
   getLastActivity(sessionId: string): number | null {
     return this.lastActivity.get(sessionId) ?? null;
   }

--- a/src/metrics/session-tracker.ts
+++ b/src/metrics/session-tracker.ts
@@ -117,8 +117,8 @@ export class SessionTracker {
 
   constructor(sessionId: string) {
     if (typeof sessionId !== 'string' || sessionId.length === 0) {
-      // Fix 3: the MCP no longer fabricates session_ids. Callers must pass
-      // the resolved Claude Code session_id (or a real UUID for tests).
+      // The MCP no longer fabricates session_ids. Callers must pass the
+      // resolved Claude Code session_id (or a real UUID for tests).
       throw new Error('SessionTracker requires a non-empty sessionId');
     }
     this.sessionId = sessionId;
@@ -297,6 +297,14 @@ export class SessionTracker {
     aggregator.record('ai.session.duration_ms', Date.now() - this.sessionStartTime);
     aggregator.record('ai.session.unique_files_read', this.filesRead.size);
     aggregator.record('ai.session.unique_files_written', this.filesWritten.size);
+  }
+
+  /** Update the session ID in place without clearing any accumulated metrics. */
+  adoptSessionId(sessionId: string): void {
+    if (typeof sessionId !== 'string' || sessionId.length === 0) {
+      throw new Error('SessionTracker.adoptSessionId() requires a non-empty sessionId');
+    }
+    this.sessionId = sessionId;
   }
 
   reset(sessionId: string): void {

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -72,7 +72,7 @@ export class LocalStore {
       resolvedSessionId =
         typeof sessionId === 'string' && SESSION_ID_RE.test(sessionId) ? sessionId : null;
     } else if (bufferPathOrSessionId !== undefined && SESSION_ID_RE.test(bufferPathOrSessionId)) {
-      // Per-session buffer scoping (Fix 3 happy path).
+      // Per-session buffer scoping.
       resolvedBufferPath = resolve(storagePath, `buffer-${bufferPathOrSessionId}.jsonl`);
       resolvedSessionId = bufferPathOrSessionId;
     } else if (bufferPathOrSessionId === undefined) {

--- a/src/transport/nr-ingest.ts
+++ b/src/transport/nr-ingest.ts
@@ -346,7 +346,7 @@ export function codingTaskToNrEvent(
   if (attrs.projectId) event.project_id = attrs.projectId;
   if (attrs.orgId) event.org_id = attrs.orgId;
 
-  // Fix 3: sessionTraceId is the resolved Claude Code session_id; the
+  // sessionTraceId is the resolved Claude Code session_id; the
   // firstRecord?.sessionId fallback was only meaningful when the MCP fabricated
   // its own UUID and lost cross-reference with the tool-call records.
   if (attrs.sessionTraceId != null) event.session_id = attrs.sessionTraceId;

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -21,11 +21,11 @@ export const fetchSessionCurrent = (): Promise<unknown> => getJson<unknown>('/ap
 export const fetchSessionToday = (): Promise<unknown> => getJson<unknown>('/api/session/today');
 export const fetchSessionsList = (limit = 50): Promise<unknown> =>
   getJson<unknown>(`/api/sessions?limit=${limit}`);
-// Task #17 (D3): cross-session aggregate KPIs for the Today view.
+// Cross-session aggregate KPIs for the Today view.
 export const fetchTodayAggregate = (): Promise<unknown> =>
   getJson<unknown>('/api/sessions/today/aggregate');
-// Task #17 (D3): currently-live session list (for the Today selector default
-// to most-recently-active).
+// Currently-live session list (for the Today selector to default to the
+// most-recently-active session).
 export const fetchLiveSessions = (): Promise<unknown> => getJson<unknown>('/api/sessions/live');
 export const fetchSessionDetail = (id: string): Promise<unknown> =>
   getJson<unknown>(`/api/sessions/${encodeURIComponent(id)}`);
@@ -124,7 +124,7 @@ export const qk = {
   context: ['context'] as const,
   modelUsage: ['model-usage'] as const,
   settings: ['settings'] as const,
-  // Task #17 (D3) query keys
+  // Query keys for live session and today aggregate endpoints
   sessionsLive: ['sessions', 'live'] as const,
   sessionsTodayAggregate: ['sessions', 'today', 'aggregate'] as const,
 };

--- a/src/web/store/liveStore.ts
+++ b/src/web/store/liveStore.ts
@@ -1,11 +1,11 @@
 import { create } from 'zustand';
 
-// Task #17 (D3): events that originate from a specific Claude Code session
-// carry `sessionId` so the Today view can filter by `activeId`. Optional on
-// the client side because (a) the SSE feed may be subscribed without a
-// sessionId filter (aggregate view), and (b) older / synthetic events from
-// hydrateFromApi flows may not have it set yet — we treat missing sessionId
-// as "always visible" to avoid surprise empty UIs during the rollout window.
+// Events that originate from a specific Claude Code session carry `sessionId`
+// so the Today view can filter by `activeId`. Optional on the client side
+// because (a) the SSE feed may be subscribed without a sessionId filter
+// (aggregate view), and (b) older / synthetic events from hydrateFromApi flows
+// may not have it set yet — we treat missing sessionId as "always visible" to
+// avoid surprise empty UIs during the rollout window.
 export interface ToolCallEvent {
   readonly id: string;
   readonly sessionId?: string;
@@ -77,12 +77,12 @@ interface LiveState {
   readonly contextBySession: Map<string, ContextUpdateEvent>;
   readonly firingAlerts: Map<string, AlertEvent>;
   readonly dismissedAlerts: Set<string>;
-  // Task #17 (D3): the user-selected session in the Today selector list.
-  // When this changes, the per-session caches (recentToolCalls,
-  // antiPatterns, cost) re-key so the previous session's events don't
-  // pollute the new selection. `null` = no session selected (e.g. nothing
-  // live yet); events with a sessionId still flow into the store but views
-  // that filter on activeSessionId render empty until a selection is made.
+  // The user-selected session in the Today selector list. When this changes,
+  // the per-session caches (recentToolCalls, antiPatterns, cost) re-key so
+  // the previous session's events don't pollute the new selection. `null` =
+  // no session selected (e.g. nothing live yet); events with a sessionId
+  // still flow into the store but views that filter on activeSessionId render
+  // empty until a selection is made.
   readonly activeSessionId: string | null;
   setConnected(v: boolean): void;
   pushToolCall(e: ToolCallEvent): void;
@@ -110,14 +110,14 @@ export const useLiveStore = create<LiveState>((set) => ({
 
   setConnected: (v) => set({ connected: v }),
 
-  // Task #17 (D3): switching the active session must not leave the previous
-  // session's tool calls and anti-patterns in view. We re-key the per-session
-  // caches by dropping entries whose sessionId doesn't match the new id.
-  // Events without a sessionId (legacy fixtures, hydrateFromApi prior to the
-  // server-side change) are dropped on switch — keeping them would create
-  // ambiguous "is this mine?" rendering. Cost is treated similarly: the SSE
-  // feed will replace it on the next cost-update from the new session, so
-  // clearing it here avoids showing an old session's last-known total.
+  // Switching the active session must not leave the previous session's tool
+  // calls and anti-patterns in view. We re-key the per-session caches by
+  // dropping entries whose sessionId doesn't match the new id. Events without
+  // a sessionId (legacy fixtures, hydrateFromApi prior to the server-side
+  // change) are dropped on switch — keeping them would create ambiguous
+  // "is this mine?" rendering. Cost is treated similarly: the SSE feed will
+  // replace it on the next cost-update from the new session, so clearing it
+  // here avoids showing an old session's last-known total.
   setActiveSession: (id) =>
     set((s) => {
       if (s.activeSessionId === id) return {};


### PR DESCRIPTION
**Problem**

Users who chose local or both mode during preflight setup found the dashboard didn't work — they had to manually run preflight --local in a separate terminal to get it going. Two root causes:

1. The MCP server (preflight --stdio) does start the dashboard when mode: local/both is configured, but only after async session ID resolution completes. On some machines this took long enough that users gave up.
2. There was no persistent background process — the dashboard only ran while Claude Code had a session open.

---

**What's new**

**Always-on background dashboard (macOS)**

The setup wizard now offers to install a launchd agent (com.preflight.dashboard) when mode is local or both:

Install always-on background dashboard? Keeps the local dashboard running
even when Claude Code is closed [Y/n]:

The daemon starts automatically at login, survives reboots, and hands the dashboard port over to active Claude Code sessions when they start — then reclaims it when they end. preflight uninstall removes it.

**Dashboard starts immediately**

When a Claude Code session begins, the dashboard is now live within milliseconds rather than waiting for session ID resolution to complete.

---

**Bug fixes**

- Dashboard daemon correctly survives port contention — previously it would exit immediately on EADDRINUSE instead of waiting to take over
- Setup wizard daemon upgrade is now atomic — reinstalling over an existing daemon no longer risks leaving the user with no daemon if the process fails partway through
- Session resolution polling is aborted cleanly on shutdown (no orphaned timers)
- OTel users: provisional session spans no longer emit a zero-call ghost span to OTLP backends
- isSyntheticSessionId now covers provisional session IDs, preventing them from appearing in audit records or the dashboard session history

---
Test plan

- [ ] npm run build && npm test — all tests pass
- [ ] preflight setup with mode local → wizard prompts for daemon install at Step 6b
- [ ] After install: launchctl list | grep preflight shows com.preflight.dashboard with a PID
- [ ] Dashboard accessible at http://127.0.0.1:7777 without an active Claude Code session open
- [ ] preflight uninstall removes the daemon (launchctl list | grep preflight returns nothing)
- [ ] Re-running preflight setup over an existing daemon upgrades it without error