### PR TITLE
Chore: v1.0.4 — WSL install/uninstall and setup wizard bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2026-06-24
+
+### Fixed
+
+- Alert rules copy during setup now correctly locates `examples/local-alert-rules.json` when installed globally via npm. The previous path resolution walked two directories up from the entry point (`dist/index.js`), overshooting the package root; it now walks up until it finds `package.json`, making it robust regardless of entry-point depth.
+- WSL install no longer defaults to Windows Claude Code mode for all WSL users. The installer previously wrote hooks to the Windows-side `.claude/settings.json` (with `wsl.exe -e` commands) whenever it detected WSL and a resolvable Windows home directory — which broke users running Linux Claude Code installed via npm inside WSL. The new behaviour: Windows CC mode is only used when explicitly requested via `--windows-cc`, or when a prior Windows CC install is recorded in `~/.newrelic-preflight/config.json`. All other WSL users get standard Linux-path hooks.
+- `preflight install` now accepts a `--windows-cc` flag to explicitly opt in to Windows Claude Code mode from WSL, making first-time Windows CC setups straightforward.
+- `preflight setup` now prompts WSL users to identify their Claude Code installation (Windows desktop app vs. Linux npm install inside WSL) before writing hooks, eliminating the silent misconfiguration that caused empty hook registries.
+- WSL install advisory message is now always shown even when the subsequent `settings.json` read or merge fails, so the `--windows-cc` routing hint reaches the user regardless of install outcome.
+
+---
+
 ## [1.0.3] - 2026-06-23
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -432,6 +432,8 @@ Expected:
 
 If you see `tool not found` or `MCP server unavailable`, the server didn't start. Check Claude Code's MCP output panel (View → Output → MCP) for errors, then re-run `preflight install` and restart.
 
+**WSL users:** Pass `--windows-cc` or `--linux-cc` to target the right Claude Code installation. Run `preflight setup` if unsure — the wizard will ask.
+
 **Checkpoint — local dashboard (local path only):**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ preflight uninstall   # Remove hooks and MCP config from your AI tool
 
 Add `--project` to `install`/`uninstall` to scope changes to the current directory only.
 
+**WSL users:** `preflight setup` will ask which Claude Code you're running. You can also set it explicitly:
+
+- `--windows-cc` — Windows Claude Code (the desktop app); uses `wsl.exe` hooks and Windows paths
+- `--linux-cc` — Linux Claude Code installed via npm inside WSL
+
 ---
 
 ## Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -231,6 +231,22 @@ describe('loadMcpConfig()', () => {
     expect(config.model).toBe('claude-haiku-4-5');
   });
 
+  it('platformTarget is read from config file', () => {
+    process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    const configPath = writeConfigFile({ platformTarget: 'wsl-linux-cc' });
+    const config = loadMcpConfig({ config: configPath });
+    expect(config.platformTarget).toBe('wsl-linux-cc');
+  });
+
+  it('platformTarget is undefined when absent from config file', () => {
+    process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    const configPath = writeConfigFile({});
+    const config = loadMcpConfig({ config: configPath });
+    expect(config.platformTarget).toBeUndefined();
+  });
+
   it('developer defaults to $USER env var', () => {
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
     process.env.NEW_RELIC_ACCOUNT_ID = '12345';

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,7 @@ export interface McpServerConfig {
   readonly otlpHeaders: Readonly<Record<string, string>>;
   readonly transport: 'nr-events-api' | 'otlp' | 'both';
   readonly mode: 'cloud' | 'local' | 'both';
+  readonly platformTarget?: PlatformTarget;
   /** Enable the local OTLP/HTTP receiver. Default: false. */
   readonly otlpReceiverEnabled: boolean;
   /** Port for the local OTLP/HTTP receiver. Default: 4318. */
@@ -82,6 +83,8 @@ export interface McpServerConfig {
 }
 
 export const DEFAULT_STORAGE_PATH = resolve(homedir(), '.newrelic-preflight');
+
+export type PlatformTarget = 'native' | 'wsl-windows-cc' | 'wsl-linux-cc';
 
 const DEFAULT_REDACTION_PATTERNS: RegExp[] = [
   /(?<![a-zA-Z])(?:API_KEY|SECRET|TOKEN|PASSWORD|PASSPHRASE|PRIVATE_KEY)(?![a-zA-Z])[\s]*[=:]\s*\S+/gi,
@@ -134,6 +137,7 @@ export const ConfigFileSchema = z
     otlpHeaders: z.record(z.string(), z.string()).optional(),
     transport: z.enum(['nr-events-api', 'otlp', 'both']).optional(),
     mode: z.enum(['cloud', 'local', 'both']).optional(),
+    platformTarget: z.enum(['native', 'wsl-windows-cc', 'wsl-linux-cc']).optional(),
     otlpReceiverEnabled: z.boolean().optional(),
     otlpReceiverPort: z.number().optional(),
     otlpReceiverBindAddress: z.string().optional(),
@@ -869,6 +873,8 @@ export function loadMcpConfig(cliOptions?: Partial<CliOptions>): Readonly<McpSer
         openOnStart: dashboardOpenOnStart,
       };
     })(),
+
+    platformTarget: file.platformTarget as PlatformTarget | undefined,
 
     alerts: (() => {
       // The alerts config is a separate top-level block from

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,7 +325,12 @@ export async function dispatchSubcommand(argv: string[]): Promise<number | null>
   // CLI subcommands (install/setup/etc.) delegate entirely to the install CLI.
   if (['install', 'uninstall', 'setup', 'validate', 'update', 'schedule'].includes(sub)) {
     const { runInstallCli } = await import('./install/cli.js');
-    await runInstallCli(argv.slice(2));
+    try {
+      await runInstallCli(argv.slice(2));
+    } catch {
+      // Error message already printed by the action handler before throwing.
+      return 1;
+    }
     return typeof process.exitCode === 'number' ? process.exitCode : 0;
   }
 

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -1,3 +1,6 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import * as fsMod from 'node:fs';
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 
 jest.mock('node:fs', () => ({
@@ -32,15 +35,31 @@ jest.mock('./install-helper.js', () => ({
   detectMcpConfigPath: jest.fn(() => '/tmp/mcp.json'),
   generateNrConfig: jest.fn(() => ({})),
 }));
+jest.mock('./platform.js', () => ({
+  isWsl: jest.fn(() => false),
+  resolveWindowsHome: jest.fn(() => null),
+}));
 
 import * as scheduleMod from './schedule.js';
+import * as platformMod from './platform.js';
 import { runInstallCli } from './cli.js';
+import * as installHelperMod from './install-helper.js';
 
 const mockedSchedule = scheduleMod as unknown as {
   installSchedule: jest.Mock;
   removeSchedule: jest.Mock;
   getScheduleStatus: jest.Mock;
   resolveBinaryPath: jest.Mock;
+};
+const mockedPlatform = platformMod as unknown as {
+  isWsl: jest.Mock;
+  resolveWindowsHome: jest.Mock;
+};
+const mockedHelper = installHelperMod as unknown as {
+  mergeSettings: jest.Mock;
+  mergeMcpConfig: jest.Mock;
+  detectSettingsPath: jest.Mock;
+  detectMcpConfigPath: jest.Mock;
 };
 
 describe('schedule subcommand', () => {
@@ -158,5 +177,811 @@ describe('uninstall calls removeSchedule', () => {
     await runInstallCli(['uninstall']);
     const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(output).toContain('Auto-update schedule removed');
+  });
+});
+
+describe('platform resolution via install', () => {
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: string | number | null | undefined) => {
+        throw new Error(`process.exit(${String(code)})`);
+      });
+    // Re-set return values reset by earlier tests (clearAllMocks doesn't undo mockReturnValue).
+    mockedSchedule.resolveBinaryPath.mockReturnValue('/usr/local/bin/preflight');
+    // Use HOME-based paths so writeJsonFile's symlink guard allows the writes.
+    mockedHelper.detectSettingsPath.mockReturnValue(`${homedir()}/.claude/settings.json`);
+    mockedHelper.detectMcpConfigPath.mockReturnValue(`${homedir()}/.mcp.json`);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('non-WSL install passes platform native to mergeSettings', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false);
+    await runInstallCli(['install']);
+    expect(mockedHelper.mergeSettings).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      platform: 'native',
+    });
+  });
+
+  it('--windows-cc outside WSL exits 1 with clear message', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false);
+    await expect(runInstallCli(['install', '--windows-cc'])).rejects.toThrow('process.exit(1)');
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('only works inside WSL');
+  });
+
+  it('--linux-cc outside WSL exits 1', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false);
+    await expect(runInstallCli(['install', '--linux-cc'])).rejects.toThrow('process.exit(1)');
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('only works inside WSL');
+  });
+
+  it('--linux-cc on WSL passes platform wsl-linux-cc to mergeSettings', async () => {
+    mockedPlatform.isWsl.mockReturnValue(true);
+    await runInstallCli(['install', '--linux-cc']);
+    expect(mockedHelper.mergeSettings).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      platform: 'wsl-linux-cc',
+    });
+  });
+
+  it('--windows-cc with no resolvable Windows home exits 1', async () => {
+    mockedPlatform.isWsl.mockReturnValue(true);
+    mockedPlatform.resolveWindowsHome.mockReturnValue(null);
+    await expect(runInstallCli(['install', '--windows-cc'])).rejects.toThrow('process.exit(1)');
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Windows home directory could not be resolved');
+  });
+
+  it('--windows-cc on WSL with resolvable home passes platform wsl-windows-cc to mergeSettings', async () => {
+    mockedPlatform.isWsl.mockReturnValue(true);
+    mockedPlatform.resolveWindowsHome.mockReturnValue('/mnt/c/Users/test');
+    await runInstallCli(['install', '--windows-cc']);
+    expect(mockedHelper.mergeSettings).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      platform: 'wsl-windows-cc',
+    });
+  });
+
+  it('both flags together exits 1', async () => {
+    await expect(runInstallCli(['install', '--windows-cc', '--linux-cc'])).rejects.toThrow(
+      'process.exit(1)',
+    );
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('mutually exclusive');
+  });
+
+  it('WSL with no prior state defaults to Linux CC with info message', async () => {
+    mockedPlatform.isWsl.mockReturnValue(true);
+    mockedPlatform.resolveWindowsHome.mockReturnValue('/mnt/c/Users/test');
+    // existsSync returns false by default — no settings.json, no config.json
+    await runInstallCli(['install']);
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Defaulting to Linux Claude Code mode');
+    expect(mockedHelper.mergeSettings).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      platform: 'wsl-linux-cc',
+    });
+  });
+});
+
+describe('platform resolution via uninstall', () => {
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: string | number | null | undefined) => {
+        throw new Error(`process.exit(${String(code)})`);
+      });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('--windows-cc outside WSL exits 1', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false);
+    await expect(runInstallCli(['uninstall', '--windows-cc'])).rejects.toThrow('process.exit(1)');
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('only works inside WSL');
+  });
+
+  it('--linux-cc outside WSL exits 1', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false);
+    await expect(runInstallCli(['uninstall', '--linux-cc'])).rejects.toThrow('process.exit(1)');
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('only works inside WSL');
+  });
+
+  it('--windows-cc and --linux-cc together exits 1', async () => {
+    await expect(runInstallCli(['uninstall', '--windows-cc', '--linux-cc'])).rejects.toThrow(
+      'process.exit(1)',
+    );
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('mutually exclusive');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Platform transition matrix — install/uninstall sequences and savedPlatform
+// ---------------------------------------------------------------------------
+
+const WINDOWS_HOME = '/mnt/c/Users/test';
+
+type MockedFs = {
+  readFileSync: jest.Mock;
+  writeFileSync: jest.Mock;
+  existsSync: jest.Mock;
+};
+
+function findConfigWrite(mockedFs: MockedFs): Record<string, unknown> | null {
+  const call = mockedFs.writeFileSync.mock.calls.find((c: unknown[]) =>
+    String(c[0]).endsWith('config.json.tmp'),
+  );
+  return call ? (JSON.parse(String(call[1])) as Record<string, unknown>) : null;
+}
+
+describe('platform transition matrix', () => {
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let mFs: MockedFs;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mFs = fsMod as unknown as MockedFs;
+    // Re-arm fs implementations: clearAllMocks() clears call records but not implementations,
+    // so a test that sets a custom mock would bleed into the next test without these resets.
+    (fsMod as unknown as { existsSync: jest.Mock }).existsSync.mockImplementation(() => false);
+    mFs.readFileSync.mockImplementation(() => '{}');
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: string | number | null | undefined) => {
+        throw new Error(`process.exit(${String(code)})`);
+      });
+    mockedSchedule.resolveBinaryPath.mockReturnValue('/usr/local/bin/preflight');
+    mockedHelper.detectSettingsPath.mockReturnValue(`${homedir()}/.claude/settings.json`);
+    mockedHelper.detectMcpConfigPath.mockReturnValue(`${homedir()}/.mcp.json`);
+    mockedPlatform.isWsl.mockReturnValue(true);
+    mockedPlatform.resolveWindowsHome.mockReturnValue(WINDOWS_HOME);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // After bare uninstall of a wsl-linux-cc user, the Windows settings.json still exists
+  // on disk (removeSettings strips hooks but leaves the file). A bare re-install must
+  // NOT use existsSync(settings.json) as evidence of Windows CC intent — it should
+  // default to wsl-linux-cc (the safe default).
+  it('bare install with no savedPlatform but Windows settings.json on disk defaults to wsl-linux-cc', async () => {
+    mFs.readFileSync.mockReturnValue('{}'); // no savedPlatform
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === join(WINDOWS_HOME, '.claude', 'settings.json'),
+    );
+
+    await runInstallCli(['install']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.platformTarget).toBe('wsl-linux-cc');
+  });
+
+  // --linux-cc is a targeted "clean Linux paths" command — it must not touch the
+  // saved platform, so a wsl-windows-cc record must survive the operation.
+  it('--linux-cc uninstall does not erase savedPlatform when it was wsl-windows-cc', async () => {
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
+
+    await runInstallCli(['uninstall', '--linux-cc']);
+
+    // Any write to config.json must preserve platformTarget (or there must be no write at all).
+    const configWrites = mFs.writeFileSync.mock.calls.filter((c: unknown[]) =>
+      String(c[0]).endsWith('config.json.tmp'),
+    );
+    const erasedPlatform = configWrites.some((c: unknown[]) => {
+      const written = JSON.parse(String(c[1])) as Record<string, unknown>;
+      return !('platformTarget' in written);
+    });
+    expect(erasedPlatform).toBe(false);
+  });
+
+  // --windows-cc uninstall clears savedPlatform (not writes wsl-linux-cc) so the
+  // user's repair-cycle intent is preserved: they must explicitly pass --windows-cc
+  // on reinstall, rather than having the wrong platform silently baked in.
+  it('--windows-cc uninstall clears platformTarget and prints reinstall reminder', async () => {
+    mockedHelper.detectSettingsPath.mockImplementation((_scope: unknown, wh: unknown) =>
+      wh ? `${String(wh)}/.claude/settings.json` : `${homedir()}/.claude/settings.json`,
+    );
+    mockedHelper.detectMcpConfigPath.mockImplementation((_scope: unknown, wh: unknown) =>
+      wh ? `${String(wh)}/.mcp.json` : `${homedir()}/.mcp.json`,
+    );
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
+    // Simulate that config.json exists (written by the prior --windows-cc install).
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+    );
+
+    await runInstallCli(['uninstall', '--windows-cc']);
+
+    // clearSavedPlatform() strips platformTarget — next bare install re-detects from scratch.
+    const written = findConfigWrite(mFs);
+    expect(written).not.toBeNull();
+    expect(written?.platformTarget).toBeUndefined();
+    // Remind the user how to get Windows CC back after uninstall.
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('preflight install --windows-cc');
+  });
+
+  // Regression guard: bare uninstall of wsl-windows-cc must clear savedPlatform.
+  it('bare uninstall of wsl-windows-cc clears platformTarget', async () => {
+    mockedHelper.detectSettingsPath.mockImplementation((_scope: unknown, wh: unknown) =>
+      wh ? `${String(wh)}/.claude/settings.json` : `${homedir()}/.claude/settings.json`,
+    );
+    mockedHelper.detectMcpConfigPath.mockImplementation((_scope: unknown, wh: unknown) =>
+      wh ? `${String(wh)}/.mcp.json` : `${homedir()}/.mcp.json`,
+    );
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+    );
+
+    await runInstallCli(['uninstall']);
+
+    const written = findConfigWrite(mFs);
+    expect(written).not.toBeNull();
+    expect(written?.platformTarget).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Install side: verify platformTarget persisted after each install variant
+  // ---------------------------------------------------------------------------
+
+  it('install --windows-cc persists platformTarget wsl-windows-cc', async () => {
+    mFs.readFileSync.mockReturnValue('{}');
+
+    await runInstallCli(['install', '--windows-cc']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.platformTarget).toBe('wsl-windows-cc');
+  });
+
+  it('install --linux-cc persists platformTarget wsl-linux-cc', async () => {
+    mFs.readFileSync.mockReturnValue('{}');
+
+    await runInstallCli(['install', '--linux-cc']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.platformTarget).toBe('wsl-linux-cc');
+  });
+
+  it('bare WSL install with savedPlatform wsl-linux-cc re-persists wsl-linux-cc', async () => {
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-linux-cc' }));
+
+    await runInstallCli(['install']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.platformTarget).toBe('wsl-linux-cc');
+  });
+
+  it('bare non-WSL install persists platformTarget native', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false);
+    mFs.readFileSync.mockReturnValue('{}');
+
+    await runInstallCli(['install']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.platformTarget).toBe('native');
+  });
+
+  // Regression guard: a stale platformTarget='native' in config.json (written by a
+  // prior non-WSL install) must not suppress the WSL-mode informational message or
+  // bypass WSL detection. 'native' is not a valid WSL target and must be treated as
+  // if no saved platform exists when isWsl() returns true.
+  it('bare WSL install with stale savedPlatform native ignores saved value and defaults to wsl-linux-cc', async () => {
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'native' }));
+
+    await runInstallCli(['install']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.platformTarget).toBe('wsl-linux-cc');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Remaining uninstall cases
+  // ---------------------------------------------------------------------------
+
+  it('--linux-cc uninstall with savedPlatform wsl-linux-cc does not erase savedPlatform', async () => {
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-linux-cc' }));
+
+    await runInstallCli(['uninstall', '--linux-cc']);
+
+    const configWrites = mFs.writeFileSync.mock.calls.filter((c: unknown[]) =>
+      String(c[0]).endsWith('config.json.tmp'),
+    );
+    const erasedPlatform = configWrites.some((c: unknown[]) => {
+      const written = JSON.parse(String(c[1])) as Record<string, unknown>;
+      return !('platformTarget' in written);
+    });
+    expect(erasedPlatform).toBe(false);
+  });
+
+  it('bare non-WSL uninstall clears platformTarget', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false);
+    mockedPlatform.resolveWindowsHome.mockReturnValue(null);
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'native' }));
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+    );
+
+    await runInstallCli(['uninstall']);
+
+    const written = findConfigWrite(mFs);
+    expect(written).not.toBeNull();
+    expect(written?.platformTarget).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // A Windows CC user who runs --linux-cc uninstall (to clean stale Linux paths)
+  // must get Windows CC back on the next bare install — savedPlatform is preserved.
+  // ---------------------------------------------------------------------------
+
+  it('install --windows-cc → uninstall --linux-cc → bare install still uses Windows CC', async () => {
+    mFs.readFileSync.mockReturnValue('{}');
+
+    // Install Windows CC
+    await runInstallCli(['install', '--windows-cc']);
+
+    // Simulate the state written above (config.json now has wsl-windows-cc)
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
+
+    // Uninstall --linux-cc — must not clear savedPlatform
+    await runInstallCli(['uninstall', '--linux-cc']);
+
+    // Bare install — savedPlatform is still wsl-windows-cc; must use Windows CC paths
+    const mergeCallsBefore = mockedHelper.mergeSettings.mock.calls.length;
+    await runInstallCli(['install']);
+
+    const lastCall = mockedHelper.mergeSettings.mock.calls[mergeCallsBefore];
+    expect(lastCall?.[2]).toEqual({ platform: 'wsl-windows-cc' });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Untested resolvePlatform branch: saved wsl-windows-cc + interop disabled
+  // ---------------------------------------------------------------------------
+
+  // Realistic scenario: user installed with --windows-cc, later disables WSL
+  // interop, then tries to reinstall. Must exit with a clear message rather
+  // than silently using the wrong platform.
+  it('bare WSL install with savedPlatform wsl-windows-cc but no windowsHome exits 1', async () => {
+    mockedPlatform.resolveWindowsHome.mockReturnValue(null);
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
+
+    await expect(runInstallCli(['install'])).rejects.toThrow('process.exit(1)');
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Windows home could not be resolved');
+  });
+
+  // Standalone confirmation that the saved wsl-windows-cc path (with interop
+  // available) uses Windows CC — the round-trip proves this indirectly, but a
+  // direct test makes the coverage explicit.
+  it('bare WSL install with savedPlatform wsl-windows-cc uses Windows CC paths', async () => {
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
+
+    await runInstallCli(['install']);
+
+    expect(mockedHelper.mergeSettings).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      platform: 'wsl-windows-cc',
+    });
+    const written = findConfigWrite(mFs);
+    expect(written?.platformTarget).toBe('wsl-windows-cc');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Untested handleUninstall branches
+  // ---------------------------------------------------------------------------
+
+  it('uninstall --windows-cc on WSL with no windowsHome exits 1', async () => {
+    mockedPlatform.resolveWindowsHome.mockReturnValue(null);
+
+    await expect(runInstallCli(['uninstall', '--windows-cc'])).rejects.toThrow('process.exit(1)');
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Windows home directory could not be resolved');
+  });
+
+  it('bare uninstall with savedPlatform wsl-windows-cc but no windowsHome exits 1', async () => {
+    mockedPlatform.resolveWindowsHome.mockReturnValue(null);
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
+
+    await expect(runInstallCli(['uninstall'])).rejects.toThrow('process.exit(1)');
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Windows home could not be resolved');
+  });
+
+  // Regression guard: non-WSL machine with stale wsl-windows-cc in config.json must not
+  // exit 1 with a "re-enable WSL interop" message — that message is impossible to action.
+  // The fix: when !wslEnv, treat Windows CC paths as unreachable and clean Linux paths only.
+  it('bare uninstall with stale savedPlatform wsl-windows-cc on non-WSL machine cleans Linux paths and succeeds', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false);
+    mockedPlatform.resolveWindowsHome.mockReturnValue(null);
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+    );
+
+    // Must NOT exit 1 — user on a native machine with a stale cross-machine config.
+    await runInstallCli(['uninstall']);
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).not.toContain('WSL interop may be disabled');
+    // Linux-side settings and MCP paths must be targeted (not Windows paths).
+    expect(mockedHelper.detectSettingsPath).toHaveBeenCalledWith(expect.anything(), null);
+    expect(mockedHelper.detectMcpConfigPath).toHaveBeenCalledWith(expect.anything(), null);
+  });
+
+  it('bare uninstall with savedPlatform wsl-linux-cc clears platformTarget and targets Windows paths', async () => {
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-linux-cc' }));
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+    );
+    mockedHelper.detectSettingsPath.mockImplementation((_scope: unknown, wh: unknown) =>
+      wh ? `${String(wh)}/.claude/settings.json` : `${homedir()}/.claude/settings.json`,
+    );
+    mockedHelper.detectMcpConfigPath.mockImplementation((_scope: unknown, wh: unknown) =>
+      wh ? `${String(wh)}/.mcp.json` : `${homedir()}/.mcp.json`,
+    );
+
+    await runInstallCli(['uninstall']);
+
+    const written = findConfigWrite(mFs);
+    expect(written).not.toBeNull();
+    expect(written?.platformTarget).toBeUndefined();
+    // wsl-linux-cc bare uninstall also cleans Windows-side hooks when interop is available
+    // (a prior --windows-cc install may have left hooks there).
+    expect(mockedHelper.detectSettingsPath).toHaveBeenCalledWith(expect.anything(), WINDOWS_HOME);
+    expect(mockedHelper.detectSettingsPath).toHaveBeenCalledWith(expect.anything(), null);
+  });
+
+  // clearSavedPlatform must preserve unrelated config fields — if it
+  // overwrote config.json with just '{}' the user's licenseKey/accountId
+  // would be silently wiped on every uninstall.
+  it('bare uninstall preserves non-platformTarget fields in config.json', async () => {
+    mFs.readFileSync.mockReturnValue(
+      JSON.stringify({
+        platformTarget: 'wsl-linux-cc',
+        licenseKey: 'NRLIC-test',
+        accountId: '12345',
+      }),
+    );
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+    );
+
+    await runInstallCli(['uninstall']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.platformTarget).toBeUndefined();
+    expect(written?.licenseKey).toBe('NRLIC-test');
+    expect(written?.accountId).toBe('12345');
+  });
+
+  // Pre-1.0.4 install: no platformTarget in config — the else branch cleans
+  // both paths as a safety net and clears whatever was there.
+  it('bare uninstall with no savedPlatform (pre-1.0.4) clears config and cleans both paths', async () => {
+    mFs.readFileSync.mockReturnValue('{}'); // no platformTarget
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+    );
+    mockedHelper.detectSettingsPath.mockImplementation((_scope: unknown, wh: unknown) =>
+      wh ? `${String(wh)}/.claude/settings.json` : `${homedir()}/.claude/settings.json`,
+    );
+    mockedHelper.detectMcpConfigPath.mockImplementation((_scope: unknown, wh: unknown) =>
+      wh ? `${String(wh)}/.mcp.json` : `${homedir()}/.mcp.json`,
+    );
+
+    await runInstallCli(['uninstall']);
+
+    // clearSavedPlatform writes to config.json — even starting from '{}', it writes '{}'
+    const written = findConfigWrite(mFs);
+    expect(written).not.toBeNull();
+    expect(written?.platformTarget).toBeUndefined();
+    // Both Windows and Linux paths were targeted (includeWindows=true when windowsHome reachable)
+    expect(mockedHelper.detectSettingsPath).toHaveBeenCalledWith(expect.anything(), WINDOWS_HOME);
+    expect(mockedHelper.detectSettingsPath).toHaveBeenCalledWith(expect.anything(), null);
+  });
+
+  // A user who ran `preflight install --linux-cc` then `preflight install --windows-cc`
+  // (without uninstalling first) has Linux-side hooks still on disk. A bare uninstall
+  // must clean both Windows AND Linux paths so those stale hooks don't keep firing.
+  it('bare uninstall with savedPlatform wsl-windows-cc also targets Linux-side paths', async () => {
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
+    mockedHelper.detectSettingsPath.mockImplementation((_scope: unknown, wh: unknown) =>
+      wh ? `${String(wh)}/.claude/settings.json` : `${homedir()}/.claude/settings.json`,
+    );
+    mockedHelper.detectMcpConfigPath.mockImplementation((_scope: unknown, wh: unknown) =>
+      wh ? `${String(wh)}/.mcp.json` : `${homedir()}/.mcp.json`,
+    );
+
+    await runInstallCli(['uninstall']);
+
+    // Both Windows-side and Linux-side paths must be targeted (symmetric with the
+    // wsl-linux-cc case which also cleans the opposite platform's leftover hooks).
+    expect(mockedHelper.detectSettingsPath).toHaveBeenCalledWith(expect.anything(), WINDOWS_HOME);
+    expect(mockedHelper.detectSettingsPath).toHaveBeenCalledWith(expect.anything(), null);
+  });
+
+  // When the MCP config write fails after the settings write succeeded, the error
+  // message must name the MCP config path so the user can diagnose which file failed.
+  it('MCP config write failure names the MCP config path in the error output', async () => {
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mFs.readFileSync.mockReturnValue('{}');
+    const writeFsMock = fsMod as unknown as { writeFileSync: jest.Mock };
+    // Call 1: settingsPath.tmp (success), Call 2: mcpPath.tmp (failure)
+    writeFsMock.writeFileSync
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+    await expect(runInstallCli(['install'])).rejects.toThrow();
+
+    const stderr = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    const mcpPath = mockedHelper.detectMcpConfigPath.mock.results[0]?.value as string;
+    expect(stderr).toContain(mcpPath);
+    expect(stderr).toContain('EACCES');
+    stderrSpy.mockRestore();
+  });
+
+  // When credentials are explicitly provided and the NR config write fails, the
+  // error must be fatal — the process must not exit 0 while silently discarding
+  // the user's credentials.
+  it('NR config write failure with credentials re-throws (fatal, not silent exit 0)', async () => {
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mFs.readFileSync.mockReturnValue('{}');
+    const writeFsMock = fsMod as unknown as { writeFileSync: jest.Mock };
+    // Calls 1+2: settings and mcp writes succeed; call 3: config.json.tmp write fails.
+    writeFsMock.writeFileSync
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+    await expect(
+      runInstallCli(['install', '--license-key', 'NRLIC-test', '--account-id', '12345']),
+    ).rejects.toThrow();
+
+    const stderr = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderr).toContain('Failed to save New Relic config');
+    expect(stderr).toContain('EACCES');
+    stderrSpy.mockRestore();
+  });
+
+  // Bare uninstall on a machine that never had preflight installed must not create
+  // config.json from scratch (clearSavedPlatform must be a no-op when the file
+  // does not exist).
+  it('bare uninstall does not create config.json on a clean machine (no prior install)', async () => {
+    // Default mock: existsSync returns false for everything — no files on disk.
+    mFs.readFileSync.mockReturnValue('{}');
+
+    await runInstallCli(['uninstall']);
+
+    const configWrites = (
+      fsMod as unknown as { writeFileSync: jest.Mock }
+    ).writeFileSync.mock.calls.filter((c: unknown[]) => String(c[0]).endsWith('config.json.tmp'));
+    expect(configWrites).toHaveLength(0);
+  });
+
+  // When the platformTarget write fails and no credentials were provided (the common
+  // case), the user must see a warning rather than a silent no-op so they know the
+  // next install will re-detect the platform from scratch.
+  it('platformTarget write failure without credentials prints a warning to stderr', async () => {
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mFs.readFileSync.mockReturnValue('{}');
+    const writeFsMock = fsMod as unknown as { writeFileSync: jest.Mock };
+    // Calls 1+2 succeed (settings and mcp), call 3 fails (config.json.tmp for platformTarget)
+    writeFsMock.writeFileSync
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw new Error('EPERM: read-only file system');
+      });
+
+    await runInstallCli(['install']); // non-fatal — must not throw
+
+    const stderr = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderr).toContain('Could not persist platform target');
+    expect(stderr).toContain('re-detect');
+    stderrSpy.mockRestore();
+  });
+
+  // Non-WSL machine: bare install (no credentials) + unreadable config.json: warn,
+  // skip config write, but complete — hooks still installed. The EACCES fires at the
+  // credentials read (second read), not in resolvePlatform, and is non-fatal when no
+  // credentials are being written. On WSL, EACCES on config.json is always fatal because
+  // it could mask a saved wsl-windows-cc platform (see 'WSL EACCES is fatal' test).
+  it('bare install with unreadable config.json warns and skips config write (non-fatal)', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false); // non-WSL: EACCES fires at credentials read
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const configPath = join(homedir(), '.newrelic-preflight', 'config.json');
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === configPath) {
+        const err = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+        throw err;
+      }
+      return '{}';
+    });
+    mFs.existsSync.mockImplementation((p: unknown) => String(p) === configPath);
+
+    await runInstallCli(['install']); // must not throw
+
+    const stderr = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderr).toContain('Could not read existing NR config');
+    expect(stderr).toContain('EACCES');
+    // No config.json write — credentials are safe.
+    const configWrites = mFs.writeFileSync.mock.calls.filter((c: unknown[]) =>
+      String(c[0]).endsWith('config.json.tmp'),
+    );
+    expect(configWrites).toHaveLength(0);
+    stderrSpy.mockRestore();
+  });
+
+  // WSL + unreadable config.json is always fatal: a saved wsl-windows-cc platform
+  // could be hiding behind the EACCES, and silently falling back to wsl-linux-cc would
+  // silently destroy the user's Windows CC setup.
+  it('WSL bare install with unreadable config.json is fatal (prevents silent wsl-windows-cc override)', async () => {
+    // isWsl=true is the beforeEach default
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const configPath = join(homedir(), '.newrelic-preflight', 'config.json');
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === configPath) {
+        const err = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+        throw err;
+      }
+      return '{}';
+    });
+    mFs.existsSync.mockImplementation((p: unknown) => String(p) === configPath);
+
+    await expect(runInstallCli(['install'])).rejects.toThrow();
+
+    const stderr = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderr).toContain('Fix file permissions');
+    // Hooks must NOT be written — install aborted before hook write.
+    const hookWrites = mFs.writeFileSync.mock.calls.filter(
+      (c: unknown[]) =>
+        String(c[0]).endsWith('settings.json.tmp') || String(c[0]).endsWith('.mcp.json.tmp'),
+    );
+    expect(hookWrites).toHaveLength(0);
+    stderrSpy.mockRestore();
+  });
+
+  // Regression guard: WSL + explicit platform flag + EACCES must NOT be fatal when no
+  // credentials are provided. The explicit flag makes savedPlatform irrelevant, so EACCES
+  // only means we can't persist platformTarget — same as the non-fatal non-WSL path.
+  it('WSL install with --windows-cc and unreadable config.json is non-fatal (explicit flag makes savedPlatform irrelevant)', async () => {
+    // isWsl=true is the beforeEach default
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const configPath = join(homedir(), '.newrelic-preflight', 'config.json');
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === configPath) {
+        const err = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+        throw err;
+      }
+      return '{}';
+    });
+    mFs.existsSync.mockImplementation((p: unknown) => String(p) === configPath);
+
+    // Must not throw — explicit flag makes the saved platform irrelevant.
+    await runInstallCli(['install', '--windows-cc']);
+
+    const stderr = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderr).toContain('Could not read existing NR config');
+    // No config.json write — platformTarget not persisted, but hooks were installed.
+    const configWrites = mFs.writeFileSync.mock.calls.filter((c: unknown[]) =>
+      String(c[0]).endsWith('config.json.tmp'),
+    );
+    expect(configWrites).toHaveLength(0);
+    stderrSpy.mockRestore();
+  });
+
+  // Credentialed install + unreadable config.json is fatal: we cannot safely persist
+  // credentials without knowing the existing file contents.
+  it('credentialed install with unreadable config.json is fatal (prevents silent credential wipe)', async () => {
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const configPath = join(homedir(), '.newrelic-preflight', 'config.json');
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === configPath) {
+        const err = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+        throw err;
+      }
+      return '{}';
+    });
+    mFs.existsSync.mockImplementation((p: unknown) => String(p) === configPath);
+
+    await expect(
+      runInstallCli(['install', '--license-key', 'NRLIC-foo', '--account-id', '12345']),
+    ).rejects.toThrow();
+
+    const stderr = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderr).toContain('Cannot read existing NR config');
+    expect(stderr).toContain('EACCES');
+    stderrSpy.mockRestore();
+  });
+
+  // Bug fix: clearSavedPlatform used readJsonFile (lenient) which silently returns {}
+  // on EACCES/EPERM, causing writeJsonFile to overwrite config.json with {} and wipe
+  // licenseKey/accountId. Fix: use readJsonFileStrict — IO errors are non-fatal (caught
+  // by the outer try/catch) and produce no write rather than a credential-destroying write.
+  it('uninstall with unreadable config.json does not write {} (no credential wipe)', async () => {
+    const configPath = join(homedir(), '.newrelic-preflight', 'config.json');
+    mFs.existsSync.mockImplementation((p: unknown) => String(p) === configPath);
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === configPath) {
+        const err = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+        throw err;
+      }
+      return '{}';
+    });
+
+    await runInstallCli(['uninstall']); // non-fatal — must not throw
+
+    // clearSavedPlatform must not write anything when the read fails.
+    const configWrites = mFs.writeFileSync.mock.calls.filter((c: unknown[]) =>
+      String(c[0]).endsWith('config.json.tmp'),
+    );
+    expect(configWrites).toHaveLength(0);
+  });
+
+  // Bug fix: !nrConfigWriteFailed guard was suppressing the "Both required" hint when
+  // a partial credential was passed AND the platformTarget write failed. Both messages
+  // carry independent information and must both fire.
+  it('partial credential + platformTarget write failure: "Both required" hint still prints', async () => {
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mFs.readFileSync.mockReturnValue('{}');
+    const writeFsMock = fsMod as unknown as { writeFileSync: jest.Mock };
+    // Settings and MCP writes succeed; config.json.tmp write fails.
+    writeFsMock.writeFileSync
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw new Error('EPERM: read-only file system');
+      });
+
+    await runInstallCli(['install', '--license-key', 'NRLIC-partial']); // non-fatal
+
+    const stdout = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stdout).toContain('Both --license-key and --account-id are required');
+    stderrSpy.mockRestore();
+  });
+
+  // Malformed config.json is always fatal: readJsonFileStrict throws SyntaxError at the
+  // single config read at the top of handleInstall. The install cannot safely write back
+  // to corrupt JSON and must abort — re-detection would overwrite unknown existing state.
+  it('install with malformed config.json is fatal (SyntaxError cannot be auto-detected around)', async () => {
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const configPath = join(homedir(), '.newrelic-preflight', 'config.json');
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === configPath) return '{"licenseKey": "NRLIC-truncated';
+      return '{}';
+    });
+    mFs.existsSync.mockImplementation((p: unknown) => String(p) === configPath);
+
+    await expect(runInstallCli(['install'])).rejects.toThrow();
+
+    const stderr = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stderr).toContain('Cannot read existing NR config');
+    expect(stderr).toContain('invalid JSON');
+    stderrSpy.mockRestore();
   });
 });

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -5,20 +5,12 @@
  * so commander and other heavy deps are never loaded on the hot hook path.
  */
 
-import { Command } from 'commander';
 import { execSync, execFileSync } from 'node:child_process';
-import {
-  readFileSync,
-  writeFileSync,
-  mkdirSync,
-  existsSync,
-  renameSync,
-  unlinkSync,
-  copyFileSync,
-  realpathSync,
-} from 'node:fs';
-import { basename, dirname, join, resolve, sep } from 'node:path';
+import { existsSync, copyFileSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { Command } from 'commander';
+
 import {
   mergeSettings,
   removeSettings,
@@ -29,7 +21,8 @@ import {
   generateNrConfig,
 } from './install-helper.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
-import { validateConfigFile, DEFAULT_STORAGE_PATH } from '../config.js';
+import { validateConfigFile, DEFAULT_STORAGE_PATH, ConfigFileSchema } from '../config.js';
+import type { PlatformTarget } from '../config.js';
 import { migrateStoragePath } from './migrate.js';
 import {
   installSchedule,
@@ -39,61 +32,123 @@ import {
   getDashboardDaemonStatus,
   resolveBinaryPath,
 } from './schedule.js';
+import { readJsonFileStrict, writeJsonFile } from './json-utils.js';
 
-const NR_CONFIG_DIR = resolve(homedir(), '.newrelic-preflight');
-const NR_CONFIG_PATH = resolve(NR_CONFIG_DIR, 'config.json');
+const NR_CONFIG_PATH = resolve(DEFAULT_STORAGE_PATH, 'config.json');
+
+// ---------------------------------------------------------------------------
+// Platform persistence helpers — read/write platformTarget in config.json
+// ---------------------------------------------------------------------------
+
+function parsePlatformTarget(value: unknown): PlatformTarget | null {
+  const result = ConfigFileSchema.shape.platformTarget.safeParse(value);
+  return result.success && result.data !== undefined ? result.data : null;
+}
+
+function clearSavedPlatform(): void {
+  try {
+    if (!existsSync(NR_CONFIG_PATH)) return;
+    const { platformTarget: _pt, ...rest } = readJsonFileStrict(NR_CONFIG_PATH);
+    writeJsonFile(NR_CONFIG_PATH, rest, DEFAULT_STORAGE_PATH);
+  } catch (err) {
+    eprint(
+      `\n⚠ Could not clear saved platform target: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    eprint(
+      '  The next install may use the stale platform target. Fix the issue and re-run uninstall.',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Platform resolution — single function, single place for all errors
+// ---------------------------------------------------------------------------
+
+function resolvePlatform(
+  options: { windowsCc?: boolean; linuxCc?: boolean },
+  savedPlatform: PlatformTarget | null,
+): {
+  platform: PlatformTarget;
+  windowsHome: string | null;
+} {
+  if (options.windowsCc && options.linuxCc) {
+    print('\n  ⚠ --windows-cc and --linux-cc are mutually exclusive. Pass only one.');
+    process.exit(1);
+  }
+  if (options.windowsCc) {
+    if (!isWsl()) {
+      print('\n  ⚠ --windows-cc only works inside WSL — this machine is not running WSL.');
+      print('  Run without --windows-cc to install normally.');
+      process.exit(1);
+    }
+    const windowsHome = resolveWindowsHome();
+    if (!windowsHome) {
+      print('\n  ⚠ --windows-cc: Windows home directory could not be resolved.');
+      print('  Check that WSL interop is enabled:');
+      print('    wsl.exe --status');
+      process.exit(1);
+    }
+    return { platform: 'wsl-windows-cc', windowsHome };
+  }
+  if (options.linuxCc) {
+    if (!isWsl()) {
+      print('\n  ⚠ --linux-cc only works inside WSL — this machine is not running WSL.');
+      print('  Run without --linux-cc to install normally.');
+      process.exit(1);
+    }
+    return { platform: 'wsl-linux-cc', windowsHome: null };
+  }
+
+  if (!isWsl()) return { platform: 'native', windowsHome: null };
+
+  // WSL auto-detect: use the savedPlatform already read by handleInstall.
+  // 'native' is excluded — it was written on a non-WSL machine and must not
+  // suppress WSL-mode guidance or the --windows-cc hint below.
+  if (savedPlatform && savedPlatform !== 'native') {
+    if (savedPlatform === 'wsl-windows-cc') {
+      const windowsHome = resolveWindowsHome();
+      if (!windowsHome) {
+        print(
+          '\n  ⚠ Saved install target is Windows Claude Code but Windows home could not be resolved.',
+        );
+        print('  WSL interop may be disabled. Re-run with --windows-cc when interop is restored,');
+        print('  or use --linux-cc to switch to Linux Claude Code mode permanently.');
+        process.exit(1);
+      }
+      return { platform: 'wsl-windows-cc', windowsHome };
+    }
+    return { platform: savedPlatform, windowsHome: null };
+  }
+
+  // WSL: no prior state — default to Linux CC, inform user about the Windows option.
+  print('\n  ℹ WSL detected with no prior install state. Defaulting to Linux Claude Code mode.');
+  print('  If you are using the Windows Claude Code desktop app, re-run with --windows-cc:');
+  print('    preflight install --windows-cc');
+  return { platform: 'wsl-linux-cc', windowsHome: null };
+}
+
+function resolveInstallPaths(
+  _platform: PlatformTarget,
+  scope: 'user' | 'project',
+  windowsHome: string | null,
+): { settingsPath: string; mcpPath: string; allowedBase: string | undefined } {
+  return {
+    settingsPath: detectSettingsPath(scope, windowsHome),
+    mcpPath: detectMcpConfigPath(scope, windowsHome),
+    allowedBase: windowsHome ?? undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// print helper
+// ---------------------------------------------------------------------------
 
 function print(msg = ''): void {
   process.stdout.write(msg + '\n');
 }
 
-// ---------------------------------------------------------------------------
-// File I/O helpers
-// ---------------------------------------------------------------------------
-
-function readJsonFile(path: string): Record<string, unknown> {
-  try {
-    return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
-}
-
-function writeJsonFile(
-  path: string,
-  data: Record<string, unknown>,
-  additionalAllowedBase?: string,
-): void {
-  const dir = dirname(path);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
-  }
-
-  // Symlink guard: verify both the resolved parent directory AND the resolved
-  // target file path are under HOME, cwd, or an explicitly allowed base (e.g.
-  // the Windows home path under /mnt/c/... when writing from WSL).
-  const resolvedDir = realpathSync(dir);
-  const resolvedPath = existsSync(path) ? realpathSync(path) : resolve(resolvedDir, basename(path));
-  const home = homedir();
-  const cwd = process.cwd();
-  const check = (p: string) =>
-    p === home ||
-    p.startsWith(home + sep) ||
-    p === cwd ||
-    p.startsWith(cwd + sep) ||
-    (additionalAllowedBase !== undefined &&
-      (p === additionalAllowedBase || p.startsWith(additionalAllowedBase + sep)));
-  if (!check(resolvedDir) || !check(resolvedPath)) {
-    throw new Error(`Refusing to write outside HOME or project root: ${resolvedPath}`);
-  }
-
-  const tmp = path + '.tmp';
-  try {
-    writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
-    renameSync(tmp, path);
-  } finally {
-    if (existsSync(tmp)) unlinkSync(tmp);
-  }
+function eprint(msg = ''): void {
+  process.stderr.write(msg + '\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -118,10 +173,10 @@ function printPathWarning(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Repo root discovery (for update command)
+// Repo root discovery (for update command and setup wizard)
 // ---------------------------------------------------------------------------
 
-function findRepoRoot(): string | null {
+export function findRepoRoot(): string | null {
   try {
     let dir = dirname(realpathSync(process.argv[1]));
     while (true) {
@@ -230,60 +285,118 @@ function handleInstall(options: {
   licenseKey?: string;
   accountId?: string;
   project?: boolean;
+  windowsCc?: boolean;
+  linuxCc?: boolean;
 }): void {
   migrateStoragePath(true);
   const scope = options.project ? 'project' : 'user';
-
-  // Resolve the full binary path at install time so hooks work in non-login
-  // shells (e.g. /bin/sh) that don't inherit NVM/nix/Homebrew PATH entries.
   const binPath = resolveBinaryPath();
+  const credentialsProvided = !!(options.licenseKey && options.accountId);
+  const inWsl = isWsl();
 
-  // On WSL, Claude Code for Windows reads settings from the Windows user home
-  // (accessible via /mnt/c/Users/<name>/). Hook commands must use wsl.exe -e
-  // so Windows Claude Code can invoke the WSL binary.
-  const wslEnv = isWsl();
-  const windowsHome = wslEnv ? resolveWindowsHome() : null;
-  const useWslMode = wslEnv && windowsHome !== null;
-
-  if (wslEnv && !useWslMode) {
-    print('\n  ⚠ WSL detected but Windows home directory could not be resolved.');
-    print('  Hooks will be written to the WSL home (~/.claude/settings.json).');
-    print('  If you are using Windows Claude Code, restart WSL interop and re-run install.');
-  }
-
-  // Hooks go in settings.json (Windows path when running under WSL)
-  const settingsPath = detectSettingsPath(scope, windowsHome);
-  let mergedSettings: ReturnType<typeof mergeSettings>;
+  // Read config.json once. Serves two purposes:
+  // (a) extract savedPlatform for resolvePlatform (needed on WSL auto-detect)
+  // (b) preserve existing fields when writing back platformTarget + credentials
+  // Fatal conditions: SyntaxError (can't safely write back to corrupt JSON),
+  // WSL without explicit platform flag + any IO error (EACCES/EPERM could mask a
+  //   saved wsl-windows-cc platform — explicit flags make savedPlatform irrelevant),
+  // credentials provided + any IO error (can't preserve without knowing existing state).
+  const explicitPlatform = !!(options.windowsCc || options.linuxCc);
+  let existingNrConfig: Record<string, unknown> = {};
+  let skipNrConfigWrite = false;
   try {
-    const existingSettings = readJsonFile(settingsPath);
-    mergedSettings = mergeSettings(existingSettings, binPath, { wsl: useWslMode });
+    // readJsonFileStrict returns {} on ENOENT; throws on IO errors or malformed JSON.
+    existingNrConfig = readJsonFileStrict(NR_CONFIG_PATH);
   } catch (err) {
-    console.error(
-      `✗ Failed to update ${settingsPath}: ${err instanceof Error ? err.message : String(err)}`,
+    const isSyntaxError = err instanceof SyntaxError;
+    if (isSyntaxError || (inWsl && !explicitPlatform) || credentialsProvided) {
+      eprint(
+        `\n✗ Cannot read existing NR config to determine install target: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      eprint(
+        isSyntaxError
+          ? '  config.json contains invalid JSON — fix or delete it, then re-run install.'
+          : '  Fix file permissions then re-run install.',
+      );
+      throw err;
+    }
+    eprint(
+      `\n⚠ Could not read existing NR config to persist platform target: ${err instanceof Error ? err.message : String(err)}`,
     );
-    process.exit(1);
+    eprint('  Platform target not persisted — hook installation will continue. Re-run to save it.');
+    skipNrConfigWrite = true;
   }
-  writeJsonFile(settingsPath, mergedSettings, windowsHome ?? undefined);
 
-  // MCP server goes in .mcp.json (Windows path when running under WSL)
-  const mcpPath = detectMcpConfigPath(scope, windowsHome);
+  const savedPlatform = parsePlatformTarget(existingNrConfig.platformTarget);
+  const { platform, windowsHome } = resolvePlatform(options, savedPlatform);
+  const { settingsPath, mcpPath, allowedBase } = resolveInstallPaths(platform, scope, windowsHome);
+
+  let mergedSettings: ReturnType<typeof mergeSettings>;
   let mergedMcp: ReturnType<typeof mergeMcpConfig>;
   try {
-    const existingMcp = readJsonFile(mcpPath);
-    mergedMcp = mergeMcpConfig(existingMcp, binPath, { wsl: useWslMode });
+    mergedSettings = mergeSettings(readJsonFileStrict(settingsPath), binPath, { platform });
+    mergedMcp = mergeMcpConfig(readJsonFileStrict(mcpPath), binPath, { platform });
   } catch (err) {
-    console.error(
-      `✗ Failed to update ${mcpPath}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    process.exit(1);
+    eprint(`\n✗ Failed to prepare config: ${err instanceof Error ? err.message : String(err)}`);
+    throw err;
   }
-  writeJsonFile(mcpPath, mergedMcp, windowsHome ?? undefined);
 
-  if (useWslMode) {
-    print(`\n  ℹ WSL detected — configuring for Windows Claude Code`);
+  try {
+    writeJsonFile(settingsPath, mergedSettings, allowedBase);
+  } catch (err) {
+    eprint(
+      `\n✗ Failed to write hooks config (${settingsPath}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    throw err;
+  }
+  try {
+    writeJsonFile(mcpPath, mergedMcp, allowedBase);
+  } catch (err) {
+    eprint(
+      `\n✗ Failed to write MCP config (${mcpPath}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    throw err;
+  }
+
+  // Persist platformTarget (and credentials if provided) — only after both hook files written.
+  let nrConfigWritten = false;
+  if (!skipNrConfigWrite) {
+    try {
+      const nrConfig: Record<string, unknown> = { ...existingNrConfig, platformTarget: platform };
+      if (credentialsProvided) {
+        Object.assign(
+          nrConfig,
+          generateNrConfig(options.licenseKey as string, options.accountId as string),
+        );
+      }
+      writeJsonFile(NR_CONFIG_PATH, nrConfig, DEFAULT_STORAGE_PATH);
+      nrConfigWritten = credentialsProvided;
+    } catch (err) {
+      if (credentialsProvided) {
+        eprint(
+          `\n✗ Failed to save New Relic config: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        throw err;
+      }
+      eprint(
+        `\n⚠ Could not persist platform target: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      eprint('  The next install will re-detect the target platform from scratch.');
+    }
+  }
+
+  if (platform === 'wsl-windows-cc') {
+    print('\n  ℹ Configured for Windows Claude Code (desktop app).');
     print(`  Hooks written to: ${settingsPath}`);
     print(`  MCP config written to: ${mcpPath}`);
     print('  Hook commands use wsl.exe -e so Windows Claude Code can invoke them.');
+    print('  To switch to Linux Claude Code mode, re-run with --linux-cc:');
+    print('    preflight install --linux-cc');
+  } else if (platform === 'wsl-linux-cc') {
+    print('\n  ℹ Configured for Linux Claude Code (npm in WSL).');
+    print(`  Hooks written to: ${settingsPath}`);
+    print('  To switch to Windows Claude Code mode, re-run with --windows-cc:');
+    print('    preflight install --windows-cc');
   }
 
   print(`\n✓ Claude Code hooks updated: ${settingsPath}`);
@@ -291,11 +404,9 @@ function handleInstall(options: {
   print(`✓ MCP server registered: ${mcpPath}`);
   print('  - Added preflight MCP server');
 
-  if (options.licenseKey && options.accountId) {
-    const config = generateNrConfig(options.licenseKey, options.accountId);
-    writeJsonFile(NR_CONFIG_PATH, config as unknown as Record<string, unknown>);
+  if (nrConfigWritten) {
     print(`\n✓ New Relic config written: ${NR_CONFIG_PATH}`);
-  } else if (options.licenseKey || options.accountId) {
+  } else if (!credentialsProvided && (options.licenseKey || options.accountId)) {
     print('\n⚠ Both --license-key and --account-id are required to save NR config. Skipped.');
   }
 
@@ -318,58 +429,173 @@ function handleInstall(options: {
 // Uninstall handler
 // ---------------------------------------------------------------------------
 
-function handleUninstall(options: { project?: boolean }): void {
+function handleUninstall(options: {
+  project?: boolean;
+  windowsCc?: boolean;
+  linuxCc?: boolean;
+}): void {
   const scope = options.project ? 'project' : 'user';
 
-  // On WSL, attempt to clean up both the Windows-side paths (current install
-  // format) and the WSL-side paths (legacy pre-WSL-support installs).
+  if (options.windowsCc && options.linuxCc) {
+    print('\n  ⚠ --windows-cc and --linux-cc are mutually exclusive. Pass only one.');
+    process.exit(1);
+  }
+  if (options.windowsCc && !isWsl()) {
+    print('\n  ⚠ --windows-cc only works inside WSL — this machine is not running WSL.');
+    print('  Run without --windows-cc to uninstall normally.');
+    process.exit(1);
+  }
+  if (options.linuxCc && !isWsl()) {
+    print('\n  ⚠ --linux-cc only works inside WSL — this machine is not running WSL.');
+    print('  Run without --linux-cc to uninstall normally.');
+    process.exit(1);
+  }
+
   const wslEnv = isWsl();
   const windowsHome = wslEnv ? resolveWindowsHome() : null;
 
-  const settingsPathsToClean = new Set<string>();
-  settingsPathsToClean.add(detectSettingsPath(scope, windowsHome));
-  if (windowsHome) settingsPathsToClean.add(detectSettingsPath(scope, null));
+  if (options.windowsCc && windowsHome === null) {
+    print('\n  ⚠ --windows-cc: Windows home directory could not be resolved.');
+    print('  Nothing to uninstall for Windows Claude Code.');
+    process.exit(1);
+  }
 
-  const mcpPathsToClean = new Set<string>();
-  mcpPathsToClean.add(detectMcpConfigPath(scope, windowsHome));
-  if (windowsHome) mcpPathsToClean.add(detectMcpConfigPath(scope, null));
+  // For bare uninstall (no flags), read the saved platform so we only clean the
+  // paths that were actually written during the matching install. Users who never
+  // ran preflight ≥1.0.4 have no saved platform, so fall back to cleaning both
+  // paths as a migration safety net.
+  // If config.json is unreadable, fall back to cleaning both paths — over-cleaning
+  // is safe, under-cleaning is not.
+  let savedPlatform: PlatformTarget | null = null;
+  if (!options.windowsCc && !options.linuxCc) {
+    try {
+      const config = readJsonFileStrict(NR_CONFIG_PATH);
+      savedPlatform = parsePlatformTarget(config.platformTarget);
+    } catch {
+      /* unreadable config — clean both paths */
+    }
+  }
+
+  let includeWindows: boolean;
+  let includeLinux: boolean;
+  if (options.windowsCc) {
+    includeWindows = true;
+    includeLinux = false;
+  } else if (options.linuxCc) {
+    includeWindows = false;
+    includeLinux = true;
+  } else if (savedPlatform === 'wsl-windows-cc') {
+    if (!wslEnv) {
+      // Not in WSL — Windows CC paths from a prior WSL install are unreachable on this machine
+      // (e.g. config copied to macOS/Linux). Clean Linux-side paths and clear the stale target.
+      includeWindows = false;
+      includeLinux = true;
+    } else if (windowsHome === null) {
+      // In WSL but interop unavailable — cannot reach Windows-side hooks without windowsHome.
+      // Exit with an actionable message rather than silently cleaning nothing and clearing the
+      // saved platform (which would make the next bare install forget the user's Windows CC intent).
+      print(
+        '\n  ⚠ Saved install target is Windows Claude Code but Windows home could not be resolved.',
+      );
+      print('  WSL interop may be disabled. To uninstall:');
+      print('    Re-enable WSL interop, then re-run: preflight uninstall');
+      print('    Or clean Linux-side hooks only:       preflight uninstall --linux-cc');
+      process.exit(1);
+    } else {
+      // Also clean Linux-side hooks — the user may have previously run --linux-cc and then
+      // switched to --windows-cc without uninstalling first. Linux paths are always reachable.
+      includeWindows = true;
+      includeLinux = true;
+    }
+  } else if (savedPlatform === 'wsl-linux-cc') {
+    // Clean Linux hooks. Also clean Windows hooks if reachable — the user may have
+    // previously run --windows-cc and then switched to --linux-cc without uninstalling first.
+    if (windowsHome !== null) {
+      print('\n  ℹ Also removing Windows-side hooks (leftover from a prior --windows-cc install).');
+    }
+    includeWindows = windowsHome !== null;
+    includeLinux = true;
+  } else if (savedPlatform === 'native') {
+    includeWindows = false;
+    includeLinux = true;
+  } else {
+    // No saved platform (pre-1.0.4 install): clean both paths as a safety net.
+    includeWindows = windowsHome !== null;
+    includeLinux = true;
+  }
+
+  // Map value is the allowedBase for writeJsonFile's symlink guard.
+  const settingsPathsToClean = new Map<string, string | undefined>();
+  const mcpPathsToClean = new Map<string, string | undefined>();
+
+  if (includeWindows && windowsHome) {
+    settingsPathsToClean.set(detectSettingsPath(scope, windowsHome), windowsHome);
+    mcpPathsToClean.set(detectMcpConfigPath(scope, windowsHome), windowsHome);
+  }
+  if (includeLinux) {
+    settingsPathsToClean.set(detectSettingsPath(scope, null), undefined);
+    mcpPathsToClean.set(detectMcpConfigPath(scope, null), undefined);
+  }
 
   print('');
 
-  // Remove hooks from settings.json (all candidate paths)
   let settingsFound = false;
-  for (const settingsPath of settingsPathsToClean) {
+  for (const [settingsPath, allowedBase] of settingsPathsToClean) {
     if (existsSync(settingsPath)) {
+      const backup = `${settingsPath}.backup-${Date.now()}`;
+      copyFileSync(settingsPath, backup);
+      print(`  Backup saved: ${backup}`);
+      try {
+        writeJsonFile(settingsPath, removeSettings(readJsonFileStrict(settingsPath)), allowedBase);
+      } catch (err) {
+        eprint(
+          `\n✗ Failed to clean hooks config (${settingsPath}): ${err instanceof Error ? err.message : String(err)}`,
+        );
+        throw err;
+      }
       settingsFound = true;
-      const settingsBackup = `${settingsPath}.backup-${Date.now()}`;
-      copyFileSync(settingsPath, settingsBackup);
-      print(`  Backup saved: ${settingsBackup}`);
-      const existingSettings = readJsonFile(settingsPath);
-      const cleanedSettings = removeSettings(existingSettings);
-      writeJsonFile(settingsPath, cleanedSettings, windowsHome ?? undefined);
       print(`✓ Hooks removed: ${settingsPath}`);
     }
   }
   if (!settingsFound) {
-    print(`No settings file found at ${[...settingsPathsToClean].join(', ')}. Skipping hooks.`);
+    print(
+      `No settings file found at ${[...settingsPathsToClean.keys()].join(', ')}. Skipping hooks.`,
+    );
   }
 
-  // Remove MCP server from .mcp.json (all candidate paths)
   let mcpFound = false;
-  for (const mcpPath of mcpPathsToClean) {
+  for (const [mcpPath, allowedBase] of mcpPathsToClean) {
     if (existsSync(mcpPath)) {
+      const backup = `${mcpPath}.backup-${Date.now()}`;
+      copyFileSync(mcpPath, backup);
+      print(`  Backup saved: ${backup}`);
+      try {
+        writeJsonFile(mcpPath, removeMcpConfig(readJsonFileStrict(mcpPath)), allowedBase);
+      } catch (err) {
+        eprint(
+          `\n✗ Failed to clean MCP config (${mcpPath}): ${err instanceof Error ? err.message : String(err)}`,
+        );
+        throw err;
+      }
       mcpFound = true;
-      const mcpBackup = `${mcpPath}.backup-${Date.now()}`;
-      copyFileSync(mcpPath, mcpBackup);
-      print(`  Backup saved: ${mcpBackup}`);
-      const existingMcp = readJsonFile(mcpPath);
-      const cleanedMcp = removeMcpConfig(existingMcp);
-      writeJsonFile(mcpPath, cleanedMcp, windowsHome ?? undefined);
       print(`✓ MCP server removed: ${mcpPath}`);
     }
   }
   if (!mcpFound) {
-    print(`No MCP config file found at ${[...mcpPathsToClean].join(', ')}. Skipping MCP server.`);
+    print(`No MCP config found at ${[...mcpPathsToClean.keys()].join(', ')}. Skipping MCP server.`);
+  }
+
+  // Update persisted platform after cleanup.
+  // --windows-cc or bare: clear savedPlatform so the next install re-detects from scratch.
+  //   After --windows-cc uninstall, the user must pass --windows-cc again to reinstall
+  //   Windows CC mode — re-detection has no heuristic for Windows CC intent.
+  // --linux-cc: leave savedPlatform untouched — this only cleans Linux-side paths and must
+  //   not destroy a wsl-windows-cc record that the user still intends to use.
+  if (options.windowsCc) {
+    print('  To reinstall Windows Claude Code mode, re-run: preflight install --windows-cc');
+  }
+  if (!options.linuxCc) {
+    clearSavedPlatform();
   }
 
   print('\nRestart Claude Code for changes to take effect.\n');
@@ -443,12 +669,16 @@ export function createInstallProgram(): Command {
     .option('--license-key <key>', 'New Relic license key')
     .option('--account-id <id>', 'New Relic account ID')
     .option('--project', 'Write to project-level .claude/settings.json instead of user-level')
+    .option('--windows-cc', 'Target Windows Claude Code (desktop app) when running inside WSL')
+    .option('--linux-cc', 'Target Linux Claude Code (npm in WSL) when running inside WSL')
     .action(handleInstall);
 
   program
     .command('uninstall')
     .description('Remove preflight hooks and MCP server from Claude Code settings')
     .option('--project', 'Remove from project-level .claude/settings.json instead of user-level')
+    .option('--windows-cc', 'Remove Windows Claude Code hooks only (WSL only)')
+    .option('--linux-cc', 'Remove Linux Claude Code hooks only (WSL only)')
     .action(handleUninstall);
 
   program

--- a/src/install/install-helper.test.ts
+++ b/src/install/install-helper.test.ts
@@ -51,7 +51,7 @@ describe('generateHookEntries', () => {
   });
 
   it('wsl mode: uses quoted wsl.exe -e with absolute path', () => {
-    const hooks = generateHookEntries('/home/user/bin/preflight', { wsl: true });
+    const hooks = generateHookEntries('/home/user/bin/preflight', { platform: 'wsl-windows-cc' });
 
     expect(hooks.PreToolUse[0].hooks[0].command).toBe(
       'wsl.exe -e "/home/user/bin/preflight-collector" pre-tool',
@@ -62,7 +62,9 @@ describe('generateHookEntries', () => {
   });
 
   it('wsl mode: quotes path with spaces so cmd.exe does not split tokens', () => {
-    const hooks = generateHookEntries('/home/john doe/bin/preflight', { wsl: true });
+    const hooks = generateHookEntries('/home/john doe/bin/preflight', {
+      platform: 'wsl-windows-cc',
+    });
 
     expect(hooks.PreToolUse[0].hooks[0].command).toBe(
       'wsl.exe -e "/home/john doe/bin/preflight-collector" pre-tool',
@@ -70,7 +72,9 @@ describe('generateHookEntries', () => {
   });
 
   it('wsl mode: escapes backslashes before quotes, matching non-wsl branch behaviour', () => {
-    const hooks = generateHookEntries('/path/with\\backslash/preflight', { wsl: true });
+    const hooks = generateHookEntries('/path/with\\backslash/preflight', {
+      platform: 'wsl-windows-cc',
+    });
 
     expect(hooks.PreToolUse[0].hooks[0].command).toBe(
       'wsl.exe -e "/path/with\\\\backslash/preflight-collector" pre-tool',
@@ -78,7 +82,7 @@ describe('generateHookEntries', () => {
   });
 
   it('wsl mode: falls back to quoted bare command name when binPath is null', () => {
-    const hooks = generateHookEntries(null, { wsl: true });
+    const hooks = generateHookEntries(null, { platform: 'wsl-windows-cc' });
 
     expect(hooks.PreToolUse[0].hooks[0].command).toBe('wsl.exe -e "preflight-collector" pre-tool');
     expect(hooks.PostToolUse[0].hooks[0].command).toBe(
@@ -129,9 +133,9 @@ describe('generateHookEntries', () => {
   });
 });
 
-describe('mergeSettings — WSL mode', () => {
+describe('mergeSettings — wsl-windows-cc platform', () => {
   it('generates quoted wsl.exe hook commands', () => {
-    const result = mergeSettings({}, '/home/user/bin/preflight', { wsl: true });
+    const result = mergeSettings({}, '/home/user/bin/preflight', { platform: 'wsl-windows-cc' });
     const hooks = result.hooks as Record<string, unknown[]>;
     const pre = hooks.PreToolUse[0] as Record<string, unknown>;
     expect((pre.hooks as Array<Record<string, string>>)[0].command).toBe(
@@ -140,17 +144,17 @@ describe('mergeSettings — WSL mode', () => {
   });
 
   it('is idempotent — re-installing with wsl mode does not duplicate entries', () => {
-    const once = mergeSettings({}, '/home/user/bin/preflight', { wsl: true });
-    const twice = mergeSettings(once, '/home/user/bin/preflight', { wsl: true });
+    const once = mergeSettings({}, '/home/user/bin/preflight', { platform: 'wsl-windows-cc' });
+    const twice = mergeSettings(once, '/home/user/bin/preflight', { platform: 'wsl-windows-cc' });
     const hooks = twice.hooks as Record<string, unknown[]>;
     expect(hooks.PreToolUse).toHaveLength(1);
     expect(hooks.PostToolUse).toHaveLength(1);
   });
 });
 
-describe('mergeMcpConfig — WSL mode', () => {
+describe('mergeMcpConfig — wsl-windows-cc platform', () => {
   it('generates wsl.exe MCP server entry', () => {
-    const result = mergeMcpConfig({}, '/home/user/bin/preflight', { wsl: true });
+    const result = mergeMcpConfig({}, '/home/user/bin/preflight', { platform: 'wsl-windows-cc' });
     const servers = result.mcpServers as Record<string, unknown>;
     expect(servers['newrelic-preflight']).toEqual({
       command: 'wsl.exe',
@@ -205,7 +209,9 @@ describe('generateMcpServerEntry', () => {
   });
 
   it('wsl mode: uses wsl.exe -e with absolute path', () => {
-    const entry = generateMcpServerEntry('/home/user/bin/preflight', { wsl: true });
+    const entry = generateMcpServerEntry('/home/user/bin/preflight', {
+      platform: 'wsl-windows-cc',
+    });
 
     expect(entry['newrelic-preflight']).toEqual({
       command: 'wsl.exe',
@@ -214,7 +220,7 @@ describe('generateMcpServerEntry', () => {
   });
 
   it('wsl mode: falls back to bare command name when binPath is null', () => {
-    const entry = generateMcpServerEntry(null, { wsl: true });
+    const entry = generateMcpServerEntry(null, { platform: 'wsl-windows-cc' });
 
     expect(entry['newrelic-preflight']).toEqual({
       command: 'wsl.exe',

--- a/src/install/install-helper.ts
+++ b/src/install/install-helper.ts
@@ -7,6 +7,7 @@
 import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { z } from 'zod';
+import type { PlatformTarget } from '../config.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -58,12 +59,12 @@ export interface NrObserveConfig {
 
 export function generateHookEntries(
   binPath?: string | null,
-  options?: { wsl?: boolean },
+  options?: { platform?: PlatformTarget },
 ): HookEntries {
   let pre: string;
   let post: string;
 
-  if (options?.wsl) {
+  if (options?.platform === 'wsl-windows-cc') {
     // Windows Claude Code runs hooks via wsl.exe — call the WSL binary through interop.
     // Quote the path so cmd.exe doesn't split on spaces (e.g. /home/john doe/...).
     const collectorPath = binPath ? join(dirname(binPath), COLLECTOR_COMMAND) : COLLECTOR_COMMAND;
@@ -88,9 +89,9 @@ export function generateHookEntries(
 
 export function generateMcpServerEntry(
   binPath?: string | null,
-  options?: { wsl?: boolean },
+  options?: { platform?: PlatformTarget },
 ): Record<string, McpServerConfig> {
-  if (options?.wsl) {
+  if (options?.platform === 'wsl-windows-cc') {
     // Windows Claude Code launches MCP servers as Windows processes — use wsl.exe interop.
     const serverPath = binPath ? join(dirname(binPath), MCP_SERVER_COMMAND) : MCP_SERVER_COMMAND;
     return {
@@ -193,7 +194,7 @@ const McpConfigSchema = z
 export function mergeSettings(
   existing: Record<string, unknown>,
   binPath?: string | null,
-  options?: { wsl?: boolean },
+  options?: { platform?: PlatformTarget },
 ): Record<string, unknown> {
   const parsed = SettingsSchema.safeParse(existing);
   if (!parsed.success) {
@@ -241,7 +242,7 @@ export function mergeSettings(
 export function mergeMcpConfig(
   existing: Record<string, unknown>,
   binPath?: string | null,
-  options?: { wsl?: boolean },
+  options?: { platform?: PlatformTarget },
 ): Record<string, unknown> {
   const parsed = McpConfigSchema.safeParse(existing);
   if (!parsed.success) {

--- a/src/install/json-utils.ts
+++ b/src/install/json-utils.ts
@@ -1,0 +1,99 @@
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  renameSync,
+  unlinkSync,
+  realpathSync,
+} from 'node:fs';
+import { basename, dirname, resolve, sep } from 'node:path';
+import { homedir } from 'node:os';
+
+export function readJsonFile(path: string): Record<string, unknown> {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+// Like readJsonFile but throws on IO errors (EBUSY, EPERM, etc.) and on
+// malformed or non-object JSON rather than returning {}. Returns {} only for
+// ENOENT (file absent). Use when the file is known to exist and its contents
+// must be preserved.
+export function readJsonFileStrict(path: string): Record<string, unknown> {
+  try {
+    const val: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+    if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+      return val as Record<string, unknown>;
+    }
+    throw new SyntaxError(
+      `Expected a JSON object but got ${Array.isArray(val) ? 'array' : typeof val}`,
+    );
+  } catch (err) {
+    if (err instanceof SyntaxError) throw err;
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw err;
+  }
+}
+
+export function writeJsonFile(
+  path: string,
+  data: Record<string, unknown>,
+  additionalAllowedBase?: string,
+): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+
+  // Symlink guard: verify both the resolved parent directory AND the resolved
+  // target file path are under HOME, cwd, or an explicitly allowed base (e.g.
+  // the Windows home path under /mnt/c/... when writing from WSL).
+  const resolvedDir = realpathSync(dir);
+  const resolvedPath = existsSync(path) ? realpathSync(path) : resolve(resolvedDir, basename(path));
+  const home = homedir();
+  const cwd = process.cwd();
+  // Resolve additionalAllowedBase so symlinked storage directories (e.g. ~/.newrelic-preflight
+  // → /data/shared/preflight) are correctly matched against the resolved target path.
+  const resolvedAllowedBase =
+    additionalAllowedBase !== undefined
+      ? (() => {
+          try {
+            return realpathSync(additionalAllowedBase);
+          } catch (err) {
+            // ENOENT: path doesn't exist yet (created by mkdirSync above on first write).
+            // All other errors (EACCES, EPERM) propagate — a permission failure here
+            // means the resolved base is unknown, which would defeat the symlink guard.
+            if ((err as NodeJS.ErrnoException).code === 'ENOENT') return additionalAllowedBase;
+            throw err;
+          }
+        })()
+      : undefined;
+  const check = (p: string) =>
+    p === home ||
+    p.startsWith(home + sep) ||
+    p === cwd ||
+    p.startsWith(cwd + sep) ||
+    (resolvedAllowedBase !== undefined &&
+      (p === resolvedAllowedBase || p.startsWith(resolvedAllowedBase + sep)));
+  if (!check(resolvedDir) || !check(resolvedPath)) {
+    throw new Error(`Refusing to write outside HOME or project root: ${resolvedPath}`);
+  }
+
+  const tmp = path + '.tmp';
+  try {
+    writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
+    renameSync(tmp, path);
+  } catch (err) {
+    // Best-effort cleanup of the temp file — suppress secondary errors so the
+    // original write/rename error is what propagates to the caller.
+    try {
+      if (existsSync(tmp)) unlinkSync(tmp);
+    } catch {
+      /* best-effort */
+    }
+    throw err;
+  }
+}

--- a/src/install/migrate.test.ts
+++ b/src/install/migrate.test.ts
@@ -1,0 +1,342 @@
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import * as fsMod from 'node:fs';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+jest.mock('node:fs', () => ({
+  existsSync: jest.fn(() => false),
+  readFileSync: jest.fn(() => '{}'),
+  writeFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  renameSync: jest.fn(),
+  unlinkSync: jest.fn(),
+  realpathSync: jest.fn((p: unknown) => p),
+  cpSync: jest.fn(),
+  rmSync: jest.fn(),
+  readSync: jest.fn(() => 0),
+  openSync: jest.fn(() => 3),
+  closeSync: jest.fn(),
+}));
+
+import { migrateStoragePath } from './migrate.js';
+
+// Paths mirror what migrate.ts derives from DEFAULT_STORAGE_PATH at runtime.
+const STORAGE = resolve(homedir(), '.newrelic-preflight');
+const MARKER = resolve(STORAGE, '.wsl-mode');
+const CONFIG = resolve(STORAGE, 'config.json');
+const CONFIG_TMP = CONFIG + '.tmp';
+const OLD_PATH = resolve(homedir(), '.nr-ai-observe');
+
+type MockedFs = {
+  existsSync: jest.Mock;
+  readFileSync: jest.Mock;
+  writeFileSync: jest.Mock;
+  renameSync: jest.Mock;
+  unlinkSync: jest.Mock;
+};
+
+// ---------------------------------------------------------------------------
+// migrateWslMarker — tested via the exported migrateStoragePath wrapper.
+// The old-path migration (nr-ai-observe → newrelic-preflight) is suppressed
+// by making existsSync return false for OLD_PATH, so only the marker logic runs.
+// ---------------------------------------------------------------------------
+
+describe('migrateWslMarker (via migrateStoragePath)', () => {
+  let mFs: MockedFs;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mFs = fsMod as unknown as MockedFs;
+    // Re-arm implementations that clearAllMocks() leaves stale between tests.
+    // clearAllMocks() only clears call records; mockImplementation() values persist.
+    // Any test that sets a custom implementation (e.g. unlinkSync that throws) would
+    // bleed into later tests without an explicit reset here.
+    (fsMod as unknown as { realpathSync: jest.Mock }).realpathSync.mockImplementation(
+      (p: unknown) => p,
+    );
+    mFs.writeFileSync.mockImplementation(() => {});
+    mFs.renameSync.mockImplementation(() => {});
+    mFs.unlinkSync.mockImplementation(() => {});
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    // Default: only the marker file exists; old storage path does not.
+    mFs.existsSync.mockImplementation((p: unknown) => String(p) === MARKER);
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'windows';
+      return '{}'; // default empty config
+    });
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it('is a no-op when .wsl-mode does not exist', () => {
+    mFs.existsSync.mockReturnValue(false);
+
+    migrateStoragePath();
+
+    expect(mFs.writeFileSync).not.toHaveBeenCalled();
+    expect(mFs.unlinkSync).not.toHaveBeenCalled();
+  });
+
+  it('migrates .wsl-mode "windows" to platformTarget wsl-windows-cc in config.json', () => {
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'windows';
+      return '{}';
+    });
+
+    migrateStoragePath();
+
+    const configWrite = mFs.writeFileSync.mock.calls.find(
+      (c: unknown[]) => String(c[0]) === CONFIG_TMP,
+    );
+    expect(configWrite).toBeDefined();
+    const written = JSON.parse(String(configWrite![1])) as Record<string, unknown>;
+    expect(written.platformTarget).toBe('wsl-windows-cc');
+    expect(mFs.renameSync).toHaveBeenCalledWith(CONFIG_TMP, CONFIG);
+    expect(mFs.unlinkSync).toHaveBeenCalledWith(MARKER);
+  });
+
+  it('migrates .wsl-mode "linux" to platformTarget wsl-linux-cc in config.json', () => {
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'linux';
+      return '{}';
+    });
+
+    migrateStoragePath();
+
+    const configWrite = mFs.writeFileSync.mock.calls.find(
+      (c: unknown[]) => String(c[0]) === CONFIG_TMP,
+    );
+    const written = JSON.parse(String(configWrite![1])) as Record<string, unknown>;
+    expect(written.platformTarget).toBe('wsl-linux-cc');
+    expect(mFs.unlinkSync).toHaveBeenCalledWith(MARKER);
+  });
+
+  it('preserves existing config.json fields when migrating', () => {
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'linux';
+      if (String(p) === CONFIG)
+        return JSON.stringify({ licenseKey: 'NRLIC-existing', accountId: '12345' });
+      return '{}';
+    });
+
+    migrateStoragePath();
+
+    const configWrite = mFs.writeFileSync.mock.calls.find(
+      (c: unknown[]) => String(c[0]) === CONFIG_TMP,
+    );
+    const written = JSON.parse(String(configWrite![1])) as Record<string, unknown>;
+    expect(written.platformTarget).toBe('wsl-linux-cc');
+    expect(written.licenseKey).toBe('NRLIC-existing');
+    expect(written.accountId).toBe('12345');
+  });
+
+  it('skips config.json write when platformTarget is already set by a ≥1.0.4 install', () => {
+    // User ran `preflight install --linux-cc` (platformTarget already wsl-linux-cc).
+    // A stale .wsl-mode marker with 'windows' must not revert the user's explicit choice.
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'windows';
+      if (String(p) === CONFIG) return JSON.stringify({ platformTarget: 'wsl-linux-cc' });
+      return '{}';
+    });
+
+    migrateStoragePath();
+
+    const configWrite = mFs.writeFileSync.mock.calls.find(
+      (c: unknown[]) => String(c[0]) === CONFIG_TMP,
+    );
+    expect(configWrite).toBeUndefined();
+    // The stale marker must still be deleted.
+    expect(mFs.unlinkSync).toHaveBeenCalledWith(MARKER);
+  });
+
+  it('migrates .wsl-mode when config.json has platformTarget "native" (cross-machine copy)', () => {
+    // User copied their macOS config.json (platformTarget='native') to a WSL machine
+    // that also has a .wsl-mode marker. 'native' must not suppress the migration —
+    // it was written on a non-WSL machine and does not reflect a deliberate WSL choice.
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'windows';
+      if (String(p) === CONFIG) return JSON.stringify({ platformTarget: 'native' });
+      return '{}';
+    });
+
+    migrateStoragePath();
+
+    const configWrite = mFs.writeFileSync.mock.calls.find(
+      (c: unknown[]) => String(c[0]) === CONFIG_TMP,
+    );
+    expect(configWrite).toBeDefined();
+    const written = JSON.parse(String(configWrite![1])) as Record<string, unknown>;
+    expect(written.platformTarget).toBe('wsl-windows-cc');
+    expect(mFs.unlinkSync).toHaveBeenCalledWith(MARKER);
+  });
+
+  it('deletes marker with unrecognized content without writing config.json', () => {
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'unrecognized-value';
+      return '{}';
+    });
+
+    migrateStoragePath();
+
+    expect(mFs.writeFileSync).not.toHaveBeenCalled();
+    expect(mFs.unlinkSync).toHaveBeenCalledWith(MARKER);
+  });
+
+  it('does not write config.json when config.json is malformed (no credential wipe)', () => {
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'windows';
+      if (String(p) === CONFIG) return '{"licenseKey": "NRLIC-truncated'; // malformed JSON
+      return '{}';
+    });
+    mFs.existsSync.mockImplementation((p: unknown) => String(p) === MARKER || String(p) === CONFIG);
+
+    expect(() => migrateStoragePath()).not.toThrow();
+
+    const configWrites = mFs.writeFileSync.mock.calls.filter(
+      (c: unknown[]) => String(c[0]) === CONFIG_TMP,
+    );
+    expect(configWrites).toHaveLength(0);
+  });
+
+  it('does not write config.json when config.json is unreadable (no credential wipe)', () => {
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'linux';
+      if (String(p) === CONFIG) {
+        const err = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+        throw err;
+      }
+      return '{}';
+    });
+    mFs.existsSync.mockImplementation((p: unknown) => String(p) === MARKER || String(p) === CONFIG);
+
+    expect(() => migrateStoragePath()).not.toThrow();
+
+    const configWrites = mFs.writeFileSync.mock.calls.filter(
+      (c: unknown[]) => String(c[0]) === CONFIG_TMP,
+    );
+    expect(configWrites).toHaveLength(0);
+  });
+
+  it('is non-fatal when writeFileSync throws', () => {
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'windows';
+      return '{}';
+    });
+    mFs.writeFileSync.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    expect(() => migrateStoragePath()).not.toThrow();
+  });
+
+  it('is non-fatal when unlinkSync on marker throws after a successful write', () => {
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'linux';
+      return '{}';
+    });
+    mFs.unlinkSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) throw new Error('EPERM: read-only file system');
+    });
+
+    expect(() => migrateStoragePath()).not.toThrow();
+    // Config was still written before the marker delete failed
+    const configWrite = mFs.writeFileSync.mock.calls.find(
+      (c: unknown[]) => String(c[0]) === CONFIG_TMP,
+    );
+    expect(configWrite).toBeDefined();
+  });
+
+  it('handles trailing whitespace in marker content', () => {
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return '  windows  \n';
+      return '{}';
+    });
+
+    migrateStoragePath();
+
+    const configWrite = mFs.writeFileSync.mock.calls.find(
+      (c: unknown[]) => String(c[0]) === CONFIG_TMP,
+    );
+    const written = JSON.parse(String(configWrite![1])) as Record<string, unknown>;
+    expect(written.platformTarget).toBe('wsl-windows-cc');
+  });
+
+  // The symlink guard in migrateWslMarker uses realpathSync to verify the storage
+  // directory is inside HOME before writing. The mock returns the path as-is
+  // (so DEFAULT_STORAGE_PATH resolves to itself, which starts with homedir()),
+  // confirming the guard allows writes for the normal installation location.
+  it('allows write when storage path resolves inside HOME', () => {
+    migrateStoragePath();
+
+    expect(mFs.writeFileSync).toHaveBeenCalled();
+  });
+
+  // migrateWslMarker passes DEFAULT_STORAGE_PATH as additionalAllowedBase so that
+  // symlinked storage directories (e.g. ~/.newrelic-preflight → /data/shared/preflight)
+  // are still writable. When realpathSync resolves DEFAULT_STORAGE_PATH outside HOME
+  // the guard compares resolved paths on both sides and allows the write because the
+  // user explicitly chose that storage location.
+  it('allows write when storage path is symlinked outside HOME (storage dir is explicit allowed base)', () => {
+    (fsMod as unknown as { realpathSync: jest.Mock }).realpathSync.mockReturnValue(
+      '/data/shared/preflight',
+    );
+
+    migrateStoragePath();
+
+    const configWrites = mFs.writeFileSync.mock.calls.filter(
+      (c: unknown[]) => String(c[0]) === CONFIG_TMP,
+    );
+    expect(configWrites).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// migrateStoragePath — old-path migration (pre-existing; tested for
+// interactions with the new migrateWslMarker call order)
+// ---------------------------------------------------------------------------
+
+describe('migrateStoragePath call order', () => {
+  let mFs: MockedFs;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mFs = fsMod as unknown as MockedFs;
+    (fsMod as unknown as { realpathSync: jest.Mock }).realpathSync.mockImplementation(
+      (p: unknown) => p,
+    );
+    mFs.writeFileSync.mockImplementation(() => {});
+    mFs.renameSync.mockImplementation(() => {});
+    mFs.unlinkSync.mockImplementation(() => {});
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it('runs migrateWslMarker before checking old storage path', () => {
+    // Both marker and old path exist.
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === MARKER || String(p) === OLD_PATH,
+    );
+    mFs.readFileSync.mockImplementation((p: unknown) => {
+      if (String(p) === MARKER) return 'linux';
+      return '{}';
+    });
+
+    migrateStoragePath();
+
+    // migrateWslMarker ran first: config was updated and marker was deleted.
+    const configCall = mFs.writeFileSync.mock.calls.find((c: unknown[]) =>
+      String(c[0]).endsWith('config.json.tmp'),
+    );
+    expect(configCall).toBeDefined();
+    const written = JSON.parse(String(configCall![1])) as Record<string, unknown>;
+    expect(written.platformTarget).toBe('wsl-linux-cc');
+    expect(mFs.unlinkSync).toHaveBeenCalledWith(MARKER);
+  });
+});

--- a/src/install/migrate.ts
+++ b/src/install/migrate.ts
@@ -1,7 +1,70 @@
-import { existsSync, renameSync, cpSync, rmSync, readSync, openSync, closeSync } from 'node:fs';
+import {
+  existsSync,
+  renameSync,
+  cpSync,
+  rmSync,
+  readSync,
+  openSync,
+  closeSync,
+  readFileSync,
+  unlinkSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { DEFAULT_STORAGE_PATH } from '../config.js';
+import type { PlatformTarget } from '../config.js';
+import { readJsonFileStrict, writeJsonFile } from './json-utils.js';
+
+function migrateWslMarker(): void {
+  const markerPath = resolve(DEFAULT_STORAGE_PATH, '.wsl-mode');
+  if (!existsSync(markerPath)) return;
+  try {
+    const raw = readFileSync(markerPath, 'utf8').trim();
+    const platform = raw === 'windows' ? 'wsl-windows-cc' : raw === 'linux' ? 'wsl-linux-cc' : null;
+    if (platform !== null) {
+      const configPath = resolve(DEFAULT_STORAGE_PATH, 'config.json');
+      // Use strict read: if config.json is malformed or unreadable (EBUSY, EPERM),
+      // throw so the outer catch skips the write and leaves credentials intact.
+      // ENOENT (file absent) still returns {} — safe to write a fresh config.
+      const existing = readJsonFileStrict(configPath);
+      // Skip the write if config.json already has a WSL platformTarget set by a
+      // ≥1.0.4 install on this machine — that value reflects a deliberate WSL
+      // mode choice and must not be overwritten by a stale marker.
+      // 'native' is intentionally excluded: it can arrive via cross-machine
+      // config copy (e.g. macOS → WSL) and must not suppress a real WSL marker.
+      // Typed constants: TypeScript will error here if these drift from PlatformTarget.
+      const wslWindowsCc: PlatformTarget = 'wsl-windows-cc';
+      const wslLinuxCc: PlatformTarget = 'wsl-linux-cc';
+      const alreadyMigrated =
+        existing.platformTarget === wslWindowsCc || existing.platformTarget === wslLinuxCc;
+      if (!alreadyMigrated) {
+        // Pass DEFAULT_STORAGE_PATH as the allowed base so the symlink guard accepts
+        // writes when the storage directory is symlinked outside HOME.
+        writeJsonFile(configPath, { ...existing, platformTarget: platform }, DEFAULT_STORAGE_PATH);
+      }
+      // Delete marker after the rename is committed (or skipped). Wrapped in its own
+      // catch so a failure here (e.g. WSL1 DrvFs read-only file attribute on .wsl-mode)
+      // is handled inline rather than propagating to the outer catch — which would
+      // exit the function without deleting the marker on the current call, but would
+      // not cause re-migration loops because config.json is already correct.
+      try {
+        unlinkSync(markerPath);
+      } catch {
+        /* re-migration on next startup is idempotent */
+      }
+    } else {
+      // Unrecognized marker content — cannot migrate, but deleting it prevents this
+      // function from re-running on every startup (existsSync would fire each time).
+      try {
+        unlinkSync(markerPath);
+      } catch {
+        /* WSL1 DrvFs read-only attribute — re-run on next startup is harmless */
+      }
+    }
+  } catch {
+    // Non-fatal: next install falls back to filesystem detection.
+  }
+}
 
 function promptYesNo(question: string): boolean {
   process.stderr.write(question);
@@ -28,6 +91,8 @@ function promptYesNo(question: string): boolean {
  * (server startup, update) print a notice instead.
  */
 export function migrateStoragePath(interactive = false): void {
+  migrateWslMarker();
+
   const oldPath = resolve(homedir(), '.nr-ai-observe');
   const newPath = DEFAULT_STORAGE_PATH;
   if (!existsSync(oldPath)) return;

--- a/src/install/setup-wizard.test.ts
+++ b/src/install/setup-wizard.test.ts
@@ -1,9 +1,12 @@
-import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { buildConfig, runSetupWizard, copyStarterAlertRules } from './setup-wizard.js';
-import * as rlMod from 'node:readline/promises';
 import * as fsMod from 'node:fs';
+import * as rlMod from 'node:readline/promises';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+import { buildConfig, runSetupWizard, copyStarterAlertRules } from './setup-wizard.js';
 import * as scheduleMod from './schedule.js';
 import * as keyValidator from './key-validator.js';
+import * as cliMod from './cli.js';
+import * as platformMod from './platform.js';
 
 // ---------------------------------------------------------------------------
 // Module-level mocks (hoisted above imports by jest at runtime).
@@ -20,7 +23,15 @@ jest.mock('node:fs', () => ({
   chmodSync: jest.fn(),
   realpathSync: jest.fn((p: unknown) => p),
 }));
-jest.mock('./cli.js', () => ({ runInstallCli: jest.fn(), verifyBinaryOnPath: jest.fn() }));
+jest.mock('./cli.js', () => ({
+  runInstallCli: jest.fn(),
+  verifyBinaryOnPath: jest.fn(),
+  findRepoRoot: jest.fn(() => null),
+}));
+jest.mock('./platform.js', () => ({
+  isWsl: jest.fn(() => false),
+  resolveWindowsHome: jest.fn(() => null),
+}));
 jest.mock('./key-validator.js', () => ({
   validateLicenseKey: jest.fn(),
   validateApiKey: jest.fn(),
@@ -56,9 +67,17 @@ const mockedSchedule = scheduleMod as unknown as {
   installSchedule: jest.Mock;
   resolveBinaryPath: jest.Mock;
 };
+const mockedCli = cliMod as unknown as {
+  runInstallCli: jest.Mock;
+  verifyBinaryOnPath: jest.Mock;
+};
+const mockedPlatform = platformMod as unknown as {
+  isWsl: jest.Mock;
+  resolveWindowsHome: jest.Mock;
+};
 
 // ---------------------------------------------------------------------------
-// copyStarterAlertRules — Phase 4 task 24
+// copyStarterAlertRules
 // ---------------------------------------------------------------------------
 
 describe('copyStarterAlertRules', () => {
@@ -299,9 +318,9 @@ describe('buildConfig', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-138: setup-wizard idempotency and env-detection tests
+// setup-wizard idempotency and env-detection tests
 // ---------------------------------------------------------------------------
-describe('F-138: setup-wizard idempotency and env-detection', () => {
+describe('setup-wizard idempotency and env-detection', () => {
   let stdoutSpy: ReturnType<typeof jest.spyOn>;
   let stderrSpy: ReturnType<typeof jest.spyOn>;
   let mockRl: { question: jest.Mock; close: jest.Mock };
@@ -384,10 +403,10 @@ describe('F-138: setup-wizard idempotency and env-detection', () => {
     expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
   });
 
-  // task #22: loadExisting() must validate via ConfigFileSchema and strip
-  // unknown top-level keys, so wizard's later spread (`...existing`) doesn't
-  // perpetuate stale fields. Recognized keys still pass through.
-  it('strips unknown top-level keys from existing config (task #22)', async () => {
+  // loadExisting() must validate via ConfigFileSchema and strip unknown top-level
+  // keys, so wizard's later spread (`...existing`) doesn't perpetuate stale fields.
+  // Recognized keys still pass through.
+  it('strips unknown top-level keys from existing config', async () => {
     const existingConfig = {
       accountId: '12345',
       licenseKey: 'NRLIC-existing',
@@ -410,10 +429,9 @@ describe('F-138: setup-wizard idempotency and env-detection', () => {
     expect(written.licenseKey).toBe('NRLIC-existing');
   });
 
-  // task #22: validation failure on a recognized key (e.g. malformed type)
-  // logs a warning and falls back to defaults rather than carrying bad data
-  // forward via the spread.
-  it('falls back to defaults when recognized key has invalid value (task #22)', async () => {
+  // Validation failure on a recognized key (e.g. malformed type) logs a warning
+  // and falls back to defaults rather than carrying bad data forward via the spread.
+  it('falls back to defaults when recognized key has invalid value', async () => {
     const stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
     try {
       // accountId must be a string; passing a number triggers safeParse failure.
@@ -532,13 +550,10 @@ describe('setupWizard mode branch', () => {
     expect(written.dashboard).toEqual({ port: 7777, host: '127.0.0.1', openOnStart: false });
   });
 
-  // F-020: in cloud mode, the wizard MUST NOT copy the starter alert
-  // rules — the alert engine isn't constructed, so the on-disk rules
-  // file would be ignored and would just clutter the user's home dir.
-  // The mode-gating in setup-wizard.ts:276 was correct, but no test
-  // pinned the negative case; removing the guard would not have broken
-  // any existing test.
-  it("when mode='cloud', does NOT copy starter alert rules (F-020)", async () => {
+  // In cloud mode the wizard must not copy the starter alert rules — the alert
+  // engine isn't constructed, so the on-disk rules file would be ignored and
+  // would just clutter the user's home dir.
+  it("when mode='cloud', does NOT copy starter alert rules", async () => {
     // Cloud mode skips the dashboardPort and copyStarterRules prompts,
     // so the answer sequence is shorter than the local/both flows.
     // Order: mode, accountId, licenseKey, environment, nrApiKey, developer, teamId, projectId,
@@ -559,7 +574,7 @@ describe('setupWizard mode branch', () => {
 });
 
 // ---------------------------------------------------------------------------
-// I11: Validation rejection paths
+// Validation rejection paths
 // ---------------------------------------------------------------------------
 describe('setupWizard input validation', () => {
   let stdoutSpy: ReturnType<typeof jest.spyOn>;
@@ -1214,5 +1229,97 @@ describe('setupWizard environment and nrApiKey steps', () => {
     const licensePrompt = promptMessages.find((m) => m.toLowerCase().includes('license key'));
     expect(licensePrompt).toContain('(already set)');
     expect(licensePrompt).toMatch(/\[.*\]/); // brackets
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WSL CC-mode selection in the hook install step
+// ---------------------------------------------------------------------------
+describe('setupWizard WSL CC-mode selection', () => {
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let mockRl: { question: jest.Mock; close: jest.Mock };
+  const savedPlatform = process.platform;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockRl = { question: jest.fn(), close: jest.fn() };
+    mockedRl.createInterface.mockReturnValue(mockRl);
+    mockedFs.mkdirSync.mockReturnValue(undefined);
+    mockedFs.writeFileSync.mockReturnValue(undefined);
+    mockedFs.readFileSync.mockReturnValue('{}');
+    mockedKeyValidator.validateLicenseKey.mockResolvedValue({ valid: true });
+    mockedKeyValidator.validateApiKey.mockResolvedValue({ valid: true });
+    // Linux platform avoids the macOS-only daemon and schedule prompts.
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    mockedPlatform.isWsl.mockReturnValue(true);
+    // Default: Windows home is resolvable (needed for wslChoice='1' tests).
+    mockedPlatform.resolveWindowsHome.mockReturnValue('/mnt/c/Users/testuser');
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    Object.defineProperty(process, 'platform', { value: savedPlatform, configurable: true });
+    mockedPlatform.isWsl.mockReturnValue(false);
+    mockedPlatform.resolveWindowsHome.mockReturnValue(null);
+  });
+
+  // Answer order for cloud mode + WSL + installHooks='y':
+  // mode, accountId, licenseKey, environment, nrApiKey, developer, teamId, projectId,
+  // sessionBudget, installHooks='y', wslChoice
+  function answers(...values: string[]): void {
+    let i = 0;
+    mockRl.question.mockImplementation(async () => values[i++] ?? '');
+  }
+
+  it("calls runInstallCli with ['install', '--windows-cc'] when wslChoice is '1'", async () => {
+    answers('cloud', '12345', 'NRLIC-test', '', '', 'tester', '', '', '', 'y', '1');
+
+    await runSetupWizard();
+
+    expect(mockedCli.runInstallCli).toHaveBeenCalledWith(['install', '--windows-cc']);
+  });
+
+  it("calls runInstallCli with ['install', '--linux-cc'] when wslChoice is '2'", async () => {
+    answers('cloud', '12345', 'NRLIC-test', '', '', 'tester', '', '', '', 'y', '2');
+
+    await runSetupWizard();
+
+    expect(mockedCli.runInstallCli).toHaveBeenCalledWith(['install', '--linux-cc']);
+  });
+
+  it("calls runInstallCli with ['install', '--linux-cc'] when wslChoice is empty (press Enter)", async () => {
+    answers('cloud', '12345', 'NRLIC-test', '', '', 'tester', '', '', '', 'y', '');
+
+    await runSetupWizard();
+
+    expect(mockedCli.runInstallCli).toHaveBeenCalledWith(['install', '--linux-cc']);
+  });
+
+  it('skips hook install (does not fall back to --linux-cc) when wslChoice is 1 but Windows home cannot be resolved', async () => {
+    mockedPlatform.resolveWindowsHome.mockReturnValue(null);
+    answers('cloud', '12345', 'NRLIC-test', '', '', 'tester', '', '', '', 'y', '1');
+
+    await runSetupWizard();
+
+    // Must NOT install with --linux-cc — that would silently write wsl-linux-cc as the
+    // saved platform, corrupting Windows CC intent on all future bare installs.
+    expect(mockedCli.runInstallCli).not.toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Windows home directory could not be resolved');
+    expect(output).toContain('preflight install --windows-cc');
+  });
+
+  it("defaults to --linux-cc and prints '3 attempts' message after 3 consecutive invalid inputs", async () => {
+    answers('cloud', '12345', 'NRLIC-test', '', '', 'tester', '', '', '', 'y', 'x', 'x', 'x');
+
+    await runSetupWizard();
+
+    expect(mockedCli.runInstallCli).toHaveBeenCalledWith(['install', '--linux-cc']);
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('No valid choice entered after 3 attempts');
   });
 });

--- a/src/install/setup-wizard.ts
+++ b/src/install/setup-wizard.ts
@@ -1,7 +1,5 @@
 import { createInterface } from 'node:readline/promises';
 import {
-  writeFileSync,
-  renameSync,
   mkdirSync,
   readFileSync,
   existsSync,
@@ -10,15 +8,14 @@ import {
   realpathSync,
 } from 'node:fs';
 import { resolve, dirname } from 'node:path';
-import { homedir } from 'node:os';
-import { normalizeDeveloperName, ConfigFileSchema } from '../config.js';
+import { normalizeDeveloperName, ConfigFileSchema, DEFAULT_STORAGE_PATH } from '../config.js';
 import { migrateStoragePath } from './migrate.js';
-import { runInstallCli, verifyBinaryOnPath } from './cli.js';
+import { runInstallCli, verifyBinaryOnPath, findRepoRoot } from './cli.js';
+import { writeJsonFile } from './json-utils.js';
 import { installSchedule, installDashboardDaemon, resolveBinaryPath } from './schedule.js';
-import { isWsl } from './platform.js';
+import { isWsl, resolveWindowsHome } from './platform.js';
 import { validateLicenseKey, validateApiKey } from './key-validator.js';
 
-const DEFAULT_STORAGE_PATH = resolve(homedir(), '.newrelic-preflight');
 const CONFIG_PATH = resolve(DEFAULT_STORAGE_PATH, 'config.json');
 const ALERT_RULES_DEST = resolve(DEFAULT_STORAGE_PATH, 'alerts', 'rules.json');
 
@@ -27,26 +24,20 @@ interface WizardLogger {
   info(msg: string, meta?: object): void;
 }
 
-/**
- * Resolve the path to the bundled `examples/local-alert-rules.json`. The
- * wizard ships from either `dist/install/` (when installed via npm) or
- * `src/install/` (when executed via `npx tsx`); both resolve to the repo
- * root by walking up two directories from the running script.
- *
- * Uses `process.argv[1]` rather than `__dirname` (which doesn't exist in
- * ESM) or `import.meta.url` (which trips Jest's TS module check). Same
- * pattern as `src/index.ts` for resolving the static dashboard dir.
- */
 function defaultStarterRulesSource(): string {
-  const rawPath = process.argv[1] ?? process.cwd();
-  const scriptPath = (() => {
-    try {
-      return realpathSync(rawPath);
-    } catch {
-      return rawPath;
-    }
-  })();
-  return resolve(dirname(scriptPath), '..', '..', 'examples', 'local-alert-rules.json');
+  const root = findRepoRoot();
+  if (root !== null) return resolve(root, 'examples', 'local-alert-rules.json');
+  // findRepoRoot() failed — fall back to walking two directories up from the
+  // real entry-point path. Resolve symlinks first so a globally-installed binary
+  // (e.g. /usr/local/bin/preflight → .../node_modules/preflight/dist/index.js)
+  // correctly walks up to the package root rather than /usr/local/bin.
+  let entryPoint: string;
+  try {
+    entryPoint = realpathSync(process.argv[1] ?? process.cwd());
+  } catch {
+    entryPoint = process.argv[1] ?? process.cwd();
+  }
+  return resolve(dirname(entryPoint), '..', '..', 'examples', 'local-alert-rules.json');
 }
 
 export interface CopyStarterAlertRulesOptions {
@@ -191,6 +182,14 @@ function parseModeAnswer(raw: string, fallback: WizardMode): WizardMode {
 export async function runSetupWizard(): Promise<void> {
   migrateStoragePath(true);
   const rl = createInterface({ input: process.stdin, output: process.stdout });
+  // Safety net: process.exit() bypasses finally blocks but still runs 'exit' handlers.
+  // If runInstallCli's resolvePlatform calls process.exit(1) (e.g. saved wsl-windows-cc
+  // with WSL interop now disabled), rl.close() would otherwise be skipped, leaving stdin
+  // with dangling readline event listeners. rl.close() is idempotent so the finally
+  // block calling it again is harmless. The listener is explicitly removed in the finally
+  // block (normal completion path) to prevent accumulation across repeated invocations.
+  const rlCleanupOnExit = () => rl.close();
+  process.once('exit', rlCleanupOnExit);
 
   try {
     print('\n=== Preflight Setup ===\n');
@@ -446,8 +445,11 @@ export async function runSetupWizard(): Promise<void> {
       }
     }
 
-    // Write config
-    const config = buildConfig(existing, {
+    // Write config. Strip platformTarget before spreading — only the install subcommand
+    // (runInstallCli) should own this field. Preserving a stale value here would silently
+    // drive the next bare install toward the wrong platform if the user declines hooks.
+    const { platformTarget: _platformTarget, ...existingForWizard } = existing;
+    const config = buildConfig(existingForWizard, {
       accountId,
       licenseKey,
       developer,
@@ -460,10 +462,7 @@ export async function runSetupWizard(): Promise<void> {
       collectorHost,
     });
 
-    mkdirSync(DEFAULT_STORAGE_PATH, { recursive: true, mode: 0o700 });
-    const configTmp = CONFIG_PATH + '.tmp';
-    writeFileSync(configTmp, JSON.stringify(config, null, 2), { mode: 0o600 });
-    renameSync(configTmp, CONFIG_PATH);
+    writeJsonFile(CONFIG_PATH, config, DEFAULT_STORAGE_PATH);
     print(`\nConfig written to ${CONFIG_PATH}`);
 
     // Step 5c: Starter alert rules (local + both modes only).
@@ -499,26 +498,83 @@ export async function runSetupWizard(): Promise<void> {
     // Step 6: Hook install
     // Config is already written above; pass no credentials to install so it only
     // wires hooks and MCP without overwriting the config we just wrote.
+    const wslEnv = isWsl();
     const installHooks = (await rl.question('\nInstall Claude Code hooks now? [Y/n]: '))
       .trim()
       .toLowerCase();
-    if (installHooks !== 'n') {
-      print('\nRunning hook installer...');
-      await runInstallCli(['install']);
-      print('Hooks installed.');
+    if (installHooks !== 'n' && installHooks !== 'no') {
+      // In WSL there are two distinct Claude Code setups that need different hook formats:
+      //   Windows CC (desktop app on Windows): hooks must use wsl.exe -e, go in Windows paths
+      //   Linux CC in WSL (npm install inside WSL): hooks are direct Linux commands, WSL paths
+      const installArgs = ['install'];
+      let skipInstall = false;
+      if (wslEnv) {
+        print('\n  ℹ WSL detected. How is Claude Code installed on this machine?');
+        print('    [1] Claude Code for Windows (the desktop app running on Windows)');
+        print('    [2] Claude Code installed inside WSL via npm (default)');
+        let wslChoice = '';
+        for (let attempt = 0; attempt < 3; attempt++) {
+          wslChoice = (await rl.question('  Choice [2]: ')).trim();
+          if (wslChoice === '1' || wslChoice === '2' || wslChoice === '') break;
+          print('  ⚠ Enter 1 or 2 (or press Enter for the default).');
+        }
+        if (wslChoice !== '1' && wslChoice !== '2' && wslChoice !== '') {
+          print(
+            '  ⚠ No valid choice entered after 3 attempts — defaulting to Linux Claude Code mode.',
+          );
+        }
+        if (wslChoice === '1') {
+          // Pre-validate before committing to --windows-cc: handleInstall calls
+          // process.exit(1) when windowsHome is null, which skips the wizard's
+          // finally block and leaves stdin with readline listeners attached.
+          const windowsHome = resolveWindowsHome();
+          if (windowsHome === null) {
+            print(
+              '  ⚠ Windows home directory could not be resolved (WSL interop may be disabled).',
+            );
+            print('  Skipping hook installation. Fix WSL interop first, then re-run:');
+            print('    preflight install --windows-cc');
+            // Skip the install entirely — falling back to --linux-cc would write
+            // wsl-linux-cc as the saved platform, silently corrupting the user's
+            // Windows CC intent on all future bare installs.
+            skipInstall = true;
+          } else {
+            installArgs.push('--windows-cc');
+            print('  → Using Windows Claude Code mode (wsl.exe hooks, Windows paths).');
+          }
+        } else {
+          // Pass --linux-cc explicitly so the installer honours this choice even
+          // when a prior Windows CC install would otherwise trigger auto-detection.
+          installArgs.push('--linux-cc');
+          print('  → Using Linux Claude Code mode (direct hooks, WSL home paths).');
+        }
+      }
+      let hooksInstalled = false;
+      if (!skipInstall) {
+        print('\nRunning hook installer...');
+        try {
+          await runInstallCli(installArgs);
+          hooksInstalled = true;
+        } catch {
+          // handleInstall already printed the specific error. Set exit code and continue
+          // so daemon, schedule, and dashboard steps still run — they do not depend on
+          // hook installation.
+          process.exitCode = 1;
+        }
+        if (hooksInstalled) print('Hooks installed.');
 
-      if (verifyBinaryOnPath()) {
-        print('✓ preflight is on your PATH');
-      } else {
-        print('\n⚠ preflight is not on your PATH.');
-        print('  Claude Code hooks will fail with "command not found" until this is resolved.');
-        print('  Fix: run `npm link` in the project directory, or install globally:');
-        print('    npm install -g @newrelic/preflight');
+        if (verifyBinaryOnPath()) {
+          print('✓ preflight is on your PATH');
+        } else {
+          print('\n⚠ preflight is not on your PATH.');
+          print('  Claude Code hooks will fail with "command not found" until this is resolved.');
+          print('  Fix: run `npm link` in the project directory, or install globally:');
+          print('    npm install -g @newrelic/preflight');
+        }
       }
     }
 
     // Step 6b: Always-on background dashboard daemon
-    const wslEnv = isWsl();
     if ((mode === 'local' || mode === 'both') && process.platform === 'darwin') {
       const binaryPath = resolveBinaryPath();
       const daemonAnswer = (
@@ -651,6 +707,7 @@ export async function runSetupWizard(): Promise<void> {
     }
     print('');
   } finally {
+    process.removeListener('exit', rlCleanupOnExit);
     rl.close();
   }
 }


### PR DESCRIPTION
## Summary

- Fixes WSL install defaulting to Windows Claude Code mode for all WSL users — Windows CC mode is now only used when explicitly requested via `--windows-cc` or when a prior Windows CC install is recorded in `~/.newrelic-preflight/config.json`
- Adds `--windows-cc` and `--linux-cc` flags to `preflight install`/`preflight uninstall` for explicit platform targeting from WSL
- `preflight setup` now prompts WSL users to identify their Claude Code installation (Windows desktop app vs. Linux npm in WSL) before writing hooks
- Alert rules copy during setup now correctly locates `examples/local-alert-rules.json` when installed globally via npm (walks up to `package.json` rather than a fixed two-directory offset)
- Extracts `readJsonFileStrict` / `writeJsonFile` into `src/install/json-utils.ts`; adds symlink guard and atomic write to all config file writes in the install system
- Migrates legacy `.wsl-mode` marker file → `platformTarget` field in `config.json` on first run of v1.0.4+
- Adds WSL install guidance to README and CONTRIBUTING

## Test plan

- [x] `npm run build && npm test` — 3563 tests pass, 0 failures
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run format:check` — clean
- [x] Multiple code review passes (8-angle methodology) — no bugs found

🤖 Generated with [Claude Code](https://claude.com/claude-code)