### PR TITLE
Fix #13: inject node dir into launchd plist PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `highSecurity` mode was not enforced in the hook collector when set via environment variable. The collector was checking `NEW_RELIC_AI_MCP_HIGH_SECURITY` instead of the documented `NEW_RELIC_AI_HIGH_SECURITY`. Users who set the environment variable (rather than the config file) would not have had content recording suppressed in the collector. Both paths now use the same variable name.
+- The `com.preflight.dashboard` and `com.preflight.update` launchd daemons crashed with `env: node: No such file or directory` (exit 127) on macOS systems where node is installed via Homebrew, nvm, volta, asdf, or any other version manager that places node outside launchd's minimal default PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). The generated plists now include an `EnvironmentVariables` block that injects the directory of the node binary used during `preflight setup`, making both daemons work regardless of how node was installed. Re-run `preflight setup` to apply this fix to an existing installation.
 
 ### Changed
 

--- a/src/alerts/alert-snapshot-collector.test.ts
+++ b/src/alerts/alert-snapshot-collector.test.ts
@@ -229,11 +229,11 @@ describe('AlertSnapshotCollector — tracker reads', () => {
     ]);
   });
 
-  // Regression for F-006: when the tracker has only p50 (no p95/p99 because
+  // Regression for : when the tracker has only p50 (no p95/p99 because
   // sample count is too low), the snapshot must still emit the tool with the
   // p50 value populated and p95/p99 as 0. Previously the entry was dropped
   // entirely because the gate required `typeof p95 === 'number'`.
-  it('emits a latency entry when only p50 is available (F-006)', () => {
+  it('emits a latency entry when only p50 is available', () => {
     const deps: AlertSnapshotCollectorDeps = {
       latencyTracker: {
         getMetrics: () => ({
@@ -248,9 +248,9 @@ describe('AlertSnapshotCollector — tracker reads', () => {
     expect(snap.latency).toEqual([{ tool: 'Read', p50Ms: 100, p95Ms: 0, p99Ms: 0 }]);
   });
 
-  // Regression for F-006: a `latency.percentile` rule asking for p99 must
+  // Regression for : a `latency.percentile` rule asking for p99 must
   // see the p99 value even when p95 is missing.
-  it('emits a latency entry when only p99 is available (F-006)', () => {
+  it('emits a latency entry when only p99 is available', () => {
     const deps: AlertSnapshotCollectorDeps = {
       latencyTracker: {
         getMetrics: () => ({

--- a/src/alerts/local-alert-engine.test.ts
+++ b/src/alerts/local-alert-engine.test.ts
@@ -259,11 +259,11 @@ describe('LocalAlertEngine — budget rules', () => {
     expect(events).toEqual([]);
   });
 
-  // F-009 + loadRules interaction: loadRules() preserves state for rules
+  // loadRules() preserves state for rules
   // whose id is unchanged. A hot-reload between fire and clear must not
   // wipe `firedSpentUsd`, otherwise the next snapshot with sessionUsd=0
   // would silently keep the rule firing.
-  it('preserves firedSpentUsd across hot-reload so the F-009 clear path still fires', () => {
+  it('preserves firedSpentUsd across hot-reload so the clear path still fires', () => {
     const engine = new LocalAlertEngine();
     const rule = makeBudgetRule({ threshold: 80 });
     engine.loadRules([rule]);

--- a/src/alerts/local-alert-rule.test.ts
+++ b/src/alerts/local-alert-rule.test.ts
@@ -238,11 +238,11 @@ describe('parseLocalAlertRules — bulk parsing', () => {
     expect(invalid).toHaveLength(0);
   });
 
-  // F-022: two rules sharing an `id` both pass schema validation, but the
+  // two rules sharing an `id` both pass schema validation, but the
   // LocalAlertEngine keys state by id, so the second silently shadowed
   // the first. Drop duplicates here, keeping the first occurrence and
   // surfacing the rest as `invalid`.
-  it('drops duplicate rule ids — keeps the first occurrence (F-022)', () => {
+  it('drops duplicate rule ids — keeps the first occurrence', () => {
     const { valid, invalid } = parseLocalAlertRules([
       {
         id: 'shared',
@@ -274,7 +274,7 @@ describe('parseLocalAlertRules — bulk parsing', () => {
     expect(invalid[0]!.error).toMatch(/duplicate rule id 'shared'/);
   });
 
-  it('logs a warning when a duplicate rule id is dropped (F-022)', () => {
+  it('logs a warning when a duplicate rule id is dropped', () => {
     const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     parseLocalAlertRules([
       {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -78,7 +78,7 @@ describe('loadMcpConfig()', () => {
     );
   });
 
-  // S-03: accountId format validation
+  // accountId format validation
   it('throws when accountId contains path-traversal characters', () => {
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key-1234567890';
     process.env.NEW_RELIC_ACCOUNT_ID = '123/../other';
@@ -114,7 +114,7 @@ describe('loadMcpConfig()', () => {
     expect(config.accountId).toBe('99999');
   });
 
-  // S-06: envInt bounds clamping for harvest intervals and port
+  // envInt bounds clamping for harvest intervals and port
   it('clamps harvest events interval to minimum 100ms', () => {
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key-1234567890';
     process.env.NEW_RELIC_ACCOUNT_ID = '12345';
@@ -328,7 +328,7 @@ describe('loadMcpConfig()', () => {
     expect(config.licenseKey).toBe('test-key');
   });
 
-  it('throws on invalid JSON in config file (F-033)', () => {
+  it('throws on invalid JSON in config file', () => {
     const path = resolve(tmpDir, 'bad.json');
     writeFileSync(path, 'not json{{{');
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
@@ -339,7 +339,7 @@ describe('loadMcpConfig()', () => {
     expect(stderrOutput).toMatch(/Invalid JSON in config file/);
   });
 
-  it('throws on invalid config file schema (F-036)', () => {
+  it('throws on invalid config file schema', () => {
     const path = resolve(tmpDir, 'bad-schema.json');
     writeFileSync(
       path,
@@ -411,7 +411,7 @@ describe('loadMcpConfig()', () => {
     expect(stderrOutput).not.toMatch(/Unknown keys in config file/);
   });
 
-  it('accepts valid config file with all optional numeric fields (F-036)', () => {
+  it('accepts valid config file with all optional numeric fields', () => {
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
     process.env.NEW_RELIC_ACCOUNT_ID = '12345';
     const path = resolve(tmpDir, 'valid-numeric.json');
@@ -528,7 +528,7 @@ describe('loadMcpConfig()', () => {
     ]);
   });
 
-  // N-10: highSecurity mode
+  // highSecurity mode
   it('highSecurity defaults to false', () => {
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
     process.env.NEW_RELIC_ACCOUNT_ID = '12345';
@@ -554,7 +554,7 @@ describe('loadMcpConfig()', () => {
     expect(config.highSecurity).toBe(true);
   });
 
-  it('highSecurity forces recordContent to false even when env var says true (N-10)', () => {
+  it('highSecurity forces recordContent to false even when env var says true', () => {
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
     process.env.NEW_RELIC_ACCOUNT_ID = '12345';
     process.env.NEW_RELIC_AI_HIGH_SECURITY = 'true';
@@ -565,7 +565,7 @@ describe('loadMcpConfig()', () => {
     expect(config.recordContent).toBe(false);
   });
 
-  it('highSecurity env var overrides highSecurity=false in config file (N-10)', () => {
+  it('highSecurity env var overrides highSecurity=false in config file', () => {
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
     process.env.NEW_RELIC_ACCOUNT_ID = '12345';
     process.env.NEW_RELIC_AI_HIGH_SECURITY = 'true';
@@ -575,7 +575,7 @@ describe('loadMcpConfig()', () => {
     expect(config.recordContent).toBe(false);
   });
 
-  it('recordContent is respected when highSecurity is false (N-10)', () => {
+  it('recordContent is respected when highSecurity is false', () => {
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
     process.env.NEW_RELIC_ACCOUNT_ID = '12345';
     process.env.NEW_RELIC_AI_MCP_RECORD_CONTENT = 'true';
@@ -867,28 +867,28 @@ describe('redactSensitive()', () => {
     }
   });
 
-  // N-02: ReDoS protection
-  it('truncates input over 1 MB before applying patterns (N-02)', () => {
+  // ReDoS protection
+  it('truncates input over 1 MB before applying patterns', () => {
     const overLimit = 'A'.repeat(1_048_577);
     const result = redactSensitive(overLimit);
     expect(result.length).toBeLessThanOrEqual(1_048_576);
   });
 
-  it('still redacts secrets that appear within the first 1 MB of a large input (N-02)', () => {
+  it('still redacts secrets that appear within the first 1 MB of a large input', () => {
     const secret = 'sk-secretvalue12345';
     const padding = 'x'.repeat(100_000);
     const result = redactSensitive(`${padding}${secret}${padding}`);
     expect(result).not.toContain(secret);
   });
 
-  it('does not match an unterminated PEM block — bounded pattern prevents ReDoS (N-02)', () => {
+  it('does not match an unterminated PEM block — bounded pattern prevents ReDoS', () => {
     const input = '-----BEGIN RSA PRIVATE KEY-----' + 'A'.repeat(200);
     const result = redactSensitive(input);
     expect(result).toBe(input);
   });
 });
 
-describe('sanitizeDeveloper() (N-07)', () => {
+describe('sanitizeDeveloper()', () => {
   it('strips ASCII control characters', () => {
     expect(sanitizeDeveloper('alice\x00bob')).toBe('alicebob');
     expect(sanitizeDeveloper('user\x1fname')).toBe('username');
@@ -979,7 +979,7 @@ describe('budget fields', () => {
   });
 });
 
-describe('developer sanitization via loadMcpConfig() (N-07)', () => {
+describe('developer sanitization via loadMcpConfig()', () => {
   it('strips control characters from NEW_RELIC_AI_MCP_DEVELOPER env var', () => {
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
     process.env.NEW_RELIC_ACCOUNT_ID = '12345';

--- a/src/config.ts
+++ b/src/config.ts
@@ -180,7 +180,7 @@ export const ConfigFileSchema = z
   // warn block can see typos like `dashboard.openOnStarrt`.
   .passthrough();
 
-// N-07: strip control chars and truncate before the value reaches any NR event field or log
+// strip control chars and truncate before the value reaches any NR event field or log
 export function sanitizeDeveloper(raw: string): string {
   return (
     raw
@@ -565,7 +565,7 @@ export function loadMcpConfig(cliOptions?: Partial<CliOptions>): Readonly<McpSer
     process.env.NEW_RELIC_AI_MCP_STORAGE_PATH ??
     (typeof file.storagePath === 'string' ? file.storagePath : DEFAULT_STORAGE_PATH);
 
-  // N-10: highSecurity must be resolved before recordContent so it can override it
+  // highSecurity must be resolved before recordContent so it can override it
   const highSecurity = envBool(
     'NEW_RELIC_AI_HIGH_SECURITY',
     typeof file.highSecurity === 'boolean' ? file.highSecurity : false,
@@ -608,7 +608,7 @@ export function loadMcpConfig(cliOptions?: Partial<CliOptions>): Readonly<McpSer
 
     highSecurity,
 
-    // N-10: highSecurity forces recordContent off regardless of other settings
+    // highSecurity forces recordContent off regardless of other settings
     recordContent: highSecurity
       ? false
       : envBool(

--- a/src/dashboard/dashboard-server.test.ts
+++ b/src/dashboard/dashboard-server.test.ts
@@ -123,10 +123,10 @@ describe('DashboardServer', () => {
     await expect(fetch(`http://127.0.0.1:${addr.port}/api/health`)).rejects.toThrow();
   });
 
-  // F-014 prerequisite: start() must reject with an Error carrying
+  // start() must reject with an Error carrying
   // code='EADDRINUSE' when the port is busy. The rewrap in index.ts that
   // adds the NR_AI_DASHBOARD_PORT remediation hint relies on this.
-  it('rejects with EADDRINUSE when the port is already in use (F-014 prerequisite)', async () => {
+  it('rejects with EADDRINUSE when the port is already in use', async () => {
     const blocker = http.createServer().listen(0, '127.0.0.1');
     await new Promise((r) => blocker.once('listening', r));
     const blockedPort = (blocker.address() as { port: number }).port;
@@ -147,12 +147,12 @@ describe('DashboardServer', () => {
     }
   });
 
-  // Regression for F-011. Before the fix, the start()-time `once('error', reject)`
+  // Regression for this. Before the fix, the start()-time `once('error', reject)`
   // listener stayed attached after the listen callback resolved. A later
   // runtime error called reject() on an already-resolved promise (a no-op)
   // and Node didn't re-emit because the once listener consumed the event —
   // production failures were invisible.
-  it('logs server errors that fire after start() resolves (F-011 regression)', async () => {
+  it('logs server errors that fire after start() resolves', async () => {
     const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     try {
       server = new DashboardServer({
@@ -175,7 +175,7 @@ describe('DashboardServer', () => {
   });
 });
 
-describe('DashboardServer staticDir bootstrap warning (F-036)', () => {
+describe('DashboardServer staticDir bootstrap warning', () => {
   let stderrSpy: jest.SpiedFunction<typeof console.error>;
   let server: DashboardServer | undefined;
 
@@ -338,25 +338,25 @@ describe('DashboardServer Host validation', () => {
   // .indexOf(':') / .slice() parser because only the host portion was
   // checked. A raw HTTP client sending `Host: 127.0.0.1:abc.evil.com`
   // would have been served — defence-in-depth gap.
-  it('rejects Host=127.0.0.1:abc.evil.com (non-numeric port — F-012)', async () => {
+  it('rejects Host=127.0.0.1:abc.evil.com (non-numeric port)', async () => {
     server = new DashboardServer({ port: 0, host: '127.0.0.1', bus: new LiveEventBus() });
     const addr = await server.start();
     expect(await requestWithHost(addr.port, '127.0.0.1:abc.evil.com')).toBe(403);
   });
 
-  it('rejects Host=127.0.0.1: (empty port suffix — F-012)', async () => {
+  it('rejects Host=127.0.0.1: (empty port suffix)', async () => {
     server = new DashboardServer({ port: 0, host: '127.0.0.1', bus: new LiveEventBus() });
     const addr = await server.start();
     expect(await requestWithHost(addr.port, '127.0.0.1:')).toBe(403);
   });
 
-  it('rejects Host=localhost:7777.evil.com (non-numeric port — F-012)', async () => {
+  it('rejects Host=localhost:7777.evil.com (non-numeric port)', async () => {
     server = new DashboardServer({ port: 0, host: '127.0.0.1', bus: new LiveEventBus() });
     const addr = await server.start();
     expect(await requestWithHost(addr.port, 'localhost:7777.evil.com')).toBe(403);
   });
 
-  it('rejects bracketed IPv6 with non-numeric port [::1]:abc (F-012)', async () => {
+  it('rejects bracketed IPv6 with non-numeric port [::1]:abc', async () => {
     server = new DashboardServer({ port: 0, host: '127.0.0.1', bus: new LiveEventBus() });
     const addr = await server.start();
     expect(await requestWithHost(addr.port, '[::1]:abc.evil.com')).toBe(403);

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -787,7 +787,7 @@ describe('api-handler GET /api/alerts/recent', () => {
     expect(JSON.parse(body())).toEqual({ error: 'not_found' });
   });
 
-  it('returns 500 with a generic error code when alertLog.readRecent rejects (F-007)', async () => {
+  it('returns 500 with a generic error code when alertLog.readRecent rejects', async () => {
     // Suppress the server-side console.error log triggered by this case so the
     // expected error doesn't pollute test output.
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);

--- a/src/dashboard/routes/sse-handler.test.ts
+++ b/src/dashboard/routes/sse-handler.test.ts
@@ -149,11 +149,11 @@ describe('sse-handler', () => {
     }
   });
 
-  // Regression for F-005. The SSE frame `id` field must use the bus's global
+  // Regression for this. The SSE frame `id` field must use the bus's global
   // sequence number, not a per-connection counter — otherwise reconnecting
   // clients send back the wrong Last-Event-ID and either miss real events
   // or replay pre-connection history.
-  it('frame id matches bus global seq (F-005 regression)', async () => {
+  it('frame id matches bus global seq', async () => {
     const bus = new LiveEventBus();
     // Prime the bus with 5 events BEFORE the client connects. Their bus
     // seqs are 1..5.
@@ -195,7 +195,7 @@ describe('sse-handler', () => {
     }
   });
 
-  // Regression for F-005. After reconnect with Last-Event-ID set to a real
+  // Regression for this. After reconnect with Last-Event-ID set to a real
   // bus seq, the server must replay only events newer than that seq. With
   // the per-connection counter bug, this test would have replayed older
   // (pre-connection) events.
@@ -254,11 +254,11 @@ describe('sse-handler', () => {
     }
   });
 
-  // Regression for F-010. A client sending Last-Event-ID: -1 (or any negative
+  // Regression for this. A client sending Last-Event-ID: -1 (or any negative
   // number) must NOT trigger a replay. With the original bug, replaySeq would
   // be -1 (no replay) but nextLocalSeq became 0; the next reconnect with
   // Last-Event-ID: 0 then replayed the entire bus buffer.
-  it('Last-Event-ID: -1 does not trigger replay (F-010 regression)', async () => {
+  it('Last-Event-ID: -1 does not trigger replay', async () => {
     const bus = new LiveEventBus();
     bus.emit('tool-call', {
       id: 'a',
@@ -302,7 +302,7 @@ describe('sse-handler', () => {
     }
   });
 
-  it('Last-Event-ID: not-a-number does not trigger replay (F-010 regression)', async () => {
+  it('Last-Event-ID: not-a-number does not trigger replay', async () => {
     const bus = new LiveEventBus();
     bus.emit('tool-call', {
       id: 'a',
@@ -348,13 +348,13 @@ describe('sse-handler', () => {
   // seq namespace. The browser sends them back as Last-Event-ID on reconnect;
   // parseInt("hb-...") → NaN → no replay. This guards against a heartbeat id
   // contaminating the seq numbering and triggering an unintended replay.
-  // Regression for F-023. Both `req.on('close')` and `res.on('close')` register
+  // Regression for this. Both `req.on('close')` and `res.on('close')` register
   // the same cleanup function — on a normal disconnect both fire. The
   // `cleaned` guard makes the second invocation a no-op so a future change
   // (e.g. wrapping cleanup in something that side-effects) can't introduce
   // a real double-execution bug. This test asserts each `bus.offWithSeq`
   // is called exactly once even when both close events fire.
-  it('cleanup runs exactly once when both req and res emit close (F-023)', () => {
+  it('cleanup runs exactly once when both req and res emit close', () => {
     const bus = new LiveEventBus();
     const offSpy = jest.spyOn(bus, 'offWithSeq');
 

--- a/src/dashboard/routes/static-handler.test.ts
+++ b/src/dashboard/routes/static-handler.test.ts
@@ -64,7 +64,7 @@ describe('static-handler', () => {
     expect(status()).toBe(404);
   });
 
-  it('serves /assets/ files with immutable, max-age=31536000 cache (F-034)', async () => {
+  it('serves /assets/ files with immutable, max-age=31536000 cache', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'static-'));
     mkdirSync(join(dir, 'assets'));
     writeFileSync(join(dir, 'assets', 'main-abc123.js'), 'console.log(1)');
@@ -75,7 +75,7 @@ describe('static-handler', () => {
     expect(headers()['cache-control']).toBe('public, max-age=31536000, immutable');
   });
 
-  it('serves index.html on / with no-cache (F-034)', async () => {
+  it('serves index.html on / with no-cache', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'static-'));
     writeFileSync(join(dir, 'index.html'), '<!doctype html>');
     const handler = createStaticHandler(dir);
@@ -85,7 +85,7 @@ describe('static-handler', () => {
     expect(headers()['cache-control']).toBe('no-cache');
   });
 
-  it('serves SPA-fallback index.html with no-cache for unknown extensionless routes (F-034)', async () => {
+  it('serves SPA-fallback index.html with no-cache for unknown extensionless routes', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'static-'));
     writeFileSync(join(dir, 'index.html'), '<!doctype html>');
     const handler = createStaticHandler(dir);
@@ -95,7 +95,7 @@ describe('static-handler', () => {
     expect(headers()['cache-control']).toBe('no-cache');
   });
 
-  it('serves non-asset top-level files with a short max-age (F-034)', async () => {
+  it('serves non-asset top-level files with a short max-age', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'static-'));
     writeFileSync(join(dir, 'index.html'), '<!doctype html>');
     writeFileSync(join(dir, 'favicon.ico'), '');
@@ -106,7 +106,7 @@ describe('static-handler', () => {
     expect(headers()['cache-control']).toBe('public, max-age=300');
   });
 
-  it('returns 404 for an existing directory request (F-033)', async () => {
+  it('returns 404 for an existing directory request', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'static-'));
     writeFileSync(join(dir, 'index.html'), '<!doctype html>');
     mkdirSync(join(dir, 'assets'));
@@ -146,12 +146,12 @@ describe('static-handler', () => {
     expect(status()).toBe(403);
   });
 
-  // Regression for F-002: vite.config.ts must use base:'/' so the built
+  // Regression for : vite.config.ts must use base:'/' so the built
   // index.html references assets via absolute paths. With base:'./', a
   // direct refresh on /sessions resolves relative './assets/x.js' against
   // /sessions/ and returns 404. This test reads vite.config.ts source
   // directly so a revert is caught even if no build artifact is present.
-  it('vite.config.ts has base:"/" (F-002 revert guard)', () => {
+  it('vite.config.ts has base:"/" (revert guard)', () => {
     const viteConfigPath = resolve(__dirname, '..', '..', '..', 'vite.config.ts');
     const src = readFileSync(viteConfigPath, 'utf-8');
     // Strip line comments first so the regex doesn't match commentary like
@@ -164,12 +164,12 @@ describe('static-handler', () => {
     // Match the actual assignment: optional whitespace, base: '/' or "/" with
     // optional trailing comma. Anchored to a line so 'base: "/foo/"' (which
     // a future contributor might add for a sub-path deployment) also passes
-    // — but 'base: "./"' (the F-002 bug) is rejected.
+    // — but 'base: "./"' (the bug) is rejected.
     expect(codeOnly).toMatch(/^\s*base:\s*['"]\/['"],?\s*$/m);
     expect(codeOnly).not.toMatch(/^\s*base:\s*['"]\.\//m);
   });
 
-  // Regression for F-002: when the SPA fallback serves index.html for an
+  // Regression for : when the SPA fallback serves index.html for an
   // extensionless route like /sessions, the served HTML must reference
   // assets via absolute paths (/assets/...) so the browser doesn't
   // resolve them against /sessions/ and produce 404s. This guards

--- a/src/digest/digest-sender.test.ts
+++ b/src/digest/digest-sender.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from '@jest/globals';
 import { sendSlackDigest } from './digest-sender.js';
 
 describe('digest-sender', () => {
-  describe('sendSlackDigest() — SSRF validation (F-016)', () => {
+  describe('sendSlackDigest() — SSRF validation', () => {
     it('rejects non-Slack webhook URLs', async () => {
       await expect(sendSlackDigest('http://evil.com/webhook', { text: 'test' })).rejects.toThrow(
         'Invalid webhook URL: must be a valid https://hooks.slack.com/ URL',

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -273,7 +273,7 @@ describe('collector-script', () => {
       expect(event.isInterrupt).toBe(true);
     });
 
-    it('redacts sensitive information in error messages (F-017)', () => {
+    it('redacts sensitive information in error messages', () => {
       const errorWithToken = 'Authorization failed: Bearer eyJhbGciOiJIUzI1NiJ9.token.signature';
       processHook(makePostToolUseFailure({ error: errorWithToken }));
 
@@ -283,7 +283,7 @@ describe('collector-script', () => {
       expect(event.error).toContain('[REDACTED]');
     });
 
-    it('redacts API keys in error messages (F-017)', () => {
+    it('redacts API keys in error messages', () => {
       const errorWithApiKey = 'Failed: API_KEY = sk-1234567890abcdef';
       processHook(makePostToolUseFailure({ error: errorWithApiKey }));
 
@@ -449,19 +449,19 @@ describe('collector-script', () => {
       expect(result).toBe('hello...[truncated]');
     });
 
-    // N-02: ReDoS protection
-    it('redact() truncates input over 1 MB before applying patterns (N-02)', () => {
+    // ReDoS protection
+    it('redact() truncates input over 1 MB before applying patterns', () => {
       const overLimit = 'A'.repeat(1_048_577);
       const result = redact(overLimit);
       expect(result.length).toBeLessThanOrEqual(1_048_576);
     });
 
-    it('redact() does not match an unterminated PEM block — bounded pattern prevents ReDoS (N-02)', () => {
+    it('redact() does not match an unterminated PEM block — bounded pattern prevents ReDoS', () => {
       const input = '-----BEGIN RSA PRIVATE KEY-----' + 'B'.repeat(200);
       expect(redact(input)).toBe(input);
     });
 
-    describe('getRecordContent() — enforcing highSecurity (F-015)', () => {
+    describe('getRecordContent() — enforcing highSecurity', () => {
       beforeEach(() => {
         delete process.env.NEW_RELIC_AI_HIGH_SECURITY;
         delete process.env.NEW_RELIC_AI_MCP_RECORD_CONTENT;
@@ -486,7 +486,7 @@ describe('collector-script', () => {
     });
   });
 
-  describe('file permissions (M-03)', () => {
+  describe('file permissions', () => {
     it('creates the buffer directory with mode 0o700', () => {
       // Point to a subdirectory that does not yet exist so mkdirSync is triggered
       const subDir = resolve(tmpDir, 'new-subdir');

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -423,10 +423,10 @@ describe('HookEventProcessor', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Pending map size cap (M-04)
+  // Pending map size cap
   // ---------------------------------------------------------------------------
 
-  describe('pending map size cap (M-04)', () => {
+  describe('pending map size cap', () => {
     it('does not exceed maxPendingEvents entries in the pending map', () => {
       const processor = new HookEventProcessor({ store, onRecord, maxPendingEvents: 5 });
 
@@ -524,10 +524,10 @@ describe('HookEventProcessor', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Edge cases: duplication, out-of-order arrivals, fallback collision (F-129)
+  // Edge cases: duplication, out-of-order arrivals, fallback collision
   // ---------------------------------------------------------------------------
 
-  describe('duplicate pre-events / out-of-order arrivals (F-129)', () => {
+  describe('duplicate pre-events / out-of-order arrivals', () => {
     it('second pre-event with same toolUseId overwrites the first; post pairs with the second', () => {
       const processor = new HookEventProcessor({ store, onRecord });
 

--- a/src/index.privacy.test.ts
+++ b/src/index.privacy.test.ts
@@ -18,7 +18,7 @@ import { resolve, join } from 'node:path';
 // proof is the second describe block, which spawns the real built binary —
 // that is the load-bearing test for the privacy promise.
 //
-// TODO(F-003 follow-up): if the in-process gating coverage becomes important,
+// TODO: if the in-process gating coverage becomes important,
 // either (a) refactor main() to extract the gate into a directly-testable
 // function, or (b) invest in a robust ESM-mock setup. For now the
 // child-process test is the privacy proof of record, and the `beforeAll`

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -214,10 +214,10 @@ describe('classifyDashboardStartError()', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-137: CLI argument edge cases
+// CLI argument edge cases
 // ---------------------------------------------------------------------------
 
-describe('F-137: CLI argument edge cases', () => {
+describe('CLI argument edge cases', () => {
   const base = ['node', 'preflight'];
 
   it('--port=0 throws (zero is not a valid port)', () => {
@@ -578,7 +578,7 @@ describe('stdio integration', () => {
       args: [binPath, '--stdio'],
       // NR_AI_DASHBOARD_PORT=0 → OS-assigned ephemeral, so this test is
       // safe to run when port 7777 is occupied (e.g. a developer running
-      // their production instance on the same host). Enabled by F-004.
+      // their production instance on the same host).
       env: { ...process.env, NR_AI_DASHBOARD_PORT: '0', CLAUDE_JOB_DIR: tmpJobDir },
     });
 

--- a/src/install/schedule.test.ts
+++ b/src/install/schedule.test.ts
@@ -1,7 +1,7 @@
 import { jest, describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals';
 import { mkdirSync, mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import * as nodeOs from 'node:os';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 
 // Prevent real launchctl calls.
 jest.mock('node:child_process', () => ({ execFileSync: jest.fn(), execSync: jest.fn() }));
@@ -18,6 +18,7 @@ import {
   removeSchedule,
   getScheduleStatus,
   resolveBinaryPath,
+  resolveNodeDir,
   installDashboardDaemon,
   removeDashboardDaemon,
   getDashboardDaemonStatus,
@@ -70,6 +71,15 @@ describe('installSchedule', () => {
     installSchedule('/usr/local/bin/preflight', 8, 0);
     const content = readFileSync(PLIST_PATH, 'utf-8');
     expect(content).toContain('.newrelic-preflight/update.log');
+  });
+
+  it('plist includes EnvironmentVariables PATH containing the node dir', () => {
+    installSchedule('/usr/local/bin/preflight', 8, 0);
+    const content = readFileSync(PLIST_PATH, 'utf-8');
+    expect(content).toContain('<key>EnvironmentVariables</key>');
+    expect(content).toContain('<key>PATH</key>');
+    expect(content).toContain(dirname(process.execPath));
+    expect(content).toContain('/usr/bin:/bin');
   });
 
   it('calls launchctl unload then load', () => {
@@ -189,6 +199,16 @@ describe('resolveBinaryPath', () => {
   });
 });
 
+describe('resolveNodeDir', () => {
+  it('returns the directory containing the current node binary', () => {
+    expect(resolveNodeDir()).toBe(dirname(process.execPath));
+  });
+
+  it('returns a non-empty string', () => {
+    expect(resolveNodeDir().length).toBeGreaterThan(0);
+  });
+});
+
 describe('installDashboardDaemon', () => {
   it('writes a plist file to the LaunchAgents directory', () => {
     installDashboardDaemon('/usr/local/bin/preflight');
@@ -209,6 +229,15 @@ describe('installDashboardDaemon', () => {
     const content = readFileSync(DASHBOARD_PLIST_PATH, 'utf-8');
     expect(content).toContain('<string>/opt/homebrew/bin/preflight</string>');
     expect(content).toContain('.newrelic-preflight/dashboard.log');
+  });
+
+  it('plist includes EnvironmentVariables PATH containing the node dir', () => {
+    installDashboardDaemon('/opt/homebrew/bin/preflight');
+    const content = readFileSync(DASHBOARD_PLIST_PATH, 'utf-8');
+    expect(content).toContain('<key>EnvironmentVariables</key>');
+    expect(content).toContain('<key>PATH</key>');
+    expect(content).toContain(dirname(process.execPath));
+    expect(content).toContain('/usr/bin:/bin');
   });
 
   it('calls launchctl unload then load', () => {

--- a/src/install/schedule.ts
+++ b/src/install/schedule.ts
@@ -9,7 +9,7 @@ import {
   unlinkSync,
   mkdirSync,
 } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { resolve, join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 
 function escapeXml(s: string): string {
@@ -39,7 +39,14 @@ function dashboardLogPath(): string {
   return resolve(homedir(), '.newrelic-preflight', 'dashboard.log');
 }
 
-function buildPlist(binaryPath: string, hour: number, minute: number): string {
+// Returns the directory containing the node binary running this process.
+// Injected into launchd plists so the daemon can find node regardless of
+// which version manager (Homebrew, nvm, volta, asdf) the user has.
+export function resolveNodeDir(): string {
+  return dirname(process.execPath);
+}
+
+function buildPlist(binaryPath: string, hour: number, minute: number, nodeDir: string): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -51,6 +58,11 @@ function buildPlist(binaryPath: string, hour: number, minute: number): string {
     <string>${escapeXml(binaryPath)}</string>
     <string>update</string>
   </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${escapeXml(nodeDir)}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>
@@ -76,9 +88,10 @@ export interface ScheduleStatus {
 }
 
 export function installSchedule(binaryPath: string, hour: number, minute: number): void {
+  const nodeDir = resolveNodeDir();
   const path = plistPath();
   mkdirSync(resolve(homedir(), 'Library', 'LaunchAgents'), { recursive: true, mode: 0o755 });
-  writeFileSync(path, buildPlist(binaryPath, hour, minute), { mode: 0o600 });
+  writeFileSync(path, buildPlist(binaryPath, hour, minute, nodeDir), { mode: 0o600 });
   try {
     execFileSync('launchctl', ['unload', path], { stdio: 'pipe' });
   } catch {
@@ -123,7 +136,7 @@ export function getScheduleStatus(): ScheduleStatus {
   }
 }
 
-function buildDashboardPlist(binaryPath: string): string {
+function buildDashboardPlist(binaryPath: string, nodeDir: string): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -135,6 +148,11 @@ function buildDashboardPlist(binaryPath: string): string {
     <string>${escapeXml(binaryPath)}</string>
     <string>--local</string>
   </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${escapeXml(nodeDir)}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
   <key>KeepAlive</key>
   <true/>
   <key>RunAtLoad</key>
@@ -153,9 +171,10 @@ export interface DashboardDaemonStatus {
 }
 
 export function installDashboardDaemon(binaryPath: string): void {
+  const nodeDir = resolveNodeDir();
   const path = dashboardPlistPath();
   mkdirSync(resolve(homedir(), 'Library', 'LaunchAgents'), { recursive: true, mode: 0o755 });
-  writeFileSync(path, buildDashboardPlist(binaryPath), { mode: 0o600 });
+  writeFileSync(path, buildDashboardPlist(binaryPath, nodeDir), { mode: 0o600 });
   try {
     execFileSync('launchctl', ['unload', path], { stdio: 'pipe' });
   } catch {

--- a/src/metrics/anti-patterns.test.ts
+++ b/src/metrics/anti-patterns.test.ts
@@ -91,7 +91,7 @@ describe('Thrashing detection', () => {
     expect(thrashing).toHaveLength(0);
   });
 
-  it('detects thrashing on flaky tests after pass without intermediate edits (F-026)', () => {
+  it('detects thrashing on flaky tests after pass without intermediate edits', () => {
     // Sequence: edit /a, test fail, test pass, test fail, test fail
     // With threshold=2, should detect after 2 consecutive fails (even after a pass)
     const detector = new AntiPatternDetector({ thrashThreshold: 2 });
@@ -493,10 +493,10 @@ describe('Over-delegation detection', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-136: threshold boundary tests (threshold-1 / threshold / threshold+1)
+// threshold boundary tests (threshold-1 / threshold / threshold+1)
 // ---------------------------------------------------------------------------
 
-describe('F-136: threshold boundary tests', () => {
+describe('threshold boundary tests', () => {
   // ---- Thrashing ----
 
   it('thrashing: 2 cycles (threshold-1=2) does NOT fire', () => {

--- a/src/metrics/budget-tracker.test.ts
+++ b/src/metrics/budget-tracker.test.ts
@@ -120,7 +120,7 @@ describe('BudgetTracker', () => {
     expect(status.pctUsed).toBeCloseTo(35);
   });
 
-  it('re-arms daily thresholds after midnight (F-020)', () => {
+  it('re-arms daily thresholds after midnight', () => {
     jest.useFakeTimers();
     const events: unknown[] = [];
     const t = new BudgetTracker({
@@ -154,7 +154,7 @@ describe('BudgetTracker', () => {
     jest.useRealTimers();
   });
 
-  it('re-arms weekly thresholds after week rollover (F-020)', () => {
+  it('re-arms weekly thresholds after week rollover', () => {
     jest.useFakeTimers();
     const events: unknown[] = [];
     const t = new BudgetTracker({

--- a/src/metrics/cost-tracker.test.ts
+++ b/src/metrics/cost-tracker.test.ts
@@ -340,10 +340,10 @@ describe('CostTracker', () => {
   });
 
   // -------------------------------------------------------------------------
-  // F-135: cost calculation edge cases
+  // cost calculation edge cases
   // -------------------------------------------------------------------------
 
-  describe('F-135: cost calculation edge cases', () => {
+  describe('cost calculation edge cases', () => {
     it('unknown model name returns all-zero cost breakdown without crashing', () => {
       const tracker = new CostTracker();
       const breakdown = tracker.recordTokenUsage(

--- a/src/metrics/latency-tracker.test.ts
+++ b/src/metrics/latency-tracker.test.ts
@@ -124,7 +124,7 @@ describe('LatencyTracker', () => {
     expect(t.getMetrics().slowestCalls).toHaveLength(0);
   });
 
-  it('byTool does not include tools with no valid samples (F-028)', () => {
+  it('byTool does not include tools with no valid samples', () => {
     const t = new LatencyTracker();
     // Record invalid duration for Read — it returns early and is never added to byTool
     t.recordToolCall(
@@ -140,7 +140,7 @@ describe('LatencyTracker', () => {
     expect(m.byTool['Bash']?.p50).toBe(100);
   });
 
-  it('overall is null when all recorded calls have null/undefined durationMs (F-028)', () => {
+  it('overall is null when all recorded calls have null/undefined durationMs', () => {
     const t = new LatencyTracker();
     t.recordToolCall(
       makeRecord({ toolName: 'Read', durationMs: null as unknown as number, success: true }),

--- a/src/platforms/generic-mcp-adapter.test.ts
+++ b/src/platforms/generic-mcp-adapter.test.ts
@@ -244,43 +244,43 @@ describe('validateReportToolCallInput', () => {
     );
   });
 
-  it('rejects non-numeric duration_ms (F-035)', () => {
+  it('rejects non-numeric duration_ms', () => {
     expect(() =>
       validateReportToolCallInput({ tool: 'Read', success: true, duration_ms: 'not-a-number' }),
     ).toThrow('Field duration_ms must be a number when present');
   });
 
-  it('rejects non-numeric input_size_bytes (F-035)', () => {
+  it('rejects non-numeric input_size_bytes', () => {
     expect(() =>
       validateReportToolCallInput({ tool: 'Read', success: true, input_size_bytes: 'large' }),
     ).toThrow('Field input_size_bytes must be a number when present');
   });
 
-  it('rejects non-numeric output_size_bytes (F-035)', () => {
+  it('rejects non-numeric output_size_bytes', () => {
     expect(() =>
       validateReportToolCallInput({ tool: 'Read', success: true, output_size_bytes: '1024' }),
     ).toThrow('Field output_size_bytes must be a number when present');
   });
 
-  it('rejects non-numeric timestamp (F-035)', () => {
+  it('rejects non-numeric timestamp', () => {
     expect(() =>
       validateReportToolCallInput({ tool: 'Read', success: true, timestamp: '2000' }),
     ).toThrow('Field timestamp must be a number when present');
   });
 
-  it('rejects non-string error (F-035)', () => {
+  it('rejects non-string error', () => {
     expect(() => validateReportToolCallInput({ tool: 'Read', success: false, error: 42 })).toThrow(
       'Field error must be a string when present',
     );
   });
 
-  it('rejects non-object input field (F-035)', () => {
+  it('rejects non-object input field', () => {
     expect(() =>
       validateReportToolCallInput({ tool: 'Read', success: true, input: 'string' }),
     ).toThrow('Field input must be an object when present');
   });
 
-  it('accepts valid optional numeric and string fields (F-035)', () => {
+  it('accepts valid optional numeric and string fields', () => {
     const input = {
       tool: 'Read',
       success: true,

--- a/src/proxy/otlp-receiver.test.ts
+++ b/src/proxy/otlp-receiver.test.ts
@@ -326,10 +326,10 @@ describe('constructor SSRF guard', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-095: Body size limit (413)
+// Body size limit (413)
 // ---------------------------------------------------------------------------
 
-describe('body size limit (F-095)', () => {
+describe('body size limit', () => {
   let receiver: OtlpReceiver;
 
   beforeEach(async () => {
@@ -356,10 +356,10 @@ describe('body size limit (F-095)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-097: Slow-loris timeout (408)
+// Slow-loris timeout (408)
 // ---------------------------------------------------------------------------
 
-describe('slow-loris timeout (F-097)', () => {
+describe('slow-loris timeout', () => {
   it('returns 408 when body delivery stalls past bodyTimeoutMs', async () => {
     const receiver = makeReceiver({ bodyTimeoutMs: 200 });
     await receiver.start();
@@ -390,10 +390,10 @@ describe('slow-loris timeout (F-097)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-098: Content-Encoding decompression
+// Content-Encoding decompression
 // ---------------------------------------------------------------------------
 
-describe('Content-Encoding decompression (F-098)', () => {
+describe('Content-Encoding decompression', () => {
   let receiver: OtlpReceiver;
 
   beforeEach(async () => {
@@ -449,10 +449,10 @@ describe('Content-Encoding decompression (F-098)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-099: Rate limiting (429)
+// Rate limiting (429)
 // ---------------------------------------------------------------------------
 
-describe('rate limiting (F-099)', () => {
+describe('rate limiting', () => {
   it('returns 429 after exceeding rateLimitPerMinute requests', async () => {
     const receiver = makeReceiver({ rateLimitPerMinute: 2 });
     await receiver.start();
@@ -471,10 +471,10 @@ describe('rate limiting (F-099)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-100: API key authentication (401)
+// API key authentication (401)
 // ---------------------------------------------------------------------------
 
-describe('API key authentication (F-100)', () => {
+describe('API key authentication', () => {
   let receiver: OtlpReceiver;
 
   beforeEach(async () => {
@@ -522,10 +522,10 @@ describe('API key authentication (F-100)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-101: Content-Type validation (415)
+// Content-Type validation (415)
 // ---------------------------------------------------------------------------
 
-describe('Content-Type validation (F-101)', () => {
+describe('Content-Type validation', () => {
   let receiver: OtlpReceiver;
 
   beforeEach(async () => {
@@ -575,10 +575,10 @@ describe('Content-Type validation (F-101)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-102: Incomplete body (400)
+// Incomplete body (400)
 // ---------------------------------------------------------------------------
 
-describe('incomplete body (F-102)', () => {
+describe('incomplete body', () => {
   it('returns 400 when received bytes are less than Content-Length', async () => {
     const receiver = makeReceiver();
     await receiver.start();
@@ -617,10 +617,10 @@ describe('incomplete body (F-102)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-103: Error message sanitization
+// Error message sanitization
 // ---------------------------------------------------------------------------
 
-describe('error message sanitization (F-103)', () => {
+describe('error message sanitization', () => {
   afterEach(() => {
     (globalThis as { fetch?: unknown }).fetch = undefined;
   });
@@ -662,10 +662,10 @@ describe('error message sanitization (F-103)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-104: Expect: 100-continue
+// Expect: 100-continue
 // ---------------------------------------------------------------------------
 
-describe('Expect: 100-continue (F-104)', () => {
+describe('Expect: 100-continue', () => {
   it('sends 100 Continue and completes the request successfully', async () => {
     const receiver = makeReceiver();
     await receiver.start();
@@ -705,12 +705,10 @@ describe('Expect: 100-continue (F-104)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-139: Remaining size-limit / encoding / Content-Type edge cases
-// (F-095–F-104 scenarios are covered in their individual describe blocks
-// above; this block adds the specific examples called out in F-139.)
+// Remaining size-limit / encoding / Content-Type edge cases
 // ---------------------------------------------------------------------------
 
-describe('F-139: Content-Type edge cases', () => {
+describe('Content-Type edge cases', () => {
   let receiver: OtlpReceiver;
 
   beforeEach(async () => {
@@ -759,10 +757,10 @@ describe('F-139: Content-Type edge cases', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-139: abort mid-stream
+// abort mid-stream
 // ---------------------------------------------------------------------------
 
-describe('F-139: abort mid-stream', () => {
+describe('abort mid-stream', () => {
   it('returns 400 when client half-closes with an incomplete body', async () => {
     const receiver = makeReceiver();
     await receiver.start();

--- a/src/proxy/proxy-manager.test.ts
+++ b/src/proxy/proxy-manager.test.ts
@@ -248,7 +248,7 @@ describe('ProxyManager HTTP server', () => {
     expect(response.statusCode).toBe(404);
     const body = JSON.parse(response.body);
     expect(body.error).toBe('upstream_not_found');
-    // M-09: server name must not be disclosed to the client
+    // server name must not be disclosed to the client
     expect(body.message).toBeUndefined();
     expect(response.body).not.toContain('unknown-server');
   });
@@ -263,7 +263,7 @@ describe('ProxyManager HTTP server', () => {
 
     expect(response.statusCode).toBe(404);
     const body = JSON.parse(response.body);
-    // M-09: request URL must not be echoed back to the client
+    // request URL must not be echoed back to the client
     expect(body.message).toBeUndefined();
     expect(response.body).not.toContain('something-else');
   });
@@ -791,10 +791,10 @@ describe('ProxyManager lifecycle', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Body limits (M-05)
+// Body limits
 // ---------------------------------------------------------------------------
 
-describe('ProxyManager body limits (M-05)', () => {
+describe('ProxyManager body limits', () => {
   let manager: ProxyManager;
   let mockServer: Server;
   let proxyPort: number;

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -150,7 +150,7 @@ export class ProxyManager {
           res.end(JSON.stringify({ error: 'internal_error' }));
         } else if (!res.writableEnded) {
           // Headers already sent (e.g. mid-SSE stream) — writing JSON would corrupt
-          // the stream. N-09: destroy the response (not just the socket) so the
+          // the stream. destroy the response (not just the socket) so the
           // writable stream and its pipe chain are fully cleaned up.
           res.on('error', () => {
             /* suppress post-destroy write errors */

--- a/src/proxy/upstream-http.test.ts
+++ b/src/proxy/upstream-http.test.ts
@@ -290,7 +290,7 @@ describe('HttpUpstream', () => {
       ).not.toThrow();
     });
 
-    describe('numeric IP encoding bypasses (F-122)', () => {
+    describe('numeric IP encoding bypasses', () => {
       it('blocks decimal encoding of loopback (2130706433 = 127.0.0.1)', () => {
         expect(
           () =>
@@ -350,7 +350,7 @@ describe('HttpUpstream', () => {
       });
     });
 
-    describe('RFC-1918 range boundaries and multicast (F-130)', () => {
+    describe('RFC-1918 range boundaries and multicast', () => {
       const blockedBoundaries: Array<[string, string]> = [
         // 10.0.0.0/8 range
         ['10.x first (10.0.0.0)', 'http://10.0.0.0/'],
@@ -389,7 +389,7 @@ describe('HttpUpstream', () => {
       });
     });
 
-    describe('userinfo bypass invariant (F-124)', () => {
+    describe('userinfo bypass invariant', () => {
       it('validates against url.hostname (not userinfo) when userinfo is present with blocked address', () => {
         // Node's URL parser correctly extracts hostname from `userinfo@hostname` format.
         // url.hostname returns the actual hostname (not the userinfo), so SSRF validation works correctly.
@@ -831,7 +831,7 @@ describe('HttpUpstream.forward()', () => {
     expect((upstream as unknown as { timeoutMs: number }).timeoutMs).toBe(30_000);
   });
 
-  // M-10: SSE detection must parse the media type, not just substring-match
+  // SSE detection must parse the media type, not just substring-match
   it('treats text/event-stream with charset parameter as streaming', async () => {
     ({ server: mockServer, port } = await createMockServer((_req, res) => {
       _req.on('data', () => {});
@@ -915,7 +915,7 @@ describe('HttpUpstream.forward()', () => {
     expect(p95).toBeLessThan(50);
   });
 
-  describe('DNS rebinding protection (F-120)', () => {
+  describe('DNS rebinding protection', () => {
     it('forwards requests after re-validating private URLs when allowPrivateHosts=true', async () => {
       ({ server: mockServer, port } = await createMockServer((_req, res) => {
         _req.on('data', () => {});

--- a/src/security/audit-trail.test.ts
+++ b/src/security/audit-trail.test.ts
@@ -446,7 +446,7 @@ describe('AuditTrailManager', () => {
     }
   });
 
-  // 18. M-08: persists each tool call record to disk immediately
+  // 18. persists each tool call record to disk immediately
   it('calls localStore.appendAuditLog on every recordToolCall', () => {
     const { store, appendSpy } = makeLocalStore();
     const mgr = makeManager({ localStore: store });
@@ -463,7 +463,7 @@ describe('AuditTrailManager', () => {
     });
   });
 
-  // 19. M-08: persists proxy call records to disk immediately
+  // 19. persists proxy call records to disk immediately
   it('calls localStore.appendAuditLog on every recordProxyCall', () => {
     const { store, appendSpy } = makeLocalStore();
     const mgr = makeManager({ localStore: store });
@@ -477,7 +477,7 @@ describe('AuditTrailManager', () => {
     });
   });
 
-  // 20. M-08: no localStore — no crash
+  // 20. no localStore — no crash
   it('does not throw when no localStore is provided', () => {
     const mgr = makeManager();
     expect(() => mgr.recordToolCall(makeRecord())).not.toThrow();
@@ -532,8 +532,8 @@ describe('securityAlertToNrEvent', () => {
   });
 });
 
-// N-11: redaction in NR event file_path and command fields
-describe('NR event field redaction (N-11)', () => {
+// redaction in NR event file_path and command fields
+describe('NR event field redaction', () => {
   it('auditRecordToNrEvent redacts secrets in file_path', () => {
     const mgr = makeManager();
     const audit = mgr.recordToolCall(
@@ -585,8 +585,8 @@ describe('NR event field redaction (N-11)', () => {
   });
 });
 
-// N-04: redaction in SecurityAlert description
-describe('SecurityAlert description redaction (N-04)', () => {
+// redaction in SecurityAlert description
+describe('SecurityAlert description redaction', () => {
   it('redacts secrets embedded in a destructive command description', () => {
     const mgr = makeManager();
     const record = makeRecord({ toolName: 'Bash', command: 'rm -rf / TOKEN=sk-secret123' });
@@ -628,10 +628,10 @@ describe('SecurityAlert description redaction (N-04)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-140: Audit-trail case/spacing/false-positive tests
+// Audit-trail case/spacing/false-positive tests
 // ---------------------------------------------------------------------------
 
-describe('F-140: Audit-trail case/spacing/false-positive tests', () => {
+describe('Audit-trail case/spacing/false-positive tests', () => {
   // Case variations — the rm regex uses \brm\s+ (no /i flag), so uppercase
   // variants do NOT currently trigger the destructive-command classifier.
   // These tests document that known limitation.

--- a/src/security/ssrf.ts
+++ b/src/security/ssrf.ts
@@ -111,7 +111,7 @@ export function validateSsrfUrl(label: string, url: URL): void {
     throw new Error(`${label}: scheme "${url.protocol}" is not allowed; use http: or https:`);
   }
 
-  // Strip trailing dot from hostname to prevent FQDN FQDN bypasses (F-123)
+  // Strip trailing dot from hostname to prevent FQDN FQDN bypasses
   // Node's URL parser preserves trailing dots, but they should be treated the same as the bare hostname
   const hostname = url.hostname.replace(/\.$/, '');
 

--- a/src/server.integration.test.ts
+++ b/src/server.integration.test.ts
@@ -59,10 +59,10 @@ function makeIngestOptions(overrides?: Partial<NrIngestOptions>): NrIngestOption
 }
 
 // ---------------------------------------------------------------------------
-// F-125: End-to-end redaction in emitted NR events
+// End-to-end redaction in emitted NR events
 // ---------------------------------------------------------------------------
 
-describe('End-to-end redaction in emitted NR events (F-125)', () => {
+describe('End-to-end redaction in emitted NR events', () => {
   beforeEach(() => {
     mockSendEvents.mockClear();
     mockSendMetrics.mockClear();
@@ -220,10 +220,10 @@ describe('End-to-end redaction in emitted NR events (F-125)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// F-126: High-security mode content verification in emitted NR events
+// High-security mode content verification in emitted NR events
 // ---------------------------------------------------------------------------
 
-describe('High-security mode content verification in emitted NR events (F-126)', () => {
+describe('High-security mode content verification in emitted NR events', () => {
   beforeEach(() => {
     mockSendEvents.mockClear();
     mockSendMetrics.mockClear();

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -277,7 +277,7 @@ describe('LocalStore', () => {
       expect(store.loadRecentSessions(7)).toEqual([]);
     });
 
-    it('rejects sessionId containing path traversal and writes no file (N-01)', () => {
+    it('rejects sessionId containing path traversal and writes no file', () => {
       const store = new LocalStore(tmpDir);
       store.initialize();
 
@@ -286,7 +286,7 @@ describe('LocalStore', () => {
       expect(readdirSync(resolve(tmpDir, 'sessions'))).toHaveLength(0);
     });
 
-    it('rejects sessionId containing a forward slash (N-01)', () => {
+    it('rejects sessionId containing a forward slash', () => {
       const store = new LocalStore(tmpDir);
       store.initialize();
 
@@ -295,7 +295,7 @@ describe('LocalStore', () => {
       expect(readdirSync(resolve(tmpDir, 'sessions'))).toHaveLength(0);
     });
 
-    it('accepts a valid UUID-style sessionId (N-01)', () => {
+    it('accepts a valid UUID-style sessionId', () => {
       const store = new LocalStore(tmpDir);
       store.initialize();
 
@@ -374,10 +374,10 @@ describe('LocalStore', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Fault injection (F-127)
+  // Fault injection
   // ---------------------------------------------------------------------------
 
-  describe('drainBuffer() fault injection (F-127)', () => {
+  describe('drainBuffer() fault injection', () => {
     it('returns [] and preserves .drain when .drain is unreadable; recovers on next poll', () => {
       if (process.getuid?.() === 0) {
         // Root bypasses file permission checks — this test is not meaningful as root
@@ -431,10 +431,10 @@ describe('LocalStore', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Directory permissions (M-03)
+  // Directory permissions
   // ---------------------------------------------------------------------------
 
-  describe('initialize() directory permissions (M-03)', () => {
+  describe('initialize() directory permissions', () => {
     it('creates all storage directories with mode 0o700', () => {
       // Use a fresh path that does not exist so initialize() creates everything
       const freshDir = resolve(tmpDir, 'fresh-store');

--- a/src/storage/retention.test.ts
+++ b/src/storage/retention.test.ts
@@ -103,10 +103,10 @@ describe('purgeOldSessions', () => {
 });
 
 // ---------------------------------------------------------------------------
-// TOCTOU / interruption tests (F-133)
+// TOCTOU / interruption tests
 // ---------------------------------------------------------------------------
 
-describe('purgeOldSessions — interruption and TOCTOU (F-133)', () => {
+describe('purgeOldSessions — interruption and TOCTOU', () => {
   const oldDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
 
   it('continues purging remaining files when unlinkSync throws for one entry (EISDIR)', () => {
@@ -169,7 +169,7 @@ describe('purgeOldSessions — interruption and TOCTOU (F-133)', () => {
     );
   });
 
-  it('handles sessions-directory write permission revoked mid-purge, then succeeds on retry (F-133)', () => {
+  it('handles sessions-directory write permission revoked mid-purge, then succeeds on retry', () => {
     if (process.getuid?.() === 0) return; // root bypasses permission checks
 
     const dir = makeTempDir();

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -187,7 +187,7 @@ describe('SessionStore', () => {
     expect(all.map((s) => s.sessionId)).toEqual(['s1', 's3', 's2']);
   });
 
-  it('saveSession rejects sessionId containing path traversal and writes no file (N-01)', () => {
+  it('saveSession rejects sessionId containing path traversal and writes no file', () => {
     const store = new SessionStore({ storagePath: tmpDir });
 
     store.saveSession(makeSummary({ sessionId: '../../etc/passwd' }));
@@ -195,7 +195,7 @@ describe('SessionStore', () => {
     expect(readdirSync(resolve(tmpDir, 'sessions'))).toHaveLength(0);
   });
 
-  it('saveSession rejects sessionId containing a forward slash (N-01)', () => {
+  it('saveSession rejects sessionId containing a forward slash', () => {
     const store = new SessionStore({ storagePath: tmpDir });
 
     store.saveSession(makeSummary({ sessionId: 'a/b' }));
@@ -203,7 +203,7 @@ describe('SessionStore', () => {
     expect(readdirSync(resolve(tmpDir, 'sessions'))).toHaveLength(0);
   });
 
-  it('saveSession accepts a valid UUID-style sessionId (N-01)', () => {
+  it('saveSession accepts a valid UUID-style sessionId', () => {
     const store = new SessionStore({ storagePath: tmpDir });
 
     store.saveSession(makeSummary({ sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }));
@@ -525,10 +525,10 @@ describe('buildSessionSummary', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Corruption-recovery (F-132)
+// Corruption-recovery
 // ---------------------------------------------------------------------------
 
-describe('SessionStore corruption-recovery (F-132)', () => {
+describe('SessionStore corruption-recovery', () => {
   it('loadSession returns null and logs warning for malformed JSON', () => {
     const store = new SessionStore({ storagePath: tmpDir });
     const sessionsDir = join(tmpDir, 'sessions');
@@ -789,8 +789,8 @@ describe('buildSessionSummary timeline', () => {
   });
 });
 
-// N-06: deserializeSession — explicit field extraction
-describe('SessionStore deserialization (N-06)', () => {
+// deserializeSession — explicit field extraction
+describe('SessionStore deserialization', () => {
   it('loads a session with prototype-shadowing toolBreakdown keys safely', () => {
     const store = new SessionStore({ storagePath: tmpDir });
     const sessionsDir = join(tmpDir, 'sessions');

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -386,7 +386,7 @@ function formatDate(date: Date): string {
 }
 
 /**
- * N-06: Explicitly extract known fields from a raw session JSON string rather
+ * Explicitly extract known fields from a raw session JSON string rather
  * than blindly casting JSON.parse output. Prevents untrusted keys from disk
  * being misinterpreted as typed properties.
  */

--- a/src/storage/weekly-summary.test.ts
+++ b/src/storage/weekly-summary.test.ts
@@ -64,8 +64,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   };
 }
 
-// N-06: null-proto accumulator tests
-describe('aggregateSessions prototype-pollution resistance (N-06)', () => {
+// null-proto accumulator tests
+describe('aggregateSessions prototype-pollution resistance', () => {
   it('handles __proto__ and constructor keys in toolBreakdown without pollution', () => {
     const store = new SessionStore({ storagePath: tmpDir });
     const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
@@ -192,20 +192,20 @@ describe('WeeklySummaryGenerator', () => {
     expect(bob.totalTasksCompleted).toBe(1);
   });
 
-  // N-03: defense-in-depth validation in generate()
-  it('generate() throws for path-traversal weekId (N-03)', () => {
+  // defense-in-depth validation in generate()
+  it('generate() throws for path-traversal weekId', () => {
     const store = new SessionStore({ storagePath: tmpDir });
     const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
     expect(() => generator.generate('../../../etc/passwd')).toThrow(/Invalid weekId format/);
   });
 
-  it('generate() throws for arbitrary string weekId (N-03)', () => {
+  it('generate() throws for arbitrary string weekId', () => {
     const store = new SessionStore({ storagePath: tmpDir });
     const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
     expect(() => generator.generate('not-a-week')).toThrow(/Invalid weekId format/);
   });
 
-  it('generate() accepts valid YYYY-Wnn weekId (N-03)', () => {
+  it('generate() accepts valid YYYY-Wnn weekId', () => {
     const store = new SessionStore({ storagePath: tmpDir });
     const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
     const { start } = getWeekDateRange('2026-W16');

--- a/src/storage/weekly-summary.ts
+++ b/src/storage/weekly-summary.ts
@@ -109,7 +109,7 @@ export class WeeklySummaryGenerator {
   }
 
   generate(weekId: string): WeeklySummary {
-    // N-03: defense-in-depth — reject non-conforming weekIds before filepath construction
+    // defense-in-depth — reject non-conforming weekIds before filepath construction
     if (!/^\d{4}-W\d{2}$/.test(weekId)) {
       throw new Error(`Invalid weekId format: "${weekId}". Expected YYYY-Wnn.`);
     }
@@ -219,7 +219,7 @@ function aggregateSessions(weekId: string, sessions: FullSessionSummary[]): Week
   let totalTestsPassed = 0;
   let efficiencySum = 0;
   let efficiencyCount = 0;
-  // N-06: null-proto accumulators — prevent prototype pollution from disk-sourced keys
+  // null-proto accumulators — prevent prototype pollution from disk-sourced keys
   const toolBreakdown = Object.create(null) as Record<string, number>;
   const antiPatternCounts = Object.create(null) as Record<string, number>;
 
@@ -275,7 +275,7 @@ function aggregateDeveloperSessions(sessions: FullSessionSummary[]): DeveloperWe
   let totalTestsPassed = 0;
   let efficiencySum = 0;
   let efficiencyCount = 0;
-  // N-06: null-proto accumulators — prevent prototype pollution from disk-sourced keys
+  // null-proto accumulators — prevent prototype pollution from disk-sourced keys
   const toolBreakdown = Object.create(null) as Record<string, number>;
   const antiPatternCounts = Object.create(null) as Record<string, number>;
 

--- a/src/tools/cost-tools.test.ts
+++ b/src/tools/cost-tools.test.ts
@@ -136,8 +136,8 @@ describe('handleReportTokens()', () => {
     expect(metrics.totalCacheCreationTokens).toBe(0);
   });
 
-  // N-05: token clamping and model truncation
-  describe('N-05: unbounded token validation', () => {
+  // token clamping and model truncation
+  describe('unbounded token validation', () => {
     it('clamps negative token counts to 0', () => {
       const tracker = new CostTracker();
       handleReportTokens(tracker, { input_tokens: -999, output_tokens: -1, model: 'x' });

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -159,10 +159,10 @@ describe('Cross-session tool handlers', () => {
   });
 
   // -------------------------------------------------------------------------
-  // N-03: handleGetWeeklySummary — weekId validation
+  // handleGetWeeklySummary — weekId validation
   // -------------------------------------------------------------------------
 
-  it('handleGetWeeklySummary returns error for path-traversal weekId (N-03)', () => {
+  it('handleGetWeeklySummary returns error for path-traversal weekId', () => {
     const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
     const result = handleGetWeeklySummary(generator, { week: '../../../etc/passwd' });
     expect(result.isError).toBe(true);
@@ -170,7 +170,7 @@ describe('Cross-session tool handlers', () => {
     expect(parsed.error).toMatch(/Invalid week format/);
   });
 
-  it('handleGetWeeklySummary returns error for arbitrary string weekId (N-03)', () => {
+  it('handleGetWeeklySummary returns error for arbitrary string weekId', () => {
     const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
     const result = handleGetWeeklySummary(generator, { week: 'not-a-week' });
     expect(result.isError).toBe(true);
@@ -178,7 +178,7 @@ describe('Cross-session tool handlers', () => {
     expect(parsed.error).toMatch(/Invalid week format/);
   });
 
-  it('handleGetWeeklySummary accepts valid YYYY-Wnn weekId (N-03)', () => {
+  it('handleGetWeeklySummary accepts valid YYYY-Wnn weekId', () => {
     const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
     const result = handleGetWeeklySummary(generator, { week: '2026-W16' });
     expect(result.isError).toBeUndefined();
@@ -612,8 +612,8 @@ describe('Cross-session tool handlers', () => {
     expect(parsed.platforms['windsurf'].average).toBeCloseTo(0.5, 2);
   });
 
-  // N-08: unbounded developer / notes inputs
-  it('handleGetSessionHistory truncates developer over 256 chars (N-08)', () => {
+  // unbounded developer / notes inputs
+  it('handleGetSessionHistory truncates developer over 256 chars', () => {
     const longDev = 'a'.repeat(300);
     store.saveSession(makeSummary({ sessionId: 'dev-long', developer: 'a'.repeat(256) }));
     // Should not throw; developer filter is truncated, returning 0 or 1 sessions
@@ -621,7 +621,7 @@ describe('Cross-session tool handlers', () => {
     expect(result.content[0]).toBeDefined();
   });
 
-  it('handleGetTrends truncates developer over 256 chars (N-08)', () => {
+  it('handleGetTrends truncates developer over 256 chars', () => {
     const analyzer = new TrendAnalyzer({ sessionStore: store });
     const longDev = 'b'.repeat(300);
     // Should not throw and returns a result object
@@ -630,7 +630,7 @@ describe('Cross-session tool handlers', () => {
     expect(parsed).toHaveProperty('data_points');
   });
 
-  it('handleGetCollaborationProfile truncates developer over 256 chars (N-08)', () => {
+  it('handleGetCollaborationProfile truncates developer over 256 chars', () => {
     const profiler = new CollaborationProfiler({ sessionStore: store });
     const longDev = 'c'.repeat(300);
     const result = handleGetCollaborationProfile(profiler, { developer: longDev });
@@ -639,7 +639,7 @@ describe('Cross-session tool handlers', () => {
     expect(parsed.developer.length).toBeLessThanOrEqual(256);
   });
 
-  it('handleGetRecommendations truncates developer over 256 chars (N-08)', () => {
+  it('handleGetRecommendations truncates developer over 256 chars', () => {
     const trendAnalyzer = new TrendAnalyzer({ sessionStore: store });
     const collaborationProfiler = new CollaborationProfiler({ sessionStore: store });
     const claudeMdTracker = new ClaudeMdTracker({ sessionStore: store });
@@ -709,7 +709,7 @@ describe('Cross-session tool handlers', () => {
     }
   });
 
-  it('rejects non-numeric accountId (F-040)', async () => {
+  it('rejects non-numeric accountId', async () => {
     const result = await handleGetTeamSummary({
       teamId: 'my-team',
       accountId: 'not-a-number',
@@ -720,7 +720,7 @@ describe('Cross-session tool handlers', () => {
     expect(parsed.error).toMatch(/Invalid accountId/);
   });
 
-  it('rejects NaN accountId (F-040)', async () => {
+  it('rejects NaN accountId', async () => {
     const result = await handleGetTeamSummary({
       teamId: 'my-team',
       accountId: 'NaN',
@@ -731,7 +731,7 @@ describe('Cross-session tool handlers', () => {
     expect(parsed.error).toMatch(/Invalid accountId/);
   });
 
-  it('surfaces NerdGraph errors instead of returning empty results (F-037)', async () => {
+  it('surfaces NerdGraph errors instead of returning empty results', async () => {
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
       ok: true,
       json: async () => ({ errors: [{ message: 'Access denied' }] }),
@@ -751,7 +751,7 @@ describe('Cross-session tool handlers', () => {
     }
   });
 
-  it('surfaces missing data structure instead of returning empty results (F-037)', async () => {
+  it('surfaces missing data structure instead of returning empty results', async () => {
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => ({ data: { actor: { account: { nrql: null } } } }),
@@ -771,10 +771,10 @@ describe('Cross-session tool handlers', () => {
   });
 
   // -------------------------------------------------------------------------
-  // F-134: negative and out-of-range inputs
+  // negative and out-of-range inputs
   // -------------------------------------------------------------------------
 
-  describe('F-134: negative and out-of-range inputs', () => {
+  describe('negative and out-of-range inputs', () => {
     it('handleGetTrends with weeks: -1 does not crash and returns data_points array', () => {
       const analyzer = new TrendAnalyzer({ sessionStore: store });
       const result = handleGetTrends(analyzer, { weeks: -1 });
@@ -881,7 +881,7 @@ describe('Cross-session tool handlers', () => {
     });
   });
 
-  describe('toFiniteNumber (F-012)', () => {
+  describe('toFiniteNumber', () => {
     it('converts valid numbers', () => {
       expect(toFiniteNumber(123)).toBe(123);
       expect(toFiniteNumber('456')).toBe(456);

--- a/src/tools/cross-session-tools.ts
+++ b/src/tools/cross-session-tools.ts
@@ -350,7 +350,7 @@ export function handleGetWeeklySummary(
     };
   }
 
-  // N-03: validate week format before it reaches file-path construction
+  // validate week format before it reaches file-path construction
   if (!/^\d{4}-W\d{2}$/.test(args.week)) {
     return {
       content: [

--- a/src/tools/workflow-tools.test.ts
+++ b/src/tools/workflow-tools.test.ts
@@ -589,8 +589,8 @@ describe('handleReportFeedback()', () => {
     expect(collector.getRecords()).toHaveLength(3);
   });
 
-  // N-08: unbounded free-text inputs
-  it('truncates notes longer than 1024 chars (N-08)', () => {
+  // unbounded free-text inputs
+  it('truncates notes longer than 1024 chars', () => {
     const collector = new FeedbackCollector();
     const longNotes = 'x'.repeat(2000);
     handleReportFeedback(collector, { quality: 'good', notes: longNotes });
@@ -598,7 +598,7 @@ describe('handleReportFeedback()', () => {
     expect(records[0].notes?.length).toBe(1024);
   });
 
-  it('passes notes shorter than 1024 chars unchanged (N-08)', () => {
+  it('passes notes shorter than 1024 chars unchanged', () => {
     const collector = new FeedbackCollector();
     const notes = 'short note';
     handleReportFeedback(collector, { quality: 'good', notes });

--- a/src/transport/log-ingest.test.ts
+++ b/src/transport/log-ingest.test.ts
@@ -95,7 +95,7 @@ describe('auditRecordToLogEntry()', () => {
     expect(entry.attributes).not.toHaveProperty('session_id');
   });
 
-  it('redacts secrets in detail, file_path, and command (F-003)', () => {
+  it('redacts secrets in detail, file_path, and command', () => {
     const SECRET_TOKEN = 'sk-test-deadbeef0123456789abcdef0123456789';
     const record = makeAuditRecord({
       detail: `Bash: curl -H "Authorization: Bearer ${SECRET_TOKEN}"`,

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -262,7 +262,7 @@ describe('toolCallToNrEvent()', () => {
     expect(event.input_hash).toBe('abc123');
   });
 
-  describe('redaction (F-001)', () => {
+  describe('redaction', () => {
     // Long enough Bearer token to match the pattern's {20,200} length constraint.
     const SECRET_TOKEN = 'sk-test-deadbeef0123456789abcdef0123456789';
 
@@ -487,7 +487,7 @@ describe('NrIngestManager', () => {
     });
   });
 
-  describe('retry classification by HTTP status code (F-131)', () => {
+  describe('retry classification by HTTP status code', () => {
     beforeEach(() => {
       jest.useFakeTimers();
     });
@@ -846,7 +846,7 @@ describe('antiPatternToNrEvent()', () => {
     expect(event.command as string).toContain('[REDACTED]');
   });
 
-  it('timestamp is in milliseconds (F-021)', () => {
+  it('timestamp is in milliseconds', () => {
     const before = Date.now();
     const event = antiPatternToNrEvent(makePattern(), {
       developer: 'd',


### PR DESCRIPTION
## Summary

- **launchd fix (Issue #13):** `com.preflight.dashboard` and `com.preflight.update` daemons now inject the directory of the node binary used during `preflight setup` into the plist `EnvironmentVariables PATH`. This fixes the `env: node: No such file or directory` crash (exit 127) on macOS systems where node is installed via Homebrew, nvm, volta, asdf, or any other version manager that places node outside launchd's minimal default PATH (`/usr/bin:/bin:/usr/sbin:/sbin`).
- **New tests:** `resolveNodeDir()` unit tests + plist PATH assertion tests in both `installSchedule` and `installDashboardDaemon` suites (26 tests, up from 22).
- **CHANGELOG:** launchd fix documented under v1.0.5.
- **Label cleanup:** stripped 208 internal tracking label references (F/M/N/S-NNN patterns) from source and test files.

> **Note for existing users:** Re-run `preflight setup` to apply the launchd fix to an existing installation.

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes (26 schedule tests including new PATH injection assertions)
- [ ] `npm run lint` clean
- [ ] On a Homebrew/nvm/volta node install: run `preflight setup`, confirm `com.preflight.dashboard` and `com.preflight.update` plists contain `EnvironmentVariables` block with correct node dir

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)