### PR TITLE
Chore: fix stale regression comment phrasing

### DIFF
--- a/src/alerts/alert-snapshot-collector.test.ts
+++ b/src/alerts/alert-snapshot-collector.test.ts
@@ -229,7 +229,7 @@ describe('AlertSnapshotCollector — tracker reads', () => {
     ]);
   });
 
-  // Regression for : when the tracker has only p50 (no p95/p99 because
+  // Regression guard: when the tracker has only p50 (no p95/p99 because
   // sample count is too low), the snapshot must still emit the tool with the
   // p50 value populated and p95/p99 as 0. Previously the entry was dropped
   // entirely because the gate required `typeof p95 === 'number'`.
@@ -248,7 +248,7 @@ describe('AlertSnapshotCollector — tracker reads', () => {
     expect(snap.latency).toEqual([{ tool: 'Read', p50Ms: 100, p95Ms: 0, p99Ms: 0 }]);
   });
 
-  // Regression for : a `latency.percentile` rule asking for p99 must
+  // Regression guard: a `latency.percentile` rule asking for p99 must
   // see the p99 value even when p95 is missing.
   it('emits a latency entry when only p99 is available', () => {
     const deps: AlertSnapshotCollectorDeps = {

--- a/src/dashboard/dashboard-server.test.ts
+++ b/src/dashboard/dashboard-server.test.ts
@@ -147,7 +147,7 @@ describe('DashboardServer', () => {
     }
   });
 
-  // Regression for this. Before the fix, the start()-time `once('error', reject)`
+  // Regression guard. Before the fix, the start()-time `once('error', reject)`
   // listener stayed attached after the listen callback resolved. A later
   // runtime error called reject() on an already-resolved promise (a no-op)
   // and Node didn't re-emit because the once listener consumed the event —

--- a/src/dashboard/routes/sse-handler.test.ts
+++ b/src/dashboard/routes/sse-handler.test.ts
@@ -149,7 +149,7 @@ describe('sse-handler', () => {
     }
   });
 
-  // Regression for this. The SSE frame `id` field must use the bus's global
+  // Regression guard. The SSE frame `id` field must use the bus's global
   // sequence number, not a per-connection counter — otherwise reconnecting
   // clients send back the wrong Last-Event-ID and either miss real events
   // or replay pre-connection history.
@@ -195,7 +195,7 @@ describe('sse-handler', () => {
     }
   });
 
-  // Regression for this. After reconnect with Last-Event-ID set to a real
+  // Regression guard. After reconnect with Last-Event-ID set to a real
   // bus seq, the server must replay only events newer than that seq. With
   // the per-connection counter bug, this test would have replayed older
   // (pre-connection) events.
@@ -254,7 +254,7 @@ describe('sse-handler', () => {
     }
   });
 
-  // Regression for this. A client sending Last-Event-ID: -1 (or any negative
+  // Regression guard. A client sending Last-Event-ID: -1 (or any negative
   // number) must NOT trigger a replay. With the original bug, replaySeq would
   // be -1 (no replay) but nextLocalSeq became 0; the next reconnect with
   // Last-Event-ID: 0 then replayed the entire bus buffer.
@@ -348,7 +348,7 @@ describe('sse-handler', () => {
   // seq namespace. The browser sends them back as Last-Event-ID on reconnect;
   // parseInt("hb-...") → NaN → no replay. This guards against a heartbeat id
   // contaminating the seq numbering and triggering an unintended replay.
-  // Regression for this. Both `req.on('close')` and `res.on('close')` register
+  // Regression guard. Both `req.on('close')` and `res.on('close')` register
   // the same cleanup function — on a normal disconnect both fire. The
   // `cleaned` guard makes the second invocation a no-op so a future change
   // (e.g. wrapping cleanup in something that side-effects) can't introduce

--- a/src/dashboard/routes/static-handler.test.ts
+++ b/src/dashboard/routes/static-handler.test.ts
@@ -146,7 +146,7 @@ describe('static-handler', () => {
     expect(status()).toBe(403);
   });
 
-  // Regression for : vite.config.ts must use base:'/' so the built
+  // Regression guard: vite.config.ts must use base:'/' so the built
   // index.html references assets via absolute paths. With base:'./', a
   // direct refresh on /sessions resolves relative './assets/x.js' against
   // /sessions/ and returns 404. This test reads vite.config.ts source
@@ -169,7 +169,7 @@ describe('static-handler', () => {
     expect(codeOnly).not.toMatch(/^\s*base:\s*['"]\.\//m);
   });
 
-  // Regression for : when the SPA fallback serves index.html for an
+  // Regression guard: when the SPA fallback serves index.html for an
   // extensionless route like /sessions, the served HTML must reference
   // assets via absolute paths (/assets/...) so the browser doesn't
   // resolve them against /sessions/ and produce 404s. This guards


### PR DESCRIPTION
## Summary

Replaces 9 malformed comment fragments left by the label-cleanup pass in PR #14:
- `// Regression for this.` → `// Regression guard.`
- `// Regression for :` → `// Regression guard:`

"Regression guard" is the conventional term for a test that exists to prevent a known bug from recurring — clear and self-contained without needing a ticket reference.

## Files changed

- `src/alerts/alert-snapshot-collector.test.ts` (2)
- `src/dashboard/dashboard-server.test.ts` (1)
- `src/dashboard/routes/static-handler.test.ts` (2)
- `src/dashboard/routes/sse-handler.test.ts` (4)

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] Comment-only change — no behaviour affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)