### PR TITLE
Chore: v1.0.7 — uninstall reliability, doctor improvements, daemon stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2026-07-01
+
+### Added
+
+- **`preflight uninstall --yes`** — skips the interactive confirmation prompt for scripted and CI use
+- **`preflight uninstall --daemon`** — removes only the background dashboard daemon (plist + `launchctl unload`) without touching hooks, MCP config, schedule, or session history
+- `preflight uninstall` now prints a full summary of exactly what will change before prompting — which hooks files, MCP config files, schedule plist, and daemon plist will be touched, with exact paths
+
+### Changed
+
+- Background dashboard daemon installation during `preflight setup` is now **opt-in** (`[y/N]`) rather than opt-out (`[Y/n]`). The daemon is a persistent `launchd` service and should require explicit consent to install. Existing installations are unaffected — only new setups or re-runs of `preflight setup` are impacted.
+- `preflight doctor` now reports a missing daemon as a **warning** (exit code 2) rather than a **failure** (exit code 1). The daemon is optional; the MCP server functions fully without it. Scripts that previously tested `[ $? -eq 1 ]` to detect a missing daemon should be updated to check for exit code 2.
+
+### Fixed
+
+**`preflight uninstall`**
+
+- Exit code is now 1 when uninstall is cancelled (non-interactive stdin or user answers `n`) or when any removal step fails — previously the process could exit 0 despite making no changes
+- Non-interactive stdin (CI pipelines, `echo "" | preflight uninstall`) now cancels cleanly and exits 1 rather than hanging indefinitely waiting for confirmation input
+- When one removal step fails (e.g. a permissions error on the schedule plist), the remaining steps (hooks, MCP config) still complete in the same run — previously a single failure stopped all subsequent steps
+- The restart prompt (`"Restart Claude Code for changes to take effect"`) is now suppressed on a partial failure; the message distinguishes between a fully successful uninstall and an incomplete one
+- WSL installations now clean both the Linux-side and Windows-side settings files in a single `preflight uninstall` run, rather than silently skipping the Windows-side path
+- If a plist file cannot be deleted after the launchd job is removed (e.g. wrong permissions on the plist), the uninstall continues rather than getting stuck in a retry loop. The launchd job is already inactive at this point, so the orphaned file is harmless; its path is included in the warning log (`~/.newrelic-preflight/` or `launchctl` output) so it can be removed manually if desired.
+- When a plist file disappears between the status check and the removal call (race window during interactive confirmation), `preflight uninstall` now prints an "already absent" message rather than silently producing no output
+- Corrupt or unreadable settings files (`settings.json`, `.mcp.json`) are now diagnosed and reported rather than silently ignored
+- The saved platform target record is cleared after a fully successful config removal and retained when the uninstall is incomplete, ensuring retry attempts continue targeting the right settings paths
+
+**`preflight doctor`**
+
+- NR endpoint reachability check is now correctly skipped when `licenseKey` is not configured, with an explanation in the output — previously it attempted a network request and reported a connection failure that had nothing to do with the network
+- Storage path check now uses the env-var-resolved path (`NEW_RELIC_AI_MCP_STORAGE_PATH`) rather than the raw config file value, so it tests the same directory the running MCP server actually writes to
+- Hooks check handles partially unparseable settings files: hooks found in valid files are reported as passing, and malformed files are surfaced as a separate warning, rather than treating any parse error as proof that no hooks are installed
+- NR reachability check is now suppressed when no config file exists (first-time setup), preventing a spurious "NR unreachable" failure from appearing alongside the expected "no config file" warning
+- Unreadable plist files (e.g. wrong permissions) are now reported as "unreadable" rather than "not installed", giving a more accurate diagnosis and a correct fix command
+- XML entity sequences (e.g. `&amp;`, `&lt;`) in plist `PATH` values are now correctly decoded before checking for a node binary — paths with special characters were previously always reported as missing
+- Daemon node-path check now probes for an actual executable `node` binary in each plist `PATH` directory; a non-executable `node` file is called out separately with its own fix advice rather than being reported the same as a missing binary. Also checks for `nodejs` as an alternate binary name (used on Debian/Ubuntu)
+- Broken node symlinks in plist `PATH` dirs (dangling after a node upgrade) are now correctly identified as non-executable candidates rather than silently treated as missing entries
+
+**Setup and daemon**
+
+- Node binary path injected into daemon and schedule plists is now resolved by probing executables in `PATH` rather than using `dirname(process.execPath)`. Version managers (Homebrew, nvm, volta) place node at stable symlink directories that survive upgrades — the previous approach resolved to versioned Cellar paths that break after `brew upgrade node`. Re-run `preflight setup` to apply this to an existing installation.
+- Dashboard daemon plist now includes `ThrottleInterval: 300` to prevent rapid crash-restart loops from filling the daemon log
+- `preflight setup` no longer hangs when run in a non-interactive environment (e.g. piped stdin); it exits cleanly with an informational message
+
+---
+
 ## [1.0.6] - 2026-06-30
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -490,7 +490,7 @@ NEW_RELIC_API_KEY=NRAK-... NEW_RELIC_ACCOUNT_ID=12345 \
 To remove all hooks and start fresh:
 
 ```bash
-preflight uninstall
+preflight uninstall --yes   # --yes skips the confirmation prompt
 rm -rf ~/.newrelic-preflight
 
 # Cloud: remove dashboards and alerts from NR
@@ -508,6 +508,7 @@ Then restart Claude Code.
 
 | Symptom                                    | Likely cause                                      | Fix                                                               |
 | ------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------------- |
+| Anything unexpected                        | Config, hooks, connectivity, or daemon issue      | Run `preflight doctor` — prints six checks with actionable fixes  |
 | `preflight: command not found`             | `npm link` not run                                | Run `npm link` in the repo root                                   |
 | `nr_observe_health` returns tool-not-found | MCP server not started                            | Restart Claude Code; check MCP output panel                       |
 | No data in NR after 5 minutes              | Wrong license key or account ID                   | Re-run `preflight setup` with correct credentials                 |

--- a/README.md
+++ b/README.md
@@ -153,10 +153,12 @@ You'll need a **license key** (telemetry ingest) and your **account ID**, plus a
 ## Other Commands
 
 ```bash
-preflight doctor      # Run 6 diagnostic checks and print actionable fix commands
-preflight validate    # Check config for syntax errors and unknown keys
-preflight update      # Pull latest version and rebuild
-preflight uninstall   # Remove hooks and MCP config from your AI tool
+preflight doctor               # Run 6 diagnostic checks and print actionable fix commands
+preflight validate             # Check config for syntax errors and unknown keys
+preflight update               # Pull latest version and rebuild
+preflight uninstall            # Remove hooks and MCP config (prompts with a summary first)
+preflight uninstall --yes      # Skip the confirmation prompt (for scripts and CI)
+preflight uninstall --daemon   # Remove only the background dashboard daemon
 ```
 
 Add `--project` to `install`/`uninstall` to scope changes to the current directory only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1711,4 +1711,63 @@ describe('validateConfigFile()', () => {
     writeFileSync(resolve(tmpDir, 'empty.json'), '');
     expect(() => validateConfigFile(resolve(tmpDir, 'empty.json'))).not.toThrow();
   });
+
+  it('returns malformed:false and no mode for a missing file', () => {
+    const result = validateConfigFile(resolve(tmpDir, 'missing.json'));
+    expect(result.malformed).toBe(false);
+    expect(result.mode).toBeUndefined();
+  });
+
+  it('returns malformed:true for a file with invalid JSON', () => {
+    writeFileSync(resolve(tmpDir, 'badjson.json'), 'not json');
+    const result = validateConfigFile(resolve(tmpDir, 'badjson.json'));
+    expect(result.malformed).toBe(true);
+    expect(result.mode).toBeUndefined();
+  });
+
+  it('returns malformed:true for a non-object JSON value', () => {
+    writeFileSync(resolve(tmpDir, 'array.json'), '[1,2]');
+    const result = validateConfigFile(resolve(tmpDir, 'array.json'));
+    expect(result.malformed).toBe(true);
+  });
+
+  it('returns malformed:false and mode from a parseable config', () => {
+    writeFileSync(resolve(tmpDir, 'withmode.json'), JSON.stringify({ mode: 'local' }));
+    const result = validateConfigFile(resolve(tmpDir, 'withmode.json'));
+    expect(result.malformed).toBe(false);
+    expect(result.mode).toBe('local');
+  });
+
+  it('returns malformed:false and mode:undefined when mode key is absent', () => {
+    writeFileSync(resolve(tmpDir, 'nomode.json'), JSON.stringify({ licenseKey: 'abc' }));
+    const result = validateConfigFile(resolve(tmpDir, 'nomode.json'));
+    expect(result.malformed).toBe(false);
+    expect(result.mode).toBeUndefined();
+  });
+
+  it('returns malformed:false and mode even when Zod reports errors', () => {
+    writeFileSync(
+      resolve(tmpDir, 'badfield.json'),
+      JSON.stringify({ mode: 'cloud', enabled: 'yes' }),
+    );
+    const result = validateConfigFile(resolve(tmpDir, 'badfield.json'));
+    expect(result.malformed).toBe(false);
+    expect(result.mode).toBe('cloud');
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('returns storagePath from the parsed config when present', () => {
+    writeFileSync(
+      resolve(tmpDir, 'withstorage.json'),
+      JSON.stringify({ storagePath: '/custom/storage' }),
+    );
+    const result = validateConfigFile(resolve(tmpDir, 'withstorage.json'));
+    expect(result.storagePath).toBe('/custom/storage');
+  });
+
+  it('returns storagePath:undefined when storagePath is absent', () => {
+    writeFileSync(resolve(tmpDir, 'nostorage.json'), JSON.stringify({ mode: 'local' }));
+    const result = validateConfigFile(resolve(tmpDir, 'nostorage.json'));
+    expect(result.storagePath).toBeUndefined();
+  });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -964,6 +964,14 @@ export function loadMcpConfig(cliOptions?: Partial<CliOptions>): Readonly<McpSer
 export interface ConfigValidationResult {
   readonly filePath: string;
   readonly fileExists: boolean;
+  /** True when the file existed but could not be read or parsed as a JSON object. */
+  readonly malformed: boolean;
+  /** The `mode` field from the parsed config, if the file was parseable. */
+  readonly mode?: string;
+  /** The `storagePath` field from the parsed config, if present and a string. */
+  readonly storagePath?: string;
+  /** True when a non-blank licenseKey is present in the parsed config. Raw value is intentionally not exposed. */
+  readonly hasLicenseKey: boolean;
   /** Fatal problems that will prevent the MCP server from starting. */
   readonly errors: readonly string[];
   /** Non-fatal problems that may cause settings to be silently ignored. */
@@ -980,7 +988,14 @@ export function validateConfigFile(filePath: string): ConfigValidationResult {
   const warnings: string[] = [];
 
   if (!existsSync(filePath)) {
-    return { filePath, fileExists: false, errors, warnings };
+    return {
+      filePath,
+      fileExists: false,
+      malformed: false,
+      hasLicenseKey: false,
+      errors,
+      warnings,
+    };
   }
 
   // Read and parse the file
@@ -989,19 +1004,19 @@ export function validateConfigFile(filePath: string): ConfigValidationResult {
     raw = readFileSync(filePath, 'utf-8');
   } catch (err) {
     errors.push(`Could not read file: ${err instanceof Error ? err.message : String(err)}`);
-    return { filePath, fileExists: true, errors, warnings };
+    return { filePath, fileExists: true, malformed: true, hasLicenseKey: false, errors, warnings };
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
     errors.push(`Invalid JSON: ${err instanceof Error ? err.message : String(err)}`);
-    return { filePath, fileExists: true, errors, warnings };
+    return { filePath, fileExists: true, malformed: true, hasLicenseKey: false, errors, warnings };
   }
 
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     errors.push('Config must be a JSON object, not an array or primitive value');
-    return { filePath, fileExists: true, errors, warnings };
+    return { filePath, fileExists: true, malformed: true, hasLicenseKey: false, errors, warnings };
   }
 
   // Zod type/value errors
@@ -1078,7 +1093,16 @@ export function validateConfigFile(filePath: string): ConfigValidationResult {
     }
   }
 
-  return { filePath, fileExists: true, errors, warnings };
+  return {
+    filePath,
+    fileExists: true,
+    malformed: false,
+    mode: typeof file.mode === 'string' ? file.mode : undefined,
+    storagePath: typeof file.storagePath === 'string' ? file.storagePath : undefined,
+    hasLicenseKey: typeof file.licenseKey === 'string' && file.licenseKey.trim().length > 0,
+    errors,
+    warnings,
+  };
 }
 
 /** Return a suggestion from known keys if the unknown key is a case-insensitive

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1293,6 +1293,9 @@ export function createApiHandler(
     const { runDiagnostics } = await import('../../install/diagnostics.js');
     const checks = await runDiagnostics({
       configPath: deps.configFilePath ?? undefined,
+      // Pass the runtime-resolved storagePath so env-var overrides are
+      // captured. diagnostics.ts prioritises this value over the file-validated
+      // storagePath, so the same path the MCP server writes to is always checked.
       storagePath: deps.config?.storagePath,
     });
     jsonOk(res, checks);

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -2,6 +2,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import * as fsMod from 'node:fs';
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
 import type { DiagnosticCheck } from './diagnostics.js';
 import * as diagnostics from './diagnostics.js';
 
@@ -24,11 +25,11 @@ jest.mock('./diagnostics.js', () => ({
 }));
 jest.mock('./schedule.js', () => ({
   installSchedule: jest.fn(),
-  removeSchedule: jest.fn(),
-  getScheduleStatus: jest.fn(() => ({ installed: false })),
+  removeSchedule: jest.fn(() => false),
+  getScheduleStatus: jest.fn(() => ({ installed: false, readable: false })),
   installDashboardDaemon: jest.fn(),
-  removeDashboardDaemon: jest.fn(),
-  getDashboardDaemonStatus: jest.fn(() => ({ installed: false })),
+  removeDashboardDaemon: jest.fn(() => false),
+  getDashboardDaemonStatus: jest.fn(() => ({ installed: false, readable: false })),
   resolveBinaryPath: jest.fn(() => '/usr/local/bin/preflight'),
 }));
 jest.mock('./install-helper.js', () => ({
@@ -43,6 +44,12 @@ jest.mock('./install-helper.js', () => ({
 jest.mock('./platform.js', () => ({
   isWsl: jest.fn(() => false),
   resolveWindowsHome: jest.fn(() => null),
+}));
+jest.mock('node:readline/promises', () => ({
+  createInterface: jest.fn(() => ({
+    question: jest.fn(async () => 'y'),
+    close: jest.fn(),
+  })),
 }));
 
 import * as scheduleMod from './schedule.js';
@@ -94,7 +101,7 @@ describe('schedule subcommand', () => {
   });
 
   it('prints status when no flags given and no schedule installed', async () => {
-    mockedSchedule.getScheduleStatus.mockReturnValue({ installed: false });
+    mockedSchedule.getScheduleStatus.mockReturnValue({ installed: false, readable: false });
     await runInstallCli(['schedule']);
     const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(output).toContain('No auto-update schedule installed');
@@ -103,6 +110,7 @@ describe('schedule subcommand', () => {
   it('prints schedule time when already installed', async () => {
     mockedSchedule.getScheduleStatus.mockReturnValue({
       installed: true,
+      readable: true,
       hour: 9,
       minute: 30,
       binaryPath: '/usr/local/bin/preflight',
@@ -110,6 +118,14 @@ describe('schedule subcommand', () => {
     await runInstallCli(['schedule']);
     const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(output).toContain('09:30');
+  });
+
+  it('prints unreadable-plist message when schedule installed but plist unreadable', async () => {
+    mockedSchedule.getScheduleStatus.mockReturnValue({ installed: true, readable: false });
+    await runInstallCli(['schedule']);
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('plist unreadable');
+    expect(output).toContain('reinstall');
   });
 
   it('installs schedule with --time 08:00', async () => {
@@ -150,7 +166,7 @@ describe('schedule subcommand', () => {
   });
 
   it('prints confirmation when --disable and schedule was installed', async () => {
-    mockedSchedule.getScheduleStatus.mockReturnValue({ installed: true });
+    mockedSchedule.removeSchedule.mockReturnValue(true);
     await runInstallCli(['schedule', '--disable']);
     const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(output).toContain('Auto-update schedule removed');
@@ -166,26 +182,171 @@ describe('schedule subcommand', () => {
 
 describe('uninstall calls removeSchedule', () => {
   let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: string | number | null | undefined) => {
+        throw new Error(`process.exit(${String(code)})`);
+      });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
   });
 
   afterEach(() => {
     stdoutSpy.mockRestore();
+    exitSpy.mockRestore();
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true });
+    process.exitCode = undefined;
   });
 
   it('calls removeSchedule during uninstall', async () => {
+    mockedSchedule.getScheduleStatus.mockReturnValue({ installed: true, readable: true });
+    mockedSchedule.removeSchedule.mockReturnValue(true);
     await runInstallCli(['uninstall']);
     expect(mockedSchedule.removeSchedule).toHaveBeenCalled();
   });
 
   it('prints removal confirmation when plist existed', async () => {
-    mockedSchedule.getScheduleStatus.mockReturnValue({ installed: true });
+    mockedSchedule.getScheduleStatus.mockReturnValue({ installed: true, readable: true });
+    mockedSchedule.removeSchedule.mockReturnValue(true);
     await runInstallCli(['uninstall']);
     const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(output).toContain('Auto-update schedule removed');
+  });
+
+  it('--yes skips the readline confirmation prompt', async () => {
+    // Must have something to remove so the confirmation block is reached.
+    mockedSchedule.getScheduleStatus.mockReturnValue({
+      installed: true,
+      readable: true,
+      hour: 8,
+      minute: 0,
+    });
+    mockedSchedule.removeSchedule.mockReturnValue(true);
+    const rlMod = await import('node:readline/promises');
+    const createInterfaceMock = rlMod.createInterface as jest.Mock;
+    createInterfaceMock.mockClear();
+    await runInstallCli(['uninstall', '--yes']);
+    expect(createInterfaceMock).not.toHaveBeenCalled();
+  });
+
+  it('cancels without readline when stdin is not a TTY', async () => {
+    const rlMod = await import('node:readline/promises');
+    const createInterfaceMock = rlMod.createInterface as jest.Mock;
+    createInterfaceMock.mockClear();
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    try {
+      await runInstallCli(['uninstall']);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+    }
+    expect(createInterfaceMock).not.toHaveBeenCalled();
+    expect(stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('')).toContain(
+      'non-interactive stdin',
+    );
+  });
+
+  it('cancels without readline when isTTY is undefined (indeterminate state)', async () => {
+    const rlMod = await import('node:readline/promises');
+    const createInterfaceMock = rlMod.createInterface as jest.Mock;
+    createInterfaceMock.mockClear();
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true });
+    try {
+      await runInstallCli(['uninstall']);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+    }
+    expect(createInterfaceMock).not.toHaveBeenCalled();
+    expect(stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('')).toContain(
+      'non-interactive stdin',
+    );
+  });
+
+  it('user answers n at confirmation prompt → prints Uninstall cancelled with exitCode 1', async () => {
+    // Need something installed so changeSummary is non-empty and the prompt is reached.
+    mockedSchedule.getScheduleStatus.mockReturnValue({ installed: true, readable: true });
+    const rlMod = await import('node:readline/promises');
+    const createInterfaceMock = rlMod.createInterface as jest.Mock;
+    // Use mockImplementationOnce so this override doesn't bleed into later describe blocks.
+    createInterfaceMock.mockImplementationOnce(() => ({
+      question: jest.fn(async () => 'n'),
+      close: jest.fn(),
+    }));
+
+    await runInstallCli(['uninstall']);
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Uninstall cancelled.');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('uninstall --daemon removes daemon plist and prints completion message', async () => {
+    const mockedRemoveDaemon = (scheduleMod as unknown as { removeDashboardDaemon: jest.Mock })
+      .removeDashboardDaemon;
+    mockedRemoveDaemon.mockReturnValue(true);
+    const mockedGetDaemonStatus = (
+      scheduleMod as unknown as { getDashboardDaemonStatus: jest.Mock }
+    ).getDashboardDaemonStatus;
+    mockedGetDaemonStatus.mockReturnValue({ installed: true, readable: true });
+    // Default readline mock returns 'y' — confirmation proceeds automatically.
+
+    await runInstallCli(['uninstall', '--daemon']);
+
+    expect(mockedRemoveDaemon).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Background dashboard daemon removed');
+    expect(output).toContain('dashboard is now only available while Claude Code is running');
+  });
+
+  it('uninstall --daemon --yes skips confirmation prompt', async () => {
+    const mockedRemoveDaemon = (scheduleMod as unknown as { removeDashboardDaemon: jest.Mock })
+      .removeDashboardDaemon;
+    mockedRemoveDaemon.mockReturnValue(true);
+    const mockedGetDaemonStatus = (
+      scheduleMod as unknown as { getDashboardDaemonStatus: jest.Mock }
+    ).getDashboardDaemonStatus;
+    mockedGetDaemonStatus.mockReturnValue({ installed: true, readable: true });
+    const rlMod = await import('node:readline/promises');
+    const createInterfaceMock = rlMod.createInterface as jest.Mock;
+    createInterfaceMock.mockClear();
+
+    await runInstallCli(['uninstall', '--daemon', '--yes']);
+
+    expect(createInterfaceMock).not.toHaveBeenCalled();
+    expect(mockedRemoveDaemon).toHaveBeenCalled();
+  });
+
+  it('uninstall --daemon when plist absent during removal prints already-absent message and exits 1', async () => {
+    // TOCTOU: daemon installed at status-check time, plist vanishes before removal call.
+    const mockedGetDaemonStatus = (
+      scheduleMod as unknown as { getDashboardDaemonStatus: jest.Mock }
+    ).getDashboardDaemonStatus;
+    mockedGetDaemonStatus.mockReturnValue({ installed: true, readable: true });
+    const mockedRemoveDaemon = (scheduleMod as unknown as { removeDashboardDaemon: jest.Mock })
+      .removeDashboardDaemon;
+    mockedRemoveDaemon.mockReturnValue(false);
+
+    await runInstallCli(['uninstall', '--daemon']);
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Background dashboard daemon already absent');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('uninstall --daemon combined with --project exits 1 with flag conflict message', async () => {
+    await expect(runInstallCli(['uninstall', '--daemon', '--project'])).rejects.toThrow(
+      'process.exit(1)',
+    );
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('--daemon cannot be combined');
   });
 });
 
@@ -298,6 +459,7 @@ describe('platform resolution via uninstall', () => {
   afterEach(() => {
     stdoutSpy.mockRestore();
     exitSpy.mockRestore();
+    process.exitCode = undefined;
   });
 
   it('--windows-cc outside WSL exits 1', async () => {
@@ -361,15 +523,29 @@ describe('platform transition matrix', () => {
         throw new Error(`process.exit(${String(code)})`);
       });
     mockedSchedule.resolveBinaryPath.mockReturnValue('/usr/local/bin/preflight');
+    mockedSchedule.getScheduleStatus.mockReturnValue({ installed: false, readable: false });
+    mockedSchedule.removeSchedule.mockReturnValue(false);
+    // Re-arm daemon mocks — clearAllMocks() clears call records but not mockReturnValue
+    // overrides, so tests that set installed:true would bleed into later tests and trigger
+    // the TOCTOU throw path in handleUninstall, causing anyFailed=true.
+    (
+      scheduleMod as unknown as { getDashboardDaemonStatus: jest.Mock }
+    ).getDashboardDaemonStatus.mockReturnValue({ installed: false, readable: false });
+    (
+      scheduleMod as unknown as { removeDashboardDaemon: jest.Mock }
+    ).removeDashboardDaemon.mockReturnValue(false);
     mockedHelper.detectSettingsPath.mockReturnValue(`${homedir()}/.claude/settings.json`);
     mockedHelper.detectMcpConfigPath.mockReturnValue(`${homedir()}/.mcp.json`);
     mockedPlatform.isWsl.mockReturnValue(true);
     mockedPlatform.resolveWindowsHome.mockReturnValue(WINDOWS_HOME);
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
   });
 
   afterEach(() => {
     stdoutSpy.mockRestore();
     exitSpy.mockRestore();
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true });
+    process.exitCode = undefined;
   });
 
   // After bare uninstall of a wsl-linux-cc user, the Windows settings.json still exists
@@ -417,9 +593,11 @@ describe('platform transition matrix', () => {
       wh ? `${String(wh)}/.mcp.json` : `${homedir()}/.mcp.json`,
     );
     mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
-    // Simulate that config.json exists (written by the prior --windows-cc install).
+    // Simulate that config.json and the Windows-side settings file exist.
     mFs.existsSync.mockImplementation(
-      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+      (p: unknown) =>
+        String(p) === join(homedir(), '.newrelic-preflight', 'config.json') ||
+        String(p) === join(WINDOWS_HOME, '.claude', 'settings.json'),
     );
 
     await runInstallCli(['uninstall', '--windows-cc']);
@@ -443,7 +621,9 @@ describe('platform transition matrix', () => {
     );
     mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-windows-cc' }));
     mFs.existsSync.mockImplementation(
-      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+      (p: unknown) =>
+        String(p) === join(homedir(), '.newrelic-preflight', 'config.json') ||
+        String(p) === join(WINDOWS_HOME, '.claude', 'settings.json'),
     );
 
     await runInstallCli(['uninstall']);
@@ -531,7 +711,9 @@ describe('platform transition matrix', () => {
     mockedPlatform.resolveWindowsHome.mockReturnValue(null);
     mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'native' }));
     mFs.existsSync.mockImplementation(
-      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+      (p: unknown) =>
+        String(p) === join(homedir(), '.newrelic-preflight', 'config.json') ||
+        String(p) === `${homedir()}/.claude/settings.json`,
     );
 
     await runInstallCli(['uninstall']);
@@ -642,7 +824,9 @@ describe('platform transition matrix', () => {
   it('bare uninstall with savedPlatform wsl-linux-cc clears platformTarget and targets Windows paths', async () => {
     mFs.readFileSync.mockReturnValue(JSON.stringify({ platformTarget: 'wsl-linux-cc' }));
     mFs.existsSync.mockImplementation(
-      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+      (p: unknown) =>
+        String(p) === join(homedir(), '.newrelic-preflight', 'config.json') ||
+        String(p) === `${homedir()}/.claude/settings.json`,
     );
     mockedHelper.detectSettingsPath.mockImplementation((_scope: unknown, wh: unknown) =>
       wh ? `${String(wh)}/.claude/settings.json` : `${homedir()}/.claude/settings.json`,
@@ -674,7 +858,9 @@ describe('platform transition matrix', () => {
       }),
     );
     mFs.existsSync.mockImplementation(
-      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+      (p: unknown) =>
+        String(p) === join(homedir(), '.newrelic-preflight', 'config.json') ||
+        String(p) === `${homedir()}/.claude/settings.json`,
     );
 
     await runInstallCli(['uninstall']);
@@ -690,7 +876,9 @@ describe('platform transition matrix', () => {
   it('bare uninstall with no savedPlatform (pre-1.0.4) clears config and cleans both paths', async () => {
     mFs.readFileSync.mockReturnValue('{}'); // no platformTarget
     mFs.existsSync.mockImplementation(
-      (p: unknown) => String(p) === join(homedir(), '.newrelic-preflight', 'config.json'),
+      (p: unknown) =>
+        String(p) === join(homedir(), '.newrelic-preflight', 'config.json') ||
+        String(p) === join(WINDOWS_HOME, '.claude', 'settings.json'),
     );
     mockedHelper.detectSettingsPath.mockImplementation((_scope: unknown, wh: unknown) =>
       wh ? `${String(wh)}/.claude/settings.json` : `${homedir()}/.claude/settings.json`,
@@ -790,6 +978,22 @@ describe('platform transition matrix', () => {
       fsMod as unknown as { writeFileSync: jest.Mock }
     ).writeFileSync.mock.calls.filter((c: unknown[]) => String(c[0]).endsWith('config.json.tmp'));
     expect(configWrites).toHaveLength(0);
+  });
+
+  it('bare uninstall on a clean machine prints "Nothing installed" and returns early', async () => {
+    // Default mock: existsSync returns false for everything — no files on disk.
+    mFs.readFileSync.mockReturnValue('{}');
+    // Explicitly reset schedule/daemon mocks — clearAllMocks() doesn't reset mockReturnValue,
+    // so a leaked installed:true from a prior describe would make changeSummary non-empty.
+    mockedSchedule.getScheduleStatus.mockReturnValue({ installed: false, readable: false });
+    (
+      scheduleMod as unknown as { getDashboardDaemonStatus: jest.Mock }
+    ).getDashboardDaemonStatus.mockReturnValue({ installed: false, readable: false });
+
+    await runInstallCli(['uninstall']);
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Nothing installed — no changes to make.');
   });
 
   // When the platformTarget write fails and no credentials were provided (the common
@@ -1074,5 +1278,20 @@ describe('preflight doctor', () => {
     const prog = createInstallProgram();
     await prog.parseAsync(['node', 'preflight', 'doctor']);
     expect(output.join('')).toContain('-');
+  });
+
+  it('sets exit code 2 (not 1) when daemon is not installed', async () => {
+    mockedRunDiagnostics.mockResolvedValue([
+      makeCheck({
+        check: 'Daemon installed',
+        status: 'warn',
+        detail: 'com.preflight.dashboard.plist not found',
+        fix: 'preflight setup',
+      }),
+    ]);
+    const { createInstallProgram } = await import('./cli.js');
+    const prog = createInstallProgram();
+    await prog.parseAsync(['node', 'preflight', 'doctor']);
+    expect(process.exitCode).toBe(2);
   });
 });

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -5,12 +5,14 @@
  * so commander and other heavy deps are never loaded on the hot hook path.
  */
 
-import { execSync, execFileSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, copyFileSync, realpathSync } from 'node:fs';
+import { createInterface } from 'node:readline/promises';
 import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { Command } from 'commander';
 
+import { createLogger } from '../shared/index.js';
 import {
   mergeSettings,
   removeSettings,
@@ -32,7 +34,9 @@ import {
   getDashboardDaemonStatus,
   resolveBinaryPath,
 } from './schedule.js';
-import { readJsonFile, readJsonFileStrict, writeJsonFile } from './json-utils.js';
+import { readJsonFileStrict, writeJsonFile, errMsg } from './json-utils.js';
+
+const logger = createLogger('cli');
 
 const NR_CONFIG_PATH = resolve(DEFAULT_STORAGE_PATH, 'config.json');
 
@@ -51,9 +55,7 @@ function clearSavedPlatform(): void {
     const { platformTarget: _pt, ...rest } = readJsonFileStrict(NR_CONFIG_PATH);
     writeJsonFile(NR_CONFIG_PATH, rest, DEFAULT_STORAGE_PATH);
   } catch (err) {
-    eprint(
-      `\n⚠ Could not clear saved platform target: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    eprint(`\n⚠ Could not clear saved platform target: ${errMsg(err)}`);
     eprint(
       '  The next install may use the stale platform target. Fix the issue and re-run uninstall.',
     );
@@ -156,12 +158,7 @@ function eprint(msg = ''): void {
 // ---------------------------------------------------------------------------
 
 export function verifyBinaryOnPath(): boolean {
-  try {
-    execSync('which preflight', { stdio: 'pipe' });
-    return true;
-  } catch {
-    return false;
-  }
+  return resolveBinaryPath() !== null;
 }
 
 function printPathWarning(): void {
@@ -231,9 +228,13 @@ function handleSchedule(options: { time?: string; disable?: boolean }): void {
   }
 
   if (options.disable) {
-    const wasInstalled = getScheduleStatus().installed;
-    removeSchedule();
-    print(wasInstalled ? '✓ Auto-update schedule removed.' : 'No schedule was installed.');
+    try {
+      const removed = removeSchedule();
+      print(removed ? '✓ Auto-update schedule removed.' : 'No schedule was installed.');
+    } catch (err) {
+      eprint(`⚠ Could not remove schedule: ${errMsg(err)}`);
+      process.exitCode = 1;
+    }
     return;
   }
 
@@ -265,10 +266,16 @@ function handleSchedule(options: { time?: string; disable?: boolean }): void {
   // No flags — show status.
   const status = getScheduleStatus();
   if (status.installed) {
-    const hh = String(status.hour ?? 0).padStart(2, '0');
-    const mm = String(status.minute ?? 0).padStart(2, '0');
-    print(`Auto-update schedule: ${hh}:${mm} daily`);
-    print(`  Binary: ${status.binaryPath ?? 'unknown'}`);
+    if (status.readable === false) {
+      print(
+        'Auto-update schedule: installed (plist unreadable — reinstall with: preflight schedule --time HH:MM)',
+      );
+    } else {
+      const hh = String(status.hour ?? 0).padStart(2, '0');
+      const mm = String(status.minute ?? 0).padStart(2, '0');
+      print(`Auto-update schedule: ${hh}:${mm} daily`);
+      print(`  Binary: ${status.binaryPath ?? 'unknown'}`);
+    }
     print('  To change: preflight schedule --time HH:MM');
     print('  To remove: preflight schedule --disable');
   } else {
@@ -310,9 +317,7 @@ function handleInstall(options: {
   } catch (err) {
     const isSyntaxError = err instanceof SyntaxError;
     if (isSyntaxError || (inWsl && !explicitPlatform) || credentialsProvided) {
-      eprint(
-        `\n✗ Cannot read existing NR config to determine install target: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      eprint(`\n✗ Cannot read existing NR config to determine install target: ${errMsg(err)}`);
       eprint(
         isSyntaxError
           ? '  config.json contains invalid JSON — fix or delete it, then re-run install.'
@@ -320,9 +325,7 @@ function handleInstall(options: {
       );
       throw err;
     }
-    eprint(
-      `\n⚠ Could not read existing NR config to persist platform target: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    eprint(`\n⚠ Could not read existing NR config to persist platform target: ${errMsg(err)}`);
     eprint('  Platform target not persisted — hook installation will continue. Re-run to save it.');
     skipNrConfigWrite = true;
   }
@@ -337,24 +340,20 @@ function handleInstall(options: {
     mergedSettings = mergeSettings(readJsonFileStrict(settingsPath), binPath, { platform });
     mergedMcp = mergeMcpConfig(readJsonFileStrict(mcpPath), binPath, { platform });
   } catch (err) {
-    eprint(`\n✗ Failed to prepare config: ${err instanceof Error ? err.message : String(err)}`);
+    eprint(`\n✗ Failed to prepare config: ${errMsg(err)}`);
     throw err;
   }
 
   try {
     writeJsonFile(settingsPath, mergedSettings, allowedBase);
   } catch (err) {
-    eprint(
-      `\n✗ Failed to write hooks config (${settingsPath}): ${err instanceof Error ? err.message : String(err)}`,
-    );
+    eprint(`\n✗ Failed to write hooks config (${settingsPath}): ${errMsg(err)}`);
     throw err;
   }
   try {
     writeJsonFile(mcpPath, mergedMcp, allowedBase);
   } catch (err) {
-    eprint(
-      `\n✗ Failed to write MCP config (${mcpPath}): ${err instanceof Error ? err.message : String(err)}`,
-    );
+    eprint(`\n✗ Failed to write MCP config (${mcpPath}): ${errMsg(err)}`);
     throw err;
   }
 
@@ -373,14 +372,10 @@ function handleInstall(options: {
       nrConfigWritten = credentialsProvided;
     } catch (err) {
       if (credentialsProvided) {
-        eprint(
-          `\n✗ Failed to save New Relic config: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        eprint(`\n✗ Failed to save New Relic config: ${errMsg(err)}`);
         throw err;
       }
-      eprint(
-        `\n⚠ Could not persist platform target: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      eprint(`\n⚠ Could not persist platform target: ${errMsg(err)}`);
       eprint('  The next install will re-detect the target platform from scratch.');
     }
   }
@@ -426,14 +421,20 @@ function handleInstall(options: {
 }
 
 // ---------------------------------------------------------------------------
-// Uninstall handler
+// Uninstall helpers
 // ---------------------------------------------------------------------------
 
-function handleUninstall(options: {
+// Resolves which settings and MCP config paths to clean based on platform
+// flags and the saved install target. Calls process.exit(1) on invalid
+// flag combinations or unresolvable state.
+function resolveUninstallPaths(options: {
   project?: boolean;
   windowsCc?: boolean;
   linuxCc?: boolean;
-}): void {
+}): {
+  settingsPathsToClean: Map<string, string | undefined>;
+  mcpPathsToClean: Map<string, string | undefined>;
+} {
   const scope = options.project ? 'project' : 'user';
 
   if (options.windowsCc && options.linuxCc) {
@@ -537,76 +538,303 @@ function handleUninstall(options: {
     mcpPathsToClean.set(detectMcpConfigPath(scope, null), undefined);
   }
 
-  print('');
+  return { settingsPathsToClean, mcpPathsToClean };
+}
 
-  let settingsFound = false;
+// One removal operation's outcome. Every uninstall step produces exactly one of
+// these; the messaging block at the end reasons over the collection rather than
+// a set of ad-hoc boolean flags.
+type RemovalResult = {
+  readonly label: string;
+  readonly removed: boolean;
+  readonly error: Error | null;
+  // True when Claude Code must restart to pick up the change (hooks / MCP config).
+  // False for schedule / daemon — launchd applies those immediately.
+  readonly requiresRestart: boolean;
+};
+
+// Backs up a config file then writes the transformed result. Returns whether
+// the write succeeded and any error encountered — never throws.
+function backupAndWrite(
+  path: string,
+  allowedBase: string | undefined,
+  transform: (data: Record<string, unknown>) => Record<string, unknown>,
+  errorLabel: string,
+): { written: boolean; error: Error | null } {
+  const backup = `${path}.backup-${Date.now()}`;
+  try {
+    const data = readJsonFileStrict(path);
+    copyFileSync(path, backup);
+    print(`  Backup saved: ${backup}`);
+    writeJsonFile(path, transform(data), allowedBase);
+    return { written: true, error: null };
+  } catch (err) {
+    // If copyFileSync and writeJsonFile both succeeded the backup is no longer
+    // needed (the write path handles it). If copyFileSync succeeded but
+    // writeJsonFile failed, the backup is the user's only recovery copy —
+    // preserve it. If readJsonFileStrict failed, no backup was created and the
+    // original is untouched, so there is nothing to recover.
+    const error = err instanceof Error ? err : new Error(String(err));
+    eprint(`\n✗ Failed to clean ${errorLabel} (${path}): ${errMsg(err)}`);
+    process.exitCode = 1;
+    return { written: false, error };
+  }
+}
+
+// Removes preflight hooks and MCP config entries from the given paths.
+// Returns a RemovalResult — never throws. Partial completion is possible:
+// removed=true even when error is non-null if at least one file succeeded.
+function removeClaudeCodeConfig(
+  settingsPathsToClean: Map<string, string | undefined>,
+  mcpPathsToClean: Map<string, string | undefined>,
+): RemovalResult {
+  let removed = false;
+  let firstError: Error | null = null;
+
+  let hadSettingsFile = false;
   for (const [settingsPath, allowedBase] of settingsPathsToClean) {
-    if (existsSync(settingsPath)) {
-      const backup = `${settingsPath}.backup-${Date.now()}`;
-      copyFileSync(settingsPath, backup);
-      print(`  Backup saved: ${backup}`);
-      try {
-        writeJsonFile(settingsPath, removeSettings(readJsonFileStrict(settingsPath)), allowedBase);
-      } catch (err) {
-        eprint(
-          `\n✗ Failed to clean hooks config (${settingsPath}): ${err instanceof Error ? err.message : String(err)}`,
-        );
-        throw err;
-      }
-      settingsFound = true;
+    if (!existsSync(settingsPath)) continue;
+    hadSettingsFile = true;
+    const { written, error } = backupAndWrite(
+      settingsPath,
+      allowedBase,
+      removeSettings,
+      'hooks config',
+    );
+    if (written) {
+      removed = true;
       print(`✓ Hooks removed: ${settingsPath}`);
+    } else {
+      firstError ??= error;
     }
   }
-  if (!settingsFound) {
+  if (!hadSettingsFile) {
     print(
       `No settings file found at ${[...settingsPathsToClean.keys()].join(', ')}. Skipping hooks.`,
     );
   }
 
-  let mcpFound = false;
+  let hadMcpFile = false;
   for (const [mcpPath, allowedBase] of mcpPathsToClean) {
-    if (existsSync(mcpPath)) {
-      const backup = `${mcpPath}.backup-${Date.now()}`;
-      copyFileSync(mcpPath, backup);
-      print(`  Backup saved: ${backup}`);
-      try {
-        writeJsonFile(mcpPath, removeMcpConfig(readJsonFileStrict(mcpPath)), allowedBase);
-      } catch (err) {
-        eprint(
-          `\n✗ Failed to clean MCP config (${mcpPath}): ${err instanceof Error ? err.message : String(err)}`,
-        );
-        throw err;
-      }
-      mcpFound = true;
+    if (!existsSync(mcpPath)) continue;
+    hadMcpFile = true;
+    const { written, error } = backupAndWrite(mcpPath, allowedBase, removeMcpConfig, 'MCP config');
+    if (written) {
+      removed = true;
       print(`✓ MCP server removed: ${mcpPath}`);
+    } else {
+      firstError ??= error;
     }
   }
-  if (!mcpFound) {
+  if (!hadMcpFile) {
     print(`No MCP config found at ${[...mcpPathsToClean.keys()].join(', ')}. Skipping MCP server.`);
   }
 
-  // Update persisted platform after cleanup.
-  // --windows-cc or bare: clear savedPlatform so the next install re-detects from scratch.
-  //   After --windows-cc uninstall, the user must pass --windows-cc again to reinstall
-  //   Windows CC mode — re-detection has no heuristic for Windows CC intent.
-  // --linux-cc: leave savedPlatform untouched — this only cleans Linux-side paths and must
-  //   not destroy a wsl-windows-cc record that the user still intends to use.
+  return { label: 'Claude Code config', removed, error: firstError, requiresRestart: true };
+}
+
+// Runs a single uninstall step. Returns a RemovalResult — never throws.
+// process.exitCode is set to 1 and a warning is printed on error.
+function runStep(label: string, requiresRestart: boolean, fn: () => boolean): RemovalResult {
+  try {
+    const removed = fn();
+    return { label, removed, error: null, requiresRestart };
+  } catch (err) {
+    process.exitCode = 1;
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.warn('uninstall step failed', { label, error });
+    eprint(`⚠ Could not remove ${label}: ${error.message}`);
+    return { label, removed: false, error, requiresRestart };
+  }
+}
+
+// Prompts the user for uninstall confirmation. Returns one of four outcomes.
+async function promptConfirm(
+  yes: boolean,
+): Promise<'confirmed' | 'declined' | 'non-interactive' | 'stdin-closed'> {
+  if (yes) return 'confirmed';
+  if (process.stdin.isTTY !== true) return 'non-interactive';
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question('Continue? [y/N]: ')).trim().toLowerCase();
+    return answer === 'y' || answer === 'yes' ? 'confirmed' : 'declined';
+  } catch {
+    return 'stdin-closed';
+  } finally {
+    rl.close();
+  }
+}
+
+// Handles a promptConfirm result: prints cancellation message and sets
+// exitCode=1 on any non-confirmed outcome. Returns true only when confirmed.
+function handleConfirm(
+  result: 'confirmed' | 'declined' | 'non-interactive' | 'stdin-closed',
+): boolean {
+  if (result === 'confirmed') return true;
+  const message =
+    result === 'non-interactive'
+      ? 'Uninstall cancelled (non-interactive stdin — rerun with --yes to confirm).'
+      : result === 'stdin-closed'
+        ? 'Uninstall cancelled (stdin closed).'
+        : 'Uninstall cancelled.';
+  print(message);
+  process.exitCode = 1;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall handler
+// ---------------------------------------------------------------------------
+
+async function handleUninstall(options: {
+  project?: boolean;
+  windowsCc?: boolean;
+  linuxCc?: boolean;
+  daemon?: boolean;
+  yes?: boolean;
+}): Promise<void> {
+  // --daemon: targeted removal of just the background dashboard daemon plist.
+  // Does not touch hooks, MCP config, schedules, or session history.
+  if (options.daemon) {
+    if (options.project || options.windowsCc || options.linuxCc) {
+      print('  ⚠ --daemon cannot be combined with --project, --windows-cc, or --linux-cc.');
+      print('  Use bare `preflight uninstall` to remove hooks and the daemon together.');
+      process.exit(1);
+    }
+    const daemonStatus = getDashboardDaemonStatus();
+    if (!daemonStatus.installed) {
+      print('No background dashboard daemon installed — nothing to remove.');
+      return;
+    }
+    print('preflight uninstall --daemon will remove the background dashboard daemon.\n');
+    if (!handleConfirm(await promptConfirm(options.yes ?? false))) return;
+
+    const step = runStep('background dashboard daemon', false, () => removeDashboardDaemon());
+    if (step.error !== null) {
+      print('\nUninstall incomplete — see errors above.\n');
+      return;
+    }
+    if (!step.removed) {
+      process.exitCode = 1;
+      print('Background dashboard daemon already absent — nothing to remove.');
+      return;
+    }
+    print('✓ Background dashboard daemon removed.');
+    print('  The dashboard is now only available while Claude Code is running.');
+    print('  To reinstall, run: preflight setup');
+    return;
+  }
+
+  const { settingsPathsToClean, mcpPathsToClean } = resolveUninstallPaths(options);
+
+  // Build a human-readable summary of what will change, then ask for
+  // confirmation before touching anything.
+  const changeSummary: string[] = [];
+  let hadConfigFiles = false;
+  for (const settingsPath of settingsPathsToClean.keys()) {
+    if (existsSync(settingsPath)) {
+      changeSummary.push(`  • Remove hooks from ${settingsPath}`);
+      hadConfigFiles = true;
+    }
+  }
+  for (const mcpPath of mcpPathsToClean.keys()) {
+    if (existsSync(mcpPath)) {
+      changeSummary.push(`  • Remove MCP server from ${mcpPath}`);
+      hadConfigFiles = true;
+    }
+  }
+  const scheduleStatus = getScheduleStatus();
+  const daemonStatus = getDashboardDaemonStatus();
+  if (scheduleStatus.installed) {
+    const action = scheduleStatus.readable
+      ? 'Unload and delete'
+      : 'Remove (plist unreadable — label removal)';
+    changeSummary.push(`  • ${action} auto-update schedule`);
+  }
+  if (daemonStatus.installed) {
+    const action = daemonStatus.readable
+      ? 'Unload and delete'
+      : 'Remove (plist unreadable — label removal)';
+    changeSummary.push(`  • ${action} background dashboard daemon`);
+  }
+
+  if (changeSummary.length === 0) {
+    print('Nothing installed — no changes to make.');
+    return;
+  }
+
+  print('preflight uninstall will make the following changes:\n');
+  for (const line of changeSummary) print(line);
+  print('');
+  print(`  Your session history and config at ${DEFAULT_STORAGE_PATH} will NOT be deleted.`);
+  print('');
+
+  if (!handleConfirm(await promptConfirm(options.yes ?? false))) return;
+
+  print('');
+
+  const configStep = removeClaudeCodeConfig(settingsPathsToClean, mcpPathsToClean);
   if (options.windowsCc) {
     print('  To reinstall Windows Claude Code mode, re-run: preflight install --windows-cc');
   }
-  if (!options.linuxCc) {
+
+  const scheduleStep = runStep('auto-update schedule', false, () => {
+    const removed = removeSchedule();
+    if (removed) print('✓ Auto-update schedule removed');
+    else if (scheduleStatus.installed) {
+      // Plist vanished between status-check and removal (TOCTOU). Throw so
+      // runStep captures this as an error and anyFailed reflects it.
+      throw new Error(
+        'Auto-update schedule already absent — may have been removed by another process',
+      );
+    }
+    return removed;
+  });
+
+  const daemonStep = runStep('background dashboard daemon', false, () => {
+    const removed = removeDashboardDaemon();
+    if (removed) print('✓ Background dashboard daemon removed');
+    else if (daemonStatus.installed) {
+      // Plist vanished between status-check and removal (TOCTOU). Throw so
+      // runStep captures this as an error and anyFailed reflects it — without
+      // this, process.exitCode=1 and the success message are contradictory.
+      throw new Error(
+        'Background dashboard daemon already absent — may have been removed by another process',
+      );
+    }
+    return removed;
+  });
+
+  const steps = [configStep, scheduleStep, daemonStep];
+  const anyRemoved = steps.some((s) => s.removed);
+  const anyFailed = steps.some((s) => s.error !== null);
+  const requiresRestart = steps.some((s) => s.removed && s.requiresRestart);
+
+  // Clear the saved platform record when hooks/MCP config was removed (even if
+  // schedule/daemon cleanup also failed — those are independent). Also clear on
+  // schedule/daemon-only removal when config files existed on disk at status-check
+  // time: absent config files mean hooks were never written (or already manually
+  // deleted) and the platform record should be preserved for a re-install attempt.
+  // Skip on --linux-cc (sibling wsl-windows-cc record may still be in use).
+  const shouldClearPlatform = configStep.removed || (anyRemoved && !anyFailed && hadConfigFiles);
+  if (!options.linuxCc && shouldClearPlatform) {
     clearSavedPlatform();
   }
 
-  print('\nRestart Claude Code for changes to take effect.\n');
-
-  const scheduleWasInstalled = getScheduleStatus().installed;
-  removeSchedule();
-  if (scheduleWasInstalled) print('✓ Auto-update schedule removed');
-
-  const daemonWasInstalled = getDashboardDaemonStatus().installed;
-  removeDashboardDaemon();
-  if (daemonWasInstalled) print('✓ Background dashboard daemon removed');
+  if (requiresRestart) {
+    if (anyFailed) {
+      print(
+        '\nRestart Claude Code to apply hook changes. Uninstall incomplete — see errors above.\n',
+      );
+    } else {
+      print('\nRestart Claude Code for changes to take effect.\n');
+    }
+  } else if (anyRemoved) {
+    // Schedule/daemon only — launchd unloaded immediately; no restart needed.
+    print(anyFailed ? '\nUninstall incomplete — see errors above.\n' : '\nUninstall complete.\n');
+  } else if (anyFailed) {
+    print('\nUninstall incomplete — see errors above.\n');
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -663,9 +891,7 @@ async function handleDoctor(options: { config?: string }): Promise<void> {
   const { runDiagnostics } = await import('./diagnostics.js');
   const configPath = options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
 
-  const raw = readJsonFile(configPath);
-  const storagePath = typeof raw.storagePath === 'string' ? raw.storagePath : undefined;
-
+  const storagePath = process.env.NEW_RELIC_AI_MCP_STORAGE_PATH ?? undefined;
   print('Running diagnostics...');
   const checks = await runDiagnostics({ configPath, storagePath });
 
@@ -721,6 +947,11 @@ export function createInstallProgram(): Command {
     .option('--project', 'Remove from project-level .claude/settings.json instead of user-level')
     .option('--windows-cc', 'Remove Windows Claude Code hooks only (WSL only)')
     .option('--linux-cc', 'Remove Linux Claude Code hooks only (WSL only)')
+    .option(
+      '--daemon',
+      'Remove only the background dashboard daemon (preserves hooks, MCP config, and session history)',
+    )
+    .option('--yes', 'Skip the confirmation prompt (useful for scripts and CI)')
     .action(handleUninstall);
 
   program
@@ -733,7 +964,7 @@ export function createInstallProgram(): Command {
         const { runSetupWizard } = await import('./setup-wizard.js');
         await runSetupWizard();
       } catch (err) {
-        print(`\n✗ Setup failed: ${err instanceof Error ? err.message : String(err)}`);
+        print(`\n✗ Setup failed: ${errMsg(err)}`);
         process.exitCode = 1;
       }
     });

--- a/src/install/diagnostics.test.ts
+++ b/src/install/diagnostics.test.ts
@@ -1,7 +1,7 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import * as nodeFs from 'node:fs';
 import * as nodeOs from 'node:os';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 
 // Suppress logger output.
 jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
@@ -14,6 +14,7 @@ jest.mock('node:fs', () => {
     existsSync: jest.fn(),
     readFileSync: jest.fn(),
     accessSync: jest.fn(),
+    statSync: jest.fn(),
     constants: real.constants,
   };
 });
@@ -26,12 +27,19 @@ jest.mock('node:os', () => {
 
 // Stub schedule module.
 jest.mock('./schedule.js', () => ({
-  getDashboardDaemonStatus: jest.fn(() => ({ installed: false })),
+  getDashboardDaemonStatus: jest.fn(() => ({ installed: false, readable: false })),
+  resolveNodeDir: jest.fn(() => dirname(process.execPath)),
+  findExecutableNodeDir: jest.fn(() => ({ dir: null, hasNonExecutable: false })),
 }));
 
 // Stub config module.
 jest.mock('../config.js', () => ({
-  validateConfigFile: jest.fn(() => ({ fileExists: false, errors: [], warnings: [] })),
+  validateConfigFile: jest.fn(() => ({
+    fileExists: false,
+    malformed: false,
+    errors: [],
+    warnings: [],
+  })),
   DEFAULT_STORAGE_PATH: '/test-home/.newrelic-preflight',
 }));
 
@@ -73,8 +81,10 @@ import * as platform from './platform.js';
 const mockedExistSync = nodeFs.existsSync as jest.Mock;
 const mockedReadFileSync = nodeFs.readFileSync as jest.Mock;
 const mockedAccessSync = nodeFs.accessSync as jest.Mock;
+const mockedStatSync = nodeFs.statSync as jest.Mock;
 const mockedPlatform = nodeOs.platform as jest.Mock;
 const mockedGetDaemonStatus = schedule.getDashboardDaemonStatus as jest.Mock;
+const mockedFindExecutableNodeDir = schedule.findExecutableNodeDir as jest.Mock;
 const mockedValidateConfig = config.validateConfigFile as jest.Mock;
 const mockedDetectSettingsPath = installHelper.detectSettingsPath as jest.Mock;
 const mockedIsWsl = platform.isWsl as jest.Mock;
@@ -98,11 +108,20 @@ describe('runDiagnostics', () => {
     mockedExistSync.mockReturnValue(false);
     mockedReadFileSync.mockReturnValue('{}');
     mockedAccessSync.mockImplementation(() => undefined);
-    mockedGetDaemonStatus.mockReturnValue({ installed: false });
-    mockedValidateConfig.mockReturnValue({ fileExists: false, errors: [], warnings: [] });
+    mockedGetDaemonStatus.mockReturnValue({ installed: false, readable: false });
+    mockedValidateConfig.mockReturnValue({
+      fileExists: false,
+      malformed: false,
+      errors: [],
+      warnings: [],
+    });
     mockedDetectSettingsPath.mockReturnValue('/test-home/.claude/settings.json');
     mockedIsWsl.mockReturnValue(false);
     mockFetch.mockResolvedValue({ ok: true } as Response);
+    mockedStatSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    mockedFindExecutableNodeDir.mockReturnValue({ dir: null, hasNonExecutable: false });
 
     const mod = await import('./diagnostics.js');
     runDiagnostics = mod.runDiagnostics;
@@ -110,7 +129,12 @@ describe('runDiagnostics', () => {
 
   describe('Check 1: Config valid', () => {
     it('returns warn when config file does not exist', async () => {
-      mockedValidateConfig.mockReturnValue({ fileExists: false, errors: [], warnings: [] });
+      mockedValidateConfig.mockReturnValue({
+        fileExists: false,
+        malformed: false,
+        errors: [],
+        warnings: [],
+      });
       const checks = await runDiagnostics(makeOpts());
       const c = checks.find((x) => x.check === 'Config valid')!;
       expect(c.status).toBe('warn');
@@ -120,6 +144,7 @@ describe('runDiagnostics', () => {
     it('returns fail when config has errors', async () => {
       mockedValidateConfig.mockReturnValue({
         fileExists: true,
+        malformed: false,
         errors: ['mode: bad value'],
         warnings: [],
       });
@@ -132,6 +157,7 @@ describe('runDiagnostics', () => {
     it('returns warn when config has warnings only', async () => {
       mockedValidateConfig.mockReturnValue({
         fileExists: true,
+        malformed: false,
         errors: [],
         warnings: ['Unknown key "foo"'],
       });
@@ -141,7 +167,12 @@ describe('runDiagnostics', () => {
     });
 
     it('returns ok when config is valid', async () => {
-      mockedValidateConfig.mockReturnValue({ fileExists: true, errors: [], warnings: [] });
+      mockedValidateConfig.mockReturnValue({
+        fileExists: true,
+        malformed: false,
+        errors: [],
+        warnings: [],
+      });
       const checks = await runDiagnostics(makeOpts());
       const c = checks.find((x) => x.check === 'Config valid')!;
       expect(c.status).toBe('ok');
@@ -155,18 +186,19 @@ describe('runDiagnostics', () => {
       expect(checks.find((x) => x.check === 'Daemon installed')?.status).toBe('skip');
     });
 
-    it('returns fail when daemon not installed', async () => {
-      mockedGetDaemonStatus.mockReturnValue({ installed: false });
+    it('returns warn when daemon not installed', async () => {
+      mockedGetDaemonStatus.mockReturnValue({ installed: false, readable: false });
       const checks = await runDiagnostics(makeOpts());
-      expect(checks.find((x) => x.check === 'Daemon installed')?.status).toBe('fail');
+      expect(checks.find((x) => x.check === 'Daemon installed')?.status).toBe('warn');
     });
 
     it('returns ok when daemon is installed', async () => {
-      mockedGetDaemonStatus.mockReturnValue({ installed: true });
+      mockedGetDaemonStatus.mockReturnValue({
+        installed: true,
+        readable: true,
+        envPath: '/opt/homebrew/bin:/usr/bin',
+      });
       mockedExistSync.mockReturnValue(true);
-      mockedReadFileSync.mockReturnValue(
-        '<key>PATH</key><string>/opt/homebrew/bin:/usr/bin</string>',
-      );
       const checks = await runDiagnostics(makeOpts());
       expect(checks.find((x) => x.check === 'Daemon installed')?.status).toBe('ok');
     });
@@ -174,35 +206,75 @@ describe('runDiagnostics', () => {
 
   describe('Check 3: Daemon node path', () => {
     it('returns skip when daemon not installed', async () => {
-      mockedGetDaemonStatus.mockReturnValue({ installed: false });
+      mockedGetDaemonStatus.mockReturnValue({ installed: false, readable: false });
       const checks = await runDiagnostics(makeOpts());
       expect(checks.find((x) => x.check === 'Daemon node path')?.status).toBe('skip');
     });
 
-    it('returns ok when node dir is in plist PATH', async () => {
+    it('returns warn for Daemon installed and skip for Daemon node path when plist is unreadable', async () => {
+      mockedGetDaemonStatus.mockReturnValue({ installed: true, readable: false });
+      const checks = await runDiagnostics(makeOpts());
+      const installed = checks.find((x) => x.check === 'Daemon installed')!;
+      expect(installed.status).toBe('warn');
+      expect(installed.detail).toContain('could not be read');
+      const nodePath = checks.find((x) => x.check === 'Daemon node path')!;
+      expect(nodePath.status).toBe('skip');
+    });
+
+    it('returns warn (not fail) when plist has no PATH key (older install without node-path injection)', async () => {
+      mockedGetDaemonStatus.mockReturnValue({ installed: true, readable: true });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Daemon node path')!;
+      expect(c.status).toBe('warn');
+      expect(c.detail).toContain('predates node-path injection');
+    });
+
+    it('returns ok when a node binary exists in plist PATH', async () => {
       const nodeDir = resolve(process.execPath, '..');
-      mockedGetDaemonStatus.mockReturnValue({ installed: true });
-      mockedExistSync.mockReturnValue(true);
-      mockedReadFileSync.mockReturnValue(`<key>PATH</key><string>${nodeDir}:/usr/bin</string>`);
+      mockedGetDaemonStatus.mockReturnValue({
+        installed: true,
+        readable: true,
+        envPath: `${nodeDir}:/usr/bin`,
+      });
+      mockedFindExecutableNodeDir.mockReturnValue({ dir: nodeDir, hasNonExecutable: false });
       const checks = await runDiagnostics(makeOpts());
       expect(checks.find((x) => x.check === 'Daemon node path')?.status).toBe('ok');
     });
 
     it('returns fail when node dir is missing from plist PATH', async () => {
-      mockedGetDaemonStatus.mockReturnValue({ installed: true });
-      mockedExistSync.mockReturnValue(true);
-      mockedReadFileSync.mockReturnValue(
-        '<key>PATH</key><string>/some/other/bin:/usr/bin</string>',
-      );
+      mockedGetDaemonStatus.mockReturnValue({
+        installed: true,
+        readable: true,
+        envPath: '/some/other/bin:/usr/bin',
+      });
       const checks = await runDiagnostics(makeOpts());
-      expect(checks.find((x) => x.check === 'Daemon node path')?.status).toBe('fail');
+      const c = checks.find((x) => x.check === 'Daemon node path')!;
+      expect(c.status).toBe('fail');
+      expect(c.detail).toContain('No executable');
     });
 
-    it('returns ok when node dir has trailing slash in plist PATH', async () => {
+    it('returns fail with permissions message when node binary exists but is not executable', async () => {
       const nodeDir = resolve(process.execPath, '..');
-      mockedGetDaemonStatus.mockReturnValue({ installed: true });
-      mockedExistSync.mockReturnValue(true);
-      mockedReadFileSync.mockReturnValue(`<key>PATH</key><string>${nodeDir}/:/usr/bin</string>`);
+      mockedGetDaemonStatus.mockReturnValue({
+        installed: true,
+        readable: true,
+        envPath: `${nodeDir}:/usr/bin`,
+      });
+      mockedFindExecutableNodeDir.mockReturnValue({ dir: null, hasNonExecutable: true });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Daemon node path')!;
+      expect(c.status).toBe('fail');
+      expect(c.detail).toContain('not executable');
+    });
+
+    it('returns ok when plist PATH dir has a trailing slash', async () => {
+      const nodeDir = resolve(process.execPath, '..');
+      mockedGetDaemonStatus.mockReturnValue({
+        installed: true,
+        readable: true,
+        envPath: `${nodeDir}/:/usr/bin`,
+      });
+      mockedFindExecutableNodeDir.mockReturnValue({ dir: nodeDir, hasNonExecutable: false });
       const checks = await runDiagnostics(makeOpts());
       expect(checks.find((x) => x.check === 'Daemon node path')?.status).toBe('ok');
     });
@@ -244,6 +316,44 @@ describe('runDiagnostics', () => {
       });
       const checks = await runDiagnostics(makeOpts());
       expect(checks.find((x) => x.check === 'Hooks wired')?.status).toBe('ok');
+    });
+
+    it('includes malformed-file note when one path parses and another fails JSON.parse', async () => {
+      mockedIsWsl.mockReturnValue(true);
+      const winHome = '/mnt/c/Users/testuser';
+      (platform.resolveWindowsHome as jest.Mock).mockReturnValue(winHome);
+      const linuxPath = '/test-home/.claude/settings.json';
+      const winPath = `${winHome}/.claude/settings.json`;
+      mockedDetectSettingsPath.mockReturnValueOnce(linuxPath).mockReturnValueOnce(winPath);
+      mockedExistSync.mockImplementation((p) => p === linuxPath || p === winPath);
+      mockedReadFileSync.mockImplementation((p) => {
+        if (p === linuxPath) throw new SyntaxError('Unexpected token');
+        return JSON.stringify({ hooks: {} }); // winPath parses but has no hooks
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hooks wired')!;
+      expect(c.status).toBe('fail');
+      expect(c.detail).toContain(linuxPath);
+      expect(c.detail).toContain('could not be parsed');
+    });
+
+    it('uses plural "files" and lists both paths when both settings files fail JSON.parse', async () => {
+      mockedIsWsl.mockReturnValue(true);
+      const winHome = '/mnt/c/Users/testuser';
+      (platform.resolveWindowsHome as jest.Mock).mockReturnValue(winHome);
+      const linuxPath = '/test-home/.claude/settings.json';
+      const winPath = `${winHome}/.claude/settings.json`;
+      mockedDetectSettingsPath.mockReturnValueOnce(linuxPath).mockReturnValueOnce(winPath);
+      mockedExistSync.mockImplementation((p) => p === linuxPath || p === winPath);
+      mockedReadFileSync.mockImplementation(() => {
+        throw new SyntaxError('Unexpected token');
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hooks wired')!;
+      expect(c.status).toBe('fail');
+      expect(c.detail).toContain('files');
+      expect(c.detail).toContain(linuxPath);
+      expect(c.detail).toContain(winPath);
     });
 
     it('returns ok when hooks are on the Windows-side path (WSL)', async () => {
@@ -300,11 +410,67 @@ describe('runDiagnostics', () => {
   });
 
   describe('Check 6: NR reachable', () => {
+    beforeEach(() => {
+      mockedValidateConfig.mockReturnValue({
+        fileExists: true,
+        malformed: false,
+        mode: 'cloud',
+        hasLicenseKey: true,
+        errors: [],
+        warnings: [],
+      });
+    });
+
+    it('skips NR check when licenseKey is absent from config and env (prevents misleading ok when events would 403)', async () => {
+      mockedValidateConfig.mockReturnValue({
+        fileExists: true,
+        malformed: false,
+        mode: 'cloud',
+        errors: [],
+        warnings: [],
+      });
+      const origEnv = process.env.NEW_RELIC_LICENSE_KEY;
+      delete process.env.NEW_RELIC_LICENSE_KEY;
+      const checks = await runDiagnostics(makeOpts());
+      process.env.NEW_RELIC_LICENSE_KEY = origEnv;
+      const c = checks.find((x) => x.check === 'NR reachable')!;
+      expect(c.status).toBe('skip');
+      expect(c.detail).toContain('licenseKey not configured');
+    });
+
+    it('skips NR check when config file is absent (prevents misleading double-failure on first-time setup)', async () => {
+      mockedValidateConfig.mockReturnValue({
+        fileExists: false,
+        malformed: false,
+        errors: [],
+        warnings: [],
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'NR reachable')!;
+      expect(c.status).toBe('skip');
+      expect(c.detail).toContain('no config file');
+    });
+
+    it('skips NR check when config.json has invalid JSON (prevents misleading fail alongside real config error)', async () => {
+      mockedValidateConfig.mockReturnValue({
+        fileExists: true,
+        malformed: true,
+        errors: ['invalid JSON'],
+        warnings: [],
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'NR reachable')!;
+      expect(c.status).toBe('skip');
+      expect(c.detail).toContain('could not be parsed');
+    });
+
     it('returns skip when mode is local', async () => {
-      mockedValidateConfig.mockReturnValue({ fileExists: true, errors: [], warnings: [] });
-      mockedReadFileSync.mockImplementation((p) => {
-        if (String(p).endsWith('config.json')) return JSON.stringify({ mode: 'local' });
-        return '{}';
+      mockedValidateConfig.mockReturnValue({
+        fileExists: true,
+        malformed: false,
+        mode: 'local',
+        errors: [],
+        warnings: [],
       });
       const checks = await runDiagnostics(makeOpts());
       expect(checks.find((x) => x.check === 'NR reachable')?.status).toBe('skip');

--- a/src/install/diagnostics.ts
+++ b/src/install/diagnostics.ts
@@ -1,12 +1,15 @@
 import { accessSync, constants, existsSync, readFileSync } from 'node:fs';
-import { homedir, platform } from 'node:os';
-import { dirname, resolve } from 'node:path';
+import { platform } from 'node:os';
+import { resolve } from 'node:path';
+
+import { createLogger } from '../shared/index.js';
 
 import { validateConfigFile, DEFAULT_STORAGE_PATH } from '../config.js';
-import { getDashboardDaemonStatus } from './schedule.js';
+import { getDashboardDaemonStatus, findExecutableNodeDir } from './schedule.js';
 import { detectSettingsPath, entryContainsNrObserve } from './install-helper.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
-import { readJsonFile } from './json-utils.js';
+
+const logger = createLogger('diagnostics');
 
 export interface DiagnosticCheck {
   readonly check: string;
@@ -15,233 +18,326 @@ export interface DiagnosticCheck {
   readonly fix?: string;
 }
 
+// Context derived from the config check that downstream checks need.
+type DiagnosticsContext = {
+  readonly storagePath: string;
+  // Non-null when the NR reachability check should be skipped; the string is
+  // used verbatim as the skip detail so the message is accurate for each cause
+  // (absent file, config errors, local mode, missing licenseKey).
+  readonly nrSkipReason: string | null;
+};
+
+function checkConfigValid(
+  configPath: string,
+  runtimeStoragePath: string | undefined,
+): { check: DiagnosticCheck; context: DiagnosticsContext } {
+  const validation = validateConfigFile(configPath);
+  // Prioritise the caller's runtime-resolved value (env-var-wins, matching
+  // loadMcpConfig priority) over the file value so the Storage writable check
+  // tests the same path the MCP server actually writes to. Falls back to the
+  // file value, then the default. Use || (not ??) so an empty string is treated
+  // like a missing value and falls through to the next tier.
+  const storagePath = runtimeStoragePath || validation.storagePath || DEFAULT_STORAGE_PATH;
+  const effectiveMode = validation.mode ?? 'cloud';
+  const licenseKeyEnv = process.env.NEW_RELIC_LICENSE_KEY;
+  // Use .trim() so a whitespace-only value (e.g. '   ') is treated as absent,
+  // preventing a false-positive NR reachability result when the key is invalid.
+  const hasLicenseKey = validation.hasLicenseKey || Boolean(licenseKeyEnv?.trim());
+  // Only skip the NR check for structural problems (no file, or file is unparseable).
+  // Zod type errors on unrelated fields do not affect reachability — the derived
+  // effectiveMode and hasLicenseKey values below still hold even when other fields
+  // fail validation, so the check can run and surface connectivity issues in parallel.
+  const nrSkipReason = !validation.fileExists
+    ? 'Skipped (no config file — run preflight setup first)'
+    : validation.malformed
+      ? 'Skipped (config could not be parsed — fix issues above first)'
+      : effectiveMode === 'local'
+        ? 'Skipped (mode: local)'
+        : !hasLicenseKey
+          ? licenseKeyEnv !== undefined
+            ? 'Skipped (NEW_RELIC_LICENSE_KEY is set but empty or blank — add a valid key)'
+            : 'Skipped (licenseKey not configured — set NEW_RELIC_LICENSE_KEY or add to config)'
+          : null;
+
+  let check: DiagnosticCheck;
+  if (!validation.fileExists) {
+    check = {
+      check: 'Config valid',
+      status: 'warn',
+      detail: `No config file at ${configPath} — defaults will apply.`,
+      fix: 'preflight setup',
+    };
+  } else if (validation.errors.length > 0) {
+    check = {
+      check: 'Config valid',
+      status: 'fail',
+      detail: validation.errors.join('; '),
+      fix: 'Fix the fields listed above, then restart.',
+    };
+  } else if (validation.warnings.length > 0) {
+    check = {
+      check: 'Config valid',
+      status: 'warn',
+      detail: validation.warnings.join('; '),
+    };
+  } else {
+    check = {
+      check: 'Config valid',
+      status: 'ok',
+      detail: `Config loaded from ${configPath}`,
+    };
+  }
+
+  return {
+    check,
+    context: { storagePath, nrSkipReason },
+  };
+}
+
+function checkDaemon(): DiagnosticCheck[] {
+  if (platform() !== 'darwin') {
+    return [
+      { check: 'Daemon installed', status: 'skip', detail: 'Daemon management is macOS-only.' },
+      { check: 'Daemon node path', status: 'skip', detail: 'Daemon management is macOS-only.' },
+    ];
+  }
+
+  const daemonStatus = getDashboardDaemonStatus();
+
+  if (!daemonStatus.installed) {
+    return [
+      {
+        check: 'Daemon installed',
+        status: 'warn',
+        detail:
+          'com.preflight.dashboard.plist not found — dashboard will only run when Claude Code is open.',
+        fix: 'preflight setup (optional: install the always-on background daemon)',
+      },
+      {
+        check: 'Daemon node path',
+        status: 'skip',
+        detail: 'Daemon not installed — install first.',
+      },
+    ];
+  }
+
+  if (!daemonStatus.readable) {
+    return [
+      {
+        check: 'Daemon installed',
+        status: 'warn',
+        detail: 'com.preflight.dashboard.plist found but could not be read',
+        fix: 'preflight uninstall --daemon, then preflight setup (answer Y to the daemon prompt)',
+      },
+      {
+        check: 'Daemon node path',
+        status: 'skip',
+        detail: 'Plist unreadable — daemon status could not be verified.',
+      },
+    ];
+  }
+
+  const installedCheck: DiagnosticCheck = {
+    check: 'Daemon installed',
+    status: 'ok',
+    detail: 'com.preflight.dashboard.plist found',
+  };
+
+  if (!daemonStatus.envPath) {
+    return [
+      installedCheck,
+      {
+        check: 'Daemon node path',
+        status: 'warn',
+        detail: 'Daemon plist predates node-path injection — node upgrades may break it',
+        fix: 'preflight uninstall --daemon, then preflight setup (answer Y to the daemon prompt)',
+      },
+    ];
+  }
+
+  const plistDirs = daemonStatus.envPath.split(':').filter(Boolean);
+  const { dir: nodeDir, hasNonExecutable } = findExecutableNodeDir(plistDirs);
+
+  let nodePathCheck: DiagnosticCheck;
+  if (nodeDir !== null) {
+    nodePathCheck = {
+      check: 'Daemon node path',
+      status: 'ok',
+      detail: 'node binary found in plist PATH',
+    };
+  } else if (hasNonExecutable) {
+    nodePathCheck = {
+      check: 'Daemon node path',
+      status: 'fail',
+      detail: 'node binary found in plist PATH but is not executable',
+      fix: 'Check node permissions (chmod +x <node>), or reinstall: preflight uninstall --daemon && preflight setup',
+    };
+  } else {
+    nodePathCheck = {
+      check: 'Daemon node path',
+      status: 'fail',
+      detail: 'No executable node binary found in plist PATH dirs',
+      fix: 'preflight uninstall --daemon, then preflight setup (answer Y to the daemon prompt)',
+    };
+  }
+
+  return [installedCheck, nodePathCheck];
+}
+
+function checkHooksWired(settingsPaths: string[]): DiagnosticCheck {
+  const anyPathExists = settingsPaths.some(existsSync);
+  let hooksPre = false;
+  let hooksPost = false;
+  const parseErrorPaths: string[] = [];
+  let anyParsed = false;
+
+  for (const sp of settingsPaths) {
+    if (!existsSync(sp)) continue;
+    try {
+      const settings = JSON.parse(readFileSync(sp, 'utf-8')) as Record<string, unknown>;
+      anyParsed = true;
+      const hooks = settings.hooks as Record<string, unknown[]> | undefined;
+      if (Array.isArray(hooks?.PreToolUse))
+        hooksPre ||= hooks.PreToolUse.some(entryContainsNrObserve);
+      if (Array.isArray(hooks?.PostToolUse))
+        hooksPost ||= hooks.PostToolUse.some(entryContainsNrObserve);
+    } catch (err) {
+      logger.debug('settings file could not be parsed — treating as not wired', { err, path: sp });
+      parseErrorPaths.push(sp);
+    }
+  }
+
+  if (!anyPathExists) {
+    return {
+      check: 'Hooks wired',
+      status: 'fail',
+      detail: `Settings file not found: ${settingsPaths.join(' or ')}`,
+      fix: 'preflight install',
+    };
+  }
+
+  if (hooksPre && hooksPost) {
+    const malformedNote =
+      parseErrorPaths.length > 0 ? `; ${parseErrorPaths.join(' and ')} could not be parsed` : '';
+    return {
+      check: 'Hooks wired',
+      status: parseErrorPaths.length > 0 ? 'warn' : 'ok',
+      detail: `PreToolUse and PostToolUse hooks found${malformedNote}`,
+      ...(parseErrorPaths.length > 0 && {
+        fix: 'Fix or delete the malformed file(s), then run: preflight install',
+      }),
+    };
+  }
+
+  if (!anyParsed) {
+    const plural = parseErrorPaths.length > 1 ? 'files' : 'file';
+    return {
+      check: 'Hooks wired',
+      status: 'fail',
+      detail: `Settings ${plural} could not be parsed (malformed JSON): ${parseErrorPaths.join(' and ')}`,
+      fix: 'Fix or delete the malformed file(s), then run: preflight install',
+    };
+  }
+
+  const missing = [!hooksPre && 'PreToolUse', !hooksPost && 'PostToolUse']
+    .filter(Boolean)
+    .join(' and ');
+  const searched = settingsPaths.filter(existsSync).join(' or ');
+  const malformedNote =
+    parseErrorPaths.length > 0 ? `; ${parseErrorPaths.join(' and ')} could not be parsed` : '';
+  return {
+    check: 'Hooks wired',
+    status: 'fail',
+    detail: `${missing} not found in ${searched}${malformedNote}`,
+    fix: 'preflight install',
+  };
+}
+
+function checkStorageWritable(storagePath: string): DiagnosticCheck {
+  try {
+    accessSync(storagePath, constants.W_OK);
+    return { check: 'Storage writable', status: 'ok', detail: `${storagePath} is writable` };
+  } catch {
+    if (!existsSync(storagePath)) {
+      return {
+        check: 'Storage writable',
+        status: 'fail',
+        detail: `Directory not found: ${storagePath}`,
+        fix: `mkdir -p ${storagePath} && chmod 700 ${storagePath}`,
+      };
+    }
+    return {
+      check: 'Storage writable',
+      status: 'fail',
+      detail: `Directory exists but is not writable: ${storagePath}`,
+      fix: `chmod 700 ${storagePath}`,
+    };
+  }
+}
+
+async function checkNrReachable(skipReason: string | null): Promise<DiagnosticCheck> {
+  if (skipReason !== null) {
+    return { check: 'NR reachable', status: 'skip', detail: skipReason };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const response = await fetch('https://insights-collector.newrelic.com', {
+      method: 'HEAD',
+      signal: controller.signal,
+    });
+    // 401/403 indicate the endpoint is reachable but rejected the credentials.
+    // Other 4xx (404, 405, etc.) just mean the HEAD / path has no handler —
+    // the endpoint is reachable and a 404 here is unrelated to the licenseKey.
+    if (response.status === 401 || response.status === 403) {
+      return {
+        check: 'NR reachable',
+        status: 'warn',
+        detail: `insights-collector.newrelic.com replied with HTTP ${response.status} — endpoint is reachable but rejected the request`,
+        fix: 'Verify that licenseKey is correct and has Ingest permissions.',
+      };
+    }
+    return {
+      check: 'NR reachable',
+      status: 'ok',
+      detail: 'insights-collector.newrelic.com reachable',
+    };
+  } catch (err) {
+    const isTimeout = err instanceof Error && err.name === 'AbortError';
+    return {
+      check: 'NR reachable',
+      status: 'fail',
+      detail: isTimeout
+        ? 'Request timed out after 5 s — endpoint may be reachable but slow'
+        : 'Could not reach insights-collector.newrelic.com',
+      fix: isTimeout
+        ? 'Check for a slow proxy or firewall blocking HTTPS.'
+        : 'Check network connectivity and that licenseKey is valid.',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export async function runDiagnostics(opts?: {
   configPath?: string;
   storagePath?: string;
 }): Promise<DiagnosticCheck[]> {
   const configPath = opts?.configPath ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
-  const storagePath = opts?.storagePath ?? DEFAULT_STORAGE_PATH;
-  const checks: DiagnosticCheck[] = [];
+  const { check: configCheck, context } = checkConfigValid(configPath, opts?.storagePath);
 
-  // Pre-read config once for mode detection; validateConfigFile also reads internally.
-  const configRaw = readJsonFile(configPath);
-  const mode = typeof configRaw.mode === 'string' ? configRaw.mode : 'cloud';
-
-  // --- Check 1: Config valid ---
-  const validation = validateConfigFile(configPath);
-  if (!validation.fileExists) {
-    checks.push({
-      check: 'Config valid',
-      status: 'warn',
-      detail: `No config file at ${configPath} — defaults will apply.`,
-      fix: 'preflight setup',
-    });
-  } else if (validation.errors.length > 0) {
-    checks.push({
-      check: 'Config valid',
-      status: 'fail',
-      detail: validation.errors.join('; '),
-      fix: 'Fix the fields listed above, then restart.',
-    });
-  } else if (validation.warnings.length > 0) {
-    checks.push({
-      check: 'Config valid',
-      status: 'warn',
-      detail: validation.warnings.join('; '),
-    });
-  } else {
-    checks.push({
-      check: 'Config valid',
-      status: 'ok',
-      detail: `Config loaded from ${configPath}`,
-    });
-  }
-
-  // --- Checks 2 + 3: Daemon (macOS only) ---
-  if (platform() !== 'darwin') {
-    checks.push({
-      check: 'Daemon installed',
-      status: 'skip',
-      detail: 'Daemon management is macOS-only.',
-    });
-    checks.push({
-      check: 'Daemon node path',
-      status: 'skip',
-      detail: 'Daemon management is macOS-only.',
-    });
-  } else {
-    const daemonStatus = getDashboardDaemonStatus();
-    if (!daemonStatus.installed) {
-      checks.push({
-        check: 'Daemon installed',
-        status: 'fail',
-        detail: 'com.preflight.dashboard.plist not found in ~/Library/LaunchAgents/',
-        fix: 'preflight install --daemon',
-      });
-      checks.push({
-        check: 'Daemon node path',
-        status: 'skip',
-        detail: 'Daemon not installed — install first.',
-      });
-    } else {
-      checks.push({
-        check: 'Daemon installed',
-        status: 'ok',
-        detail: 'com.preflight.dashboard.plist found',
-      });
-
-      // --- Check 3: Daemon node path ---
-      try {
-        const plistFilePath = resolve(
-          homedir(),
-          'Library',
-          'LaunchAgents',
-          'com.preflight.dashboard.plist',
-        );
-        const plistContent = readFileSync(plistFilePath, 'utf-8');
-        const pathMatch = plistContent.match(/<key>PATH<\/key>\s*<string>([^<]+)<\/string>/);
-        const plistPathValue = pathMatch ? pathMatch[1] : '';
-        const stripTrailingSlash = (p: string) => p.replace(/\/+$/, '');
-        const plistDirs = plistPathValue.split(':').map(stripTrailingSlash);
-        const nodeDir = stripTrailingSlash(dirname(process.execPath));
-        if (plistDirs.includes(nodeDir)) {
-          checks.push({
-            check: 'Daemon node path',
-            status: 'ok',
-            detail: `${nodeDir} in plist PATH`,
-          });
-        } else {
-          checks.push({
-            check: 'Daemon node path',
-            status: 'fail',
-            detail: `Node directory ${nodeDir} missing from plist PATH`,
-            fix: 'preflight install --daemon',
-          });
-        }
-      } catch {
-        checks.push({
-          check: 'Daemon node path',
-          status: 'warn',
-          detail: 'Could not read plist to verify node path',
-          fix: 'preflight install --daemon',
-        });
-      }
-    }
-  }
-
-  // --- Check 4: Hooks wired ---
-  // On WSL with --windows-cc installs, hooks live on the Windows-side path.
-  // Check both the Linux-side path and, when running under WSL, the Windows-side path.
   const settingsPaths: string[] = [detectSettingsPath('user')];
   if (isWsl()) {
     const winHome = resolveWindowsHome();
     if (winHome) settingsPaths.push(detectSettingsPath('user', winHome));
   }
 
-  const anyPathExists = settingsPaths.some(existsSync);
-  let hooksPre = false;
-  let hooksPost = false;
-  for (const sp of settingsPaths) {
-    if (!existsSync(sp)) continue;
-    try {
-      const settings = JSON.parse(readFileSync(sp, 'utf-8')) as Record<string, unknown>;
-      const hooks = settings.hooks as Record<string, unknown[]> | undefined;
-      if (Array.isArray(hooks?.PreToolUse))
-        hooksPre ||= hooks.PreToolUse.some(entryContainsNrObserve);
-      if (Array.isArray(hooks?.PostToolUse))
-        hooksPost ||= hooks.PostToolUse.some(entryContainsNrObserve);
-    } catch {
-      /* treat as not wired */
-    }
-  }
-
-  if (!anyPathExists) {
-    checks.push({
-      check: 'Hooks wired',
-      status: 'fail',
-      detail: `Settings file not found: ${settingsPaths.join(' or ')}`,
-      fix: 'preflight install',
-    });
-  } else if (!hooksPre || !hooksPost) {
-    const missing = [!hooksPre && 'PreToolUse', !hooksPost && 'PostToolUse']
-      .filter(Boolean)
-      .join(' and ');
-    checks.push({
-      check: 'Hooks wired',
-      status: 'fail',
-      detail: `${missing} not found in ${settingsPaths.filter(existsSync).join(' or ')}`,
-      fix: 'preflight install',
-    });
-  } else {
-    checks.push({
-      check: 'Hooks wired',
-      status: 'ok',
-      detail: 'PreToolUse and PostToolUse hooks found',
-    });
-  }
-
-  // --- Check 5: Storage writable ---
-  try {
-    accessSync(storagePath, constants.W_OK);
-    checks.push({
-      check: 'Storage writable',
-      status: 'ok',
-      detail: `${storagePath} is writable`,
-    });
-  } catch {
-    if (!existsSync(storagePath)) {
-      checks.push({
-        check: 'Storage writable',
-        status: 'fail',
-        detail: `Directory not found: ${storagePath}`,
-        fix: `mkdir -p ${storagePath} && chmod 700 ${storagePath}`,
-      });
-    } else {
-      checks.push({
-        check: 'Storage writable',
-        status: 'fail',
-        detail: `Directory exists but is not writable: ${storagePath}`,
-        fix: `chmod 700 ${storagePath}`,
-      });
-    }
-  }
-
-  // --- Check 6: NR reachable ---
-  if (mode === 'local') {
-    checks.push({
-      check: 'NR reachable',
-      status: 'skip',
-      detail: 'Skipped (mode: local)',
-    });
-  } else {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
-    try {
-      await fetch('https://insights-collector.newrelic.com', {
-        method: 'HEAD',
-        signal: controller.signal,
-      });
-      checks.push({
-        check: 'NR reachable',
-        status: 'ok',
-        detail: 'insights-collector.newrelic.com reachable',
-      });
-    } catch (err) {
-      const isTimeout = err instanceof Error && err.name === 'AbortError';
-      checks.push({
-        check: 'NR reachable',
-        status: 'fail',
-        detail: isTimeout
-          ? 'Request timed out after 5 s — endpoint may be reachable but slow'
-          : 'Could not reach insights-collector.newrelic.com',
-        fix: isTimeout
-          ? 'Check for a slow proxy or firewall blocking HTTPS.'
-          : 'Check network connectivity and that licenseKey is valid.',
-      });
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-
-  return checks;
+  return [
+    configCheck,
+    ...checkDaemon(),
+    checkHooksWired(settingsPaths),
+    checkStorageWritable(context.storagePath),
+    await checkNrReachable(context.nrSkipReason),
+  ];
 }

--- a/src/install/json-utils.ts
+++ b/src/install/json-utils.ts
@@ -10,6 +10,10 @@ import {
 import { basename, dirname, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 
+export function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function readJsonFile(path: string): Record<string, unknown> {
   try {
     return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;

--- a/src/install/schedule.test.ts
+++ b/src/install/schedule.test.ts
@@ -1,7 +1,20 @@
-import { jest, describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals';
-import { mkdirSync, mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  symlinkSync,
+} from 'node:fs';
 import * as nodeOs from 'node:os';
 import { join, dirname } from 'node:path';
+
+import { jest, describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals';
+
+// Suppress logger and fallback warning output.
+jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
 // Prevent real launchctl calls.
 jest.mock('node:child_process', () => ({ execFileSync: jest.fn(), execSync: jest.fn() }));
@@ -22,6 +35,8 @@ import {
   installDashboardDaemon,
   removeDashboardDaemon,
   getDashboardDaemonStatus,
+  unescapeXml,
+  findExecutableNodeDir,
 } from './schedule.js';
 
 const mockedExecFileSync = childProcess.execFileSync as jest.Mock;
@@ -78,7 +93,7 @@ describe('installSchedule', () => {
     const content = readFileSync(PLIST_PATH, 'utf-8');
     expect(content).toContain('<key>EnvironmentVariables</key>');
     expect(content).toContain('<key>PATH</key>');
-    expect(content).toContain(dirname(process.execPath));
+    expect(content).toContain(resolveNodeDir());
     expect(content).toContain('/usr/bin:/bin');
   });
 
@@ -144,14 +159,15 @@ const FIXTURE_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
 </plist>`;
 
 describe('getScheduleStatus', () => {
-  it('returns installed:false when plist is absent', () => {
-    expect(getScheduleStatus()).toEqual({ installed: false });
+  it('returns installed:false readable:false when plist is absent', () => {
+    expect(getScheduleStatus()).toEqual({ installed: false, readable: false });
   });
 
-  it('returns installed:true with hour, minute, binaryPath after install', () => {
+  it('returns installed:true readable:true with hour, minute, binaryPath after install', () => {
     installSchedule('/usr/local/bin/preflight', 9, 15);
     const status = getScheduleStatus();
     expect(status.installed).toBe(true);
+    expect(status.readable).toBe(true);
     expect(status.hour).toBe(9);
     expect(status.minute).toBe(15);
     expect(status.binaryPath).toBe('/usr/local/bin/preflight');
@@ -161,9 +177,22 @@ describe('getScheduleStatus', () => {
     writeFileSync(PLIST_PATH, FIXTURE_PLIST);
     const status = getScheduleStatus();
     expect(status.installed).toBe(true);
+    expect(status.readable).toBe(true);
     expect(status.hour).toBe(22);
     expect(status.minute).toBe(45);
     expect(status.binaryPath).toBe('/opt/homebrew/bin/preflight');
+  });
+
+  it('returns installed:true readable:false when plist exists but is unreadable', () => {
+    writeFileSync(PLIST_PATH, '<plist/>', { mode: 0o600 });
+    chmodSync(PLIST_PATH, 0o000);
+    try {
+      const status = getScheduleStatus();
+      expect(status.installed).toBe(true);
+      expect(status.readable).toBe(false);
+    } finally {
+      chmodSync(PLIST_PATH, 0o600);
+    }
   });
 });
 
@@ -200,12 +229,33 @@ describe('resolveBinaryPath', () => {
 });
 
 describe('resolveNodeDir', () => {
-  it('returns the directory containing the current node binary', () => {
-    expect(resolveNodeDir()).toBe(dirname(process.execPath));
+  const originalPath = process.env.PATH;
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
   });
 
   it('returns a non-empty string', () => {
     expect(resolveNodeDir().length).toBeGreaterThan(0);
+  });
+
+  it('returns the unresolved PATH dir containing node, not the resolved execPath dir', () => {
+    // Create a temp dir with a symlink "node" → process.execPath to simulate
+    // the Homebrew layout (stable /opt/homebrew/bin symlink → versioned Cellar binary).
+    const tmpDir = mkdtempSync(join(nodeOs.tmpdir(), 'nr-nodedir-test-'));
+    try {
+      symlinkSync(process.execPath, join(tmpDir, 'node'));
+      process.env.PATH = `${tmpDir}:${originalPath}`;
+      // resolveNodeDir() must return the symlink dir, not dirname(process.execPath).
+      expect(resolveNodeDir()).toBe(tmpDir);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to dirname(process.execPath) when node is not on PATH', () => {
+    process.env.PATH = '/nonexistent/dir1:/nonexistent/dir2';
+    expect(resolveNodeDir()).toBe(dirname(process.execPath));
   });
 });
 
@@ -236,7 +286,7 @@ describe('installDashboardDaemon', () => {
     const content = readFileSync(DASHBOARD_PLIST_PATH, 'utf-8');
     expect(content).toContain('<key>EnvironmentVariables</key>');
     expect(content).toContain('<key>PATH</key>');
-    expect(content).toContain(dirname(process.execPath));
+    expect(content).toContain(resolveNodeDir());
     expect(content).toContain('/usr/bin:/bin');
   });
 
@@ -275,14 +325,88 @@ describe('removeDashboardDaemon', () => {
 });
 
 describe('getDashboardDaemonStatus', () => {
-  it('returns installed:false when plist is absent', () => {
-    expect(getDashboardDaemonStatus()).toEqual({ installed: false });
+  it('returns installed:false readable:false when plist is absent', () => {
+    expect(getDashboardDaemonStatus()).toEqual({ installed: false, readable: false });
   });
 
-  it('returns installed:true with binaryPath after install', () => {
+  it('returns installed:true readable:true with binaryPath and envPath after install', () => {
     installDashboardDaemon('/usr/local/bin/preflight');
     const status = getDashboardDaemonStatus();
     expect(status.installed).toBe(true);
+    expect(status.readable).toBe(true);
     expect(status.binaryPath).toBe('/usr/local/bin/preflight');
+    expect(status.envPath).toContain(resolveNodeDir());
+    expect(status.envPath).toContain('/usr/bin');
+  });
+
+  it('returns installed:true readable:false when plist exists but is unreadable', () => {
+    writeFileSync(DASHBOARD_PLIST_PATH, '<plist/>', { mode: 0o600 });
+    chmodSync(DASHBOARD_PLIST_PATH, 0o000);
+    try {
+      const status = getDashboardDaemonStatus();
+      expect(status.installed).toBe(true);
+      expect(status.readable).toBe(false);
+      expect(status.envPath).toBeUndefined();
+    } finally {
+      chmodSync(DASHBOARD_PLIST_PATH, 0o600);
+    }
+  });
+
+  it('returns envPath:undefined for an older plist without PATH injection', () => {
+    const legacyPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.preflight.dashboard</string>
+  <key>ProgramArguments</key><array><string>/usr/local/bin/preflight</string><string>--local</string></array>
+</dict></plist>`;
+    writeFileSync(DASHBOARD_PLIST_PATH, legacyPlist);
+    const status = getDashboardDaemonStatus();
+    expect(status.installed).toBe(true);
+    expect(status.readable).toBe(true);
+    expect(status.envPath).toBeUndefined();
+  });
+});
+
+describe('unescapeXml', () => {
+  it('round-trips basic entities', () => {
+    expect(unescapeXml('&lt;&gt;&amp;&quot;&apos;')).toBe('<>&"\'');
+  });
+
+  it('decodes &amp; last so &amp;lt; becomes &lt; not <', () => {
+    expect(unescapeXml('&amp;lt;')).toBe('&lt;');
+  });
+
+  it('does not double-decode a path that escapeXml would produce for a path containing &lt;', () => {
+    // A path containing the literal text '&lt;' (five chars):
+    // escapeXml encodes '&' → '&amp;', so the full encoding is '&amp;lt;'.
+    // unescapeXml must decode back to '&lt;', not '<'.
+    const original = '/some/path/&lt;version&gt;/node';
+    const escaped = original.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    expect(unescapeXml(escaped)).toBe(original);
+  });
+});
+
+describe('findExecutableNodeDir', () => {
+  it('returns hasNonExecutable:false for a broken symlink named node (treated as not found; fix is reinstall, not chmod)', () => {
+    const tmpDir = mkdtempSync(join(nodeOs.tmpdir(), 'nr-findnode-test-'));
+    try {
+      const target = join(tmpDir, 'nonexistent-target');
+      symlinkSync(target, join(tmpDir, 'node'));
+      const result = findExecutableNodeDir([tmpDir]);
+      expect(result.dir).toBeNull();
+      expect(result.hasNonExecutable).toBe(false);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns hasNonExecutable:false for a dir with no node entry at all', () => {
+    const tmpDir = mkdtempSync(join(nodeOs.tmpdir(), 'nr-findnode-test-'));
+    try {
+      const result = findExecutableNodeDir([tmpDir]);
+      expect(result.dir).toBeNull();
+      expect(result.hasNonExecutable).toBe(false);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/install/schedule.ts
+++ b/src/install/schedule.ts
@@ -12,22 +12,37 @@ import {
 import { resolve, join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 
+import { createLogger } from '../shared/index.js';
+import { errMsg } from './json-utils.js';
+
+const logger = createLogger('schedule');
+
 function escapeXml(s: string): string {
   return s
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export function unescapeXml(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
 }
 
 const PLIST_LABEL = 'com.preflight.update';
 const DASHBOARD_PLIST_LABEL = 'com.preflight.dashboard';
 
-function plistPath(): string {
+export function plistPath(): string {
   return resolve(homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.plist`);
 }
 
-function dashboardPlistPath(): string {
+export function dashboardPlistPath(): string {
   return resolve(homedir(), 'Library', 'LaunchAgents', `${DASHBOARD_PLIST_LABEL}.plist`);
 }
 
@@ -39,11 +54,73 @@ function dashboardLogPath(): string {
   return resolve(homedir(), '.newrelic-preflight', 'dashboard.log');
 }
 
+export interface FindExecutableNodeDirResult {
+  readonly dir: string | null;
+  /** True if a `node` binary was found in one of the dirs but lacked execute permission. */
+  readonly hasNonExecutable: boolean;
+}
+
+// Scans dirs for an executable node binary. Checks both 'node' (standard) and
+// 'nodejs' (Debian/Ubuntu package name). Returns the first matching dir and
+// whether any non-executable candidates were seen (useful for actionable
+// error messages when no match is found).
+export function findExecutableNodeDir(dirs: string[]): FindExecutableNodeDirResult {
+  let hasNonExecutable = false;
+  for (const dir of dirs) {
+    for (const name of ['node', 'nodejs']) {
+      const candidate = join(dir, name);
+      try {
+        if (!statSync(candidate).isFile()) {
+          // Not a file (directory, device node, etc.) — not a permission problem,
+          // so don't set hasNonExecutable which would produce misleading chmod advice.
+          continue;
+        }
+        try {
+          accessSync(candidate, constants.X_OK);
+          return { dir, hasNonExecutable: false };
+        } catch {
+          hasNonExecutable = true;
+        }
+      } catch {
+        // statSync follows symlinks. Both a genuinely absent file and a broken symlink
+        // (dangling after a node upgrade) throw ENOENT here. Treat both as not found —
+        // the right fix for a dangling symlink is "reinstall node", which is what the
+        // 'No executable node binary found' message in diagnostics already suggests.
+      }
+    }
+  }
+  return { dir: null, hasNonExecutable };
+}
+
 // Returns the directory containing the node binary running this process.
 // Injected into launchd plists so the daemon can find node regardless of
-// which version manager (Homebrew, nvm, volta, asdf) the user has.
+// which version manager the user has.
+//
+// We walk PATH and return the directory of the first unresolved `node` match
+// rather than dirname(process.execPath). process.execPath resolves symlinks,
+// which on Homebrew gives the versioned Cellar path that `brew upgrade node`
+// removes. Returning the unresolved PATH dir (e.g. /opt/homebrew/bin) gives
+// a stable symlink that survives node upgrades without re-running setup.
+// Note: nvm uses version-specific dirs (e.g. ~/.nvm/versions/node/v20/bin)
+// that disappear after `nvm uninstall <version>` — run `preflight setup`
+// again after switching nvm versions.
 export function resolveNodeDir(): string {
-  return dirname(process.execPath);
+  const pathDirs = (process.env.PATH ?? '').split(':').filter(Boolean);
+  const { dir } = findExecutableNodeDir(pathDirs);
+  if (dir !== null) return dir;
+  const fallback = dirname(process.execPath);
+  logger.warn(
+    'No executable node binary found in PATH dirs; falling back to dirname(process.execPath) — this may be a versioned path that breaks after upgrades. Re-run preflight setup to fix.',
+    { fallback },
+  );
+  // Also write a plain-text warning for interactive terminals: the logger.warn
+  // above emits structured JSON which a terminal user cannot read without a log
+  // viewer, so this gives the same message in human-readable form.
+  process.stderr.write(
+    `\nWarning: node binary not found in PATH — the daemon plist will use '${fallback}',\n` +
+      `which may break after a node upgrade. Run 'preflight setup' again after updating node.\n\n`,
+  );
+  return fallback;
 }
 
 function buildPlist(binaryPath: string, hour: number, minute: number, nodeDir: string): string {
@@ -82,6 +159,7 @@ function buildPlist(binaryPath: string, hour: number, minute: number, nodeDir: s
 
 export interface ScheduleStatus {
   readonly installed: boolean;
+  readonly readable: boolean;
   readonly hour?: number;
   readonly minute?: number;
   readonly binaryPath?: string;
@@ -100,24 +178,38 @@ export function installSchedule(binaryPath: string, hour: number, minute: number
   try {
     execFileSync('launchctl', ['load', path], { stdio: 'pipe' });
   } catch (err) {
-    throw new Error(`launchctl load failed: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`launchctl load failed: ${errMsg(err)}`);
   }
 }
 
-export function removeSchedule(): void {
+export function removeSchedule(): boolean {
   const path = plistPath();
-  if (!existsSync(path)) return;
+  if (!existsSync(path)) return false;
   try {
     execFileSync('launchctl', ['unload', path], { stdio: 'pipe' });
   } catch {
-    // Already unloaded.
+    // Plist may be unreadable — remove by label so the job isn't orphaned in launchd.
+    try {
+      execFileSync('launchctl', ['remove', PLIST_LABEL], { stdio: 'pipe' });
+    } catch {
+      // Job was not loaded — fine.
+    }
   }
-  unlinkSync(path);
+  try {
+    unlinkSync(path);
+  } catch (err) {
+    // The launchd job was removed above; the plist file is now an orphaned artifact
+    // but harmless (launchctl will not auto-load it). Log the failure so the user
+    // can clean it manually if desired, but report success so the uninstall can
+    // proceed without trapping the user in a retry loop.
+    logger.warn('schedule plist could not be deleted', { path, err: errMsg(err) });
+  }
+  return true;
 }
 
 export function getScheduleStatus(): ScheduleStatus {
   const path = plistPath();
-  if (!existsSync(path)) return { installed: false };
+  if (!existsSync(path)) return { installed: false, readable: false };
   try {
     const content = readFileSync(path, 'utf-8');
     const hourMatch = content.match(/<key>Hour<\/key>\s*<integer>(\d+)<\/integer>/);
@@ -127,12 +219,13 @@ export function getScheduleStatus(): ScheduleStatus {
     );
     return {
       installed: true,
+      readable: true,
       hour: hourMatch ? parseInt(hourMatch[1], 10) : undefined,
       minute: minuteMatch ? parseInt(minuteMatch[1], 10) : undefined,
-      binaryPath: binaryMatch ? binaryMatch[1] : undefined,
+      binaryPath: binaryMatch ? unescapeXml(binaryMatch[1]) : undefined,
     };
   } catch {
-    return { installed: false };
+    return { installed: true, readable: false };
   }
 }
 
@@ -155,6 +248,8 @@ function buildDashboardPlist(binaryPath: string, nodeDir: string): string {
   </dict>
   <key>KeepAlive</key>
   <true/>
+  <key>ThrottleInterval</key>
+  <integer>300</integer>
   <key>RunAtLoad</key>
   <true/>
   <key>StandardOutPath</key>
@@ -167,7 +262,10 @@ function buildDashboardPlist(binaryPath: string, nodeDir: string): string {
 
 export interface DashboardDaemonStatus {
   readonly installed: boolean;
+  readonly readable: boolean;
   readonly binaryPath?: string;
+  /** Decoded PATH value from the plist EnvironmentVariables. Absent on older plists that predate node-path injection. */
+  readonly envPath?: string;
 }
 
 export function installDashboardDaemon(binaryPath: string): void {
@@ -183,35 +281,52 @@ export function installDashboardDaemon(binaryPath: string): void {
   try {
     execFileSync('launchctl', ['load', path], { stdio: 'pipe' });
   } catch (err) {
-    throw new Error(`launchctl load failed: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`launchctl load failed: ${errMsg(err)}`);
   }
 }
 
-export function removeDashboardDaemon(): void {
+export function removeDashboardDaemon(): boolean {
   const path = dashboardPlistPath();
-  if (!existsSync(path)) return;
+  if (!existsSync(path)) return false;
   try {
     execFileSync('launchctl', ['unload', path], { stdio: 'pipe' });
   } catch {
-    // Already unloaded.
+    // Plist may be unreadable — remove by label so the job isn't orphaned in launchd.
+    try {
+      execFileSync('launchctl', ['remove', DASHBOARD_PLIST_LABEL], { stdio: 'pipe' });
+    } catch {
+      // Job was not loaded — fine.
+    }
   }
-  unlinkSync(path);
+  try {
+    unlinkSync(path);
+  } catch (err) {
+    // The launchd job was removed above; the plist file is now an orphaned artifact
+    // but harmless (launchctl will not auto-load it). Log the failure so the user
+    // can clean it manually if desired, but report success so the uninstall can
+    // proceed without trapping the user in a retry loop.
+    logger.warn('daemon plist could not be deleted', { path, err: errMsg(err) });
+  }
+  return true;
 }
 
 export function getDashboardDaemonStatus(): DashboardDaemonStatus {
   const path = dashboardPlistPath();
-  if (!existsSync(path)) return { installed: false };
+  if (!existsSync(path)) return { installed: false, readable: false };
   try {
     const content = readFileSync(path, 'utf-8');
     const binaryMatch = content.match(
       /<key>ProgramArguments<\/key>\s*<array>\s*<string>([^<]+)<\/string>/,
     );
+    const pathMatch = content.match(/<key>PATH<\/key>\s*<string>([^<]+)<\/string>/);
     return {
       installed: true,
-      binaryPath: binaryMatch ? binaryMatch[1] : undefined,
+      readable: true,
+      binaryPath: binaryMatch ? unescapeXml(binaryMatch[1]) : undefined,
+      envPath: pathMatch ? unescapeXml(pathMatch[1]) : undefined,
     };
   } catch {
-    return { installed: false };
+    return { installed: true, readable: false };
   }
 }
 

--- a/src/install/setup-wizard.test.ts
+++ b/src/install/setup-wizard.test.ts
@@ -41,7 +41,7 @@ jest.mock('./key-validator.js', () => ({
 jest.mock('./schedule.js', () => ({
   installSchedule: jest.fn(),
   removeSchedule: jest.fn(),
-  getScheduleStatus: jest.fn(() => ({ installed: false })),
+  getScheduleStatus: jest.fn(() => ({ installed: false, readable: false })),
   resolveBinaryPath: jest.fn(() => null),
 }));
 

--- a/src/install/setup-wizard.ts
+++ b/src/install/setup-wizard.ts
@@ -579,12 +579,14 @@ export async function runSetupWizard(): Promise<void> {
       const binaryPath = resolveBinaryPath();
       const daemonAnswer = (
         await rl.question(
-          '\nInstall always-on background dashboard? Keeps the local dashboard running even when Claude Code is closed [Y/n]: ',
+          '\nInstall always-on background dashboard? Keeps the local dashboard running even when Claude Code is closed [y/N]: ',
         )
       )
         .trim()
         .toLowerCase();
-      if (daemonAnswer !== 'n' && daemonAnswer !== 'no') {
+      // Daemon install is explicitly opt-in ([y/N]) — unlike every other wizard prompt —
+      // because it installs a persistent launchd service that survives Claude Code restarts.
+      if (daemonAnswer === 'y' || daemonAnswer === 'yes') {
         if (binaryPath) {
           try {
             // installDashboardDaemon calls launchctl unload before load, so


### PR DESCRIPTION
## Summary

This release focuses on reliability and correctness across uninstall, the `preflight doctor` command, and the background dashboard daemon.

### Uninstall improvements

- **`preflight uninstall --daemon`** — new flag that removes only the background dashboard daemon (launchd plist) without touching hooks, MCP config, schedule, or session history. Useful when you just need to stop a broken or unwanted daemon.
- **Confirmation prompt** — bare `preflight uninstall` now lists every file and plist that will be affected and explicitly notes that session history will _not_ be deleted, before asking `Continue? [y/N]`.
- **`--yes` flag** — skips the interactive prompt for use in scripts and CI pipelines.
- **Non-TTY detection** — exits cleanly with code 1 when stdin is not a terminal and `--yes` is not passed, instead of hanging.
- **Correct exit codes** — cancellation (interactive `n` or non-TTY without `--yes`) exits 1 to match script expectations. Partial failure (e.g. a permission error mid-removal) also sets exit code 1.
- **TOCTOU safety** — handles the case where a file is externally removed between the confirmation check and the actual removal.

### `preflight doctor` improvements

- **Daemon-not-installed is now a warning, not a failure** — the always-on dashboard daemon is an optional feature; not having it installed is not a problem.
- **Correct Homebrew node path detection** — the doctor check now validates against the stable symlink directory (e.g. `/opt/homebrew/bin`) rather than the resolved Cellar path that `brew upgrade node` removes.
- **Pre-v1.0.6 plist compatibility** — if you installed the daemon before the PATH injection fix landed, the doctor check now shows `warn + reinstall guidance` instead of a spurious `fail`.
- **NR reachability skipped when config is absent or invalid** — prevents the misleading double-failure (config missing + NR unreachable) on first-time setups.
- **4xx responses surfaced as warnings** — a wrong or expired license key on the NR reachability check is now reported as `warn` instead of silently counted as `ok`.
- **Accurate skip messages** — "no config file — run `preflight setup` first" vs. "config errors present" are now distinct messages.
- **EACCES vs ENOENT for node binary** — a node binary that exists but is not executable gets its own diagnostic message and fix advice, distinct from a missing binary.

### Daemon stability

- **`ThrottleInterval: 300`** added to the launchd plist — prevents the daemon from spinning at high CPU in a tight crash loop if node is missing or the binary is unreachable.
- **Daemon prompt changed from `[Y/n]` to `[y/N]`** — installing a persistent launchd service is now explicitly opt-in rather than the default.
- **`launchctl remove <label>` fallback** — if `launchctl unload <path>` fails (e.g. plist is unreadable), the job is removed by label to prevent an orphan surviving until reboot.

## Test plan

- [ ] `npm run build && npm test` passes
- [ ] `preflight uninstall` shows confirmation prompt listing affected files
- [ ] `preflight uninstall --yes` completes without prompting
- [ ] `preflight uninstall --daemon` removes only the daemon plist
- [ ] `preflight doctor` shows `warn` (not `fail`) when daemon is not installed
- [ ] CI passes on public repo