### PR TITLE
Fix + Docs: v1.0.8 — preflight update reliability + tool selection score guidance (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.8] - 2026-07-02
+
+### Fixed
+
+- **`preflight update` with package manager installs** — when preflight is installed via a package manager (global `npm install -g`, `pnpm add -g`, or a local `npm install` into `node_modules`), running `preflight update` now prints a clear reinstall command instead of failing with a cryptic `not a git repository` error from git
+- **`preflight update` divergent branches** — when `git pull` fails (e.g. local commits ahead of remote), the error output now includes a `git fetch origin && git reset --hard origin/<branch>` command (replace `<branch>` with your default branch name) rather than a generic "check the output above" message
+
+### Changed
+
+- New **Improving Your Tool Selection Score** section in `docs/ADVANCED.md` — explains what triggers each of the three tool selection penalties (redundant reads, repeated failures, unused large outputs) and gives concrete prompt-writing tips to avoid them. Cross-referenced from the `nr_observe_get_tool_selection_score` entry in `docs/COMMANDS_TABLE.md`.
+
+---
+
 ## [1.0.7] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ You'll need a **license key** (telemetry ingest) and your **account ID**, plus a
 ```bash
 preflight doctor               # Run 6 diagnostic checks and print actionable fix commands
 preflight validate             # Check config for syntax errors and unknown keys
-preflight update               # Pull latest version and rebuild
+preflight update               # Pull latest version and rebuild (source installs only — npm installs: npm install -g @newrelic/preflight@latest)
 preflight uninstall            # Remove hooks and MCP config (prompts with a summary first)
 preflight uninstall --yes      # Skip the confirmation prompt (for scripts and CI)
 preflight uninstall --daemon   # Remove only the background dashboard daemon

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -225,3 +225,44 @@ terraform apply
 ```bash
 TF_VAR_account_id=... TF_VAR_api_key=... terraform destroy
 ```
+
+---
+
+## Improving Your Tool Selection Score
+
+`nr_observe_get_tool_selection_score` reports a 0–1 score based on three penalty categories. Here's what each one means and how to write prompts that avoid triggering them.
+
+### Redundant reads
+
+**Triggered when:** the same file is read 3 or more times in a session without an intervening edit or write to that file.
+
+The first two reads of any file are always free. The penalty only applies from the third read onward when no edit or write to that file occurred between the previous read and the current one.
+
+**How to avoid:** Front-load context in your prompt. Name the specific file and describe the change you want in a single request rather than asking exploratory questions first.
+
+- Instead of: _"What's in cost-tracker.ts? ... What does getMetrics return? ... Now update it."_
+- Use: _"In `src/metrics/cost-tracker.ts`, update the `getMetrics()` return type to include..."_
+
+### Repeated failures
+
+**Triggered when:** the same tool fails on consecutive calls (back-to-back failures of the same tool name).
+
+A single failure followed by a success does not count. The streak resets only on a successful call to the same tool — calling a different tool between failures does not reset it.
+
+**How to avoid:** When a tool call fails, provide corrective context in your next prompt rather than letting the AI retry identically.
+
+- Instead of: _(letting the AI retry the same failing command)_
+- Use: _"That failed because X isn't installed — use Y instead."_
+
+### Unused large outputs
+
+**Triggered when:** a tool returns 4,000 bytes or more and the output is never acted on. This applies to all tool calls except file-modifying operations (edits, writes, commands). For `Read` calls, the penalty is waived if the same file is subsequently edited or written in the session.
+
+**How to avoid:** Prefer targeted reads over broad ones when you only need to understand something, not change it. Use `grep`/`Bash` for lookups rather than reading entire files.
+
+- Instead of: _"Read `src/metrics/` for background."_
+- Use: _"Search for all callers of `getMetrics()` in `src/metrics/`."_
+
+### Score floor
+
+Even with many penalties the score won't drop below 0.3, so the metric is intended to track trends over time, not penalize individual sessions heavily.

--- a/docs/COMMANDS_TABLE.md
+++ b/docs/COMMANDS_TABLE.md
@@ -1435,7 +1435,7 @@ Tool selection quality score with penalty breakdown for redundant reads, repeate
 
 **Data source:** `ToolSelectionScorer`
 
-**How it works:** Scores the full session tool call sequence. Penalizes: redundant reads (same file read again without intervening modification), repeated failures (same Bash command failed twice), and unused large outputs (tool returned a large response that was never referenced). Score 0–1 where 1 is perfect selection. `worstOffenders` lists the highest-penalty calls.
+**How it works:** Scores the full session tool call sequence. Penalizes: redundant reads (same file read again without intervening modification), repeated failures (same Bash command failed twice), and unused large outputs (tool returned a large response that was never referenced). Score 0–1 where 1 is perfect selection. `worstOffenders` lists the highest-penalty calls. See [Improving Your Tool Selection Score](ADVANCED.md#improving-your-tool-selection-score) for prompt-writing tips to reduce penalties.
 
 **Requires:** `ToolSelectionScorer`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -1,6 +1,8 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import * as fsMod from 'node:fs';
+import * as childMod from 'node:child_process';
+
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 
 import type { DiagnosticCheck } from './diagnostics.js';
@@ -1196,6 +1198,184 @@ describe('platform transition matrix', () => {
     expect(stderr).toContain('Cannot read existing NR config');
     expect(stderr).toContain('invalid JSON');
     stderrSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// preflight update
+// ---------------------------------------------------------------------------
+
+describe('preflight update', () => {
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let mFs: { existsSync: jest.Mock; realpathSync: jest.Mock };
+  let mExec: { execFileSync: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mFs = fsMod as unknown as { existsSync: jest.Mock; realpathSync: jest.Mock };
+    mExec = childMod as unknown as { execFileSync: jest.Mock };
+    // Reset implementations (clearAllMocks only clears call records, not implementations).
+    mExec.execFileSync.mockReset();
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: string | number | null | undefined) => {
+        throw new Error(`process.exit(${String(code)})`);
+      });
+    mFs.existsSync.mockImplementation(() => false);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    exitSpy.mockRestore();
+    process.exitCode = undefined;
+  });
+
+  function getOutput(): string {
+    return stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+  }
+
+  it('exits 1 with package-manager hint when not a git repository (npm global install)', async () => {
+    mFs.realpathSync.mockReturnValue(
+      '/usr/local/lib/node_modules/@newrelic/preflight/dist/index.js',
+    );
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === '/usr/local/lib/node_modules/@newrelic/preflight/package.json',
+    );
+    mExec.execFileSync.mockImplementation((cmd: unknown) => {
+      if (cmd === 'git') throw new Error('not a git repository');
+    });
+    await expect(runInstallCli(['update'])).rejects.toThrow('process.exit(1)');
+    const output = getOutput();
+    expect(output).toContain('package manager');
+    expect(output).toContain('npm install -g @newrelic/preflight@latest');
+  });
+
+  it('exits 1 with package-manager hint when installed into node_modules (local npm install)', async () => {
+    mFs.realpathSync.mockReturnValue(
+      '/home/user/myproject/node_modules/@newrelic/preflight/dist/index.js',
+    );
+    mFs.existsSync.mockImplementation(
+      (p: unknown) =>
+        String(p) === '/home/user/myproject/node_modules/@newrelic/preflight/package.json',
+    );
+    // git root is the project root; repoRoot sits below node_modules in the tree
+    mExec.execFileSync.mockImplementation((cmd: unknown, args: unknown) => {
+      if (cmd === 'git' && (args as string[]).includes('--show-toplevel'))
+        return '/home/user/myproject';
+    });
+    await expect(runInstallCli(['update'])).rejects.toThrow('process.exit(1)');
+    const output = getOutput();
+    expect(output).toContain('package manager');
+    expect(output).toContain('npm install -g @newrelic/preflight@latest');
+  });
+
+  it('exits 1 with git-not-installed hint when git binary is absent', async () => {
+    mFs.realpathSync.mockReturnValue('/home/user/projects/preflight/dist/index.js');
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === '/home/user/projects/preflight/package.json',
+    );
+    mExec.execFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('spawn git ENOENT'), { code: 'ENOENT' });
+    });
+    await expect(runInstallCli(['update'])).rejects.toThrow('process.exit(1)');
+    const output = getOutput();
+    expect(output).toContain('git is not installed');
+    expect(output).toContain('https://git-scm.com');
+    expect(output).not.toContain('package manager');
+  });
+
+  it('proceeds with update when source clone is inside a path with a node_modules ancestor', async () => {
+    mFs.realpathSync.mockReturnValue('/home/user/node_modules/preflight/dist/index.js');
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === '/home/user/node_modules/preflight/package.json',
+    );
+    // git root IS repoRoot — no node_modules in the relative path, so it is a source clone
+    mExec.execFileSync.mockImplementation((cmd: unknown, args: unknown) => {
+      if (cmd === 'git' && (args as string[]).includes('--show-toplevel'))
+        return '/home/user/node_modules/preflight';
+      return undefined;
+    });
+    await runInstallCli(['update']);
+    const output = getOutput();
+    expect(output).toContain('Update complete');
+    expect(output).not.toContain('package manager');
+    expect(mExec.execFileSync).toHaveBeenCalledWith(
+      'git',
+      ['pull'],
+      expect.objectContaining({ cwd: '/home/user/node_modules/preflight' }),
+    );
+    expect(mExec.execFileSync).toHaveBeenCalledWith(
+      'npm',
+      ['run', 'build'],
+      expect.objectContaining({ cwd: '/home/user/node_modules/preflight' }),
+    );
+  });
+
+  it('exits 1 with diverged-branch hint when git pull fails', async () => {
+    mFs.realpathSync.mockReturnValue('/home/user/projects/preflight/dist/index.js');
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === '/home/user/projects/preflight/package.json',
+    );
+    mExec.execFileSync.mockImplementation((cmd: unknown, args: unknown) => {
+      const a = args as string[];
+      if (cmd === 'git' && a.includes('--show-toplevel')) return '/home/user/projects/preflight';
+      if (cmd === 'git' && a[0] === 'pull') throw new Error('fatal: divergent branches');
+    });
+    await expect(runInstallCli(['update'])).rejects.toThrow('process.exit(1)');
+    const output = getOutput();
+    expect(output).toContain('git pull failed');
+    expect(output).toContain('diverged');
+    expect(output).toContain('fetch origin');
+    expect(output).toContain('reset --hard');
+  });
+
+  it('exits 1 with plain build error and no divergence hint when npm build fails', async () => {
+    mFs.realpathSync.mockReturnValue('/home/user/projects/preflight/dist/index.js');
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === '/home/user/projects/preflight/package.json',
+    );
+    mExec.execFileSync.mockImplementation((cmd: unknown, args: unknown) => {
+      const a = args as string[];
+      if (cmd === 'git' && a.includes('--show-toplevel')) return '/home/user/projects/preflight';
+      if (cmd === 'npm') throw new Error('Build failed');
+    });
+    await expect(runInstallCli(['update'])).rejects.toThrow('process.exit(1)');
+    const output = getOutput();
+    expect(output).toContain('Build failed');
+    expect(output).not.toContain('diverged');
+    expect(output).not.toContain('fetch origin');
+    expect(
+      (mExec.execFileSync.mock.calls as unknown[][]).filter(
+        (c) => c[0] === 'git' && (c[1] as string[])[0] === 'pull',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('proceeds with update when package is a subdirectory of the git root (monorepo layout)', async () => {
+    mFs.realpathSync.mockReturnValue('/repo/packages/preflight/dist/index.js');
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === '/repo/packages/preflight/package.json',
+    );
+    mExec.execFileSync.mockImplementation((cmd: unknown, args: unknown) => {
+      if (cmd === 'git' && (args as string[]).includes('--show-toplevel')) return '/repo';
+      return undefined;
+    });
+    await runInstallCli(['update']);
+    const output = getOutput();
+    expect(output).toContain('Update complete');
+    expect(output).not.toContain('package manager');
+    expect(mExec.execFileSync).toHaveBeenCalledWith(
+      'git',
+      ['pull'],
+      expect.objectContaining({ cwd: '/repo/packages/preflight' }),
+    );
+    expect(mExec.execFileSync).toHaveBeenCalledWith(
+      'npm',
+      ['run', 'build'],
+      expect.objectContaining({ cwd: '/repo/packages/preflight' }),
+    );
   });
 });
 

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -8,7 +8,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, copyFileSync, realpathSync } from 'node:fs';
 import { createInterface } from 'node:readline/promises';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import { Command } from 'commander';
 
@@ -201,18 +201,61 @@ function handleUpdate(): void {
     process.exit(1);
   }
 
+  let gitRoot!: string;
+  try {
+    gitRoot = execFileSync('git', ['-C', repoRoot, 'rev-parse', '--show-toplevel'], {
+      stdio: 'pipe',
+      env: { ...process.env, GIT_DIR: undefined, GIT_WORK_TREE: undefined },
+    })
+      .toString()
+      .trim();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      print('✗ git is not installed or not found on PATH.');
+      print('  Install git (https://git-scm.com) then retry: preflight update');
+    } else {
+      print('✗ preflight was installed via a package manager, not cloned from source.');
+      print('  (If your .git directory is missing or corrupt, re-clone the repo instead.)');
+      print('  To update, reinstall using your package manager, e.g.:');
+      print('    npm install -g @newrelic/preflight@latest');
+      print('    pnpm add -g @newrelic/preflight@latest');
+    }
+    process.exit(1);
+  }
+  // If repoRoot sits below a node_modules directory within the git tree,
+  // preflight is installed as a dependency — not a source clone.
+  // path.relative() normalises separators on all platforms (robust on Windows).
+  if (relative(gitRoot, repoRoot).split(sep).includes('node_modules')) {
+    print('✗ preflight was installed via a package manager, not cloned from source.');
+    print('  To update, reinstall using your package manager, e.g.:');
+    print('    npm install -g @newrelic/preflight@latest');
+    print('    pnpm add -g @newrelic/preflight@latest');
+    process.exit(1);
+  }
+
   print(`Updating Preflight from ${repoRoot}...\n`);
 
   try {
     print('→ git pull');
     execFileSync('git', ['pull'], { cwd: repoRoot, stdio: 'inherit' });
+  } catch {
+    print('\n✗ git pull failed. Check the output above for details.');
+    print('  If the output shows diverged branches and you have no local commits to keep,');
+    print('  you can reset to the remote HEAD (replace <branch> with your default branch):');
+    print(`    git -C "${repoRoot}" fetch origin`);
+    print(`    git -C "${repoRoot}" reset --hard origin/<branch>`);
+    print('  WARNING: reset --hard permanently discards any local commits not yet on origin.');
+    process.exit(1);
+  }
+
+  try {
     print('\n→ npm run build');
     execFileSync('npm', ['run', 'build'], { cwd: repoRoot, stdio: 'inherit' });
     print('\n✓ Update complete.');
     print('  Restart Claude Code to pick up the new version.');
     print('  Run `preflight install` to update the MCP server key in ~/.mcp.json.');
   } catch {
-    print('\n✗ Update failed. Check the output above for details.');
+    print('\n✗ Build failed. Check the output above for details.');
     process.exit(1);
   }
 }


### PR DESCRIPTION
## What's in this release

### Fix: `preflight update` now works correctly for package manager installs

Previously, running `preflight update` on a copy of preflight installed via `npm install -g`, `pnpm add -g`, or as a local `node_modules` dependency would fail with a cryptic `not a git repository` error from git. The command is only meaningful for source clones, where it runs `git pull` + `npm run build`.

This release fixes that with a two-step detection:

1. If `git` is not on PATH, a clear installation link is shown.
2. If `git --show-toplevel` succeeds but `node_modules` appears in the relative path from the git root to the install directory, preflight recognises the install as a package manager dependency and prints the correct reinstall command instead.

The check uses `path.relative()` for cross-platform path comparison, so it works correctly on Windows.

**Before:**
```
$ preflight update
fatal: not a git repository (or any of the parent directories): .git
```

**After:**
```
$ preflight update
✗ preflight was installed via a package manager, not cloned from source.
  To update, reinstall using your package manager, e.g.:
    npm install -g @newrelic/preflight@latest
    pnpm add -g @newrelic/preflight@latest
```

### Fix: clearer error when `git pull` fails with diverged branches

When `git pull` fails (e.g. because you have local commits that have diverged from the remote), the error output now includes a ready-to-run reset command:

```
✗ git pull failed. Check the output above for details.
  If the output shows diverged branches and you have no local commits to keep,
  you can reset to the remote HEAD (replace <branch> with your default branch):
    git -C "/path/to/preflight" fetch origin
    git -C "/path/to/preflight" reset --hard origin/<branch>
  WARNING: reset --hard permanently discards any local commits not yet on origin.
```

The try/catch was also split so the diverged-branch hint only shows when `git pull` specifically fails, not when the subsequent build step fails.

### Docs: tool selection score guide in `docs/ADVANCED.md`

A new **Improving Your Tool Selection Score** section explains the three penalty categories reported by `nr_observe_get_tool_selection_score`, with concrete before/after prompt examples for each:

- **Redundant reads** — reading the same file 3+ times without an edit in between; fix by front-loading context in your prompt
- **Repeated failures** — consecutive failures of the same tool; fix by providing corrective context instead of letting the AI retry identically
- **Unused large outputs** — tool responses ≥ 4 KB that are never acted on; fix by using targeted grep/bash lookups rather than reading full files

`docs/COMMANDS_TABLE.md` is updated to cross-reference the new section.

## Test plan

- [x] All 3,663 tests pass
- [x] Package manager install detection tested: global npm install, local `node_modules` dependency, source clone inside a path containing a `node_modules` ancestor (false-positive regression)
- [x] `git not on PATH` (ENOENT) path tested
- [x] Diverged-branch and build-failure error paths tested with distinct assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)