### PR TITLE
Chore: v1.0.10 — WSL2 ancestor PID walk, symlink version fix, doctor warn fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.10] - 2026-07-03
+
+### Fixed
+
+- **WSL2 + fish shell session tracking** — the hook collector now walks `/proc/<pid>/stat` to find ancestor PIDs (up to 5 levels deep), so the MCP server can match a hook event to its session even when intermediate shell processes (e.g. a fish shell started by WSL2) sit between Claude Code and the collector. On macOS and Windows the behaviour is unchanged.
+- **Version reporting when installed as a symlink** — `preflight --version` now resolves symlinks before locating `package.json`, fixing cases where the binary is installed via `npm link` or a package manager that places a symlink in a `bin/` directory separate from the package root.
+- **`preflight doctor` false alarm for custom hook wrappers** — when a hook event type (e.g. `PostToolUse`) has a hook command that is not the official preflight collector, the doctor check now reports a **warning** rather than a failure, since the user may be wrapping `preflight-collector` in a custom script. A hook event type with no command at all still reports as a failure.
+
+---
+
 ## [1.0.9] - 2026-07-02
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -15,6 +15,8 @@ import {
   getTranscriptPath,
   getBufferPath,
   writePpidBreadcrumb,
+  getLinuxAncestorPids,
+  _procFs,
 } from './collector-script.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -895,6 +897,134 @@ describe('collector-script', () => {
       processHook(makePreToolUse({ session_id: 'sess-bc' }));
       const breadcrumbPath = resolve(tmpDir, 'session-by-ppid', `${process.ppid}.txt`);
       expect(readFileSync(breadcrumbPath, 'utf-8')).toBe('sess-bc');
+    });
+
+    it('writes breadcrumb at each ancestor PID (end-to-end WSL+fish path)', () => {
+      // Inject a fake /proc chain: process.ppid → fakeGrandpid → (ENOENT, stop).
+      // Both the direct-ppid slot and the ancestor slot must be written.
+      const ppid = process.ppid;
+      const fakeGrandpid = 99_997;
+      const origReadFile = _procFs.readFile;
+      _procFs.readFile = (path: string): string => {
+        if (path === `/proc/${ppid}/stat`)
+          return `${ppid} (sh) S ${fakeGrandpid} ${ppid} ${ppid} 0 -1 0`;
+        throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
+      };
+      try {
+        writePpidBreadcrumb('sess-ancestor');
+      } finally {
+        _procFs.readFile = origReadFile;
+      }
+
+      const breadcrumbDir = resolve(tmpDir, 'session-by-ppid');
+
+      const directCrumb = resolve(breadcrumbDir, `${ppid}.txt`);
+      expect(existsSync(directCrumb)).toBe(true);
+      expect(readFileSync(directCrumb, 'utf-8')).toBe('sess-ancestor');
+
+      const ancestorCrumb = resolve(breadcrumbDir, `${fakeGrandpid}.txt`);
+      expect(existsSync(ancestorCrumb)).toBe(true);
+      expect(readFileSync(ancestorCrumb, 'utf-8')).toBe('sess-ancestor');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getLinuxAncestorPids
+  // ---------------------------------------------------------------------------
+  describe('getLinuxAncestorPids()', () => {
+    let originalReadFile: typeof _procFs.readFile;
+
+    beforeEach(() => {
+      originalReadFile = _procFs.readFile;
+    });
+
+    afterEach(() => {
+      _procFs.readFile = originalReadFile;
+    });
+
+    function mockProc(statMap: Record<string, string>): void {
+      _procFs.readFile = (path: string): string => {
+        if (path in statMap) return statMap[path]!;
+        if (/^\/proc\/\d+\/stat$/.test(path)) {
+          throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
+        }
+        // Real call for non-/proc/ paths (other tests in this file use real fs)
+        throw Object.assign(new Error(`unexpected readFile: ${path}`), { code: 'ENOENT' });
+      };
+    }
+
+    it('returns [startPpid] when /proc/<pid>/stat is not readable', () => {
+      mockProc({}); // all /proc/ reads throw ENOENT
+      expect(getLinuxAncestorPids(1001)).toEqual([1001]);
+    });
+
+    it('walks one intermediate shell process (the WSL+fish case)', () => {
+      // claude=1000, sh=1001, collector ppid=1001
+      mockProc({
+        '/proc/1001/stat': '1001 (sh) S 1000 1001 1000 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 0',
+        // /proc/1000/stat not present → stops there
+      });
+      expect(getLinuxAncestorPids(1001)).toEqual([1001, 1000]);
+    });
+
+    it('handles process names that contain parentheses', () => {
+      // lastIndexOf(')') must find the field-separator paren, not one inside the name
+      mockProc({
+        '/proc/2000/stat': '2000 (my(app)name) S 1999 2000 2000 0 -1 0 0 0 0 0',
+      });
+      expect(getLinuxAncestorPids(2000)).toEqual([2000, 1999]);
+    });
+
+    it('does not include PID 1 (init/systemd)', () => {
+      mockProc({
+        '/proc/100/stat': '100 (daemon) S 1 100 100 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 0',
+      });
+      // ppid of 100 is 1 → stop condition: parentPid <= 1
+      expect(getLinuxAncestorPids(100)).toEqual([100]);
+    });
+
+    it('does not include PID 0', () => {
+      mockProc({
+        '/proc/50/stat': '50 (kthread) S 0 0 0 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 0',
+      });
+      expect(getLinuxAncestorPids(50)).toEqual([50]);
+    });
+
+    it('stops at maxDepth and returns startPpid + that many ancestors', () => {
+      // Chain: 100 → 99 → 98 → 97 → 96 → 95 (unlimited)
+      const statMap: Record<string, string> = {};
+      for (let pid = 100; pid > 90; pid--) {
+        statMap[`/proc/${pid}/stat`] = `${pid} (proc) S ${pid - 1} ${pid} ${pid} 0 -1 0`;
+      }
+      mockProc(statMap);
+      // default maxDepth=5: starts with [100], walks 5 times → [100,99,98,97,96,95]
+      const result = getLinuxAncestorPids(100);
+      expect(result).toHaveLength(6);
+      expect(result[0]).toBe(100);
+      expect(result[5]).toBe(95);
+
+      // explicit maxDepth=2: [100, 99, 98]
+      expect(getLinuxAncestorPids(100, 2)).toEqual([100, 99, 98]);
+    });
+
+    it('breaks on a cycle and does not loop infinitely', () => {
+      // 100 → 99 → 100 (cycle)
+      mockProc({
+        '/proc/100/stat': '100 (proc) S 99 100 100 0 -1 0',
+        '/proc/99/stat': '99 (proc) S 100 99 99 0 -1 0', // cycle back to 100
+      });
+      const result = getLinuxAncestorPids(100);
+      expect(result).toEqual([100, 99]); // stops before re-adding 100
+    });
+
+    it('returns [startPpid] when stat has no closing parenthesis', () => {
+      mockProc({ '/proc/300/stat': '300 malformed-no-parens' });
+      expect(getLinuxAncestorPids(300)).toEqual([300]);
+    });
+
+    it('returns [startPpid] when parsed ppid is NaN', () => {
+      mockProc({ '/proc/400/stat': '400 (proc) S notanumber ...' });
+      expect(getLinuxAncestorPids(400)).toEqual([400]);
     });
   });
 });

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -344,32 +344,92 @@ function collectTranscriptTokens(data: {
 // stat() and one read — well under the <5ms budget.
 // ---------------------------------------------------------------------------
 
+/**
+ * Seam for unit tests: replace `readFile` to inject fake `/proc/<pid>/stat`
+ * content without touching the real filesystem. Production code never sets this.
+ * @internal
+ */
+export const _procFs = {
+  readFile: (path: string): string => readFileSync(path, 'utf-8'),
+};
+
+/**
+ * Returns an array starting with `startPpid` and appended with each successive
+ * parent PID read from `/proc/<pid>/stat`, up to `maxDepth` levels deep.
+ *
+ * On non-Linux systems `/proc` is absent; the first read throws, the loop
+ * breaks immediately, and the return value is `[startPpid]` — identical to
+ * the pre-walk behaviour. On Linux with a direct parent relationship it also
+ * returns `[startPpid]` because the parent's ppid will be ≤ 1 (or absent).
+ *
+ * The walk is needed on WSL2 with fish/bash hook-runners that interpose an
+ * intermediate `sh` process: the MCP server's `process.ppid` is Claude's PID,
+ * but the collector's `process.ppid` is the interposed shell. Writing the
+ * breadcrumb at every ancestor ensures the server finds it at its own ppid.
+ */
+export function getLinuxAncestorPids(startPpid: number, maxDepth = 5): number[] {
+  const pids: number[] = [startPpid];
+  let pid = startPpid;
+  for (let depth = 0; depth < maxDepth && pid > 1; depth++) {
+    try {
+      const stat = _procFs.readFile(`/proc/${pid}/stat`);
+      // Format: "pid (comm) state ppid pgrp ..."
+      // The comm field can contain spaces and parentheses; use lastIndexOf to
+      // find the field-separator ')' reliably.
+      const lastParen = stat.lastIndexOf(')');
+      if (lastParen === -1) break;
+      // After the last ')': " state ppid ..." — split on space, index [1] is ppid.
+      const parentPid = parseInt(stat.slice(lastParen + 2).split(' ')[1] ?? '0', 10);
+      if (!Number.isFinite(parentPid) || parentPid <= 1) break;
+      if (pids.includes(parentPid)) break; // cycle guard
+      pids.push(parentPid);
+      pid = parentPid;
+    } catch {
+      break;
+    }
+  }
+  return pids;
+}
+
 let _breadcrumbWriteFailed = false;
 
 function writePpidBreadcrumb(sessionId: string): void {
   if (!SESSION_ID_RE.test(sessionId)) return;
-  // process.ppid is undefined on a few exotic platforms; bail without writing.
   const ppid = process.ppid;
   if (typeof ppid !== 'number' || ppid <= 0) return;
 
   try {
     const storageDir = process.env.NEW_RELIC_AI_MCP_STORAGE_PATH ?? DEFAULT_STORAGE_DIR;
     const breadcrumbDir = resolve(storageDir, 'session-by-ppid');
-    const breadcrumbPath = resolve(breadcrumbDir, `${ppid}.txt`);
+    mkdirSync(breadcrumbDir, { recursive: true, mode: 0o700 });
 
-    // Steady-state short-circuit: most hook fires after the first one are
-    // no-ops because the breadcrumb already contains the right session_id.
-    if (existsSync(breadcrumbPath)) {
-      try {
-        if (readFileSync(breadcrumbPath, 'utf-8').trim() === sessionId) return;
-      } catch {
-        // Fall through and rewrite if the read failed for any reason
+    // Walk ancestor PIDs. On Linux this includes any intermediate shell
+    // processes interposed by the hook runner. On macOS/Windows the array
+    // has exactly one element (process.ppid) — identical to before.
+    // pids[0] (direct ppid) is the authoritative slot — the MCP server uses
+    // its own process.ppid for lookup. Ancestor slots are best-effort; concurrent
+    // sessions sharing a common ancestor PID may overwrite each other there.
+    const pids = getLinuxAncestorPids(ppid);
+
+    let wroteAny = false;
+    for (const pid of pids) {
+      const breadcrumbPath = resolve(breadcrumbDir, `${pid}.txt`);
+      // Short-circuit: no write needed if content already matches.
+      if (existsSync(breadcrumbPath)) {
+        try {
+          if (readFileSync(breadcrumbPath, 'utf-8').trim() === sessionId) {
+            wroteAny = true;
+            continue;
+          }
+        } catch {
+          // Fall through to rewrite if the read failed.
+        }
       }
+      writeFileSync(breadcrumbPath, sessionId, { mode: 0o600 });
+      wroteAny = true;
     }
 
-    mkdirSync(breadcrumbDir, { recursive: true, mode: 0o700 });
-    writeFileSync(breadcrumbPath, sessionId, { mode: 0o600 });
-    _breadcrumbWriteFailed = false;
+    if (wroteAny) _breadcrumbWriteFailed = false;
   } catch (err) {
     if (!_breadcrumbWriteFailed) {
       process.stderr.write(

--- a/src/install/diagnostics.test.ts
+++ b/src/install/diagnostics.test.ts
@@ -60,6 +60,17 @@ jest.mock('./install-helper.js', () => ({
     if (typeof obj.command === 'string') return re.test(obj.command);
     return false;
   }),
+  entryHasAnyCommandHook: jest.fn((entry: unknown) => {
+    if (typeof entry !== 'object' || entry === null) return false;
+    const obj = entry as Record<string, unknown>;
+    if (Array.isArray(obj.hooks)) {
+      return (obj.hooks as Array<Record<string, unknown>>).some(
+        (h) => typeof h.command === 'string' && h.command !== '',
+      );
+    }
+    if (typeof obj.command === 'string') return obj.command !== '';
+    return false;
+  }),
 }));
 
 // Stub platform module.
@@ -379,6 +390,72 @@ describe('runDiagnostics', () => {
       });
       const checks = await runDiagnostics(makeOpts());
       expect(checks.find((x) => x.check === 'Hooks wired')?.status).toBe('ok');
+    });
+
+    it('returns warn when both PreToolUse and PostToolUse have custom (non-NR) commands', async () => {
+      const preEntry = {
+        matcher: '',
+        hooks: [{ type: 'command', command: '/home/user/wrapper.sh pre-tool' }],
+      };
+      const postEntry = {
+        matcher: '',
+        hooks: [{ type: 'command', command: '/home/user/wrapper.sh post-tool' }],
+      };
+      mockedExistSync.mockImplementation((p) => p === '/test-home/.claude/settings.json');
+      mockedReadFileSync.mockImplementation((p) => {
+        if (p === '/test-home/.claude/settings.json')
+          return JSON.stringify({ hooks: { PreToolUse: [preEntry], PostToolUse: [postEntry] } });
+        return '{}';
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hooks wired')!;
+      expect(c.status).toBe('warn');
+      expect(c.detail).toContain('custom hook command');
+      expect(c.detail).toContain('preflight-collector');
+      expect(c.fix).toBeDefined();
+    });
+
+    it('returns warn when one event has the NR hook and the other has a custom command', async () => {
+      const preNrEntry = {
+        matcher: '',
+        hooks: [{ type: 'command', command: 'preflight-collector pre-tool' }],
+      };
+      const postCustomEntry = {
+        matcher: '',
+        hooks: [{ type: 'command', command: '/home/user/wrapper.sh post-tool' }],
+      };
+      mockedExistSync.mockImplementation((p) => p === '/test-home/.claude/settings.json');
+      mockedReadFileSync.mockImplementation((p) => {
+        if (p === '/test-home/.claude/settings.json')
+          return JSON.stringify({
+            hooks: { PreToolUse: [preNrEntry], PostToolUse: [postCustomEntry] },
+          });
+        return '{}';
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hooks wired')!;
+      expect(c.status).toBe('warn');
+      expect(c.detail).toContain('PostToolUse');
+      expect(c.detail).toContain('custom hook command');
+    });
+
+    it('returns fail when one event has the NR hook and the other has no hook at all', async () => {
+      // PostToolUse is completely absent — this is a misconfiguration, not a wrapper.
+      const preNrEntry = {
+        matcher: '',
+        hooks: [{ type: 'command', command: 'preflight-collector pre-tool' }],
+      };
+      mockedExistSync.mockImplementation((p) => p === '/test-home/.claude/settings.json');
+      mockedReadFileSync.mockImplementation((p) => {
+        if (p === '/test-home/.claude/settings.json')
+          return JSON.stringify({ hooks: { PreToolUse: [preNrEntry] } }); // PostToolUse absent
+        return '{}';
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hooks wired')!;
+      expect(c.status).toBe('fail');
+      expect(c.detail).toContain('PostToolUse');
+      expect(c.detail).not.toContain('warn');
     });
   });
 

--- a/src/install/diagnostics.ts
+++ b/src/install/diagnostics.ts
@@ -6,7 +6,11 @@ import { createLogger } from '../shared/index.js';
 
 import { validateConfigFile, DEFAULT_STORAGE_PATH } from '../config.js';
 import { getDashboardDaemonStatus, findExecutableNodeDir } from './schedule.js';
-import { detectSettingsPath, entryContainsNrObserve } from './install-helper.js';
+import {
+  detectSettingsPath,
+  entryContainsNrObserve,
+  entryHasAnyCommandHook,
+} from './install-helper.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
 
 const logger = createLogger('diagnostics');
@@ -188,6 +192,8 @@ function checkHooksWired(settingsPaths: string[]): DiagnosticCheck {
   const anyPathExists = settingsPaths.some(existsSync);
   let hooksPre = false;
   let hooksPost = false;
+  let hooksPreAny = false;
+  let hooksPostAny = false;
   const parseErrorPaths: string[] = [];
   let anyParsed = false;
 
@@ -197,10 +203,14 @@ function checkHooksWired(settingsPaths: string[]): DiagnosticCheck {
       const settings = JSON.parse(readFileSync(sp, 'utf-8')) as Record<string, unknown>;
       anyParsed = true;
       const hooks = settings.hooks as Record<string, unknown[]> | undefined;
-      if (Array.isArray(hooks?.PreToolUse))
+      if (Array.isArray(hooks?.PreToolUse)) {
         hooksPre ||= hooks.PreToolUse.some(entryContainsNrObserve);
-      if (Array.isArray(hooks?.PostToolUse))
+        hooksPreAny ||= hooks.PreToolUse.some(entryHasAnyCommandHook);
+      }
+      if (Array.isArray(hooks?.PostToolUse)) {
         hooksPost ||= hooks.PostToolUse.some(entryContainsNrObserve);
+        hooksPostAny ||= hooks.PostToolUse.some(entryHasAnyCommandHook);
+      }
     } catch (err) {
       logger.debug('settings file could not be parsed — treating as not wired', { err, path: sp });
       parseErrorPaths.push(sp);
@@ -239,16 +249,41 @@ function checkHooksWired(settingsPaths: string[]): DiagnosticCheck {
     };
   }
 
-  const missing = [!hooksPre && 'PreToolUse', !hooksPost && 'PostToolUse']
-    .filter(Boolean)
-    .join(' and ');
+  // Determine which event types are missing the official NR collector hook.
+  const missingNrEvents = (
+    [!hooksPre && 'PreToolUse', !hooksPost && 'PostToolUse'] as (string | false)[]
+  ).filter((x): x is string => x !== false);
+
+  const customEvents = missingNrEvents.filter((ev) =>
+    ev === 'PreToolUse' ? hooksPreAny : hooksPostAny,
+  );
+  const trulyMissingEvents = missingNrEvents.filter((ev) =>
+    ev === 'PreToolUse' ? !hooksPreAny : !hooksPostAny,
+  );
+
   const searched = settingsPaths.filter(existsSync).join(' or ');
   const malformedNote =
     parseErrorPaths.length > 0 ? `; ${parseErrorPaths.join(' and ')} could not be parsed` : '';
+
+  // All missing NR hooks have some other hook command — likely a custom wrapper.
+  if (trulyMissingEvents.length === 0) {
+    return {
+      check: 'Hooks wired',
+      status: 'warn',
+      detail: `${customEvents.join(' and ')} ${customEvents.length > 1 ? 'have' : 'has'} a custom hook command in ${searched} — verify it calls preflight-collector${malformedNote}`,
+      fix: 'Run preflight install to use the official hook, or confirm your script calls preflight-collector <event>-tool',
+    };
+  }
+
+  // At least one event type has no hook command at all — this is a real misconfiguration.
+  const customNote =
+    customEvents.length > 0
+      ? `; ${customEvents.join(' and ')} ${customEvents.length > 1 ? 'have' : 'has'} a custom hook (verify it calls preflight-collector)`
+      : '';
   return {
     check: 'Hooks wired',
     status: 'fail',
-    detail: `${missing} not found in ${searched}${malformedNote}`,
+    detail: `${trulyMissingEvents.join(' and ')} not found in ${searched}${customNote}${malformedNote}`,
     fix: 'preflight install',
   };
 }

--- a/src/install/install-helper.test.ts
+++ b/src/install/install-helper.test.ts
@@ -12,6 +12,7 @@ import {
   removeMcpConfig,
   detectSettingsPath,
   detectMcpConfigPath,
+  entryHasAnyCommandHook,
 } from './install-helper.js';
 
 // ---------------------------------------------------------------------------
@@ -698,5 +699,54 @@ describe('integration: install/uninstall cycle', () => {
     const readBack = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
     expect(readBack.licenseKey).toBe('NRAK-test123');
     expect(readBack.accountId).toBe('99999');
+  });
+});
+
+describe('entryHasAnyCommandHook()', () => {
+  it('returns false for null / non-object entries', () => {
+    expect(entryHasAnyCommandHook(null)).toBe(false);
+    expect(entryHasAnyCommandHook(undefined)).toBe(false);
+    expect(entryHasAnyCommandHook('string')).toBe(false);
+    expect(entryHasAnyCommandHook(42)).toBe(false);
+  });
+
+  it('returns false when hooks array contains no command entries', () => {
+    expect(entryHasAnyCommandHook({ matcher: '', hooks: [] })).toBe(false);
+    expect(entryHasAnyCommandHook({ matcher: '', hooks: [{ type: 'something-else' }] })).toBe(
+      false,
+    );
+  });
+
+  it('returns false for an empty command string', () => {
+    expect(entryHasAnyCommandHook({ matcher: '', hooks: [{ type: 'command', command: '' }] })).toBe(
+      false,
+    );
+    expect(entryHasAnyCommandHook({ command: '' })).toBe(false); // legacy format
+  });
+
+  it('returns true for the official NR collector command (new format)', () => {
+    expect(
+      entryHasAnyCommandHook({
+        matcher: '',
+        hooks: [{ type: 'command', command: 'preflight-collector pre-tool' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for a custom wrapper command (new format)', () => {
+    expect(
+      entryHasAnyCommandHook({
+        matcher: '',
+        hooks: [{ type: 'command', command: '/home/user/wrapper.sh pre-tool' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for the official NR collector command (legacy flat format)', () => {
+    expect(entryHasAnyCommandHook({ command: 'preflight-collector pre-tool' })).toBe(true);
+  });
+
+  it('returns true for a custom command (legacy flat format)', () => {
+    expect(entryHasAnyCommandHook({ command: '/usr/local/bin/my-wrapper post-tool' })).toBe(true);
   });
 });

--- a/src/install/install-helper.ts
+++ b/src/install/install-helper.ts
@@ -160,6 +160,37 @@ export function entryContainsNrObserve(entry: unknown): boolean {
   return false;
 }
 
+/**
+ * Returns true when a hook entry contains any non-empty command hook,
+ * regardless of whether the command matches NR_HOOK_RE.
+ *
+ * Used by the doctor check to distinguish "custom hook that might work"
+ * (worth a warn) from "no hook at all" (definitely broken, needs a fail).
+ */
+export function entryHasAnyCommandHook(entry: unknown): boolean {
+  if (typeof entry !== 'object' || entry === null) return false;
+  const obj = entry as Record<string, unknown>;
+
+  // New format: { matcher, hooks: [{ type, command }] }
+  if (Array.isArray(obj.hooks)) {
+    return obj.hooks.some(
+      (h: unknown) =>
+        typeof h === 'object' &&
+        h !== null &&
+        'command' in (h as Record<string, unknown>) &&
+        typeof (h as Record<string, unknown>).command === 'string' &&
+        (h as Record<string, unknown>).command !== '',
+    );
+  }
+
+  // Legacy flat format: { matcher, command }
+  if ('command' in obj && typeof obj.command === 'string' && obj.command !== '') {
+    return true;
+  }
+
+  return false;
+}
+
 function filterNrObserveEntries(entries: unknown[]): unknown[] {
   return entries.filter((e) => !entryContainsNrObserve(e));
 }

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,0 +1,88 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdirSync, writeFileSync, symlinkSync, rmSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Suppress logger stderr
+jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+let tmpRoot: string;
+const originalArgv1 = process.argv[1];
+
+beforeEach(() => {
+  tmpRoot = resolve(
+    tmpdir(),
+    `nr-version-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(tmpRoot, { recursive: true });
+});
+
+afterEach(() => {
+  process.argv[1] = originalArgv1;
+  if (existsSync(tmpRoot)) rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// Import after mocks are set up.
+// readVersion is re-executed on each call (it's a function, not just the
+// cached VERSION constant), so we can test it with different argv[1] values.
+import { readVersion } from './version.js';
+
+describe('readVersion()', () => {
+  it('reads version from package.json when argv[1] is a direct path', () => {
+    const distDir = resolve(tmpRoot, 'dist');
+    mkdirSync(distDir);
+    writeFileSync(resolve(distDir, 'index.js'), '');
+    writeFileSync(resolve(tmpRoot, 'package.json'), JSON.stringify({ version: '1.2.3' }));
+    process.argv[1] = resolve(distDir, 'index.js');
+    expect(readVersion()).toBe('1.2.3');
+  });
+
+  it('reads version when argv[1] is a symlink pointing into dist/', () => {
+    // Structure: tmpRoot/dist/index.js  ← real file
+    //            tmpRoot/package.json   ← version source
+    //            tmpRoot/bin/preflight  ← symlink → ../dist/index.js
+    const distDir = resolve(tmpRoot, 'dist');
+    const binDir = resolve(tmpRoot, 'bin');
+    mkdirSync(distDir);
+    mkdirSync(binDir);
+    writeFileSync(resolve(distDir, 'index.js'), '');
+    writeFileSync(resolve(tmpRoot, 'package.json'), JSON.stringify({ version: '9.9.9' }));
+    const symlinkPath = resolve(binDir, 'preflight');
+    symlinkSync(resolve(distDir, 'index.js'), symlinkPath);
+
+    process.argv[1] = symlinkPath;
+    // Without realpathSync: dirname(symlinkPath) = binDir → binDir/../package.json → tmpRoot/bin/../package.json → doesn't exist → falls to cwd → '0.0.0'
+    // With realpathSync: resolves to distDir/index.js → distDir/../package.json → tmpRoot/package.json → '9.9.9'
+    expect(readVersion()).toBe('9.9.9');
+  });
+
+  it('falls back gracefully when realpathSync would fail (e.g. broken symlink)', () => {
+    // realpathSync throws ENOENT → falls back to the unresolved path.
+    // Place argv[1] one level inside tmpRoot so dirname/../package.json = tmpRoot/package.json
+    // (doesn't exist). Stub cwd to tmpRoot (also no package.json) → '0.0.0'.
+    const binDir = resolve(tmpRoot, 'bin');
+    mkdirSync(binDir);
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpRoot);
+    try {
+      process.argv[1] = resolve(binDir, 'nonexistent-target');
+      expect(readVersion()).toBe('0.0.0');
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+
+  it('returns "0.0.0" when no package.json is reachable', () => {
+    // argv[1] in tmpRoot/a/b/c — dirname/../package.json = tmpRoot/a/b/package.json (absent).
+    // Stub cwd to tmpRoot (no package.json there either) → both paths miss → '0.0.0'.
+    const deepDir = resolve(tmpRoot, 'a', 'b', 'c');
+    mkdirSync(deepDir, { recursive: true });
+    writeFileSync(resolve(deepDir, 'script.js'), '');
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpRoot);
+    try {
+      process.argv[1] = resolve(deepDir, 'script.js');
+      expect(readVersion()).toBe('0.0.0');
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,17 +1,23 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
-function readVersion(): string {
-  // Binary path: dist/index.js → ../package.json. Only valid from dist/index.js;
-  // dist/hooks/collector-script.js resolves to dist/package.json (nonexistent) and falls through.
-  const scriptDir = process.argv[1] ? dirname(process.argv[1]) : null;
-  if (scriptDir) {
-    const fromScript = resolve(scriptDir, '..', 'package.json');
+export function readVersion(): string {
+  const scriptArg = process.argv[1];
+  if (scriptArg) {
+    let resolved: string;
+    try {
+      resolved = realpathSync(scriptArg);
+    } catch {
+      // Broken symlink or permission error — fall back to the unresolved path.
+      // The existsSync guard below will prevent reading a nonexistent file.
+      resolved = scriptArg;
+    }
+    const fromScript = resolve(dirname(resolved), '..', 'package.json');
     if (existsSync(fromScript)) {
       return (JSON.parse(readFileSync(fromScript, 'utf-8')) as { version: string }).version;
     }
   }
-  // Fallback: cwd is reliable when running tests or `node dist/index.js` from repo root
+  // Fallback: cwd is reliable when running tests or `node dist/index.js` from repo root.
   const fromCwd = resolve(process.cwd(), 'package.json');
   if (existsSync(fromCwd)) {
     return (JSON.parse(readFileSync(fromCwd, 'utf-8')) as { version: string }).version;


### PR DESCRIPTION
## Summary

Related to #17 

- **WSL2 + fish shell session tracking** — hook collector now walks `/proc/<pid>/stat` up to 5 levels deep to find ancestor PIDs, so the MCP server can match sessions even when intermediate shell processes sit between Claude Code and the collector. macOS/Windows behaviour unchanged.
- **Version reporting when installed as a symlink** — `preflight --version` now resolves symlinks before locating `package.json`, fixing `0.0.0` version output when installed via `npm link` or a package manager.
- **`preflight doctor` warn-not-fail for custom hook wrappers** — a hook event type with a non-preflight command now reports a warning with fix guidance rather than a failure; a hook event type with no command at all still fails.

## Test plan

- [ ] Full test suite passes (`npm test`)
- [ ] Build clean (`npm run build`)
- [ ] Lint clean (`npm run lint`)