### PR TITLE
Feat: v1.1.0 — Amazon Kiro platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-07-03
+
+### Added
+
+- **Amazon Kiro platform adapter** — Preflight now detects and normalizes tool calls from [Amazon Kiro](https://kiro.dev), AWS's agentic, MCP-native IDE. Kiro sessions are automatically detected via environment variables (`KIRO_SESSION_ID`, `KIRO_IDE`, `MCP_CLIENT=kiro`, or `NEW_RELIC_AI_PLATFORM=kiro`) and all standard Kiro tool names are mapped to the normalized Preflight vocabulary. Install instructions are included in `preflight install` output. **Note:** tool-name mappings are best-effort pending validation against a live Kiro install — unmapped tools record as `Unknown` with the original tool name preserved in telemetry.
+
+---
+
 ## [1.0.10] - 2026-07-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ preflight/
       task-completion-tracker.ts    # Task lifecycle tracking (completed/abandoned)
       model-usage-tracker.ts        # Cost-efficiency per AI model
       personal-coach.ts             # Narrative coaching report comparing weekly metrics to personal baseline
-    platforms/                      # 8 platform adapters
+    platforms/                      # 9 platform adapters
       claude-code-adapter.ts        # Claude Code (default)
       cursor-adapter.ts             # Cursor IDE
       windsurf-adapter.ts           # Windsurf IDE
@@ -85,6 +85,7 @@ preflight/
       zed-adapter.ts                # Zed IDE
       continue-adapter.ts           # Continue.dev
       amazon-q-adapter.ts           # Amazon Q Developer
+      kiro-adapter.ts               # Amazon Kiro (agentic IDE, MCP-native)
       generic-mcp-adapter.ts        # Generic fallback adapter for any MCP-speaking client
       platform-registry.ts          # Registry + factory
     proxy/                          # HTTP proxy layer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ preflight/
     security/      # Audit trail + SSRF helpers
     tracing/       # OTel span lifecycle
     transport/     # NR ingest manager + log ingest
-    platforms/     # 8 platform adapters — 7 named (Claude Code, Cursor, Windsurf, Copilot, Zed, Continue.dev, Amazon Q) + 1 generic MCP fallback
+    platforms/     # 9 platform adapters — 8 named (Claude Code, Cursor, Windsurf, Copilot, Zed, Continue.dev, Amazon Q, Amazon Kiro) + 1 generic MCP fallback
     digest/        # Slack digest formatter and sender
     install/       # preflight install / setup CLI
     alerts/        # Alert TS types (JSON files live in alerts/ at repo root)
@@ -305,6 +305,7 @@ The MCP server automatically detects and supports multiple AI coding platforms:
 | **Zed**            | Env var: `NEW_RELIC_AI_PLATFORM=zed`      | Auto-detected from Zed config directory                |
 | **Continue.dev**   | Env var: `NEW_RELIC_AI_PLATFORM=continue` | Auto-detected from Continue config                     |
 | **Amazon Q**       | Env var: `NEW_RELIC_AI_PLATFORM=amazonq`  | Requires AWS IDE plugin setup                          |
+| **Amazon Kiro**    | Env var: `NEW_RELIC_AI_PLATFORM=kiro`     | MCP-native; add server to `.kiro/settings/mcp.json`    |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Restart your AI tool — hooks and the MCP server load at session start. Every t
 
 ## Works With
 
-**Claude Code** • **Cursor** • **Windsurf** • **GitHub Copilot** • **Zed** • **Continue.dev** • **Amazon Q Developer**
+**Claude Code** • **Cursor** • **Windsurf** • **GitHub Copilot** • **Zed** • **Continue.dev** • **Amazon Q Developer** • **Amazon Kiro**
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.0.10",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -13,6 +13,7 @@ export { parseCopilotUsageResponse } from './copilot-adapter.js';
 export { ZedAdapter } from './zed-adapter.js';
 export { ContinueAdapter } from './continue-adapter.js';
 export { AmazonQAdapter } from './amazon-q-adapter.js';
+export { KiroAdapter } from './kiro-adapter.js';
 export { GenericMcpAdapter, validateReportToolCallInput } from './generic-mcp-adapter.js';
 export type {
   ReportToolCallInput,

--- a/src/platforms/kiro-adapter.test.ts
+++ b/src/platforms/kiro-adapter.test.ts
@@ -1,0 +1,250 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { KiroAdapter } from './kiro-adapter.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  for (const key of [
+    'KIRO_SESSION_ID',
+    'KIRO_IDE',
+    'KIRO_VERSION',
+    'MCP_CLIENT',
+    'NEW_RELIC_AI_PLATFORM',
+  ]) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('KiroAdapter', () => {
+  const adapter = new KiroAdapter();
+
+  it('has platformName "kiro"', () => {
+    expect(adapter.platformName).toBe('kiro');
+  });
+
+  describe('normalizeToolCall', () => {
+    it('maps "fsRead" to "Read"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'fsRead',
+        timestamp: 2000,
+        success: true,
+      });
+      expect(normalized.toolName).toBe('Read');
+      expect(normalized.platformToolName).toBe('fsRead');
+      expect(normalized.platform).toBe('kiro');
+    });
+
+    it('maps "fsWrite" to "Write"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'fsWrite', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Write');
+    });
+
+    it('maps "fsAppend" to "Edit"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'fsAppend',
+        timestamp: 2000,
+        filePath: '/src/app.ts',
+      });
+      expect(normalized.toolName).toBe('Edit');
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('maps "strReplace" to "Edit"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'strReplace', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Edit');
+    });
+
+    it('maps "fsCreate" to "Write"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'fsCreate', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Write');
+    });
+
+    it('maps "deletePath" to "Delete"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'deletePath', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Delete');
+    });
+
+    it('maps "listDirectory" to "Glob"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'listDirectory', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Glob');
+    });
+
+    it('maps "fileSearch" to "Glob"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'fileSearch', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Glob');
+    });
+
+    it('maps "grepSearch" to "Grep"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'grepSearch', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Grep');
+    });
+
+    it('maps "executeBash" to "Bash"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'executeBash',
+        timestamp: 2000,
+        command: 'npm test',
+      });
+      expect(normalized.toolName).toBe('Bash');
+      expect(normalized.command).toBe('npm test');
+    });
+
+    it('maps "executePwsh" to "Bash"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'executePwsh', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Bash');
+    });
+
+    it('maps snake_case alias "fs_read" to "Read"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'fs_read', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Read');
+    });
+
+    it('accepts "toolName" field as an alternative to "tool"', () => {
+      const normalized = adapter.normalizeToolCall({ toolName: 'fsRead', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Read');
+      expect(normalized.platformToolName).toBe('fsRead');
+    });
+
+    it('normalizes path to filePath', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'fsRead', path: '/src/app.ts' });
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('maps unknown tool to "Unknown" with platformToolName preserved', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'custom_kiro_tool', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('custom_kiro_tool');
+    });
+
+    it('defaults missing tool name to "unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ timestamp: 2000 });
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.toolName).toBe('Unknown');
+    });
+
+    it('defaults success to true when not provided', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'fsRead', timestamp: 2000 });
+      expect(normalized.success).toBe(true);
+    });
+
+    it('preserves error field', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'fsAppend',
+        timestamp: 2000,
+        success: false,
+        error: 'permission denied',
+      });
+      expect(normalized.success).toBe(false);
+      expect(normalized.error).toBe('permission denied');
+    });
+
+    it('uses current time when timestamp is missing', () => {
+      const before = Date.now();
+      const normalized = adapter.normalizeToolCall({ tool: 'fsRead' });
+      const after = Date.now();
+      expect(normalized.timestamp).toBeGreaterThanOrEqual(before);
+      expect(normalized.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('includes inputSizeBytes and outputSizeBytes when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'fsRead',
+        timestamp: 2000,
+        inputSizeBytes: 50,
+        outputSizeBytes: 1000,
+      });
+      expect(normalized.inputSizeBytes).toBe(50);
+      expect(normalized.outputSizeBytes).toBe(1000);
+    });
+
+    it('includes sessionId when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'fsRead',
+        timestamp: 2000,
+        sessionId: 'kiro-sess-001',
+      });
+      expect(normalized.sessionId).toBe('kiro-sess-001');
+    });
+  });
+
+  describe('getSessionMetadata', () => {
+    it('returns platform "kiro"', () => {
+      const meta = adapter.getSessionMetadata();
+      expect(meta.platform).toBe('kiro');
+    });
+
+    it('includes ideVersion from KIRO_VERSION env var', () => {
+      process.env.KIRO_VERSION = '0.1.0';
+      const meta = adapter.getSessionMetadata();
+      expect(meta.ideVersion).toBe('0.1.0');
+    });
+
+    it('omits ideVersion when KIRO_VERSION is unset', () => {
+      const meta = adapter.getSessionMetadata();
+      expect(meta.ideVersion).toBeUndefined();
+    });
+  });
+
+  describe('isSupported', () => {
+    it('returns true when KIRO_SESSION_ID is set', () => {
+      process.env.KIRO_SESSION_ID = 'abc123';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns true when KIRO_IDE is set', () => {
+      process.env.KIRO_IDE = '1';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns true when MCP_CLIENT is "kiro"', () => {
+      process.env.MCP_CLIENT = 'kiro';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns true when NEW_RELIC_AI_PLATFORM is "kiro"', () => {
+      process.env.NEW_RELIC_AI_PLATFORM = 'kiro';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns false in a non-Kiro environment', () => {
+      expect(adapter.isSupported()).toBe(false);
+    });
+  });
+
+  describe('getHookInstallInstructions', () => {
+    it('returns non-empty Kiro-specific instructions', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions.length).toBeGreaterThan(0);
+      expect(instructions).toContain('Kiro');
+    });
+
+    it('references the Kiro MCP settings file', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('.kiro/settings/mcp.json');
+    });
+
+    it('mentions NEW_RELIC_LICENSE_KEY', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_LICENSE_KEY');
+    });
+
+    it('mentions NEW_RELIC_ACCOUNT_ID', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
+    });
+  });
+
+  describe('initialize', () => {
+    it('completes without error', async () => {
+      await expect(adapter.initialize({})).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/platforms/kiro-adapter.ts
+++ b/src/platforms/kiro-adapter.ts
@@ -1,0 +1,124 @@
+import type {
+  PlatformAdapter,
+  PlatformConfig,
+  PlatformSessionMetadata,
+  NormalizedToolCall,
+} from './types.js';
+
+/**
+ * Maps Amazon Kiro agent tool names to the normalized Claude Code tool
+ * vocabulary. Kiro exposes both camelCase tool names (e.g. `fsRead`) and
+ * snake_case aliases depending on configuration, so both are covered.
+ */
+const KIRO_TOOL_MAP: Record<string, string> = {
+  fsRead: 'Read',
+  fs_read: 'Read',
+  readFile: 'Read',
+  readMultipleFiles: 'Read',
+  fsWrite: 'Write',
+  fs_write: 'Write',
+  writeFile: 'Write',
+  fsCreate: 'Write',
+  fsAppend: 'Edit',
+  fsReplace: 'Edit',
+  fs_edit: 'Edit',
+  editFile: 'Edit',
+  strReplace: 'Edit',
+  deletePath: 'Delete',
+  fs_delete: 'Delete',
+  deleteFile: 'Delete',
+  listDirectory: 'Glob',
+  fs_list: 'Glob',
+  fileSearch: 'Glob',
+  fs_find: 'Glob',
+  findFiles: 'Glob',
+  grepSearch: 'Grep',
+  grep: 'Grep',
+  search_code: 'Grep',
+  executeBash: 'Bash',
+  execute_bash: 'Bash',
+  executePwsh: 'Bash',
+  run_command: 'Bash',
+};
+
+interface KiroToolCallEvent {
+  tool?: string;
+  toolName?: string;
+  timestamp?: number;
+  durationMs?: number;
+  success?: boolean;
+  error?: string;
+  filePath?: string;
+  path?: string;
+  command?: string;
+  inputSizeBytes?: number;
+  outputSizeBytes?: number;
+  sessionId?: string;
+  [key: string]: unknown;
+}
+
+export class KiroAdapter implements PlatformAdapter {
+  readonly platformName = 'kiro';
+
+  async initialize(_config: PlatformConfig): Promise<void> {
+    // Amazon Kiro connects via the MCP stdio protocol.
+  }
+
+  normalizeToolCall(raw: unknown): NormalizedToolCall {
+    const event = raw as KiroToolCallEvent;
+    const platformToolName = event.tool ?? event.toolName ?? 'unknown';
+    const toolName = KIRO_TOOL_MAP[platformToolName] ?? 'Unknown';
+    const filePath = event.filePath ?? event.path;
+
+    return {
+      toolName,
+      platformToolName,
+      platform: this.platformName,
+      timestamp: event.timestamp ?? Date.now(),
+      durationMs: event.durationMs ?? null,
+      success: event.success ?? true,
+      ...(event.error !== undefined && { error: event.error }),
+      ...(event.inputSizeBytes !== undefined && { inputSizeBytes: event.inputSizeBytes }),
+      ...(event.outputSizeBytes !== undefined && { outputSizeBytes: event.outputSizeBytes }),
+      ...(filePath !== undefined && { filePath }),
+      ...(event.command !== undefined && { command: event.command }),
+      ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+    };
+  }
+
+  getSessionMetadata(): PlatformSessionMetadata {
+    return {
+      platform: this.platformName,
+      ...(process.env.KIRO_VERSION && { ideVersion: process.env.KIRO_VERSION }),
+    };
+  }
+
+  getHookInstallInstructions(): string {
+    return [
+      'Amazon Kiro Setup:',
+      '1. Open your Kiro MCP configuration file',
+      '   (user-level ~/.kiro/settings/mcp.json or workspace-level .kiro/settings/mcp.json)',
+      '2. Add to "mcpServers":',
+      '   {',
+      '     "preflight": {',
+      '       "command": "npx",',
+      '       "args": ["preflight", "--stdio"],',
+      '       "env": {',
+      '         "NEW_RELIC_LICENSE_KEY": "<your-key>",',
+      '         "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"',
+      '       }',
+      '     }',
+      '   }',
+      '3. Restart Kiro (or reconnect MCP servers from the Kiro MCP panel).',
+    ].join('\n');
+  }
+
+  isSupported(): boolean {
+    return (
+      process.env.KIRO_SESSION_ID !== undefined ||
+      process.env.KIRO_IDE !== undefined ||
+      process.env.MCP_CLIENT === 'kiro' ||
+      process.env.NEW_RELIC_AI_PLATFORM === 'kiro'
+    );
+  }
+}

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -8,6 +8,7 @@ import { GenericMcpAdapter } from './generic-mcp-adapter.js';
 import { ZedAdapter } from './zed-adapter.js';
 import { ContinueAdapter } from './continue-adapter.js';
 import { AmazonQAdapter } from './amazon-q-adapter.js';
+import { KiroAdapter } from './kiro-adapter.js';
 import type { PlatformAdapter, PlatformSessionMetadata, NormalizedToolCall } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -33,6 +34,9 @@ const ENV_KEYS = [
   'Q_DEVELOPER_SESSION',
   'AWS_CODEWHISPERER_SESSION',
   'AMAZON_Q_VERSION',
+  'KIRO_SESSION_ID',
+  'KIRO_IDE',
+  'KIRO_VERSION',
 ];
 
 beforeEach(() => {
@@ -236,6 +240,15 @@ describe('PlatformRegistry', () => {
       expect(detected!.platformName).toBe('amazon-q');
     });
 
+    it('selects Kiro adapter when Kiro env vars are present', () => {
+      process.env.KIRO_SESSION_ID = 'kiro-abc';
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('kiro');
+    });
+
     it('falls back to generic-mcp when no specific platform detected', () => {
       const registry = createDefaultRegistry();
 
@@ -294,7 +307,7 @@ describe('createDefaultRegistry', () => {
     const registry = createDefaultRegistry();
     const registered = registry.getRegistered();
 
-    expect(registered).toHaveLength(8);
+    expect(registered).toHaveLength(9);
     expect(registered[0]).toBeInstanceOf(ClaudeCodeAdapter);
     expect(registered[1]).toBeInstanceOf(CursorAdapter);
     expect(registered[2]).toBeInstanceOf(WindsurfAdapter);
@@ -302,15 +315,17 @@ describe('createDefaultRegistry', () => {
     expect(registered[4]).toBeInstanceOf(ZedAdapter);
     expect(registered[5]).toBeInstanceOf(ContinueAdapter);
     expect(registered[6]).toBeInstanceOf(AmazonQAdapter);
-    expect(registered[7]).toBeInstanceOf(GenericMcpAdapter);
+    expect(registered[7]).toBeInstanceOf(KiroAdapter);
+    expect(registered[8]).toBeInstanceOf(GenericMcpAdapter);
   });
 
-  it('includes zed, continue, and amazon-q adapters', () => {
+  it('includes zed, continue, amazon-q, and kiro adapters', () => {
     const registry = createDefaultRegistry();
     const names = registry.getRegistered().map((a) => a.platformName);
     expect(names).toContain('zed');
     expect(names).toContain('continue');
     expect(names).toContain('amazon-q');
+    expect(names).toContain('kiro');
   });
 
   it('ends with generic-mcp as fallback', () => {
@@ -329,6 +344,7 @@ describe('all adapters implement PlatformAdapter interface', () => {
     new ZedAdapter(),
     new ContinueAdapter(),
     new AmazonQAdapter(),
+    new KiroAdapter(),
     new GenericMcpAdapter(),
   ];
 

--- a/src/platforms/platform-registry.ts
+++ b/src/platforms/platform-registry.ts
@@ -7,6 +7,7 @@ import { CopilotAdapter } from './copilot-adapter.js';
 import { ZedAdapter } from './zed-adapter.js';
 import { ContinueAdapter } from './continue-adapter.js';
 import { AmazonQAdapter } from './amazon-q-adapter.js';
+import { KiroAdapter } from './kiro-adapter.js';
 import { GenericMcpAdapter } from './generic-mcp-adapter.js';
 
 const logger = createLogger('platform-registry');
@@ -59,6 +60,7 @@ export function createDefaultRegistry(): PlatformRegistry {
   registry.register(new ZedAdapter());
   registry.register(new ContinueAdapter());
   registry.register(new AmazonQAdapter());
+  registry.register(new KiroAdapter());
   registry.register(new GenericMcpAdapter()); // always last
   return registry;
 }


### PR DESCRIPTION
## Summary

- **Amazon Kiro platform adapter** — Preflight now detects and normalizes tool calls from [Amazon Kiro](https://kiro.dev), AWS's agentic, MCP-native IDE. Sessions are detected via `KIRO_SESSION_ID`, `KIRO_IDE`, `MCP_CLIENT=kiro`, or `NEW_RELIC_AI_PLATFORM=kiro`. All standard Kiro tool names are mapped to the normalized Preflight vocabulary. Install instructions included in `preflight install` output.
- **Note:** tool-name mappings are best-effort pending validation against a live Kiro install — unmapped tools record as `Unknown` with the original tool name preserved in telemetry.
- Bumps version to `1.1.0`.

## Test plan

- [ ] `npm run build` clean
- [ ] `npm test` passing
- [ ] `npm run lint` clean