### PR TITLE
Docs: link ARCHITECTURE.md from README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,8 @@ The foundation layer is vendored in `src/shared/`. Provides:
 
 ## Key Concepts
 
+See [**ARCHITECTURE.md**](docs/ARCHITECTURE.md) for a full data-flow diagram and component reference. The concepts below cover the most important building blocks.
+
 ### ToolCallRecord
 
 The central data type. Every tool call captured by the hooks becomes a `ToolCallRecord` with fields like `toolName`, `durationMs`, `success`, `filePath`, `command`, `exitCode`, etc. This record flows through all metric trackers.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Add `--project` to `install`/`uninstall` to scope changes to the current directo
 ## Documentation
 
 - [**ADVANCED.md**](docs/ADVANCED.md) — Configuration, dashboards, alerts, Terraform
+- [**ARCHITECTURE.md**](docs/ARCHITECTURE.md) — Data flow, component reference, and operating modes
 - [**CONTRIBUTING.md**](CONTRIBUTING.md) — Development, testing, submitting PRs
 - [**SECURITY.md**](./SECURITY.md) — Security guidelines and best practices
 - [**PRIVACY.md**](./PRIVACY.md) — Data collection inventory and pre-cloud checklist


### PR DESCRIPTION
## Summary

- Adds `ARCHITECTURE.md` to the Documentation section in `README.md`
- Adds a forward reference to `ARCHITECTURE.md` at the top of the Key Concepts section in `CONTRIBUTING.md`

## Test plan

- [ ] Verify both links render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)