### PR TITLE
Feat: Smithery registry support + hook self-install via MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-07-08
+
+### Added
+
+- **Smithery MCP registry support** — added `smithery.yaml` at the repo root so Preflight can be discovered and installed via the [Smithery](https://smithery.ai) registry. Configures `npx -y @newrelic/preflight@latest --stdio` with a UI for `licenseKey`, `accountId`, `developer`, and `mode` (`cloud`/`local`).
+- **`nr_observe_install_hooks` MCP tool** — since Smithery only wires up the MCP server and doesn't touch `~/.claude/settings.json`, this tool lets users finish setup from within a Claude Code chat session by writing the `PreToolUse`/`PostToolUse` monitoring hooks headlessly (no TTY required). A Claude Code restart is still needed to activate monitoring.
+- **`nr_observe_health` reports hook status** — the health check now includes `hooks_installed` and `setup_required` booleans, so an AI tool can detect an incomplete setup (e.g. after a Smithery install) and prompt the user to call `nr_observe_install_hooks`.
+
+---
+
 ## [1.1.1] - 2026-07-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ preflight/
       cli.ts                        # preflight install/uninstall commands
       setup-wizard.ts               # preflight setup interactive wizard
       migrate.ts                    # migrateStoragePath() — one-time rename ~/.nr-ai-observe → ~/.newrelic-preflight
+      headless-install.ts           # installHooksHeadless() — no-TTY hook install for the Smithery self-install MCP flow
     alerts/                         # Alert TypeScript types + validation tests
       types.ts                      # AlertConditionDefinition, AlertPolicyDefinition interfaces
       alerts.test.ts                # JSON structure validation (reads from ../alerts/)
@@ -247,7 +248,8 @@ Tools are conditionally registered based on available dependencies (e.g., cross-
 - `nr_observe_get_session_stats` — current session metrics
 - `nr_observe_get_session_timeline` — recent tool calls with timestamps
 - `nr_observe_get_efficiency_score` — composite efficiency scoring
-- `nr_observe_health` — server health check: version, uptime, session ID
+- `nr_observe_health` — server health check: version, uptime, session ID, hook install status
+- `nr_observe_install_hooks` — headlessly install PreToolUse/PostToolUse hooks into `~/.claude/settings.json` (Smithery self-install flow)
 
 **Cost and Budget Tools:**
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ See cost breakdown, efficiency scoring, anti-patterns, and live session tracking
 npm install -g @newrelic/preflight
 ```
 
+> **Using [Smithery](https://smithery.ai)?** Installing Preflight from the Smithery MCP registry wires up the MCP server for you, but Smithery has no mechanism to write Claude Code hooks. After install, ask Claude Code to call the `nr_observe_install_hooks` MCP tool (it will offer to do this automatically once `nr_observe_health` reports `setup_required: true`), then restart Claude Code to activate monitoring.
+
 ### 2. Run setup
 
 ```bash

--- a/docs/COMMANDS_TABLE.md
+++ b/docs/COMMANDS_TABLE.md
@@ -23,15 +23,43 @@ Check server health and connection status.
   "developer": "alice",
   "session_id": "uuid-string",
   "connected_at": "2026-06-03T10:00:00.000Z",
-  "uptime_seconds": 3600
+  "uptime_seconds": 3600,
+  "hooks_installed": true,
+  "setup_required": false
 }
 ```
 
 **Data source:** Server startup metadata
 
-**How it works:** Returns the current server version, the resolved developer name, how long the server has been running (`uptime_seconds`), the current session ID, and the ISO timestamp of when the MCP connection was established. Use this to confirm the MCP server is responsive and to verify the expected developer identity is being used.
+**How it works:** Returns the current server version, the resolved developer name, how long the server has been running (`uptime_seconds`), the current session ID, and the ISO timestamp of when the MCP connection was established. Use this to confirm the MCP server is responsive and to verify the expected developer identity is being used. When a hook-detection function is available (e.g. in a Claude Code environment), also reports `hooks_installed` and `setup_required` so the caller can detect an incomplete setup — for example, right after a Smithery-driven install that only wired up the MCP server — and prompt to call `nr_observe_install_hooks`. Both fields are omitted when hook detection isn't wired up for the current server mode.
 
 **Requires:** Always available
+
+Source: `src/tools/session-stats.ts`
+
+---
+
+### `nr_observe_install_hooks`
+
+Install `PreToolUse` and `PostToolUse` monitoring hooks into `~/.claude/settings.json`, headlessly (no TTY required).
+
+**Parameters:** None
+
+**Returns:**
+
+```json
+{
+  "status": "installed",
+  "message": "Monitoring hooks installed at /Users/alice/.claude/settings.json. Restart Claude Code to activate tool monitoring.",
+  "settings_path": "/Users/alice/.claude/settings.json"
+}
+```
+
+**Data source:** Reads and writes `~/.claude/settings.json` directly
+
+**How it works:** Call this when `nr_observe_health` reports `setup_required: true` — most commonly after installing Preflight via the Smithery MCP registry, which wires up the MCP server but has no mechanism to write Claude Code hooks. Returns `status: "already_installed"` if hooks are already present (no changes made), or `status: "error"` with a `message` if the settings file couldn't be written. Only touches hook configuration in `~/.claude/settings.json` — never modifies `~/.mcp.json`. A Claude Code restart is required after installation for monitoring to activate.
+
+**Requires:** A headless installer wired into `ToolRegistrationOptions.headlessInstaller` (available in the standard MCP server startup path)
 
 Source: `src/tools/session-stats.ts`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,53 @@
+name: newrelic-preflight
+description: >-
+  AI coding observability for Claude Code. Tracks tool calls, cost,
+  anti-patterns, and efficiency metrics — and ships them to New Relic.
+  Works across Claude Code, Cursor, Windsurf, and 6 other platforms.
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      licenseKey:
+        type: string
+        title: License Key
+        description: >-
+          New Relic license key (NRII-... or eu01xx...).
+          Required when mode is "cloud". Leave blank to use local-dashboard-only mode.
+      accountId:
+        type: string
+        title: Account ID
+        description: >-
+          New Relic account ID (numeric, e.g. 1234567).
+          Required when mode is "cloud".
+      developer:
+        type: string
+        title: Developer Name
+        description: >-
+          Your identifier on NR events (e.g. "alice" or "alice_smith").
+          Defaults to $USER when blank.
+      mode:
+        type: string
+        enum:
+          - cloud
+          - local
+        default: cloud
+        title: Mode
+        description: >-
+          "cloud": send metrics to New Relic (requires licenseKey + accountId).
+          "local": local dashboard only, no data egress.
+    required: []
+  commandFunction: |-
+    (config) => {
+      const env = {};
+      if (config.licenseKey) env.NEW_RELIC_LICENSE_KEY = config.licenseKey;
+      if (config.accountId)  env.NEW_RELIC_AI_ACCOUNT_ID = config.accountId;
+      if (config.developer)  env.NEW_RELIC_AI_MCP_DEVELOPER = config.developer;
+      if (config.mode)       env.NR_AI_MODE = config.mode;
+      return {
+        command: "npx",
+        args: ["-y", "@newrelic/preflight@latest", "--stdio"],
+        env,
+      };
+    }

--- a/src/install/headless-install.test.ts
+++ b/src/install/headless-install.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { jest } from '@jest/globals';
+
+// Mock schedule.ts so resolveBinaryPath is injectable
+jest.mock('./schedule.js', () => ({
+  resolveBinaryPath: jest.fn<typeof import('./schedule.js').resolveBinaryPath>(),
+}));
+
+import { resolveBinaryPath } from './schedule.js';
+import { writeJsonFile, readJsonFileStrict } from './json-utils.js';
+import { installHooksHeadless } from './headless-install.js';
+
+const mockResolveBinaryPath = resolveBinaryPath as jest.MockedFunction<typeof resolveBinaryPath>;
+
+describe('installHooksHeadless()', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'headless-install-test-'));
+    mockResolveBinaryPath.mockReturnValue(null); // bare-name install by default
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it('creates settings.json with hooks when file does not exist', () => {
+    const settingsPath = join(tmpDir, 'settings.json');
+    const result = installHooksHeadless({ _settingsPathOverride: settingsPath });
+
+    expect(result.status).toBe('installed');
+    if (result.status === 'installed') {
+      expect(result.settingsPath).toBe(settingsPath);
+    }
+
+    const written = readJsonFileStrict(settingsPath);
+    expect(typeof (written.hooks as Record<string, unknown>)?.PreToolUse).toBe('object');
+  });
+
+  it('adds hooks to existing settings.json that has no hooks', () => {
+    const settingsPath = join(tmpDir, 'settings.json');
+    writeJsonFile(settingsPath, { permissions: { allow: [] } }, tmpDir);
+
+    const result = installHooksHeadless({ _settingsPathOverride: settingsPath });
+    expect(result.status).toBe('installed');
+  });
+
+  it('returns already_installed when hooks are already present', () => {
+    const settingsPath = join(tmpDir, 'settings.json');
+    const pre = [
+      { matcher: '', hooks: [{ type: 'command', command: 'preflight-collector pre-tool' }] },
+    ];
+    const post = [
+      { matcher: '', hooks: [{ type: 'command', command: 'preflight-collector post-tool' }] },
+    ];
+    writeJsonFile(settingsPath, { hooks: { PreToolUse: pre, PostToolUse: post } }, tmpDir);
+
+    const result = installHooksHeadless({ _settingsPathOverride: settingsPath });
+    expect(result.status).toBe('already_installed');
+  });
+
+  it('returns error when settings directory is not writable', () => {
+    // Point at a non-existent deep path to trigger write failure
+    const settingsPath = '/nonexistent/deeply/nested/settings.json';
+    const result = installHooksHeadless({ _settingsPathOverride: settingsPath });
+    expect(result.status).toBe('error');
+    if (result.status === 'error') {
+      expect(result.message.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/install/headless-install.ts
+++ b/src/install/headless-install.ts
@@ -1,0 +1,38 @@
+import { dirname } from 'node:path';
+import { areHooksInstalled, mergeSettings, detectSettingsPath } from './install-helper.js';
+import { readJsonFileStrict, writeJsonFile, errMsg } from './json-utils.js';
+import { resolveBinaryPath } from './schedule.js';
+
+export type HeadlessInstallResult =
+  | { readonly status: 'installed'; readonly settingsPath: string }
+  | { readonly status: 'already_installed'; readonly settingsPath: string }
+  | { readonly status: 'error'; readonly message: string };
+
+/**
+ * Installs PreToolUse/PostToolUse hooks into ~/.claude/settings.json (or
+ * the project-level equivalent) without a TTY. Does NOT touch ~/.mcp.json —
+ * Smithery handles MCP server registration separately.
+ *
+ * Returns a typed result so MCP tool callers can format a user-facing message.
+ */
+export function installHooksHeadless(
+  options: { scope?: 'user' | 'project'; _settingsPathOverride?: string } = {},
+): HeadlessInstallResult {
+  const scope = options.scope ?? 'user';
+  const settingsPath = options._settingsPathOverride ?? detectSettingsPath(scope, null);
+  const binPath = resolveBinaryPath();
+
+  try {
+    const existing = readJsonFileStrict(settingsPath);
+
+    if (areHooksInstalled(existing)) {
+      return { status: 'already_installed', settingsPath };
+    }
+
+    const merged = mergeSettings(existing, binPath);
+    writeJsonFile(settingsPath, merged, dirname(settingsPath));
+    return { status: 'installed', settingsPath };
+  } catch (err) {
+    return { status: 'error', message: errMsg(err) };
+  }
+}

--- a/src/install/install-helper.test.ts
+++ b/src/install/install-helper.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { resolve, join } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 import {
   generateHookEntries,
@@ -13,7 +14,10 @@ import {
   detectSettingsPath,
   detectMcpConfigPath,
   entryHasAnyCommandHook,
+  areHooksInstalled,
+  readAndCheckHooks,
 } from './install-helper.js';
+import { writeJsonFile } from './json-utils.js';
 
 // ---------------------------------------------------------------------------
 // Temp directory setup (mirrors collector-script.test.ts)
@@ -748,5 +752,99 @@ describe('entryHasAnyCommandHook()', () => {
 
   it('returns true for a custom command (legacy flat format)', () => {
     expect(entryHasAnyCommandHook({ command: '/usr/local/bin/my-wrapper post-tool' })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// areHooksInstalled
+// ---------------------------------------------------------------------------
+
+describe('areHooksInstalled()', () => {
+  it('returns false when hooks field is missing', () => {
+    expect(areHooksInstalled({})).toBe(false);
+  });
+
+  it('returns false when hooks exists but PreToolUse is empty', () => {
+    expect(areHooksInstalled({ hooks: { PreToolUse: [], PostToolUse: [] } })).toBe(false);
+  });
+
+  it('returns false when only PreToolUse has NR hook (PostToolUse missing)', () => {
+    const pre = [
+      { matcher: '', hooks: [{ type: 'command', command: 'preflight-collector pre-tool' }] },
+    ];
+    expect(areHooksInstalled({ hooks: { PreToolUse: pre, PostToolUse: [] } })).toBe(false);
+  });
+
+  it('returns false when hooks exist but belong to another tool', () => {
+    const other = [{ matcher: '', hooks: [{ type: 'command', command: 'my-tool pre-tool' }] }];
+    expect(areHooksInstalled({ hooks: { PreToolUse: other, PostToolUse: other } })).toBe(false);
+  });
+
+  it('returns true when both PreToolUse and PostToolUse contain NR hooks', () => {
+    const pre = [
+      { matcher: '', hooks: [{ type: 'command', command: 'preflight-collector pre-tool' }] },
+    ];
+    const post = [
+      { matcher: '', hooks: [{ type: 'command', command: 'preflight-collector post-tool' }] },
+    ];
+    expect(areHooksInstalled({ hooks: { PreToolUse: pre, PostToolUse: post } })).toBe(true);
+  });
+
+  it('returns true when absolute path form is used', () => {
+    const pre = [
+      {
+        matcher: '',
+        hooks: [
+          { type: 'command', command: '/home/alice/.local/bin/preflight-collector pre-tool' },
+        ],
+      },
+    ];
+    const post = [
+      {
+        matcher: '',
+        hooks: [
+          { type: 'command', command: '/home/alice/.local/bin/preflight-collector post-tool' },
+        ],
+      },
+    ];
+    expect(areHooksInstalled({ hooks: { PreToolUse: pre, PostToolUse: post } })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readAndCheckHooks
+// ---------------------------------------------------------------------------
+
+describe('readAndCheckHooks()', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'hooks-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns false when settings file does not exist', () => {
+    expect(readAndCheckHooks(join(tmpDir, 'nonexistent.json'))).toBe(false);
+  });
+
+  it('returns false when settings file has no hooks', () => {
+    const path = join(tmpDir, 'settings.json');
+    writeJsonFile(path, { permissions: {} }, tmpDir);
+    expect(readAndCheckHooks(path)).toBe(false);
+  });
+
+  it('returns true when settings file has NR hooks', () => {
+    const path = join(tmpDir, 'settings.json');
+    const pre = [
+      { matcher: '', hooks: [{ type: 'command', command: 'preflight-collector pre-tool' }] },
+    ];
+    const post = [
+      { matcher: '', hooks: [{ type: 'command', command: 'preflight-collector post-tool' }] },
+    ];
+    writeJsonFile(path, { hooks: { PreToolUse: pre, PostToolUse: post } }, tmpDir);
+    expect(readAndCheckHooks(path)).toBe(true);
   });
 });

--- a/src/install/install-helper.ts
+++ b/src/install/install-helper.ts
@@ -8,6 +8,7 @@ import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { z } from 'zod';
 import type { PlatformTarget } from '../config.js';
+import { readJsonFileStrict } from './json-utils.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -193,6 +194,35 @@ export function entryHasAnyCommandHook(entry: unknown): boolean {
 
 function filterNrObserveEntries(entries: unknown[]): unknown[] {
   return entries.filter((e) => !entryContainsNrObserve(e));
+}
+
+/**
+ * Returns true when settingsContent contains both a PreToolUse and PostToolUse
+ * entry that match the NR hook pattern (NR_HOOK_RE).
+ * Pure — no file I/O.
+ */
+export function areHooksInstalled(settingsContent: Record<string, unknown>): boolean {
+  const hooks = settingsContent.hooks;
+  if (typeof hooks !== 'object' || hooks === null) return false;
+  const h = hooks as Record<string, unknown>;
+
+  const preArr = Array.isArray(h.PreToolUse) ? (h.PreToolUse as unknown[]) : [];
+  const postArr = Array.isArray(h.PostToolUse) ? (h.PostToolUse as unknown[]) : [];
+
+  return preArr.some(entryContainsNrObserve) && postArr.some(entryContainsNrObserve);
+}
+
+/**
+ * Reads settingsPath (defaults to ~/.claude/settings.json) and returns
+ * whether NR hooks are installed. Returns false on any I/O error.
+ */
+export function readAndCheckHooks(settingsPath?: string): boolean {
+  const path = settingsPath ?? detectSettingsPath('user', null);
+  try {
+    return areHooksInstalled(readJsonFileStrict(path));
+  } catch {
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -54,10 +54,12 @@ describe('MCP protocol via InMemoryTransport', () => {
     await server.close();
   });
 
-  it('responds to tools/list with only the health tool when no trackers configured', async () => {
+  it('responds to tools/list with health and install_hooks tools when no trackers configured', async () => {
     const result = await client.listTools();
-    expect(result.tools).toHaveLength(1);
-    expect(result.tools[0]!.name).toBe('nr_observe_health');
+    expect(result.tools).toHaveLength(2);
+    const toolNames = result.tools.map((t) => t.name);
+    expect(toolNames).toContain('nr_observe_health');
+    expect(toolNames).toContain('nr_observe_install_hooks');
   });
 
   it('responds to resources/list with an empty resource list', async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,8 @@ import { createLogger } from './shared/index.js';
 import { VERSION } from './version.js';
 import type { ServerOptions } from './types.js';
 import { registerTools } from './tools/session-stats.js';
+import { readAndCheckHooks } from './install/install-helper.js';
+import { installHooksHeadless } from './install/headless-install.js';
 
 const logger = createLogger('mcp-server');
 
@@ -61,6 +63,8 @@ export class NrMcpServer {
       teamId: options.teamId,
       projectId: options.projectId,
       sessionStartMs: serverStartMs,
+      hooksInstalledFn: () => readAndCheckHooks(),
+      headlessInstaller: installHooksHeadless,
     });
 
     this.server.setRequestHandler(ListResourcesRequestSchema, async () => {

--- a/src/tools/session-stats.test.ts
+++ b/src/tools/session-stats.test.ts
@@ -10,8 +10,10 @@ import {
   handleGetSessionTimeline,
   handleHealth,
   handleGetConfig,
+  handleInstallHooks,
 } from './session-stats.js';
 import type { ConfigSummary } from './session-stats.js';
+import type { HeadlessInstallResult } from '../install/headless-install.js';
 import type { ToolCallRecord } from '../storage/types.js';
 import type { SessionStore } from '../storage/session-store.js';
 import type { WeeklySummaryGenerator } from '../storage/weekly-summary.js';
@@ -235,6 +237,27 @@ describe('handleHealth()', () => {
     expect(data.developer).toBe('alice');
     expect(data.session_id).toBe('health-session-id');
   });
+
+  it('omits hooks_installed when hooksInstalledFn is not provided', () => {
+    const result = handleHealth({});
+    const data = JSON.parse(result.content[0].text);
+    expect('hooks_installed' in data).toBe(false);
+    expect('setup_required' in data).toBe(false);
+  });
+
+  it('includes hooks_installed: true and setup_required: false when hooks are installed', () => {
+    const result = handleHealth({ hooksInstalledFn: () => true });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.hooks_installed).toBe(true);
+    expect(data.setup_required).toBe(false);
+  });
+
+  it('includes hooks_installed: false and setup_required: true when hooks are missing', () => {
+    const result = handleHealth({ hooksInstalledFn: () => false });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.hooks_installed).toBe(false);
+    expect(data.setup_required).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -297,6 +320,57 @@ describe('handleGetConfig()', () => {
   });
 });
 
+describe('handleInstallHooks()', () => {
+  it('returns installed response with restart instruction', () => {
+    const installer = (): HeadlessInstallResult => ({
+      status: 'installed',
+      settingsPath: '/home/alice/.claude/settings.json',
+    });
+    const result = handleInstallHooks(installer);
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.status).toBe('installed');
+    expect(data.settings_path).toBe('/home/alice/.claude/settings.json');
+    expect(typeof data.message).toBe('string');
+    expect(data.message).toContain('Restart');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('returns already_installed response', () => {
+    const installer = (): HeadlessInstallResult => ({
+      status: 'already_installed',
+      settingsPath: '/home/alice/.claude/settings.json',
+    });
+    const result = handleInstallHooks(installer);
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.status).toBe('already_installed');
+    expect(typeof data.message).toBe('string');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('returns error response with isError: true when install fails', () => {
+    const installer = (): HeadlessInstallResult => ({
+      status: 'error',
+      message: "EACCES: permission denied, open '/root/.claude/settings.json'",
+    });
+    const result = handleInstallHooks(installer);
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.status).toBe('error');
+    expect(data.message).toContain('EACCES');
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns error response with isError: true when installer is undefined', () => {
+    const result = handleInstallHooks(undefined);
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.error).toBeTruthy();
+    expect(result.isError).toBe(true);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // MCP protocol integration (via InMemoryTransport)
 // ---------------------------------------------------------------------------
@@ -340,10 +414,11 @@ describe('MCP protocol integration', () => {
   it('tools/list includes health and session tools', async () => {
     const result = await client.listTools();
 
-    expect(result.tools).toHaveLength(3);
+    expect(result.tools).toHaveLength(4);
 
     const names = result.tools.map((t) => t.name);
     expect(names).toContain('nr_observe_health');
+    expect(names).toContain('nr_observe_install_hooks');
     expect(names).toContain('nr_observe_get_session_stats');
     expect(names).toContain('nr_observe_get_session_timeline');
 
@@ -358,7 +433,11 @@ describe('MCP protocol integration', () => {
     const result = await client.listTools();
 
     for (const tool of result.tools) {
-      expect(tool.annotations?.readOnlyHint).toBe(true);
+      if (tool.name === 'nr_observe_install_hooks') {
+        expect(tool.annotations?.readOnlyHint).toBe(false);
+      } else {
+        expect(tool.annotations?.readOnlyHint).toBe(true);
+      }
     }
   });
 
@@ -482,7 +561,7 @@ describe('MCP protocol integration — cost tools', () => {
     expect(names).toContain('nr_observe_report_tokens');
     expect(names).toContain('nr_observe_get_cost_breakdown');
     expect(names).toContain('nr_observe_get_cost_forecast');
-    expect(result.tools).toHaveLength(6);
+    expect(result.tools).toHaveLength(7);
 
     await bothClient.close();
     await bothServer.close();
@@ -582,8 +661,10 @@ describe('Server without any trackers', () => {
 
   it('returns only health tool when no trackers provided', async () => {
     const result = await client.listTools();
-    expect(result.tools).toHaveLength(1);
-    expect(result.tools[0]!.name).toBe('nr_observe_health');
+    expect(result.tools).toHaveLength(2);
+    const names = result.tools.map((t) => t.name);
+    expect(names).toContain('nr_observe_health');
+    expect(names).toContain('nr_observe_install_hooks');
   });
 });
 
@@ -719,9 +800,12 @@ describe('registerPendingTools()', () => {
     registerPendingTools(server.server, { sessionStartMs: Date.now(), developer: 'tester' });
     await Promise.all([server.server.connect(st), client.connect(ct)]);
 
-    // List should expose only the health tool while pending
+    // List should expose health and install_hooks tools while pending
     const tools = await client.listTools();
-    expect(tools.tools.map((t) => t.name)).toEqual(['nr_observe_health']);
+    expect(tools.tools.map((t) => t.name)).toEqual([
+      'nr_observe_health',
+      'nr_observe_install_hooks',
+    ]);
 
     // Health still works
     const health = await client.callTool({ name: 'nr_observe_health', arguments: {} });

--- a/src/tools/session-stats.ts
+++ b/src/tools/session-stats.ts
@@ -203,6 +203,16 @@ const TURN_ANALYSIS_TOOL = {
   annotations: { readOnlyHint: true },
 };
 
+const INSTALL_HOOKS_TOOL = {
+  name: 'nr_observe_install_hooks',
+  description:
+    'Install PreToolUse and PostToolUse monitoring hooks into ~/.claude/settings.json. ' +
+    'Call when nr_observe_health reports hooks_installed: false. ' +
+    'Requires a Claude Code restart to activate monitoring.',
+  inputSchema: { type: 'object' as const, properties: {} },
+  annotations: { readOnlyHint: false },
+};
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -264,27 +274,86 @@ export function handleHealth(options: {
   sessionStartMs?: number;
   developer?: string;
   sessionId?: string;
+  hooksInstalledFn?: () => boolean;
 }): { content: [{ type: 'text'; text: string }] } {
   const nowMs = Date.now();
   const startMs = options.sessionStartMs ?? nowMs;
+
+  const hooksInstalled =
+    options.hooksInstalledFn !== undefined ? options.hooksInstalledFn() : undefined;
+
+  const payload: Record<string, unknown> = {
+    status: 'ok',
+    version: VERSION,
+    developer: options.developer ?? 'unknown',
+    session_id: options.sessionId ?? null,
+    connected_at: new Date(startMs).toISOString(),
+    uptime_seconds: Math.round((nowMs - startMs) / 1000),
+  };
+
+  if (hooksInstalled !== undefined) {
+    payload.hooks_installed = hooksInstalled;
+    payload.setup_required = !hooksInstalled;
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(
-          {
-            status: 'ok',
-            version: VERSION,
-            developer: options.developer ?? 'unknown',
-            session_id: options.sessionId ?? null,
-            connected_at: new Date(startMs).toISOString(),
-            uptime_seconds: Math.round((nowMs - startMs) / 1000),
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify(payload, null, 2),
       },
     ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// handleInstallHooks
+// ---------------------------------------------------------------------------
+
+export function handleInstallHooks(
+  installer: (() => import('../install/headless-install.js').HeadlessInstallResult) | undefined,
+): { content: [{ type: 'text'; text: string }]; isError?: true } {
+  if (!installer) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({ error: 'Hook installer not available in this server mode' }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const installResult = installer();
+  let output: Record<string, unknown>;
+
+  if (installResult.status === 'installed') {
+    output = {
+      status: 'installed',
+      message: `Monitoring hooks installed at ${installResult.settingsPath}. Restart Claude Code to activate tool monitoring.`,
+      settings_path: installResult.settingsPath,
+    };
+  } else if (installResult.status === 'already_installed') {
+    output = {
+      status: 'already_installed',
+      message: 'Hooks are already installed. No changes made.',
+      settings_path: installResult.settingsPath,
+    };
+  } else {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({ status: 'error', message: installResult.message }, null, 2),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }],
   };
 }
 
@@ -391,6 +460,8 @@ export interface ToolRegistrationOptions {
   collectorHost?: string | null;
   configFilePath?: string;
   configSummary?: ConfigSummary;
+  hooksInstalledFn?: () => boolean;
+  headlessInstaller?: () => import('../install/headless-install.js').HeadlessInstallResult;
 }
 
 // ---------------------------------------------------------------------------
@@ -435,9 +506,14 @@ export function registerPendingTools(
     sessionStartMs?: number;
     developer?: string;
     configSummary?: ConfigSummary;
+    hooksInstalledFn?: () => boolean;
+    headlessInstaller?: () => import('../install/headless-install.js').HeadlessInstallResult;
   },
 ): void {
-  const tools: (typeof HEALTH_TOOL)[] = [HEALTH_TOOL];
+  const tools: Array<typeof HEALTH_TOOL | typeof INSTALL_HOOKS_TOOL> = [
+    HEALTH_TOOL,
+    INSTALL_HOOKS_TOOL,
+  ];
   if (options.configSummary) tools.push(CONFIG_TOOL);
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
@@ -448,10 +524,14 @@ export function registerPendingTools(
         sessionStartMs: options.sessionStartMs,
         developer: options.developer,
         sessionId: undefined,
+        hooksInstalledFn: options.hooksInstalledFn,
       });
     }
     if (name === 'nr_observe_get_config' && options.configSummary) {
       return handleGetConfig(options.configSummary);
+    }
+    if (name === 'nr_observe_install_hooks') {
+      return handleInstallHooks(options.headlessInstaller);
     }
     return {
       content: [
@@ -506,6 +586,7 @@ export function registerTools(server: Server, options: ToolRegistrationOptions):
 
   // Build combined tool list
   const tools: (typeof SESSION_STATS_TOOL)[] = [HEALTH_TOOL];
+  tools.push(INSTALL_HOOKS_TOOL);
   if (options.configSummary) {
     tools.push(CONFIG_TOOL);
   }
@@ -630,7 +711,12 @@ export function registerTools(server: Server, options: ToolRegistrationOptions):
             sessionStartMs,
             developer: options.developer,
             sessionId: sessionTracker?.getMetrics().sessionId,
+            hooksInstalledFn: options.hooksInstalledFn,
           });
+        }
+
+        case 'nr_observe_install_hooks': {
+          return handleInstallHooks(options.headlessInstaller);
         }
 
         case 'nr_observe_get_config': {


### PR DESCRIPTION
Closes #29

## Summary

- Add `smithery.yaml` at the repo root — enables discovery and one-click install via the [Smithery](https://smithery.ai) MCP registry. Configures `npx -y @newrelic/preflight@latest --stdio` with a config UI for `licenseKey`, `accountId`, `developer`, and `mode` (`cloud`/`local`).
- Add `nr_observe_install_hooks` MCP tool — after Smithery installs the server, users can call this tool from a Claude Code chat session to write `PreToolUse`/`PostToolUse` hooks to `~/.claude/settings.json` without leaving the session. Only writes hooks; never touches `~/.mcp.json`.
- Update `nr_observe_health` — now reports `hooks_installed` and `setup_required` booleans so an AI tool can detect an incomplete setup and prompt the user to call `nr_observe_install_hooks`.
- Add `areHooksInstalled()` / `readAndCheckHooks()` utilities and `installHooksHeadless()` for headless (no-TTY) hook installation.
- Version bump to 1.2.0.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 3751 passing, 3 skipped (pre-existing), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)