### PR TITLE
Fix: v1.3.1 — Windows dashboard/hook fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-07-08
+
+### Fixed
+
+- **Dashboard 403 on Windows** — the static file handler's root-containment check only recognized `/` as a path separator, so every static asset request (including `index.html`) was rejected on Windows, where `resolve()`/`join()` produce backslash-joined paths. Added a platform-separator fallback alongside the existing literal `/` check.
+- **Hook collector silently dropped all session data on Windows** — the hook collector read stdin via the POSIX-only `/dev/stdin` device path, which doesn't exist on Windows, so every `PreToolUse`/`PostToolUse` hook failed silently and the Sessions tab stayed empty with no indication of failure. Windows now reads stdin via its file descriptor directly instead.
+
+---
+
 ## [1.3.0] - 2026-07-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/static-handler.ts
+++ b/src/dashboard/routes/static-handler.ts
@@ -23,6 +23,20 @@ const MIME: Record<string, string> = {
   '.txt': 'text/plain; charset=utf-8',
 };
 
+/**
+ * True if `target` resolves to a path inside `root`. Checks the literal '/'
+ * separator first — kept so static analysis tools (CodeQL js/path-injection)
+ * recognise this as the standard path-containment sanitizer pattern, since
+ * CodeQL cannot statically prove that node:path's `sep` is '/'. The
+ * `platformSep` check is required as a fallback because on Windows
+ * resolve()/join() produce backslash-joined paths, which never match a
+ * hardcoded '/'. Defaults to the real platform separator; overridable so
+ * tests can exercise the Windows branch deterministically on any OS.
+ */
+export function isWithinRoot(root: string, target: string, platformSep: string = sep): boolean {
+  return target.startsWith(root + '/') || target.startsWith(root + platformSep);
+}
+
 async function serveIndexFallback(root: string, res: ServerResponse): Promise<void> {
   try {
     const indexPath = join(root, 'index.html');
@@ -61,11 +75,7 @@ export function createStaticHandler(
     }
 
     const target = resolve(join(root, filename));
-    // Use a literal '/' so static analysis tools (CodeQL js/path-injection)
-    // can recognise this as the standard path-containment sanitizer pattern.
-    // The runtime sep from node:path would be equivalent on POSIX, but CodeQL
-    // cannot statically prove that sep === '/' and therefore misses the guard.
-    if (!target.startsWith(root + '/')) {
+    if (!isWithinRoot(root, target)) {
       res.writeHead(403);
       res.end();
       return;

--- a/src/dashboard/routes/static-handler.windows-sep.test.ts
+++ b/src/dashboard/routes/static-handler.windows-sep.test.ts
@@ -1,11 +1,11 @@
 import { isWithinRoot } from './static-handler.js';
 
 // static-handler.ts resolves paths with node:path's `resolve`/`join`, which on
-// Windows produce backslash-joined paths — the '/'-only containment check
-// (issue #24) never matched them. `platformSep` is passed explicitly here so
-// the Windows branch is exercised deterministically regardless of the OS
-// actually running this test.
-describe('isWithinRoot — Windows separator (#24)', () => {
+// Windows produce backslash-joined paths — a '/'-only containment check
+// never matches them. `platformSep` is passed explicitly here so the Windows
+// branch is exercised deterministically regardless of the OS actually
+// running this test.
+describe('isWithinRoot — Windows separator', () => {
   it('accepts a child path joined with backslashes', () => {
     expect(isWithinRoot('C:\\Users\\dev\\dist', 'C:\\Users\\dev\\dist\\index.html', '\\')).toBe(
       true,

--- a/src/dashboard/routes/static-handler.windows-sep.test.ts
+++ b/src/dashboard/routes/static-handler.windows-sep.test.ts
@@ -1,0 +1,28 @@
+import { isWithinRoot } from './static-handler.js';
+
+// static-handler.ts resolves paths with node:path's `resolve`/`join`, which on
+// Windows produce backslash-joined paths — the '/'-only containment check
+// (issue #24) never matched them. `platformSep` is passed explicitly here so
+// the Windows branch is exercised deterministically regardless of the OS
+// actually running this test.
+describe('isWithinRoot — Windows separator (#24)', () => {
+  it('accepts a child path joined with backslashes', () => {
+    expect(isWithinRoot('C:\\Users\\dev\\dist', 'C:\\Users\\dev\\dist\\index.html', '\\')).toBe(
+      true,
+    );
+  });
+
+  it('rejects a sibling path that merely shares a prefix', () => {
+    expect(isWithinRoot('C:\\Users\\dev\\dist', 'C:\\Users\\dev\\dist-evil\\secret', '\\')).toBe(
+      false,
+    );
+  });
+
+  it('still accepts POSIX-style child paths using the default separator', () => {
+    expect(isWithinRoot('/app/dist', '/app/dist/index.html')).toBe(true);
+  });
+
+  it('still rejects POSIX-style sibling paths using the default separator', () => {
+    expect(isWithinRoot('/app/dist', '/app/dist-evil/secret')).toBe(false);
+  });
+});

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -1031,7 +1031,7 @@ describe('collector-script', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // readStdinSync (#24 — /dev/stdin has no Windows equivalent)
+  // readStdinSync (/dev/stdin has no Windows equivalent)
   // ---------------------------------------------------------------------------
   describe('readStdinSync()', () => {
     const originalPlatform = process.platform;

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -17,6 +17,8 @@ import {
   writePpidBreadcrumb,
   getLinuxAncestorPids,
   _procFs,
+  readStdinSync,
+  _stdinFs,
 } from './collector-script.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -1025,6 +1027,45 @@ describe('collector-script', () => {
     it('returns [startPpid] when parsed ppid is NaN', () => {
       mockProc({ '/proc/400/stat': '400 (proc) S notanumber ...' });
       expect(getLinuxAncestorPids(400)).toEqual([400]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // readStdinSync (#24 — /dev/stdin has no Windows equivalent)
+  // ---------------------------------------------------------------------------
+  describe('readStdinSync()', () => {
+    const originalPlatform = process.platform;
+    let originalReadFileSync: typeof _stdinFs.readFileSync;
+
+    beforeEach(() => {
+      originalReadFileSync = _stdinFs.readFileSync;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+      _stdinFs.readFileSync = originalReadFileSync;
+    });
+
+    it('reads /dev/stdin on POSIX platforms', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      const calls: Array<string | number> = [];
+      _stdinFs.readFileSync = (pathOrFd) => {
+        calls.push(pathOrFd);
+        return '{"hook_event_name":"PreToolUse"}';
+      };
+      expect(readStdinSync()).toBe('{"hook_event_name":"PreToolUse"}');
+      expect(calls).toEqual(['/dev/stdin']);
+    });
+
+    it('reads via the stdin fd on Windows, not /dev/stdin', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      const calls: Array<string | number> = [];
+      _stdinFs.readFileSync = (pathOrFd) => {
+        calls.push(pathOrFd);
+        return '{}';
+      };
+      readStdinSync();
+      expect(calls).toEqual([process.stdin.fd]);
     });
   });
 });

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -745,6 +745,7 @@ export {
   getTranscriptPath,
   getBufferPath,
   writePpidBreadcrumb,
+  readStdinSync,
 };
 
 // ---------------------------------------------------------------------------
@@ -763,9 +764,38 @@ const _resolvedScript = (() => {
 const _isDirectExecution =
   _resolvedScript != null && /collector-script\.[jt]s$/.test(_resolvedScript);
 
+/**
+ * Seam for unit tests: replace the underlying synchronous read so tests can
+ * exercise both platform branches without reading the real fd 0, which can
+ * hang inside a test runner. Production code never sets this.
+ * @internal
+ */
+export const _stdinFs = {
+  readFileSync: (pathOrFd: string | number): string => readFileSync(pathOrFd, 'utf-8'),
+};
+
+/**
+ * Windows has no `/dev/stdin` device file, so reading stdin synchronously
+ * there requires going through its file descriptor (0) directly instead.
+ * POSIX keeps using the `/dev/stdin` path rather than switching to the fd
+ * everywhere, since reading a pipe fd directly can throw EAGAIN there.
+ *
+ * The win32 branch relies on a libuv fix (v1.44, Feb 2022) that stopped
+ * treating a closed pipe as an EOF *error* on Windows — before that, reading
+ * fd 0 while stdin was piped (exactly how Claude Code invokes this script)
+ * threw instead of returning cleanly. package.json's `engines.node` floor
+ * (>=22) is well past every Node release carrying that fix; don't lower it
+ * without re-checking this. See nodejs/node#35997 and libuv/libuv#3043.
+ */
+function readStdinSync(): string {
+  return process.platform === 'win32'
+    ? _stdinFs.readFileSync(process.stdin.fd)
+    : _stdinFs.readFileSync('/dev/stdin');
+}
+
 if (_isDirectExecution) {
   try {
-    const stdin = readFileSync('/dev/stdin', 'utf-8');
+    const stdin = readStdinSync();
     if (stdin.trim()) {
       processHook(stdin);
     }


### PR DESCRIPTION
## Summary

Fixes two Windows-only bugs reported in #24 — thanks @sgwrmctk for the detailed report and suggested fixes.

- **Dashboard 403 on every static asset request.** The static file handler's root-containment check only recognized `/` as a path separator, so it never matched on Windows, where `resolve()`/`join()` produce backslash-joined paths.
- **Hook collector silently dropped all session data.** It read stdin via the POSIX-only `/dev/stdin` device path, which doesn't exist on Windows, so every `PreToolUse`/`PostToolUse` hook failed silently with no error surfaced anywhere.

## Changes

- `static-handler.ts`: extracted `isWithinRoot(root, target, platformSep = sep)` — checks the literal `'/'` first, then falls back to the platform separator. `platformSep` is overridable so the Windows branch is testable deterministically on any OS.
- `collector-script.ts`: extracted `readStdinSync()` — reads via `process.stdin.fd` on `win32`, keeps `/dev/stdin` on POSIX.

## Test plan

- [x] `npm run build && npm test && npm run lint` all pass locally
- [x] New regression tests for both platform branches (fabricated Windows-style path strings / mocked `process.platform`, not dependent on the CI runner's actual OS)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>