### PR TITLE
Feat: v1.4.0 — offer to restart stale dashboard/daemon processes on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-07-08
+
+### Added
+
+- **`preflight update` offers to restart stale dashboard/daemon processes** — after a successful `git pull` + rebuild, `--local` now writes a small PID file (`local-dashboard.pid`: pid/argv/cwd) the moment it wins the dashboard port bind, giving `update` a reliable way to find its own dashboard process instead of a running instance silently continuing to serve the old cached version. If the macOS launchd dashboard daemon is installed, it's restarted automatically (no prompt). Otherwise, if a live ad-hoc `--local` process is found, `update` prompts (default yes) to restart it — killing it gracefully and respawning it detached with its original arguments. `--stdio` (Claude Code) sessions are never touched; they keep the existing "restart Claude Code" guidance.
+
 ## [1.3.1] - 2026-07-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ You'll need a **license key** (telemetry ingest) and your **account ID**, plus a
 ```bash
 preflight doctor               # Run 6 diagnostic checks and print actionable fix commands
 preflight validate             # Check config for syntax errors and unknown keys
-preflight update               # Pull latest version and rebuild (source installs only — npm installs: npm install -g @newrelic/preflight@latest)
+preflight update               # Pull latest version, rebuild, and offer to restart a running dashboard (source installs only — npm installs: npm install -g @newrelic/preflight@latest)
 preflight uninstall            # Remove hooks and MCP config (prompts with a summary first)
 preflight uninstall --yes      # Skip the confirmation prompt (for scripts and CI)
 preflight uninstall --daemon   # Remove only the background dashboard daemon

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -333,23 +333,32 @@ describe('setupDashboardPostBind()', () => {
     gcStaleBreadcrumbs: ReturnType<typeof jest.fn>;
     gcOrphanBuffers: ReturnType<typeof jest.fn>;
     getActiveSessionIdsFromHeartbeats: ReturnType<typeof jest.fn>;
+    writeLocalDashboardPid: ReturnType<typeof jest.fn>;
   } {
     const gcStaleBreadcrumbs = jest.fn();
     const gcOrphanBuffers = jest.fn();
     const getActiveSessionIdsFromHeartbeats = jest.fn(() => new Set<string>());
+    const writeLocalDashboardPid = jest.fn();
     const store = {
       gcStaleBreadcrumbs,
       gcOrphanBuffers,
       getActiveSessionIdsFromHeartbeats,
+      writeLocalDashboardPid,
     } as unknown as LocalStore;
-    return { store, gcStaleBreadcrumbs, gcOrphanBuffers, getActiveSessionIdsFromHeartbeats };
+    return {
+      store,
+      gcStaleBreadcrumbs,
+      gcOrphanBuffers,
+      getActiveSessionIdsFromHeartbeats,
+      writeLocalDashboardPid,
+    };
   }
 
   it('runs a GC pass immediately on bind and returns an unref-able interval', () => {
     const { store, gcStaleBreadcrumbs, gcOrphanBuffers } = makeLocalStore();
     const handle = setupDashboardPostBind(
       { address: '127.0.0.1', port: 7777 },
-      { localStore: store, liveSessionRegistry: undefined, openOnStart: false },
+      { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: false },
     );
     expect(gcStaleBreadcrumbs).toHaveBeenCalledTimes(1);
     expect(gcOrphanBuffers).toHaveBeenCalledTimes(1);
@@ -361,7 +370,7 @@ describe('setupDashboardPostBind()', () => {
     const { store, gcStaleBreadcrumbs } = makeLocalStore();
     const handle = setupDashboardPostBind(
       { address: '127.0.0.1', port: 7777 },
-      { localStore: store, liveSessionRegistry: undefined, openOnStart: false },
+      { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: false },
     );
     expect(gcStaleBreadcrumbs).toHaveBeenCalledTimes(1);
     jest.advanceTimersByTime(5 * 60 * 1000);
@@ -379,11 +388,31 @@ describe('setupDashboardPostBind()', () => {
     } as unknown as Parameters<typeof setupDashboardPostBind>[1]['liveSessionRegistry'];
     const handle = setupDashboardPostBind(
       { address: '127.0.0.1', port: 7777 },
-      { localStore: store, liveSessionRegistry, openOnStart: false },
+      { localStore: store, liveSessionRegistry, openOnStart: false, isLocalMode: false },
     );
     const liveArg = gcOrphanBuffers.mock.calls[0]?.[0] as Set<string>;
     expect(liveArg.has('heartbeat-only')).toBe(true);
     expect(liveArg.has('registry-only')).toBe(true);
+    clearInterval(handle);
+  });
+
+  it('writes the local-dashboard pid file when isLocalMode is true', () => {
+    const { store, writeLocalDashboardPid } = makeLocalStore();
+    const handle = setupDashboardPostBind(
+      { address: '127.0.0.1', port: 7777 },
+      { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: true },
+    );
+    expect(writeLocalDashboardPid).toHaveBeenCalledWith(process.argv.slice(1), process.cwd());
+    clearInterval(handle);
+  });
+
+  it('does not write the local-dashboard pid file when isLocalMode is false (--stdio)', () => {
+    const { store, writeLocalDashboardPid } = makeLocalStore();
+    const handle = setupDashboardPostBind(
+      { address: '127.0.0.1', port: 7777 },
+      { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: false },
+    );
+    expect(writeLocalDashboardPid).not.toHaveBeenCalled();
     clearInterval(handle);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,8 @@ export interface DashboardPostBindDeps {
   readonly localStore: LocalStore;
   readonly liveSessionRegistry: LiveSessionRegistry | undefined;
   readonly openOnStart: boolean;
+  /** True for `--local` mode — writes the local-dashboard PID file so `preflight update` can find and restart this process. Never true for `--stdio`. */
+  readonly isLocalMode: boolean;
 }
 
 export function setupDashboardPostBind(
@@ -208,6 +210,10 @@ export function setupDashboardPostBind(
 ): NodeJS.Timeout {
   const log = createLogger('mcp-cli');
   log.info(`Dashboard ready at http://${addr.address}:${addr.port}`);
+
+  if (deps.isLocalMode) {
+    deps.localStore.writeLocalDashboardPid(process.argv.slice(1), process.cwd());
+  }
 
   // Only the dashboard owner runs orphan-buffer/breadcrumb GC — running it
   // from every MCP would race with itself and re-archive files repeatedly.
@@ -563,6 +569,12 @@ async function main(): Promise<void> {
       // Remove this MCP's heartbeat so the next dashboard-owner GC pass
       // doesn't have to mtime-archive our buffer file.
       localStoreForShutdown?.removeHeartbeat();
+      // If this was a --local process that won the dashboard port, remove
+      // its PID file so `preflight update` doesn't try to restart a process
+      // that's already exiting cleanly. No-op for --stdio and for --local
+      // instances that never won the port (removeLocalDashboardPid() itself
+      // also guards on pid ownership as a second layer of safety).
+      if (options.local) localStoreForShutdown?.removeLocalDashboardPid();
       if (alertRulesWatchTimer) clearTimeout(alertRulesWatchTimer);
       if (alertRulesWatcher) {
         try {
@@ -1086,6 +1098,7 @@ async function main(): Promise<void> {
         localStore,
         liveSessionRegistry,
         openOnStart: config.dashboard.openOnStart,
+        isLocalMode: options.local,
       };
       const runPostBind = (boundAddr: { address: string; port: number }): NodeJS.Timeout =>
         setupDashboardPostBind(boundAddr, postBindDeps);

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -21,6 +21,7 @@ jest.mock('node:fs', () => ({
 jest.mock('node:child_process', () => ({
   execSync: jest.fn(),
   execFileSync: jest.fn(),
+  spawn: jest.fn(() => ({ unref: jest.fn() })),
 }));
 jest.mock('./diagnostics.js', () => ({
   runDiagnostics: jest.fn(async () => []),
@@ -53,7 +54,13 @@ jest.mock('node:readline/promises', () => ({
     close: jest.fn(),
   })),
 }));
+jest.mock('../storage/index.js', () => ({
+  LocalStore: jest.fn().mockImplementation(() => ({
+    getLiveLocalDashboardProcess: jest.fn(() => null),
+  })),
+}));
 
+import { LocalStore } from '../storage/index.js';
 import * as scheduleMod from './schedule.js';
 import * as platformMod from './platform.js';
 import { runInstallCli } from './cli.js';
@@ -67,6 +74,8 @@ const mockedSchedule = scheduleMod as unknown as {
   installSchedule: jest.Mock;
   removeSchedule: jest.Mock;
   getScheduleStatus: jest.Mock;
+  installDashboardDaemon: jest.Mock;
+  getDashboardDaemonStatus: jest.Mock;
   resolveBinaryPath: jest.Mock;
 };
 const mockedPlatform = platformMod as unknown as {
@@ -1211,7 +1220,7 @@ describe('preflight update', () => {
   let mFs: { existsSync: jest.Mock; realpathSync: jest.Mock };
   let mExec: { execFileSync: jest.Mock };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     mFs = fsMod as unknown as { existsSync: jest.Mock; realpathSync: jest.Mock };
     mExec = childMod as unknown as { execFileSync: jest.Mock };
@@ -1224,6 +1233,19 @@ describe('preflight update', () => {
         throw new Error(`process.exit(${String(code)})`);
       });
     mFs.existsSync.mockImplementation(() => false);
+    // Reset implementations set per-test (clearAllMocks only clears call records).
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+    }));
+    const readlineMod = await import('node:readline/promises');
+    (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
+      question: jest.fn(async () => 'y'),
+      close: jest.fn(),
+    });
+    const childModForSpawn = await import('node:child_process');
+    (childModForSpawn.spawn as unknown as jest.Mock).mockImplementation(() => ({
+      unref: jest.fn(),
+    }));
   });
 
   afterEach(() => {
@@ -1376,6 +1398,122 @@ describe('preflight update', () => {
       ['run', 'build'],
       expect.objectContaining({ cwd: '/repo/packages/preflight' }),
     );
+  });
+
+  function mockSuccessfulBuild(): void {
+    mFs.realpathSync.mockReturnValue('/home/user/projects/preflight/dist/index.js');
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === '/home/user/projects/preflight/package.json',
+    );
+    mExec.execFileSync.mockImplementation((cmd: unknown, args: unknown) => {
+      if (cmd === 'git' && (args as string[]).includes('--show-toplevel'))
+        return '/home/user/projects/preflight';
+      return undefined;
+    });
+  }
+
+  it('auto-restarts the dashboard daemon with no prompt when installed', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({
+      installed: true,
+      readable: true,
+      binaryPath: '/usr/local/bin/preflight',
+    });
+    await runInstallCli(['update']);
+    expect(mockedSchedule.installDashboardDaemon).toHaveBeenCalledWith('/usr/local/bin/preflight');
+    const output = getOutput();
+    expect(output).toContain('Restarted the dashboard daemon');
+  });
+
+  it('warns without restarting when the daemon plist exists but is unreadable', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({ installed: true, readable: false });
+    await runInstallCli(['update']);
+    expect(mockedSchedule.installDashboardDaemon).not.toHaveBeenCalled();
+    const output = getOutput();
+    expect(output).toContain('unreadable');
+  });
+
+  it('does nothing further when no daemon and no live ad-hoc process are found', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({ installed: false, readable: false });
+    await runInstallCli(['update']);
+    const output = getOutput();
+    expect(output).not.toContain('Restart the running dashboard');
+  });
+
+  it('prompts default-yes and kills+respawns the ad-hoc process on accept', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({ installed: false, readable: false });
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => ({
+        pid: 4242,
+        argv: ['/repo/dist/index.js', '--local'],
+        cwd: '/repo',
+      })),
+    }));
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' });
+    });
+    const childMod2 = await import('node:child_process');
+    const spawnMock = childMod2.spawn as unknown as jest.Mock;
+    await runInstallCli(['update']);
+    expect(killSpy).toHaveBeenCalledWith(4242, 'SIGTERM');
+    expect(spawnMock).toHaveBeenCalledWith(
+      process.execPath,
+      ['/repo/dist/index.js', '--local'],
+      expect.objectContaining({ cwd: '/repo', detached: true }),
+    );
+    const output = getOutput();
+    expect(output).toContain('Dashboard restarted');
+    killSpy.mockRestore();
+  });
+
+  it('does not kill the ad-hoc process when the user declines the prompt', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({ installed: false, readable: false });
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => ({
+        pid: 4242,
+        argv: ['/repo/dist/index.js', '--local'],
+        cwd: '/repo',
+      })),
+    }));
+    const readlineMod = await import('node:readline/promises');
+    (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
+      question: jest.fn(async () => 'n'),
+      close: jest.fn(),
+    });
+    const killSpy = jest.spyOn(process, 'kill');
+    await runInstallCli(['update']);
+    expect(killSpy).not.toHaveBeenCalled();
+    killSpy.mockRestore();
+  });
+
+  it('does not report "Build failed" or exit(1) when the restart-offer prompt rejects', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({ installed: false, readable: false });
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => ({
+        pid: 4242,
+        argv: ['/repo/dist/index.js', '--local'],
+        cwd: '/repo',
+      })),
+    }));
+    const readlineMod = await import('node:readline/promises');
+    (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
+      question: jest.fn(async () => {
+        throw new Error('stdin stream error');
+      }),
+      close: jest.fn(),
+    });
+    // Build succeeded and completed normally; only the restart-offer prompt failed.
+    await runInstallCli(['update']);
+    const output = getOutput();
+    expect(output).toContain('Update complete');
+    expect(output).not.toContain('Build failed');
+    expect(output).toContain('Restart offer failed unexpectedly');
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -5,7 +5,7 @@
  * so commander and other heavy deps are never loaded on the hot hook path.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { existsSync, copyFileSync, realpathSync } from 'node:fs';
 import { createInterface } from 'node:readline/promises';
 import { dirname, join, relative, resolve, sep } from 'node:path';
@@ -30,11 +30,13 @@ import {
   installSchedule,
   removeSchedule,
   getScheduleStatus,
+  installDashboardDaemon,
   removeDashboardDaemon,
   getDashboardDaemonStatus,
   resolveBinaryPath,
 } from './schedule.js';
 import { readJsonFileStrict, writeJsonFile, errMsg } from './json-utils.js';
+import { LocalStore } from '../storage/index.js';
 
 const logger = createLogger('cli');
 
@@ -191,7 +193,105 @@ export function findRepoRoot(): string | null {
 // Update handler
 // ---------------------------------------------------------------------------
 
-function handleUpdate(): void {
+function sleep(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+/**
+ * Liveness probe via signal 0 — mirrors `isPidAlive()` in
+ * `src/storage/local-store.ts`. Duplicated rather than shared: it's ten
+ * lines and the two files don't otherwise depend on each other.
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Kill the given PID (SIGTERM, escalating to SIGKILL after a 2s grace period
+ * if it hasn't exited — Windows terminates immediately on any signal, so the
+ * grace period is a no-op there), then respawn it detached with its original
+ * argv/cwd so it comes back up exactly as it was invoked.
+ */
+async function killAndRespawnLocalDashboard(proc: {
+  pid: number;
+  argv: string[];
+  cwd: string;
+}): Promise<void> {
+  try {
+    process.kill(proc.pid, 'SIGTERM');
+  } catch (err) {
+    // ESRCH: the process already exited between the liveness check and here
+    // — nothing left to signal, proceed straight to respawn. Any other
+    // error (e.g. EPERM) is a real failure and should propagate.
+    if ((err as NodeJS.ErrnoException).code !== 'ESRCH') throw err;
+  }
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline && isProcessAlive(proc.pid)) {
+    await sleep(100);
+  }
+  if (isProcessAlive(proc.pid)) {
+    process.kill(proc.pid, 'SIGKILL');
+  }
+  spawn(process.execPath, proc.argv, { cwd: proc.cwd, detached: true, stdio: 'ignore' }).unref();
+}
+
+/**
+ * Called at the end of a successful `preflight update` build. Handles the
+ * two restart-able cases (daemon and ad-hoc `--local`); `--stdio` (Claude
+ * Code MCP sessions) is intentionally never touched here — killing one
+ * mid-session would break in-flight tool calls, so it keeps the existing
+ * static "Restart Claude Code" message printed unconditionally by the
+ * caller.
+ */
+async function offerRestarts(): Promise<void> {
+  const daemonStatus = getDashboardDaemonStatus();
+  if (daemonStatus.installed) {
+    if (daemonStatus.readable && daemonStatus.binaryPath) {
+      try {
+        installDashboardDaemon(daemonStatus.binaryPath);
+        print('\n✓ Restarted the dashboard daemon (launchctl unload/load).');
+      } catch (err) {
+        print(`\n⚠ Could not restart the dashboard daemon: ${errMsg(err)}`);
+        print(
+          '  Run `launchctl unload`/`load` on it manually, or `preflight setup` to reinstall it.',
+        );
+      }
+    } else {
+      print('\n⚠ Dashboard daemon plist found but unreadable; restart it manually if needed.');
+    }
+    return;
+  }
+
+  const localStore = new LocalStore(DEFAULT_STORAGE_PATH);
+  const proc = localStore.getLiveLocalDashboardProcess();
+  if (!proc) return;
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  let answer: string;
+  try {
+    answer = (await rl.question(`\nRestart the running dashboard (PID ${proc.pid})? [Y/n]: `))
+      .trim()
+      .toLowerCase();
+  } finally {
+    rl.close();
+  }
+  if (answer === 'n' || answer === 'no') return;
+
+  try {
+    await killAndRespawnLocalDashboard(proc);
+    print('✓ Dashboard restarted.');
+  } catch (err) {
+    print(`⚠ Could not restart the dashboard automatically: ${errMsg(err)}`);
+    print('  Run `preflight --local` to restart it manually.');
+  }
+}
+
+async function handleUpdate(): Promise<void> {
   migrateStoragePath();
   const repoRoot = findRepoRoot();
   if (!repoRoot) {
@@ -257,6 +357,12 @@ function handleUpdate(): void {
   } catch {
     print('\n✗ Build failed. Check the output above for details.');
     process.exit(1);
+  }
+
+  try {
+    await offerRestarts();
+  } catch (err) {
+    print(`\n⚠ Restart offer failed unexpectedly: ${errMsg(err)}`);
   }
 }
 

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -1061,4 +1061,61 @@ describe('LocalStore', () => {
       expect(existsSync(resolve(breadcrumbDir, 'not-a-pid.txt'))).toBe(true);
     });
   });
+
+  describe('local dashboard PID file', () => {
+    it('writes pid/argv/cwd as JSON and reads it back', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      store.writeLocalDashboardPid(['dist/index.js', '--local'], '/repo', 12345);
+      // Fake the write PID as alive by using our own process's PID for the liveness check.
+      store.writeLocalDashboardPid(['dist/index.js', '--local'], '/repo', process.pid);
+      const proc = store.getLiveLocalDashboardProcess();
+      expect(proc).toEqual({ pid: process.pid, argv: ['dist/index.js', '--local'], cwd: '/repo' });
+    });
+
+    it('returns null when no pid file exists', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      expect(store.getLiveLocalDashboardProcess()).toBeNull();
+    });
+
+    it('returns null when the recorded pid is dead', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      // PID 1 is init/launchd — always alive and never our own; use an
+      // obviously-dead high PID instead (unlikely to collide with a live process
+      // in the test sandbox, and isPidAlive() treats ESRCH as dead).
+      writeFileSync(
+        resolve(tmpDir, 'local-dashboard.pid'),
+        JSON.stringify({ pid: 999999, argv: ['dist/index.js', '--local'], cwd: '/repo' }),
+      );
+      expect(store.getLiveLocalDashboardProcess()).toBeNull();
+    });
+
+    it('returns null when the pid file is malformed JSON', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      writeFileSync(resolve(tmpDir, 'local-dashboard.pid'), 'not json');
+      expect(store.getLiveLocalDashboardProcess()).toBeNull();
+    });
+
+    it('removeLocalDashboardPid deletes the file when it matches our own pid', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      store.writeLocalDashboardPid(['dist/index.js', '--local'], '/repo', process.pid);
+      store.removeLocalDashboardPid();
+      expect(existsSync(resolve(tmpDir, 'local-dashboard.pid'))).toBe(false);
+    });
+
+    it('removeLocalDashboardPid does NOT delete the file when it belongs to a different pid', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      writeFileSync(
+        resolve(tmpDir, 'local-dashboard.pid'),
+        JSON.stringify({ pid: process.pid + 1, argv: ['dist/index.js', '--local'], cwd: '/repo' }),
+      );
+      store.removeLocalDashboardPid();
+      expect(existsSync(resolve(tmpDir, 'local-dashboard.pid'))).toBe(true);
+    });
+  });
 });

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -282,6 +282,78 @@ export class LocalStore {
   }
 
   /**
+   * Write the PID/argv/cwd of the current `--local` process to
+   * `local-dashboard.pid`. Called only after this process has actually won
+   * the dashboard port bind (see `setupDashboardPostBind()` in index.ts) —
+   * not at CLI-arg-parse time — so the file always names whichever process
+   * currently owns the dashboard, even when multiple `--local` instances are
+   * competing for the port (EADDRINUSE re-poll takeover).
+   */
+  writeLocalDashboardPid(argv: readonly string[], cwd: string, pid: number = process.pid): void {
+    const path = resolve(this.storagePath, 'local-dashboard.pid');
+    try {
+      if (!existsSync(this.storagePath)) {
+        mkdirSync(this.storagePath, { recursive: true, mode: 0o700 });
+      }
+      writeFileSync(path, JSON.stringify({ pid, argv: Array.from(argv), cwd }), {
+        mode: 0o600,
+      });
+    } catch (err) {
+      logger.warn('Failed to write local dashboard pid file', { error: String(err) });
+    }
+  }
+
+  /**
+   * Read `local-dashboard.pid` and return its contents only if the named
+   * process is still alive. Returns null if the file is missing, malformed,
+   * or names a dead process — callers should treat all of these as "nothing
+   * to restart" rather than distinguishing them.
+   */
+  getLiveLocalDashboardProcess(): { pid: number; argv: string[]; cwd: string } | null {
+    const path = resolve(this.storagePath, 'local-dashboard.pid');
+    if (!existsSync(path)) return null;
+    try {
+      const parsed = JSON.parse(readFileSync(path, 'utf-8')) as {
+        pid?: unknown;
+        argv?: unknown;
+        cwd?: unknown;
+      };
+      const pid = parsed.pid;
+      const argv = parsed.argv;
+      const cwd = parsed.cwd;
+      if (
+        typeof pid !== 'number' ||
+        !Array.isArray(argv) ||
+        !argv.every((a) => typeof a === 'string') ||
+        typeof cwd !== 'string'
+      ) {
+        return null;
+      }
+      if (!isPidAlive(pid)) return null;
+      return { pid, argv: argv as string[], cwd };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Remove `local-dashboard.pid`, but only if it still names this process —
+   * protects against a headless (non-owning) `--local` instance deleting the
+   * actual owner's file out from under it on its own shutdown.
+   */
+  removeLocalDashboardPid(): void {
+    const path = resolve(this.storagePath, 'local-dashboard.pid');
+    try {
+      if (!existsSync(path)) return;
+      const parsed = JSON.parse(readFileSync(path, 'utf-8')) as { pid?: unknown };
+      if (parsed.pid !== process.pid) return;
+      unlinkSync(path);
+    } catch (err) {
+      logger.debug('Failed to remove local dashboard pid file', { error: String(err) });
+    }
+  }
+
+  /**
    * Garbage-collect orphan per-session buffer files. A buffer is orphan when
    * no live process is currently draining it; we determine that with two
    * signals:


### PR DESCRIPTION
Fixes #79

## Summary
- `--local` now writes a small PID file (`~/.newrelic-preflight/local-dashboard.pid`: `{pid, argv, cwd}`) the moment it wins the dashboard port bind, and removes it on graceful shutdown — giving `preflight update` a reliable way to identify its own dashboard process.
- `preflight update` now offers to restart stale processes after a successful build:
  - Auto-restarts the macOS launchd dashboard daemon (no prompt) if installed.
  - Otherwise, if the PID file names a live ad-hoc `--local` process, prompts default-yes `[Y/n]` to kill (SIGTERM → 2s grace → SIGKILL) and respawn it detached with its original argv/cwd.
  - `--stdio` (Claude Code MCP sessions) is never touched — it keeps the existing static "Restart Claude Code" message.

## Test plan
- [x] `npm ci && npm run build && npm test` — 3786/3789 passing (3 pre-existing skips), clean
- [x] `npm run lint` / `npm run format:check` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>