### PR TITLE
Fix: v1.4.1 — verify dashboard restarts actually succeed before reporting success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-07-08
+
+### Fixed
+
+- **`preflight update` could report a restart succeeded when it hadn't** — both restart paths (the macOS launchd daemon and an ad-hoc `--local` process) declared success as soon as the restart _action_ didn't throw (`launchctl load` returning success, or the respawned process not throwing synchronously), without checking that the dashboard actually came back up. A daemon that crashed immediately after a "successful" `launchctl load` — for example due to a macOS Full Disk Access restriction — would print a false "restarted" message while a stale process kept serving the old version. `update` now polls the dashboard's health endpoint for a healthy response reporting the freshly-built version before declaring success, and falls back to checking for an ad-hoc process if the daemon restart can't be verified.
+
 ## [1.4.0] - 2026-07-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -59,12 +59,17 @@ jest.mock('../storage/index.js', () => ({
     getLiveLocalDashboardProcess: jest.fn(() => null),
   })),
 }));
+jest.mock('../config.js', () => ({
+  ...(jest.requireActual('../config.js') as object),
+  loadMcpConfig: jest.fn(),
+}));
 
 import { LocalStore } from '../storage/index.js';
 import * as scheduleMod from './schedule.js';
 import * as platformMod from './platform.js';
 import { runInstallCli } from './cli.js';
 import * as installHelperMod from './install-helper.js';
+import * as configMod from '../config.js';
 
 const mockedRunDiagnostics = diagnostics.runDiagnostics as jest.MockedFunction<
   typeof diagnostics.runDiagnostics
@@ -88,6 +93,7 @@ const mockedHelper = installHelperMod as unknown as {
   detectSettingsPath: jest.Mock;
   detectMcpConfigPath: jest.Mock;
 };
+const mockedConfig = configMod as unknown as { loadMcpConfig: jest.Mock };
 
 describe('schedule subcommand', () => {
   let stdoutSpy: ReturnType<typeof jest.spyOn>;
@@ -1217,15 +1223,21 @@ describe('platform transition matrix', () => {
 describe('preflight update', () => {
   let stdoutSpy: ReturnType<typeof jest.spyOn>;
   let exitSpy: ReturnType<typeof jest.spyOn>;
-  let mFs: { existsSync: jest.Mock; realpathSync: jest.Mock };
+  let fetchSpy: ReturnType<typeof jest.spyOn>;
+  let mFs: { existsSync: jest.Mock; realpathSync: jest.Mock; readFileSync: jest.Mock };
   let mExec: { execFileSync: jest.Mock };
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    mFs = fsMod as unknown as { existsSync: jest.Mock; realpathSync: jest.Mock };
+    mFs = fsMod as unknown as {
+      existsSync: jest.Mock;
+      realpathSync: jest.Mock;
+      readFileSync: jest.Mock;
+    };
     mExec = childMod as unknown as { execFileSync: jest.Mock };
     // Reset implementations (clearAllMocks only clears call records, not implementations).
     mExec.execFileSync.mockReset();
+    mFs.readFileSync.mockReturnValue('{}');
     stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
     exitSpy = jest
       .spyOn(process, 'exit')
@@ -1246,12 +1258,21 @@ describe('preflight update', () => {
     (childModForSpawn.spawn as unknown as jest.Mock).mockImplementation(() => ({
       unref: jest.fn(),
     }));
+    // Default: config can't be loaded, so verification is skipped silently and
+    // the pre-existing unconditional-success messages are preserved. Tests that
+    // want to exercise real verification override this explicitly.
+    mockedConfig.loadMcpConfig.mockImplementation(() => {
+      throw new Error('no config file');
+    });
+    fetchSpy = jest.spyOn(global, 'fetch').mockRejectedValue(new Error('fetch not mocked'));
   });
 
   afterEach(() => {
     stdoutSpy.mockRestore();
     exitSpy.mockRestore();
+    fetchSpy.mockRestore();
     process.exitCode = undefined;
+    jest.useRealTimers();
   });
 
   function getOutput(): string {
@@ -1412,17 +1433,40 @@ describe('preflight update', () => {
     });
   }
 
-  it('auto-restarts the dashboard daemon with no prompt when installed', async () => {
+  it('auto-restarts the dashboard daemon with no prompt when installed, verifying it comes back healthy', async () => {
     mockSuccessfulBuild();
     mockedSchedule.getDashboardDaemonStatus.mockReturnValue({
       installed: true,
       readable: true,
       binaryPath: '/usr/local/bin/preflight',
     });
+    mFs.readFileSync.mockReturnValue('{"version":"1.4.0"}');
+    mockedConfig.loadMcpConfig.mockReturnValue({
+      dashboard: { host: '127.0.0.1', port: 7777 },
+    });
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, version: '1.4.0' }),
+    } as unknown as Response);
     await runInstallCli(['update']);
     expect(mockedSchedule.installDashboardDaemon).toHaveBeenCalledWith('/usr/local/bin/preflight');
     const output = getOutput();
     expect(output).toContain('Restarted the dashboard daemon');
+    expect(output).not.toContain('could not be verified');
+  });
+
+  it('skips verification silently and keeps the success message when config cannot be loaded', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({
+      installed: true,
+      readable: true,
+      binaryPath: '/usr/local/bin/preflight',
+    });
+    // loadMcpConfig throws by default in this suite's beforeEach — no override needed.
+    await runInstallCli(['update']);
+    const output = getOutput();
+    expect(output).toContain('Restarted the dashboard daemon');
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('warns without restarting when the daemon plist exists but is unreadable', async () => {
@@ -1513,6 +1557,110 @@ describe('preflight update', () => {
     expect(output).toContain('Update complete');
     expect(output).not.toContain('Build failed');
     expect(output).toContain('Restart offer failed unexpectedly');
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the ad-hoc check when the daemon restart cannot be verified as healthy', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({
+      installed: true,
+      readable: true,
+      binaryPath: '/usr/local/bin/preflight',
+    });
+    mockedConfig.loadMcpConfig.mockReturnValue({
+      dashboard: { host: '127.0.0.1', port: 7777 },
+    });
+    fetchSpy.mockRejectedValue(new Error('connection refused'));
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => ({
+        pid: 4242,
+        argv: ['/repo/dist/index.js', '--local'],
+        cwd: '/repo',
+      })),
+    }));
+    const childMod2 = await import('node:child_process');
+    const spawnMock = childMod2.spawn as unknown as jest.Mock;
+    const readlineMod = await import('node:readline/promises');
+    const questionMock = jest.fn(async (_prompt: string) => 'y');
+    (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
+      question: questionMock,
+      close: jest.fn(),
+    });
+
+    jest.useFakeTimers();
+    const updatePromise = runInstallCli(['update']);
+    // Two verification passes (daemon, then ad-hoc), 5s timeout each — advance
+    // past both in one jump.
+    await jest.advanceTimersByTimeAsync(11_000);
+    await updatePromise;
+    jest.useRealTimers();
+
+    const output = getOutput();
+    expect(output).toContain('could not be verified as healthy');
+    expect(output).toContain('Checking for another running dashboard process instead');
+    // The ad-hoc prompt text is passed to the (mocked) readline `question()`
+    // call rather than written to stdout directly, so assert on the call
+    // args to confirm the fallthrough actually reached the ad-hoc path.
+    expect(questionMock).toHaveBeenCalledWith(
+      expect.stringContaining('Restart the running dashboard (PID 4242)'),
+    );
+    expect(spawnMock).toHaveBeenCalled();
+    expect(output).not.toContain('✓ Restarted the dashboard daemon');
+  });
+
+  it('prints a warning instead of a false success when the ad-hoc respawn cannot be verified as healthy', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({ installed: false, readable: false });
+    mockedConfig.loadMcpConfig.mockReturnValue({
+      dashboard: { host: '127.0.0.1', port: 7777 },
+    });
+    fetchSpy.mockRejectedValue(new Error('connection refused'));
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => ({
+        pid: 4242,
+        argv: ['/repo/dist/index.js', '--local'],
+        cwd: '/repo',
+      })),
+    }));
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' });
+    });
+
+    jest.useFakeTimers();
+    const updatePromise = runInstallCli(['update']);
+    await jest.advanceTimersByTimeAsync(6_000);
+    await updatePromise;
+    jest.useRealTimers();
+
+    const output = getOutput();
+    expect(output).toContain('could not be verified as healthy');
+    expect(output).not.toContain('✓ Dashboard restarted.');
+    killSpy.mockRestore();
+  });
+
+  it('prints both warnings and does not crash when the daemon is unverified and no ad-hoc process exists', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({
+      installed: true,
+      readable: true,
+      binaryPath: '/usr/local/bin/preflight',
+    });
+    mockedConfig.loadMcpConfig.mockReturnValue({
+      dashboard: { host: '127.0.0.1', port: 7777 },
+    });
+    fetchSpy.mockRejectedValue(new Error('connection refused'));
+    // LocalStore default (from beforeEach) already returns null — no live ad-hoc process.
+
+    jest.useFakeTimers();
+    const updatePromise = runInstallCli(['update']);
+    await jest.advanceTimersByTimeAsync(6_000);
+    await updatePromise;
+    jest.useRealTimers();
+
+    const output = getOutput();
+    expect(output).toContain('could not be verified as healthy');
+    expect(output).toContain('Checking for another running dashboard process instead');
+    expect(output).not.toContain('Restart the running dashboard');
     expect(exitSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -6,7 +6,7 @@
  */
 
 import { execFileSync, spawn } from 'node:child_process';
-import { existsSync, copyFileSync, realpathSync } from 'node:fs';
+import { existsSync, copyFileSync, realpathSync, readFileSync } from 'node:fs';
 import { createInterface } from 'node:readline/promises';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
@@ -23,7 +23,12 @@ import {
   generateNrConfig,
 } from './install-helper.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
-import { validateConfigFile, DEFAULT_STORAGE_PATH, ConfigFileSchema } from '../config.js';
+import {
+  validateConfigFile,
+  DEFAULT_STORAGE_PATH,
+  ConfigFileSchema,
+  loadMcpConfig,
+} from '../config.js';
 import type { PlatformTarget } from '../config.js';
 import { migrateStoragePath } from './migrate.js';
 import {
@@ -241,6 +246,100 @@ async function killAndRespawnLocalDashboard(proc: {
 }
 
 /**
+ * Reads the `version` field from `<repoRoot>/package.json` fresh off disk —
+ * i.e. the version that was JUST built by the `npm run build` above, not the
+ * one baked into this already-running process (this process's own `VERSION`
+ * constant was captured at startup, before `git pull` ran, so it can't be
+ * used here). Returns null on any read/parse failure, or if the field isn't
+ * a string.
+ */
+function readLocalPackageVersion(repoRoot: string): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf-8')) as {
+      version?: unknown;
+    };
+    return typeof parsed.version === 'string' ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves the dashboard's configured host/port, or null if the config
+ * can't be loaded (e.g. a cloud-mode config missing credentials). Callers
+ * treat null as "skip verification" rather than a hard failure — restart
+ * verification is a best-effort enhancement, never a new way for `update`
+ * to fail.
+ */
+function getDashboardAddress(): { host: string; port: number } | null {
+  try {
+    const config = loadMcpConfig();
+    return { host: config.dashboard.host, port: config.dashboard.port };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Polls `GET /api/health` until it reports a healthy, current-version
+ * response or `timeoutMs` elapses. Connection errors (server not listening
+ * yet) and malformed responses are treated as "not yet" and retried, not as
+ * failures. When `expectedVersion` is null, the version check is skipped —
+ * any healthy response counts.
+ */
+async function waitForHealthyDashboard(
+  host: string,
+  port: number,
+  expectedVersion: string | null,
+  timeoutMs = 5000,
+  intervalMs = 300,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const res = await fetch(`http://${host}:${port}/api/health`);
+      if (res.ok) {
+        const body = (await res.json()) as { ok?: unknown; version?: unknown };
+        if (body.ok === true && (expectedVersion === null || body.version === expectedVersion)) {
+          return true;
+        }
+      }
+    } catch {
+      // Not listening yet, or a malformed response — keep polling.
+    }
+    if (Date.now() >= deadline) return false;
+    await sleep(intervalMs);
+  }
+}
+
+/**
+ * Shared verification glue for both restart paths. If the dashboard's
+ * address can't be determined, verification is skipped silently and
+ * `successMsg` is printed as before (today's behavior, preserved as a
+ * fallback). Otherwise polls for a healthy, current-version response and
+ * prints `successMsg`/`failMsg` accordingly.
+ *
+ * @returns true if the caller should stop here (verified, or skipped);
+ *   false if verification explicitly failed and the caller should fall
+ *   through to another restart path.
+ */
+async function verifyRestart(
+  repoRoot: string,
+  successMsg: string,
+  failMsg: string,
+): Promise<boolean> {
+  const address = getDashboardAddress();
+  if (!address) {
+    print(successMsg);
+    return true;
+  }
+  const expectedVersion = readLocalPackageVersion(repoRoot);
+  const healthy = await waitForHealthyDashboard(address.host, address.port, expectedVersion);
+  print(healthy ? successMsg : failMsg);
+  return healthy;
+}
+
+/**
  * Called at the end of a successful `preflight update` build. Handles the
  * two restart-able cases (daemon and ad-hoc `--local`); `--stdio` (Claude
  * Code MCP sessions) is intentionally never touched here — killing one
@@ -248,13 +347,18 @@ async function killAndRespawnLocalDashboard(proc: {
  * static "Restart Claude Code" message printed unconditionally by the
  * caller.
  */
-async function offerRestarts(): Promise<void> {
+async function offerRestarts(repoRoot: string): Promise<void> {
   const daemonStatus = getDashboardDaemonStatus();
+  let daemonHandled = false;
   if (daemonStatus.installed) {
     if (daemonStatus.readable && daemonStatus.binaryPath) {
       try {
         installDashboardDaemon(daemonStatus.binaryPath);
-        print('\n✓ Restarted the dashboard daemon (launchctl unload/load).');
+        daemonHandled = await verifyRestart(
+          repoRoot,
+          '\n✓ Restarted the dashboard daemon (launchctl unload/load).',
+          '\n⚠ Dashboard daemon restarted but could not be verified as healthy — it may still be starting up, or may have failed silently. Check `launchctl list | grep com.preflight.dashboard` and `~/.newrelic-preflight/dashboard.log`.',
+        );
       } catch (err) {
         print(`\n⚠ Could not restart the dashboard daemon: ${errMsg(err)}`);
         print(
@@ -264,7 +368,8 @@ async function offerRestarts(): Promise<void> {
     } else {
       print('\n⚠ Dashboard daemon plist found but unreadable; restart it manually if needed.');
     }
-    return;
+    if (daemonHandled) return;
+    print('\n  Checking for another running dashboard process instead...');
   }
 
   const localStore = new LocalStore(DEFAULT_STORAGE_PATH);
@@ -284,7 +389,11 @@ async function offerRestarts(): Promise<void> {
 
   try {
     await killAndRespawnLocalDashboard(proc);
-    print('✓ Dashboard restarted.');
+    await verifyRestart(
+      repoRoot,
+      '✓ Dashboard restarted.',
+      '⚠ Dashboard process respawned but could not be verified as healthy — check manually.',
+    );
   } catch (err) {
     print(`⚠ Could not restart the dashboard automatically: ${errMsg(err)}`);
     print('  Run `preflight --local` to restart it manually.');
@@ -360,7 +469,7 @@ async function handleUpdate(): Promise<void> {
   }
 
   try {
-    await offerRestarts();
+    await offerRestarts(repoRoot);
   } catch (err) {
     print(`\n⚠ Restart offer failed unexpectedly: ${errMsg(err)}`);
   }


### PR DESCRIPTION
Fixes #83

## Summary
- `preflight update`'s restart-offer feature previously declared restart success purely based on the restart *action* not throwing (`launchctl load` exit code, or `spawn()` not throwing synchronously) — never verifying the resulting process actually stayed alive and served the dashboard.
- Adds a shared post-restart verification step: poll `GET /api/health` (Node's built-in global `fetch`, no new dependency) for a healthy response whose reported version matches the just-rebuilt local `package.json` version — applied to both the daemon-restart path and the ad-hoc-respawn path.
- If daemon verification fails, execution now falls through to check the ad-hoc PID-file path instead of returning unconditionally.
- Every new failure mode (config load, version read, fetch, JSON parse) degrades to a printed warning or a silent skip — never a new way for `update` to crash or exit non-zero.

## Test plan
- [x] `npm run build && npm test` — 3790/3793 passing (3 pre-existing skips), clean
- [x] `npm run lint` / `npm run format:check` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>