### PR TITLE
Feat: v1.4.2 — preflight local command to find and clean up orphaned processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-07-09
+
+### Added
+
+- **`preflight local` command** — lists every `--local` dashboard process preflight has launched (not just whichever one currently owns the dashboard port), and `preflight local --clean` offers to kill the ones that lost the port race and have been running headless ever since. Every `--local` process now registers itself in a small per-PID registry at startup regardless of port outcome; dead entries (from a process that didn't shut down cleanly) are garbage-collected automatically every 5 minutes by whichever process owns the dashboard. `preflight doctor` gained a matching "Local instances" check that reports idle processes and points at `preflight local --clean`.
+
 ## [1.4.1] - 2026-07-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -155,9 +155,11 @@ You'll need a **license key** (telemetry ingest) and your **account ID**, plus a
 ## Other Commands
 
 ```bash
-preflight doctor               # Run 6 diagnostic checks and print actionable fix commands
+preflight doctor               # Run 7 diagnostic checks and print actionable fix commands
 preflight validate             # Check config for syntax errors and unknown keys
 preflight update               # Pull latest version, rebuild, and offer to restart a running dashboard (source installs only — npm installs: npm install -g @newrelic/preflight@latest)
+preflight local                # List running --local dashboard processes
+preflight local --clean        # Kill orphaned --local processes (prompts for confirmation)
 preflight uninstall            # Remove hooks and MCP config (prompts with a summary first)
 preflight uninstall --yes      # Skip the confirmation prompt (for scripts and CI)
 preflight uninstall --daemon   # Remove only the background dashboard daemon

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -334,16 +334,19 @@ describe('setupDashboardPostBind()', () => {
     gcOrphanBuffers: ReturnType<typeof jest.fn>;
     getActiveSessionIdsFromHeartbeats: ReturnType<typeof jest.fn>;
     writeLocalDashboardPid: ReturnType<typeof jest.fn>;
+    gcDeadLocalInstances: ReturnType<typeof jest.fn>;
   } {
     const gcStaleBreadcrumbs = jest.fn();
     const gcOrphanBuffers = jest.fn();
     const getActiveSessionIdsFromHeartbeats = jest.fn(() => new Set<string>());
     const writeLocalDashboardPid = jest.fn();
+    const gcDeadLocalInstances = jest.fn(() => 0);
     const store = {
       gcStaleBreadcrumbs,
       gcOrphanBuffers,
       getActiveSessionIdsFromHeartbeats,
       writeLocalDashboardPid,
+      gcDeadLocalInstances,
     } as unknown as LocalStore;
     return {
       store,
@@ -351,6 +354,7 @@ describe('setupDashboardPostBind()', () => {
       gcOrphanBuffers,
       getActiveSessionIdsFromHeartbeats,
       writeLocalDashboardPid,
+      gcDeadLocalInstances,
     };
   }
 
@@ -413,6 +417,18 @@ describe('setupDashboardPostBind()', () => {
       { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: false },
     );
     expect(writeLocalDashboardPid).not.toHaveBeenCalled();
+    clearInterval(handle);
+  });
+
+  it('runs gcDeadLocalInstances as part of the GC pass', () => {
+    const { store, gcDeadLocalInstances } = makeLocalStore();
+    const handle = setupDashboardPostBind(
+      { address: '127.0.0.1', port: 7777 },
+      { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: false },
+    );
+    expect(gcDeadLocalInstances).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(5 * 60 * 1000);
+    expect(gcDeadLocalInstances).toHaveBeenCalledTimes(2);
     clearInterval(handle);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,6 +223,7 @@ export function setupDashboardPostBind(
   const runGc = (): void => {
     try {
       localStore.gcStaleBreadcrumbs();
+      localStore.gcDeadLocalInstances();
       const live = localStore.getActiveSessionIdsFromHeartbeats();
       if (liveSessionRegistry) {
         for (const id of liveSessionRegistry.getLiveSessions()) live.add(id);
@@ -575,6 +576,7 @@ async function main(): Promise<void> {
       // instances that never won the port (removeLocalDashboardPid() itself
       // also guards on pid ownership as a second layer of safety).
       if (options.local) localStoreForShutdown?.removeLocalDashboardPid();
+      if (options.local) localStoreForShutdown?.unregisterLocalInstance();
       if (alertRulesWatchTimer) clearTimeout(alertRulesWatchTimer);
       if (alertRulesWatcher) {
         try {
@@ -699,6 +701,14 @@ async function main(): Promise<void> {
         ? new LocalStore(config.storagePath, sessionTraceId)
         : new LocalStore(config.storagePath);
     localStore.initialize();
+
+    // Register every --local process in the instance registry, regardless
+    // of whether it goes on to win the dashboard port bind — this is what
+    // lets `preflight local`/`preflight doctor` see processes that lose the
+    // EADDRINUSE race and would otherwise run headless with no visibility.
+    if (options.local) {
+      localStore.registerLocalInstance(process.argv.slice(1), process.cwd());
+    }
 
     // Every MCP writes its heartbeat once it has bound a session_id so the
     // dashboard owner's GC pass can tell which buffer files still have a live

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -57,6 +57,9 @@ jest.mock('node:readline/promises', () => ({
 jest.mock('../storage/index.js', () => ({
   LocalStore: jest.fn().mockImplementation(() => ({
     getLiveLocalDashboardProcess: jest.fn(() => null),
+    listLocalInstances: jest.fn(() => []),
+    gcDeadLocalInstances: jest.fn(() => 0),
+    unregisterLocalInstance: jest.fn(),
   })),
 }));
 jest.mock('../config.js', () => ({
@@ -1662,6 +1665,164 @@ describe('preflight update', () => {
     expect(output).toContain('Checking for another running dashboard process instead');
     expect(output).not.toContain('Restart the running dashboard');
     expect(exitSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// preflight local
+// ---------------------------------------------------------------------------
+
+describe('preflight local', () => {
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+      listLocalInstances: jest.fn(() => []),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+    }));
+    const readlineMod = await import('node:readline/promises');
+    (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
+      question: jest.fn(async () => 'y'),
+      close: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  function getOutput(): string {
+    return stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+  }
+
+  it('prints "No --local processes running" when the registry is empty', async () => {
+    await runInstallCli(['local']);
+    expect(getOutput()).toContain('No --local processes running');
+  });
+
+  it('cleans up dead entries silently before listing', async () => {
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+      listLocalInstances: jest.fn(() => []),
+      gcDeadLocalInstances: jest.fn(() => 2),
+      unregisterLocalInstance: jest.fn(),
+    }));
+    await runInstallCli(['local']);
+    expect(getOutput()).toContain('Cleaned up 2 stale registry entries');
+  });
+
+  it('lists live instances and marks the dashboard owner', async () => {
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => ({ pid: 100, argv: [], cwd: '/owner' })),
+      listLocalInstances: jest.fn(() => [
+        { pid: 100, argv: [], cwd: '/owner', startedAt: Date.now() - 1000, alive: true },
+        { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now() - 2000, alive: true },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+    }));
+    await runInstallCli(['local']);
+    const output = getOutput();
+    expect(output).toContain('2 --local process(es) running');
+    expect(output).toContain('PID 100');
+    expect(output).toContain('dashboard owner');
+    expect(output).toContain('PID 200');
+    expect(output).toContain('idle');
+  });
+
+  it('does not prompt or kill when --clean is omitted, even with orphans present', async () => {
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+      listLocalInstances: jest.fn(() => [
+        { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now(), alive: true },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+    }));
+    const killSpy = jest.spyOn(process, 'kill');
+    await runInstallCli(['local']);
+    expect(killSpy).not.toHaveBeenCalled();
+    killSpy.mockRestore();
+  });
+
+  it('--clean prompts default-yes and kills+unregisters every orphan on accept', async () => {
+    const unregisterLocalInstance = jest.fn();
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => ({ pid: 100, argv: [], cwd: '/owner' })),
+      listLocalInstances: jest.fn(() => [
+        { pid: 100, argv: [], cwd: '/owner', startedAt: Date.now(), alive: true },
+        { pid: 200, argv: [], cwd: '/orphan-a', startedAt: Date.now(), alive: true },
+        { pid: 201, argv: [], cwd: '/orphan-b', startedAt: Date.now(), alive: true },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance,
+    }));
+    const readlineMod = await import('node:readline/promises');
+    const questionMock = jest.fn(async (_prompt: string) => 'y');
+    (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
+      question: questionMock,
+      close: jest.fn(),
+    });
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' });
+    });
+    await runInstallCli(['local', '--clean']);
+    expect(killSpy).toHaveBeenCalledWith(200, 'SIGTERM');
+    expect(killSpy).toHaveBeenCalledWith(201, 'SIGTERM');
+    expect(unregisterLocalInstance).toHaveBeenCalledWith(200);
+    expect(unregisterLocalInstance).toHaveBeenCalledWith(201);
+    // The confirmation prompt text is passed as the argument to the (mocked)
+    // readline `question()` call rather than written to stdout directly —
+    // real readline writes it to the output stream itself, which this bare
+    // mock doesn't replicate. Same pattern used by the `preflight update`
+    // ad-hoc-restart prompt tests above.
+    expect(questionMock).toHaveBeenCalledWith(
+      expect.stringContaining('Kill 2 orphaned processes?'),
+    );
+    const output = getOutput();
+    expect(output).toContain('Killed PID 200');
+    expect(output).toContain('Killed PID 201');
+    killSpy.mockRestore();
+  });
+
+  it('--clean does not kill anything when the user declines', async () => {
+    const readlineMod = await import('node:readline/promises');
+    (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
+      question: jest.fn(async () => 'n'),
+      close: jest.fn(),
+    });
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+      listLocalInstances: jest.fn(() => [
+        { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now(), alive: true },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+    }));
+    const killSpy = jest.spyOn(process, 'kill');
+    await runInstallCli(['local', '--clean']);
+    expect(killSpy).not.toHaveBeenCalled();
+    killSpy.mockRestore();
+  });
+
+  it('--clean prints "No orphaned processes" when every live instance is the owner', async () => {
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => ({ pid: 100, argv: [], cwd: '/owner' })),
+      listLocalInstances: jest.fn(() => [
+        { pid: 100, argv: [], cwd: '/owner', startedAt: Date.now(), alive: true },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+    }));
+    const killSpy = jest.spyOn(process, 'kill');
+    await runInstallCli(['local', '--clean']);
+    expect(getOutput()).toContain('No orphaned processes to clean up');
+    expect(killSpy).not.toHaveBeenCalled();
+    killSpy.mockRestore();
   });
 });
 

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -217,9 +217,28 @@ function isProcessAlive(pid: number): boolean {
 }
 
 /**
- * Kill the given PID (SIGTERM, escalating to SIGKILL after a 2s grace period
- * if it hasn't exited — Windows terminates immediately on any signal, so the
- * grace period is a no-op there), then respawn it detached with its original
+ * Kill the given PID: SIGTERM, escalating to SIGKILL after a 2s grace period
+ * if it hasn't exited (Windows terminates immediately on any signal, so the
+ * grace period is a no-op there). Tolerates the process having already
+ * exited between the caller's liveness check and this call (ESRCH).
+ */
+async function killProcessGracefully(pid: number): Promise<void> {
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ESRCH') throw err;
+  }
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline && isProcessAlive(pid)) {
+    await sleep(100);
+  }
+  if (isProcessAlive(pid)) {
+    process.kill(pid, 'SIGKILL');
+  }
+}
+
+/**
+ * Kill the given process, then respawn it detached with its original
  * argv/cwd so it comes back up exactly as it was invoked.
  */
 async function killAndRespawnLocalDashboard(proc: {
@@ -227,21 +246,7 @@ async function killAndRespawnLocalDashboard(proc: {
   argv: string[];
   cwd: string;
 }): Promise<void> {
-  try {
-    process.kill(proc.pid, 'SIGTERM');
-  } catch (err) {
-    // ESRCH: the process already exited between the liveness check and here
-    // — nothing left to signal, proceed straight to respawn. Any other
-    // error (e.g. EPERM) is a real failure and should propagate.
-    if ((err as NodeJS.ErrnoException).code !== 'ESRCH') throw err;
-  }
-  const deadline = Date.now() + 2000;
-  while (Date.now() < deadline && isProcessAlive(proc.pid)) {
-    await sleep(100);
-  }
-  if (isProcessAlive(proc.pid)) {
-    process.kill(proc.pid, 'SIGKILL');
-  }
+  await killProcessGracefully(proc.pid);
   spawn(process.execPath, proc.argv, { cwd: proc.cwd, detached: true, stdio: 'ignore' }).unref();
 }
 
@@ -397,6 +402,86 @@ async function offerRestarts(repoRoot: string): Promise<void> {
   } catch (err) {
     print(`⚠ Could not restart the dashboard automatically: ${errMsg(err)}`);
     print('  Run `preflight --local` to restart it manually.');
+  }
+}
+
+function formatAge(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) return `${totalHours}h`;
+  const totalDays = Math.floor(totalHours / 24);
+  return `${totalDays}d`;
+}
+
+/**
+ * `preflight local` — lists every `--local` process preflight has
+ * registered (see `LocalStore.registerLocalInstance()`), marking whichever
+ * one currently owns the dashboard port. `--clean` additionally offers to
+ * kill every live, non-owning entry (a single combined prompt, default
+ * yes) — these are processes that lost the dashboard port race and have
+ * been running headless ever since, with no other way to detect them
+ * short of scanning the OS process table, which this feature deliberately
+ * avoids.
+ */
+async function handleLocal(options: { clean?: boolean }): Promise<void> {
+  const localStore = new LocalStore(DEFAULT_STORAGE_PATH);
+  const deleted = localStore.gcDeadLocalInstances();
+  if (deleted > 0) {
+    print(`Cleaned up ${deleted} stale registry entr${deleted > 1 ? 'ies' : 'y'}.`);
+    print();
+  }
+
+  const owner = localStore.getLiveLocalDashboardProcess();
+  const instances = localStore.listLocalInstances().filter((i) => i.alive);
+
+  if (instances.length === 0) {
+    print('No --local processes running.');
+    return;
+  }
+
+  print(`${instances.length} --local process(es) running:`);
+  print();
+  for (const inst of instances) {
+    const status = inst.pid === owner?.pid ? 'dashboard owner' : 'idle';
+    print(
+      `  PID ${inst.pid}  (${status}, started ${formatAge(Date.now() - inst.startedAt)} ago)  ${inst.cwd}`,
+    );
+  }
+
+  if (!options.clean) return;
+
+  const orphans = instances.filter((i) => i.pid !== owner?.pid);
+  if (orphans.length === 0) {
+    print('\nNo orphaned processes to clean up.');
+    return;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  let answer: string;
+  try {
+    answer = (
+      await rl.question(
+        `\nKill ${orphans.length} orphaned process${orphans.length > 1 ? 'es' : ''}? [Y/n]: `,
+      )
+    )
+      .trim()
+      .toLowerCase();
+  } finally {
+    rl.close();
+  }
+  if (answer === 'n' || answer === 'no') return;
+
+  for (const orphan of orphans) {
+    try {
+      await killProcessGracefully(orphan.pid);
+      localStore.unregisterLocalInstance(orphan.pid);
+      print(`✓ Killed PID ${orphan.pid}.`);
+    } catch (err) {
+      print(`⚠ Could not kill PID ${orphan.pid}: ${errMsg(err)}`);
+    }
   }
 }
 
@@ -1250,6 +1335,15 @@ export function createInstallProgram(): Command {
     .option('--time <HH:MM>', 'Set the daily update time (24-hour format, e.g. 08:00)')
     .option('--disable', 'Remove the auto-update schedule')
     .action(handleSchedule);
+
+  program
+    .command('local')
+    .description('List running --local dashboard processes and clean up orphaned ones')
+    .option(
+      '--clean',
+      'Kill orphaned --local processes after listing them (prompts for confirmation)',
+    )
+    .action(handleLocal);
 
   return program;
 }

--- a/src/install/diagnostics.test.ts
+++ b/src/install/diagnostics.test.ts
@@ -79,6 +79,14 @@ jest.mock('./platform.js', () => ({
   resolveWindowsHome: jest.fn(() => null),
 }));
 
+// Stub storage module.
+jest.mock('../storage/index.js', () => ({
+  LocalStore: jest.fn().mockImplementation(() => ({
+    getLiveLocalDashboardProcess: jest.fn(() => null),
+    listLocalInstances: jest.fn(() => []),
+  })),
+}));
+
 // Stub global fetch.
 const mockFetch = jest.fn<typeof fetch>();
 global.fetch = mockFetch as unknown as typeof fetch;
@@ -88,6 +96,7 @@ import * as schedule from './schedule.js';
 import * as config from '../config.js';
 import * as installHelper from './install-helper.js';
 import * as platform from './platform.js';
+import { LocalStore } from '../storage/index.js';
 
 const mockedExistSync = nodeFs.existsSync as jest.Mock;
 const mockedReadFileSync = nodeFs.readFileSync as jest.Mock;
@@ -578,8 +587,75 @@ describe('runDiagnostics', () => {
     });
   });
 
-  it('returns exactly 6 checks on macOS', async () => {
+  describe('Check 7: Local instances', () => {
+    it('reports ok with no --local processes running', async () => {
+      (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+        getLiveLocalDashboardProcess: jest.fn(() => null),
+        listLocalInstances: jest.fn(() => []),
+      }));
+      const checks = await runDiagnostics({ configPath: '/tmp/does-not-exist.json' });
+      const check = checks.find((c) => c.check === 'Local instances');
+      expect(check?.status).toBe('ok');
+      expect(check?.detail).toContain('No --local processes running');
+    });
+
+    it('reports ok when every live instance is the dashboard owner', async () => {
+      (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+        getLiveLocalDashboardProcess: jest.fn(() => ({ pid: 100, argv: [], cwd: '/owner' })),
+        listLocalInstances: jest.fn(() => [
+          { pid: 100, argv: [], cwd: '/owner', startedAt: Date.now(), alive: true },
+        ]),
+      }));
+      const checks = await runDiagnostics({ configPath: '/tmp/does-not-exist.json' });
+      const check = checks.find((c) => c.check === 'Local instances');
+      expect(check?.status).toBe('ok');
+      expect(check?.fix).toBeUndefined();
+    });
+
+    it('reports warn with orphan PIDs and a fix command when idle instances exist', async () => {
+      (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+        getLiveLocalDashboardProcess: jest.fn(() => ({ pid: 100, argv: [], cwd: '/owner' })),
+        listLocalInstances: jest.fn(() => [
+          { pid: 100, argv: [], cwd: '/owner', startedAt: Date.now(), alive: true },
+          { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now(), alive: true },
+        ]),
+      }));
+      const checks = await runDiagnostics({ configPath: '/tmp/does-not-exist.json' });
+      const check = checks.find((c) => c.check === 'Local instances');
+      expect(check?.status).toBe('warn');
+      expect(check?.detail).toContain('200');
+      expect(check?.fix).toBe('preflight local --clean');
+    });
+
+    it('ignores dead entries when counting orphans', async () => {
+      (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+        getLiveLocalDashboardProcess: jest.fn(() => null),
+        listLocalInstances: jest.fn(() => [
+          { pid: 200, argv: [], cwd: '/dead', startedAt: Date.now(), alive: false },
+        ]),
+      }));
+      const checks = await runDiagnostics({ configPath: '/tmp/does-not-exist.json' });
+      const check = checks.find((c) => c.check === 'Local instances');
+      expect(check?.status).toBe('ok');
+    });
+
+    it('degrades to a warn check instead of crashing runDiagnostics when LocalStore throws', async () => {
+      (LocalStore as unknown as jest.Mock).mockImplementation(() => {
+        throw new Error('registry file is corrupt');
+      });
+      const checks = await runDiagnostics({ configPath: '/tmp/does-not-exist.json' });
+      // All 7 checks must still be present — one throwing dependency must not
+      // take down the rest of the diagnostic run.
+      expect(checks).toHaveLength(7);
+      const check = checks.find((c) => c.check === 'Local instances');
+      expect(check?.status).toBe('warn');
+      expect(check?.detail).toContain('registry file is corrupt');
+      expect(check?.fix).toBeUndefined();
+    });
+  });
+
+  it('returns exactly 7 checks on macOS', async () => {
     const checks = await runDiagnostics(makeOpts());
-    expect(checks).toHaveLength(6);
+    expect(checks).toHaveLength(7);
   });
 });

--- a/src/install/diagnostics.ts
+++ b/src/install/diagnostics.ts
@@ -12,6 +12,7 @@ import {
   entryHasAnyCommandHook,
 } from './install-helper.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
+import { LocalStore } from '../storage/index.js';
 
 const logger = createLogger('diagnostics');
 
@@ -355,6 +356,41 @@ async function checkNrReachable(skipReason: string | null): Promise<DiagnosticCh
   }
 }
 
+function checkLocalInstances(storagePath: string): DiagnosticCheck {
+  try {
+    const store = new LocalStore(storagePath);
+    const owner = store.getLiveLocalDashboardProcess();
+    const instances = store.listLocalInstances().filter((i) => i.alive);
+    const orphans = instances.filter((i) => i.pid !== owner?.pid);
+
+    if (orphans.length === 0) {
+      return {
+        check: 'Local instances',
+        status: 'ok',
+        detail:
+          instances.length === 0
+            ? 'No --local processes running'
+            : `${instances.length} --local process(es) running, all accounted for`,
+      };
+    }
+    return {
+      check: 'Local instances',
+      status: 'warn',
+      detail: `${orphans.length} idle --local process(es) running (PID${
+        orphans.length > 1 ? 's' : ''
+      }: ${orphans.map((o) => o.pid).join(', ')})`,
+      fix: 'preflight local --clean',
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      check: 'Local instances',
+      status: 'warn',
+      detail: `Could not check local instances: ${message}`,
+    };
+  }
+}
+
 export async function runDiagnostics(opts?: {
   configPath?: string;
   storagePath?: string;
@@ -373,6 +409,7 @@ export async function runDiagnostics(opts?: {
     ...checkDaemon(),
     checkHooksWired(settingsPaths),
     checkStorageWritable(context.storagePath),
+    checkLocalInstances(context.storagePath),
     await checkNrReachable(context.nrSkipReason),
   ];
 }

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -1118,4 +1118,80 @@ describe('LocalStore', () => {
       expect(existsSync(resolve(tmpDir, 'local-dashboard.pid'))).toBe(true);
     });
   });
+
+  describe('local instance registry', () => {
+    it('registers and lists a live instance', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      store.registerLocalInstance(['dist/index.js', '--local'], '/repo', process.pid);
+      const instances = store.listLocalInstances();
+      expect(instances).toHaveLength(1);
+      expect(instances[0]).toMatchObject({
+        pid: process.pid,
+        argv: ['dist/index.js', '--local'],
+        cwd: '/repo',
+        alive: true,
+      });
+      expect(typeof instances[0]!.startedAt).toBe('number');
+    });
+
+    it('lists multiple registered instances, tagging dead ones as not alive', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      store.registerLocalInstance(['dist/index.js', '--local'], '/repo-a', process.pid);
+      store.registerLocalInstance(['dist/index.js', '--local'], '/repo-b', 999999);
+      const instances = store.listLocalInstances();
+      expect(instances).toHaveLength(2);
+      const live = instances.find((i) => i.pid === process.pid);
+      const dead = instances.find((i) => i.pid === 999999);
+      expect(live?.alive).toBe(true);
+      expect(dead?.alive).toBe(false);
+    });
+
+    it('returns an empty array when the registry directory does not exist', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      expect(store.listLocalInstances()).toEqual([]);
+    });
+
+    it('skips malformed registry entries silently', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      mkdirSync(resolve(tmpDir, 'local-instances'), { recursive: true });
+      writeFileSync(resolve(tmpDir, 'local-instances', '123.json'), 'not json');
+      expect(store.listLocalInstances()).toEqual([]);
+    });
+
+    it('unregisterLocalInstance removes its own entry', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      store.registerLocalInstance(['dist/index.js', '--local'], '/repo', process.pid);
+      store.unregisterLocalInstance(process.pid);
+      expect(store.listLocalInstances()).toEqual([]);
+    });
+
+    it('unregisterLocalInstance is a no-op when the entry does not exist', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      expect(() => store.unregisterLocalInstance(process.pid)).not.toThrow();
+    });
+
+    it('gcDeadLocalInstances deletes only dead entries and returns the count', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      store.registerLocalInstance(['dist/index.js', '--local'], '/repo-live', process.pid);
+      store.registerLocalInstance(['dist/index.js', '--local'], '/repo-dead', 999999);
+      const deleted = store.gcDeadLocalInstances();
+      expect(deleted).toBe(1);
+      const remaining = store.listLocalInstances();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]!.pid).toBe(process.pid);
+    });
+
+    it('gcDeadLocalInstances returns 0 when the registry directory does not exist', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      expect(store.gcDeadLocalInstances()).toBe(0);
+    });
+  });
 });

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -354,6 +354,147 @@ export class LocalStore {
   }
 
   /**
+   * Register the current `--local` process in the instance registry
+   * (`local-instances/<pid>.json`: pid/argv/cwd/startedAt) — called
+   * unconditionally at `--local` startup, regardless of whether this
+   * process wins the dashboard port bind. This is what lets `preflight
+   * local` and `preflight doctor` see EVERY `--local` process preflight
+   * launched, not just whichever one currently owns the dashboard (that's
+   * `local-dashboard.pid`, a separate single-slot mechanism — see
+   * `writeLocalDashboardPid()`).
+   */
+  registerLocalInstance(argv: readonly string[], cwd: string, pid: number = process.pid): void {
+    const dir = resolve(this.storagePath, 'local-instances');
+    const path = resolve(dir, `${pid}.json`);
+    try {
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true, mode: 0o700 });
+      }
+      writeFileSync(
+        path,
+        JSON.stringify({ pid, argv: Array.from(argv), cwd, startedAt: Date.now() }),
+        { mode: 0o600 },
+      );
+    } catch (err) {
+      logger.warn('Failed to register local instance', { error: String(err) });
+    }
+  }
+
+  /**
+   * Remove this process's own instance-registry entry. Safe to call
+   * unconditionally on shutdown — a missing file is a no-op. Unlike
+   * `removeLocalDashboardPid()`, no ownership check is needed: the filename
+   * itself (`<pid>.json`) already scopes the entry to a specific PID.
+   */
+  unregisterLocalInstance(pid: number = process.pid): void {
+    const path = resolve(this.storagePath, 'local-instances', `${pid}.json`);
+    try {
+      if (existsSync(path)) unlinkSync(path);
+    } catch (err) {
+      logger.debug('Failed to remove local instance registry entry', { error: String(err) });
+    }
+  }
+
+  /**
+   * List every `--local` process preflight has registered that hasn't been
+   * unregistered yet — including ones whose PID is no longer alive (tagged
+   * `alive: false`). Callers that only want live entries should filter;
+   * `gcDeadLocalInstances()` is what actually cleans up the dead ones.
+   * Malformed entries are skipped silently.
+   */
+  listLocalInstances(): Array<{
+    pid: number;
+    argv: string[];
+    cwd: string;
+    startedAt: number;
+    alive: boolean;
+  }> {
+    const dir = resolve(this.storagePath, 'local-instances');
+    if (!existsSync(dir)) return [];
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch (err) {
+      logger.warn('Failed to enumerate local-instances dir', { error: String(err) });
+      return [];
+    }
+    const result: Array<{
+      pid: number;
+      argv: string[];
+      cwd: string;
+      startedAt: number;
+      alive: boolean;
+    }> = [];
+    for (const name of entries) {
+      if (!name.endsWith('.json')) continue;
+      try {
+        const parsed = JSON.parse(readFileSync(resolve(dir, name), 'utf-8')) as {
+          pid?: unknown;
+          argv?: unknown;
+          cwd?: unknown;
+          startedAt?: unknown;
+        };
+        const { pid, argv, cwd, startedAt } = parsed;
+        if (
+          typeof pid !== 'number' ||
+          !Array.isArray(argv) ||
+          !argv.every((a) => typeof a === 'string') ||
+          typeof cwd !== 'string' ||
+          typeof startedAt !== 'number'
+        ) {
+          continue;
+        }
+        result.push({ pid, argv: argv as string[], cwd, startedAt, alive: isPidAlive(pid) });
+      } catch {
+        continue;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Garbage-collect instance-registry entries whose PID is no longer alive —
+   * mirrors `gcStaleBreadcrumbs()`. Called opportunistically from the
+   * dashboard owner's periodic GC pass (see `setupDashboardPostBind()` in
+   * index.ts), so entries left behind by a process that didn't shut down
+   * cleanly don't accumulate indefinitely.
+   *
+   * @returns the number of entries deleted
+   */
+  gcDeadLocalInstances(): number {
+    const dir = resolve(this.storagePath, 'local-instances');
+    if (!existsSync(dir)) return 0;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch (err) {
+      logger.warn('Failed to enumerate local-instances dir for gcDeadLocalInstances', {
+        error: String(err),
+      });
+      return 0;
+    }
+    let deleted = 0;
+    for (const name of entries) {
+      if (!name.endsWith('.json')) continue;
+      const pidStr = name.slice(0, -'.json'.length);
+      const pid = Number.parseInt(pidStr, 10);
+      if (!Number.isFinite(pid) || pid <= 0) continue;
+      if (isPidAlive(pid)) continue;
+      const path = resolve(dir, name);
+      try {
+        unlinkSync(path);
+        deleted++;
+      } catch (err) {
+        logger.debug('Failed to delete dead local instance entry', { pid, error: String(err) });
+      }
+    }
+    if (deleted > 0) {
+      logger.info('Cleaned up dead local instance entries', { deleted });
+    }
+    return deleted;
+  }
+
+  /**
    * Garbage-collect orphan per-session buffer files. A buffer is orphan when
    * no live process is currently draining it; we determine that with two
    * signals:


### PR DESCRIPTION
Fixes #86

## Summary
- Orphaned `--local` processes had zero visibility before this: the restart-offer feature only ever tracks whichever `--local` process wins the dashboard port bind, so any process that loses that race just runs headless forever with no way to detect it.
- Every `--local` process now registers itself in a small per-PID registry (`local-instances/<pid>.json`: pid/argv/cwd/startedAt) at startup, regardless of port outcome, and removes itself on clean shutdown. This is purely additive — the existing single-slot `local-dashboard.pid` mechanism is untouched.
- New `preflight local` command: lists every registered instance and marks the current dashboard owner. `preflight local --clean` prompts (single combined `[Y/n]`, default yes) to kill every live instance that isn't the owner.
- Dead registry entries (from a process that didn't shut down cleanly) are garbage-collected automatically every 5 minutes by whichever process owns the dashboard.
- `preflight doctor` gained a matching read-only "Local instances" check that reports idle processes and points at `preflight local --clean`.
- Never scans the OS process table anywhere — every kill/list/report action only ever acts on a PID that preflight itself wrote into a registry file.

## Test plan
- [x] `npm run build && npm test` — 3811/3814 passing (3 pre-existing skips), clean
- [x] `npm run lint` / `npm run format:check` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>