### PR TITLE
Fix: make Release workflow idempotent and resilient to npm publish flakiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,38 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git tag v$(node -p "require('./package.json').version")
-          git push --tags
+          TAG="v$(node -p "require('./package.json').version")"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on origin, skipping"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
 
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create v$(node -p "require('./package.json').version") --generate-notes
+          TAG="v$(node -p "require('./package.json').version")"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping"
+          else
+            gh release create "$TAG" --generate-notes
+          fi
 
       - name: Publish to npm
-        run: npm publish
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if npm view "@newrelic/preflight@$VERSION" version >/dev/null 2>&1; then
+            echo "@newrelic/preflight@$VERSION already published, skipping"
+            exit 0
+          fi
+
+          for attempt in 1 2 3; do
+            if npm publish; then
+              exit 0
+            fi
+            echo "npm publish attempt $attempt failed"
+            [ "$attempt" -lt 3 ] && sleep $((attempt * 10))
+          done
+          exit 1


### PR DESCRIPTION
## Summary
- Today's manual Release run tagged v1.4.2 and created the GitHub release successfully, then failed on **Publish to npm** with `npm error code IDENTITY_TOKEN_READ_ERROR` (transient OIDC identity-token fetch failure).
- Re-running the workflow then failed immediately at **Create tag** / **Create release** since both already existed, blocking any retry from reaching npm publish.
- Makes each step idempotent so re-running Release after a partial failure always converges: `Create tag` and `Create release` skip if they already exist, and `Publish to npm` skips if the version is already on the registry and retries up to 3 times with backoff on transient failures.

## Test plan
- [x] `npm run build && npm test` pass locally
- [ ] Re-run the `Release` workflow via `workflow_dispatch` to confirm it publishes `@newrelic/preflight@1.4.2` to npm without re-creating the existing tag/release