### PR TITLE
Fix: v1.4.3 — Kiro hook adapter fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2026-07-09
+
+### Fixed
+
+- **Kiro hook events were silently dropped** — `preflight-collector` matched Claude Code's exact PascalCase hook event names (`PreToolUse`); Kiro sends lower-camelCase (`preToolUse`) per its own docs, so every Kiro hook event fell through to a silent no-op — nothing was written to the buffer, but the collector still exited 0. The event-name check is now case-insensitive. (#84)
+- **Hook-sourced tool names were never normalized for any platform** — `PlatformAdapter.normalizeToolCall()` and `PlatformRegistry` were fully implemented and tested but never actually called from the running hook pipeline; every platform's tool names passed through to trackers and the dashboard unmapped. Added `PlatformAdapter.mapToolName()` and wired it into `HookEventProcessor`, and corrected Kiro's tool-name map with its documented aliases (`read`/`write`/`shell`/`aws`).
+
+### Added
+
+- **`preflight doctor --platform <name>`** — the "Hooks wired" check previously only validated Claude Code's `settings.json` and stayed green regardless of whether a non-Claude-Code platform's hooks actually worked. Passing `--platform kiro` (or any other registered platform name) now skips the Claude-Code-specific check in favor of an explicit reminder to verify that platform's own hook/MCP config and to confirm events land in `~/.newrelic-preflight/buffer-*.jsonl`.
+
 ## [1.4.2] - 2026-07-09
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -395,6 +395,51 @@ describe('collector-script', () => {
     });
   });
 
+  function makeKiroPreToolUse(overrides?: Record<string, unknown>): string {
+    return JSON.stringify({
+      hook_event_name: 'preToolUse',
+      tool_name: 'read',
+      tool_input: { operations: [{ mode: 'Line', path: '/tmp/test.ts' }] },
+      session_id: 'kiro-sess-001',
+      cwd: '/projects/test',
+      ...overrides,
+    });
+  }
+
+  function makeKiroPostToolUse(overrides?: Record<string, unknown>): string {
+    return JSON.stringify({
+      hook_event_name: 'postToolUse',
+      tool_name: 'read',
+      tool_response: { success: true },
+      session_id: 'kiro-sess-001',
+      cwd: '/projects/test',
+      ...overrides,
+    });
+  }
+
+  describe('collector-script — Kiro hook event names (lower-camelCase)', () => {
+    it('writes a pre event when hook_event_name is "preToolUse" (not "PreToolUse")', () => {
+      processHook(makeKiroPreToolUse());
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].mode).toBe('pre');
+      expect(events[0].tool).toBe('read');
+    });
+
+    it('writes a post event when hook_event_name is "postToolUse" (not "PostToolUse")', () => {
+      processHook(makeKiroPostToolUse());
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].mode).toBe('post');
+      expect(events[0].success).toBe(true);
+    });
+
+    it('still ignores a genuinely unknown hook_event_name', () => {
+      processHook(makeKiroPreToolUse({ hook_event_name: 'agentSpawn' }));
+      expect(readBufferEvents()).toHaveLength(0);
+    });
+  });
+
   describe('helper functions', () => {
     it('redact() replaces API keys', () => {
       expect(redact('API_KEY = my-secret-key')).toContain('[REDACTED]');

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -627,7 +627,12 @@ function processHook(raw: string): void {
     writePpidBreadcrumb(data.session_id);
   }
 
-  const eventName = data.hook_event_name;
+  // Claude Code sends PascalCase hook names ('PreToolUse'); Kiro sends
+  // lower-camelCase ('preToolUse') per https://kiro.dev/docs/cli/hooks.
+  // Normalize case so both are recognized without hard-coding per-platform
+  // spellings here (this file intentionally has no platform-adapter import —
+  // see the file's own "no heavy imports" design constraint).
+  const eventName = data.hook_event_name?.toLowerCase();
   const toolName = data.tool_name ?? 'unknown';
   const timestamp = Date.now();
   const recordContent = getRecordContent();
@@ -635,7 +640,7 @@ function processHook(raw: string): void {
 
   let event: Record<string, unknown>;
 
-  if (eventName === 'PreToolUse') {
+  if (eventName === 'pretooluse') {
     event = {
       mode: 'pre' as const,
       tool: toolName,
@@ -653,7 +658,7 @@ function processHook(raw: string): void {
         typeof data.tool_input === 'string' ? data.tool_input : JSON.stringify(data.tool_input);
       event.inputContent = redact(truncate(content, maxContentLen));
     }
-  } else if (eventName === 'PostToolUse') {
+  } else if (eventName === 'posttooluse') {
     event = {
       mode: 'post' as const,
       tool: toolName,
@@ -677,7 +682,7 @@ function processHook(raw: string): void {
           : JSON.stringify(data.tool_response);
       event.outputContent = redact(truncate(content, maxContentLen));
     }
-  } else if (eventName === 'PostToolUseFailure') {
+  } else if (eventName === 'posttoolusefailure') {
     event = {
       mode: 'post' as const,
       tool: toolName,
@@ -723,7 +728,7 @@ function processHook(raw: string): void {
 
   // After writing the tool event, collect token usage from the transcript.
   // Only on PostToolUse — each assistant turn produces exactly one usage object.
-  if (eventName === 'PostToolUse') {
+  if (eventName === 'posttooluse') {
     try {
       collectTranscriptTokens(data);
     } catch {

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -692,4 +692,132 @@ describe('HookEventProcessor', () => {
       expect(records).toHaveLength(0);
     });
   });
+
+  describe('platform tool-name mapping', () => {
+    it('maps a non-canonical tool name using the injected platform adapter', () => {
+      const fakeAdapter = {
+        platformName: 'fake',
+        initialize: async () => {},
+        normalizeToolCall: () => {
+          throw new Error('not used by this test');
+        },
+        mapToolName: (name: string) => (name === 'fs_read' ? 'Read' : 'Unknown'),
+        getSessionMetadata: () => ({ platform: 'fake' }),
+        getHookInstallInstructions: () => '',
+        isSupported: () => true,
+      };
+
+      const processor = new HookEventProcessor({ store, onRecord, platformAdapter: fakeAdapter });
+      processor.processEvents([
+        makePreEvent({ tool: 'fs_read', toolUseId: 'toolu_map' }),
+        makePostEvent({ tool: 'fs_read', toolUseId: 'toolu_map' }),
+      ]);
+
+      expect(records).toHaveLength(1);
+      expect(records[0]!.toolName).toBe('Read');
+    });
+
+    it('defaults to the process-detected platform adapter when none is injected', () => {
+      // No platformAdapter option passed — falls back to createDefaultRegistry().getActive(),
+      // which resolves to GenericMcpAdapter (identity mapping) when no platform env vars are set.
+      const processor = new HookEventProcessor({ store, onRecord });
+      processor.processEvents([
+        makePreEvent({ tool: 'Read', toolUseId: 'toolu_default' }),
+        makePostEvent({ tool: 'Read', toolUseId: 'toolu_default' }),
+      ]);
+
+      expect(records).toHaveLength(1);
+      expect(records[0]!.toolName).toBe('Read');
+    });
+
+    it('maps tool names correctly when pairing falls back to findOldestPendingKey (no toolUseId)', () => {
+      const fakeAdapter = {
+        platformName: 'fake',
+        initialize: async () => {},
+        normalizeToolCall: () => {
+          throw new Error('not used by this test');
+        },
+        mapToolName: (name: string) => (name === 'fs_read' ? 'Read' : 'Unknown'),
+        getSessionMetadata: () => ({ platform: 'fake' }),
+        getHookInstallInstructions: () => '',
+        isSupported: () => true,
+      };
+
+      const processor = new HookEventProcessor({ store, onRecord, platformAdapter: fakeAdapter });
+      // No toolUseId on either event — forces pairing through findOldestPendingKey(),
+      // which compares mapped tool names case-insensitively.
+      processor.processEvents([
+        makePreEvent({ tool: 'fs_read', toolUseId: undefined, timestamp: 1000 }),
+        makePostEvent({ tool: 'fs_read', toolUseId: undefined, timestamp: 1050 }),
+      ]);
+
+      expect(records).toHaveLength(1);
+      expect(records[0]!.toolName).toBe('Read');
+      // Assert real pairing occurred via findOldestPendingKey, not an orphaned post:
+      // a genuine pair reports the pre-event's timestamp and a non-null duration;
+      // an orphaned post (durationMs: null) would report the post-event's own
+      // timestamp (1050) instead, so this discriminates between the two outcomes.
+      expect(records[0]!.durationMs).toBe(50);
+      expect(records[0]!.timestamp).toBe(1000);
+    });
+
+    it('preserves the original tool name when the platform adapter cannot map it', () => {
+      const fakeAdapter = {
+        platformName: 'fake',
+        initialize: async () => {},
+        normalizeToolCall: () => {
+          throw new Error('not used by this test');
+        },
+        mapToolName: () => 'Unknown', // simulates an adapter with no entry for this tool
+        getSessionMetadata: () => ({ platform: 'fake' }),
+        getHookInstallInstructions: () => '',
+        isSupported: () => true,
+      };
+
+      const processor = new HookEventProcessor({ store, onRecord, platformAdapter: fakeAdapter });
+      processor.processEvents([
+        makePreEvent({ tool: 'some_unmapped_mcp_tool', toolUseId: 'toolu_unmapped' }),
+        makePostEvent({ tool: 'some_unmapped_mcp_tool', toolUseId: 'toolu_unmapped' }),
+      ]);
+
+      expect(records).toHaveLength(1);
+      expect(records[0]!.toolName).toBe('some_unmapped_mcp_tool');
+    });
+
+    it('does not cross-pair two different unmapped tools that share no toolUseId', () => {
+      const fakeAdapter = {
+        platformName: 'fake',
+        initialize: async () => {},
+        normalizeToolCall: () => {
+          throw new Error('not used by this test');
+        },
+        mapToolName: () => 'Unknown', // every raw name maps to 'Unknown'
+        getSessionMetadata: () => ({ platform: 'fake' }),
+        getHookInstallInstructions: () => '',
+        isSupported: () => true,
+      };
+
+      const processor = new HookEventProcessor({ store, onRecord, platformAdapter: fakeAdapter });
+      // Two distinct unmapped tools, no toolUseId, fired concurrently at the same
+      // timestamp. Before the fix, both pre-events collapsed to the same pairing
+      // key ('Unknown:1000:...') by coincidence of mapping, and pairing relied on
+      // raw-name distinctness to avoid cross-matching foo's post to bar's pre.
+      processor.processEvents([
+        makePreEvent({ tool: 'foo_tool', toolUseId: undefined, timestamp: 1000 }),
+        makePreEvent({ tool: 'bar_tool', toolUseId: undefined, timestamp: 1000 }),
+        makePostEvent({ tool: 'bar_tool', toolUseId: undefined, timestamp: 1050 }),
+        makePostEvent({ tool: 'foo_tool', toolUseId: undefined, timestamp: 1060 }),
+      ]);
+
+      expect(records).toHaveLength(2);
+      const fooRecord = records.find((r) => r.toolName === 'foo_tool');
+      const barRecord = records.find((r) => r.toolName === 'bar_tool');
+      expect(fooRecord).toBeDefined();
+      expect(barRecord).toBeDefined();
+      // Each post paired with its own tool's pre-event (both started at 1000),
+      // not cross-matched to the other tool.
+      expect(fooRecord!.durationMs).toBe(60);
+      expect(barRecord!.durationMs).toBe(50);
+    });
+  });
 });

--- a/src/hooks/event-processor.ts
+++ b/src/hooks/event-processor.ts
@@ -12,11 +12,25 @@
 
 import { randomUUID } from 'node:crypto';
 import { createLogger } from '../shared/index.js';
+import { createDefaultRegistry } from '../platforms/index.js';
+import type { PlatformAdapter } from '../platforms/types.js';
 import type { LocalStore } from '../storage/local-store.js';
 import type { HookEvent, ToolCallRecord, TokenEvent } from '../storage/types.js';
 import { parseToolSpecificFields } from './tool-parsers.js';
 
 const logger = createLogger('event-processor');
+
+/**
+ * Maps a raw platform tool name via the adapter, falling back to the raw
+ * name when the adapter can't recognize it (i.e. returns the literal string
+ * `'Unknown'`). Without this fallback, every unmapped tool would collapse
+ * into the same `'Unknown'` bucket — losing the original name in telemetry
+ * and letting distinct unmapped tools collide on the same pairing key.
+ */
+function mapToolNameOrOriginal(adapter: PlatformAdapter, rawToolName: string): string {
+  const mapped = adapter.mapToolName(rawToolName);
+  return mapped === 'Unknown' ? rawToolName : mapped;
+}
 
 export interface HookEventProcessorOptions {
   store: LocalStore;
@@ -34,6 +48,14 @@ export interface HookEventProcessorOptions {
   drainAllSessions?: boolean;
   onRecord: (record: ToolCallRecord) => void;
   onTokenEvent?: (event: TokenEvent) => void;
+  /**
+   * Adapter used to map each platform's raw tool names (e.g. Kiro's `fs_read`)
+   * to Preflight's canonical vocabulary (`Read`) before pairing/emitting.
+   * Defaults to the process's auto-detected platform (env-var based via
+   * `createDefaultRegistry().getActive()`), which resolves to `GenericMcpAdapter`
+   * (identity mapping) when no platform-specific env vars are present.
+   */
+  platformAdapter?: PlatformAdapter;
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 100;
@@ -47,6 +69,7 @@ export class HookEventProcessor {
   private drainAllSessions: boolean;
   private readonly onRecord: (record: ToolCallRecord) => void;
   private readonly onTokenEvent: ((event: TokenEvent) => void) | null;
+  private readonly platformAdapter: PlatformAdapter;
 
   private readonly pending: Map<string, HookEvent> = new Map();
   private readonly maxPendingEvents: number;
@@ -64,6 +87,7 @@ export class HookEventProcessor {
     this.maxPendingEvents = options.maxPendingEvents ?? DEFAULT_MAX_PENDING;
     this.onRecord = options.onRecord;
     this.onTokenEvent = options.onTokenEvent ?? null;
+    this.platformAdapter = options.platformAdapter ?? createDefaultRegistry().getActive();
 
     this.boundBeforeExit = () => {
       this.stop();
@@ -144,7 +168,11 @@ export class HookEventProcessor {
    * Exported for direct testing — in production, called by poll().
    */
   processEvents(events: HookEvent[]): void {
-    for (const event of events) {
+    for (const rawEvent of events) {
+      const event: HookEvent =
+        rawEvent.mode === 'pre' || rawEvent.mode === 'post'
+          ? { ...rawEvent, tool: mapToolNameOrOriginal(this.platformAdapter, rawEvent.tool) }
+          : rawEvent;
       try {
         if (event.mode === 'token') {
           this.handleTokenEvent(event);

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -1230,13 +1230,13 @@ function handleValidate(options: { config?: string }): void {
 // Doctor handler
 // ---------------------------------------------------------------------------
 
-async function handleDoctor(options: { config?: string }): Promise<void> {
+async function handleDoctor(options: { config?: string; platform?: string }): Promise<void> {
   const { runDiagnostics } = await import('./diagnostics.js');
   const configPath = options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
 
   const storagePath = process.env.NEW_RELIC_AI_MCP_STORAGE_PATH ?? undefined;
   print('Running diagnostics...');
-  const checks = await runDiagnostics({ configPath, storagePath });
+  const checks = await runDiagnostics({ configPath, storagePath, platform: options.platform });
 
   const ICON: Record<string, string> = { ok: '✓', warn: '⚠', fail: '✗', skip: '-' };
   const COL = 22;
@@ -1322,6 +1322,10 @@ export function createInstallProgram(): Command {
     .command('doctor')
     .description('Check configuration, hooks, daemon, and connectivity for common setup problems')
     .option('--config <path>', 'Path to config file (default: ~/.newrelic-preflight/config.json)')
+    .option(
+      '--platform <name>',
+      'Platform to check hooks for (e.g. kiro, cursor) — Claude Code checked by default',
+    )
     .action(handleDoctor);
 
   program

--- a/src/install/diagnostics.test.ts
+++ b/src/install/diagnostics.test.ts
@@ -120,6 +120,7 @@ describe('runDiagnostics', () => {
   let runDiagnostics: (opts?: {
     configPath?: string;
     storagePath?: string;
+    platform?: string;
   }) => Promise<DiagnosticCheck[]>;
 
   beforeEach(async () => {
@@ -465,6 +466,31 @@ describe('runDiagnostics', () => {
       expect(c.status).toBe('fail');
       expect(c.detail).toContain('PostToolUse');
       expect(c.detail).not.toContain('warn');
+    });
+
+    it('skips the Claude Code check and gives manual-verification guidance for a non-Claude platform', async () => {
+      mockedExistSync.mockReturnValue(false);
+      const checks = await runDiagnostics({ ...makeOpts(), platform: 'kiro' });
+      const hooksCheck = checks.find((c: DiagnosticCheck) => c.check === 'Hooks wired');
+      expect(hooksCheck?.status).toBe('warn');
+      expect(hooksCheck?.detail).toContain('kiro');
+      expect(hooksCheck?.fix).toContain('buffer-*.jsonl');
+    });
+
+    it('fails with the list of known platforms when given an unrecognized platform name', async () => {
+      const checks = await runDiagnostics({ ...makeOpts(), platform: 'not-a-real-platform' });
+      const hooksCheck = checks.find((c: DiagnosticCheck) => c.check === 'Hooks wired');
+      expect(hooksCheck?.status).toBe('fail');
+      expect(hooksCheck?.detail).toContain('Unknown platform');
+      expect(hooksCheck?.detail).toContain('kiro');
+    });
+
+    it('runs the existing Claude Code check unchanged when --platform is omitted', async () => {
+      mockedExistSync.mockReturnValue(false);
+      const checks = await runDiagnostics(makeOpts());
+      const hooksCheck = checks.find((c: DiagnosticCheck) => c.check === 'Hooks wired');
+      expect(hooksCheck?.status).toBe('fail');
+      expect(hooksCheck?.detail).toContain('Settings file not found');
     });
   });
 

--- a/src/install/diagnostics.ts
+++ b/src/install/diagnostics.ts
@@ -13,6 +13,7 @@ import {
 } from './install-helper.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
 import { LocalStore } from '../storage/index.js';
+import { createDefaultRegistry } from '../platforms/index.js';
 
 const logger = createLogger('diagnostics');
 
@@ -189,7 +190,25 @@ function checkDaemon(): DiagnosticCheck[] {
   return [installedCheck, nodePathCheck];
 }
 
-function checkHooksWired(settingsPaths: string[]): DiagnosticCheck {
+function checkHooksWired(settingsPaths: string[], platform: string | undefined): DiagnosticCheck {
+  if (platform !== undefined && platform !== 'claude-code') {
+    const registry = createDefaultRegistry();
+    const known = registry.getRegistered().map((a) => a.platformName);
+    if (!known.includes(platform)) {
+      return {
+        check: 'Hooks wired',
+        status: 'fail',
+        detail: `Unknown platform "${platform}". Supported: ${known.join(', ')}`,
+      };
+    }
+    return {
+      check: 'Hooks wired',
+      status: 'warn',
+      detail: `This check only validates Claude Code's settings.json — not applicable to "${platform}"`,
+      fix: `Verify manually: confirm ${platform}'s own hook or MCP config invokes preflight-collector (or reports via MCP), then tail ~/.newrelic-preflight/buffer-*.jsonl while using ${platform} to confirm events actually arrive.`,
+    };
+  }
+
   const anyPathExists = settingsPaths.some(existsSync);
   let hooksPre = false;
   let hooksPost = false;
@@ -394,6 +413,7 @@ function checkLocalInstances(storagePath: string): DiagnosticCheck {
 export async function runDiagnostics(opts?: {
   configPath?: string;
   storagePath?: string;
+  platform?: string;
 }): Promise<DiagnosticCheck[]> {
   const configPath = opts?.configPath ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
   const { check: configCheck, context } = checkConfigValid(configPath, opts?.storagePath);
@@ -407,7 +427,7 @@ export async function runDiagnostics(opts?: {
   return [
     configCheck,
     ...checkDaemon(),
-    checkHooksWired(settingsPaths),
+    checkHooksWired(settingsPaths, opts?.platform),
     checkStorageWritable(context.storagePath),
     checkLocalInstances(context.storagePath),
     await checkNrReachable(context.nrSkipReason),

--- a/src/platforms/amazon-q-adapter.test.ts
+++ b/src/platforms/amazon-q-adapter.test.ts
@@ -258,4 +258,14 @@ describe('AmazonQAdapter', () => {
       await expect(adapter.initialize({})).resolves.toBeUndefined();
     });
   });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('fs_read')).toBe('Read');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
 });

--- a/src/platforms/amazon-q-adapter.ts
+++ b/src/platforms/amazon-q-adapter.ts
@@ -68,6 +68,10 @@ export class AmazonQAdapter implements PlatformAdapter {
     };
   }
 
+  mapToolName(platformToolName: string): string {
+    return AMAZON_Q_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
   getSessionMetadata(): PlatformSessionMetadata {
     return {
       platform: this.platformName,

--- a/src/platforms/claude-code-adapter.test.ts
+++ b/src/platforms/claude-code-adapter.test.ts
@@ -153,4 +153,10 @@ describe('ClaudeCodeAdapter', () => {
       await expect(adapter.initialize({})).resolves.toBeUndefined();
     });
   });
+
+  describe('mapToolName', () => {
+    it('passes the tool name through unchanged', () => {
+      expect(adapter.mapToolName('Read')).toBe('Read');
+    });
+  });
 });

--- a/src/platforms/claude-code-adapter.ts
+++ b/src/platforms/claude-code-adapter.ts
@@ -35,6 +35,10 @@ export class ClaudeCodeAdapter implements PlatformAdapter {
     };
   }
 
+  mapToolName(platformToolName: string): string {
+    return platformToolName;
+  }
+
   getSessionMetadata(): PlatformSessionMetadata {
     return {
       platform: this.platformName,

--- a/src/platforms/continue-adapter.test.ts
+++ b/src/platforms/continue-adapter.test.ts
@@ -251,4 +251,14 @@ describe('ContinueAdapter', () => {
       await expect(adapter.initialize({})).resolves.toBeUndefined();
     });
   });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('readFile')).toBe('Read');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totallyMadeUpTool')).toBe('Unknown');
+    });
+  });
 });

--- a/src/platforms/continue-adapter.ts
+++ b/src/platforms/continue-adapter.ts
@@ -68,6 +68,10 @@ export class ContinueAdapter implements PlatformAdapter {
     };
   }
 
+  mapToolName(platformToolName: string): string {
+    return CONTINUE_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
   getSessionMetadata(): PlatformSessionMetadata {
     return {
       platform: this.platformName,

--- a/src/platforms/copilot-adapter.test.ts
+++ b/src/platforms/copilot-adapter.test.ts
@@ -250,6 +250,16 @@ describe('CopilotAdapter', () => {
       await expect(adapter.initialize({})).resolves.toBeUndefined();
     });
   });
+
+  describe('mapToolName', () => {
+    it('maps a known event type', () => {
+      expect(adapter.mapToolName('file_edit')).toBe('Edit');
+    });
+
+    it('returns "Unknown" for an unrecognized event type', () => {
+      expect(adapter.mapToolName('totally_made_up_type')).toBe('Unknown');
+    });
+  });
 });
 
 describe('parseCopilotUsageResponse', () => {

--- a/src/platforms/copilot-adapter.ts
+++ b/src/platforms/copilot-adapter.ts
@@ -86,6 +86,10 @@ export class CopilotAdapter implements PlatformAdapter {
     };
   }
 
+  mapToolName(platformToolName: string): string {
+    return COPILOT_EVENT_TYPE_MAP[platformToolName] ?? 'Unknown';
+  }
+
   getSessionMetadata(): PlatformSessionMetadata {
     return {
       platform: this.platformName,

--- a/src/platforms/cursor-adapter.test.ts
+++ b/src/platforms/cursor-adapter.test.ts
@@ -194,4 +194,14 @@ describe('CursorAdapter', () => {
       await expect(adapter.initialize({})).resolves.toBeUndefined();
     });
   });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('read_file')).toBe('Read');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
 });

--- a/src/platforms/cursor-adapter.ts
+++ b/src/platforms/cursor-adapter.ts
@@ -61,6 +61,10 @@ export class CursorAdapter implements PlatformAdapter {
     };
   }
 
+  mapToolName(platformToolName: string): string {
+    return CURSOR_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
   getSessionMetadata(): PlatformSessionMetadata {
     return {
       platform: this.platformName,

--- a/src/platforms/generic-mcp-adapter.test.ts
+++ b/src/platforms/generic-mcp-adapter.test.ts
@@ -192,6 +192,12 @@ describe('GenericMcpAdapter', () => {
     });
   });
 
+  describe('mapToolName', () => {
+    it('passes the tool name through unchanged', () => {
+      expect(adapter.mapToolName('Read')).toBe('Read');
+    });
+  });
+
   describe('integration: report_tool_call pipeline', () => {
     it('processes 10 tool calls through normalizeToolCall', () => {
       const results = [];

--- a/src/platforms/generic-mcp-adapter.ts
+++ b/src/platforms/generic-mcp-adapter.ts
@@ -148,6 +148,10 @@ export class GenericMcpAdapter implements PlatformAdapter {
     };
   }
 
+  mapToolName(platformToolName: string): string {
+    return platformToolName;
+  }
+
   handleSessionStart(input: ReportSessionStartInput): void {
     this.sessionMetadata = {
       platform: input.platform || 'generic-mcp',

--- a/src/platforms/kiro-adapter.test.ts
+++ b/src/platforms/kiro-adapter.test.ts
@@ -110,6 +110,31 @@ describe('KiroAdapter', () => {
       expect(normalized.toolName).toBe('Read');
     });
 
+    it('maps "read" (alias) to "Read"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'read', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Read');
+    });
+
+    it('maps "write" (alias) to "Write"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'write', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Write');
+    });
+
+    it('maps "shell" (alias) to "Bash"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'shell', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Bash');
+    });
+
+    it('maps "use_aws" to "Bash"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'use_aws', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Bash');
+    });
+
+    it('maps "aws" (alias) to "Bash"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'aws', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Bash');
+    });
+
     it('accepts "toolName" field as an alternative to "tool"', () => {
       const normalized = adapter.normalizeToolCall({ toolName: 'fsRead', timestamp: 2000 });
       expect(normalized.toolName).toBe('Read');
@@ -245,6 +270,16 @@ describe('KiroAdapter', () => {
   describe('initialize', () => {
     it('completes without error', async () => {
       await expect(adapter.initialize({})).resolves.toBeUndefined();
+    });
+  });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('fsRead')).toBe('Read');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
     });
   });
 });

--- a/src/platforms/kiro-adapter.ts
+++ b/src/platforms/kiro-adapter.ts
@@ -6,17 +6,23 @@ import type {
 } from './types.js';
 
 /**
- * Maps Amazon Kiro agent tool names to the normalized Claude Code tool
- * vocabulary. Kiro exposes both camelCase tool names (e.g. `fsRead`) and
- * snake_case aliases depending on configuration, so both are covered.
+ * Maps Amazon Kiro tool names to the normalized Claude Code tool vocabulary.
+ * Kiro's hook events (https://kiro.dev/docs/cli/hooks) send `tool_name` as
+ * either a tool's canonical name (`fs_read`) or a documented alias (`read`) —
+ * both forms are covered. Entries without a confirmed source in Kiro's docs
+ * (e.g. `fsRead`, `fsCreate`) are kept as best-effort coverage for IDE-surface
+ * tool names not yet documented publicly; don't remove them without positive
+ * evidence they're wrong.
  */
 const KIRO_TOOL_MAP: Record<string, string> = {
   fsRead: 'Read',
   fs_read: 'Read',
+  read: 'Read',
   readFile: 'Read',
   readMultipleFiles: 'Read',
   fsWrite: 'Write',
   fs_write: 'Write',
+  write: 'Write',
   writeFile: 'Write',
   fsCreate: 'Write',
   fsAppend: 'Edit',
@@ -37,8 +43,11 @@ const KIRO_TOOL_MAP: Record<string, string> = {
   search_code: 'Grep',
   executeBash: 'Bash',
   execute_bash: 'Bash',
+  shell: 'Bash',
   executePwsh: 'Bash',
   run_command: 'Bash',
+  use_aws: 'Bash',
+  aws: 'Bash',
 };
 
 interface KiroToolCallEvent {
@@ -84,6 +93,10 @@ export class KiroAdapter implements PlatformAdapter {
       ...(event.command !== undefined && { command: event.command }),
       ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
     };
+  }
+
+  mapToolName(platformToolName: string): string {
+    return KIRO_TOOL_MAP[platformToolName] ?? 'Unknown';
   }
 
   getSessionMetadata(): PlatformSessionMetadata {

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -77,6 +77,10 @@ class FakeAdapter implements PlatformAdapter {
     };
   }
 
+  mapToolName(): string {
+    return 'Test';
+  }
+
   getSessionMetadata(): PlatformSessionMetadata {
     return { platform: this.platformName };
   }
@@ -141,6 +145,9 @@ describe('PlatformRegistry', () => {
             durationMs: null,
             success: true,
           };
+        },
+        mapToolName() {
+          return 'T';
         },
         getSessionMetadata() {
           return { platform: 'mutable' };

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -32,6 +32,13 @@ export interface PlatformAdapter {
   readonly platformName: string;
   initialize(config: PlatformConfig): Promise<void>;
   normalizeToolCall(raw: unknown): NormalizedToolCall;
+  /**
+   * Maps a platform's raw tool name (e.g. Kiro's `fs_read`) to Preflight's
+   * canonical vocabulary (`Read`). Returns `'Unknown'` for names the adapter
+   * doesn't recognize, preserving the platform's original name in telemetry
+   * via the caller (never throws).
+   */
+  mapToolName(platformToolName: string): string;
   getSessionMetadata(): PlatformSessionMetadata;
   getHookInstallInstructions(): string;
   isSupported(): boolean;

--- a/src/platforms/windsurf-adapter.test.ts
+++ b/src/platforms/windsurf-adapter.test.ts
@@ -214,4 +214,14 @@ describe('WindsurfAdapter', () => {
       await expect(adapter.initialize({})).resolves.toBeUndefined();
     });
   });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('read_file')).toBe('Read');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
 });

--- a/src/platforms/windsurf-adapter.ts
+++ b/src/platforms/windsurf-adapter.ts
@@ -64,6 +64,10 @@ export class WindsurfAdapter implements PlatformAdapter {
     };
   }
 
+  mapToolName(platformToolName: string): string {
+    return WINDSURF_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
   getSessionMetadata(): PlatformSessionMetadata {
     return {
       platform: this.platformName,

--- a/src/platforms/zed-adapter.test.ts
+++ b/src/platforms/zed-adapter.test.ts
@@ -231,4 +231,14 @@ describe('ZedAdapter', () => {
       await expect(adapter.initialize({})).resolves.toBeUndefined();
     });
   });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('read_file')).toBe('Read');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
 });

--- a/src/platforms/zed-adapter.ts
+++ b/src/platforms/zed-adapter.ts
@@ -63,6 +63,10 @@ export class ZedAdapter implements PlatformAdapter {
     };
   }
 
+  mapToolName(platformToolName: string): string {
+    return ZED_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
   getSessionMetadata(): PlatformSessionMetadata {
     return {
       platform: this.platformName,


### PR DESCRIPTION
## Summary

- Fixes Kiro IDE hook events being silently dropped: `preflight-collector` matched Claude Code's exact PascalCase hook event names (`PreToolUse`); Kiro sends lower-camelCase (`preToolUse`) per its own docs, so every Kiro hook event fell through to a silent no-op — nothing written to the buffer, collector still exited 0. The event-name check is now case-insensitive.
- Wires the platform-adapter system into the real hook pipeline: `PlatformAdapter`/`PlatformRegistry` were fully built and tested but never actually called from the running hook pipeline, so every platform's tool names passed through unmapped. Added `PlatformAdapter.mapToolName()`, wired it into `HookEventProcessor`, corrected `KIRO_TOOL_MAP` against Kiro's documented aliases (`read`/`write`/`shell`/`aws`), and made sure a tool's original name is preserved instead of collapsing into a generic `"Unknown"` bucket when a platform adapter has no mapping for it.
- Adds `preflight doctor --platform <name>` so the "Hooks wired" check isn't silently Claude-Code-only.

Closes #84

## Test plan

- [x] `npm run build && npm test && npm run lint` green (3843 passed, 3 skipped, 0 failed; 0 lint errors/warnings)
- [x] Manual smoke test: `preflight doctor --platform kiro` and `preflight doctor --platform not-a-real-platform` both produce expected output
- [ ] Manual end-to-end test against a live Kiro install (deferred — the fix is verified against Kiro's documented hook payload shape at https://kiro.dev/docs/cli/hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)