### PR TITLE
Fix: v1.4.4 — Cursor hook adapter fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.4] - 2026-07-09
+
+### Fixed
+
+- **Cursor hook events were silently dropped** — `preflight-collector` only recognized Claude Code's/Kiro's generic `PreToolUse`/`PostToolUse` hook names. Cursor's real hooks system (`.cursor/hooks.json`) sends a completely different, per-action-type event vocabulary (`beforeShellExecution`/`afterShellExecution`, `beforeMCPExecution`/`afterMCPExecution`, `beforeReadFile`, `afterFileEdit`), so every Cursor hook event fell through to a silent no-op. The collector now recognizes and correctly parses all six events.
+- **`CursorAdapter`'s setup instructions and tool-name map described a nonexistent integration** — `getHookInstallInstructions()` and `initialize()`'s comment claimed built-in tool calls (file edits, terminal) were captured via "a file watcher or Cursor extension"; no such mechanism exists anywhere in this codebase. Instructions now document the real `.cursor/hooks.json` setup, and `CURSOR_TOOL_MAP` now covers Cursor's confirmed generic `preToolUse`/`postToolUse` tool-name vocabulary (`Shell`, `Task`, `Read`, `Write`) alongside its existing built-in-action-name entries.
+
 ## [1.4.3] - 2026-07-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -440,6 +440,169 @@ describe('collector-script', () => {
     });
   });
 
+  function makeCursorBeforeShellExecution(overrides?: Record<string, unknown>): string {
+    return JSON.stringify({
+      hook_event_name: 'beforeShellExecution',
+      conversation_id: '668320d2-2fd8-4888-b33c-2a466fec86e7',
+      generation_id: '490b90b7-a2ce-4c2c-bb76-cb77b125df2f',
+      command: 'git status',
+      cwd: '/Users/schacon/projects/cc-hooks-example',
+      workspace_roots: ['/Users/schacon/projects/cc-hooks-example'],
+      ...overrides,
+    });
+  }
+
+  function makeCursorAfterShellExecution(overrides?: Record<string, unknown>): string {
+    return JSON.stringify({
+      hook_event_name: 'afterShellExecution',
+      conversation_id: '668320d2-2fd8-4888-b33c-2a466fec86e7',
+      generation_id: '490b90b7-a2ce-4c2c-bb76-cb77b125df2f',
+      workspace_roots: ['/Users/schacon/projects/cc-hooks-example'],
+      ...overrides,
+    });
+  }
+
+  function makeCursorBeforeMCPExecution(overrides?: Record<string, unknown>): string {
+    return JSON.stringify({
+      hook_event_name: 'beforeMCPExecution',
+      conversation_id: 'cdefee2d-2727-4b73-bf77-d9d830f31d2a',
+      generation_id: '63feaa30-ae88-4e47-b6c7-70ee4c39980c',
+      tool_name: 'gitbutler_update_branches',
+      tool_input: '{"changesSummary": "Added a README to the project"}',
+      command: 'but',
+      workspace_roots: ['/Users/schacon/projects/cc-hooks-example'],
+      ...overrides,
+    });
+  }
+
+  function makeCursorAfterMCPExecution(overrides?: Record<string, unknown>): string {
+    return JSON.stringify({
+      hook_event_name: 'afterMCPExecution',
+      conversation_id: 'cdefee2d-2727-4b73-bf77-d9d830f31d2a',
+      generation_id: '63feaa30-ae88-4e47-b6c7-70ee4c39980c',
+      tool_name: 'gitbutler_update_branches',
+      workspace_roots: ['/Users/schacon/projects/cc-hooks-example'],
+      ...overrides,
+    });
+  }
+
+  function makeCursorBeforeReadFile(overrides?: Record<string, unknown>): string {
+    return JSON.stringify({
+      hook_event_name: 'beforeReadFile',
+      conversation_id: '668320d2-2fd8-4888-b33c-2a466fec86e7',
+      generation_id: '490b90b7-a2ce-4c2c-bb76-cb77b125df2f',
+      content: "#!/bin/bash\n\necho 'my_github_access_token'\n",
+      file_path: 'leaks/github_tokens.sh',
+      workspace_roots: ['/Users/schacon/projects/cc-hooks-example'],
+      ...overrides,
+    });
+  }
+
+  function makeCursorAfterFileEdit(overrides?: Record<string, unknown>): string {
+    return JSON.stringify({
+      hook_event_name: 'afterFileEdit',
+      conversation_id: 'cdefee2d-2727-4b73-bf77-d9d830f31d2a',
+      generation_id: '23681cf0-a483-49ab-9748-36044efcef52',
+      file_path: 'README.md',
+      edits: [{ old_string: '# OLD README', new_string: '# NEW README' }],
+      workspace_roots: ['/Users/schacon/projects/cc-hooks-example'],
+      ...overrides,
+    });
+  }
+
+  describe('collector-script — Cursor hook event names (https://cursor.com/docs/agent/hooks)', () => {
+    it('beforeShellExecution writes a pre/Bash event with the command redacted', () => {
+      processHook(
+        makeCursorBeforeShellExecution({ command: 'curl https://x.com?token=SECRET_ABC123XYZ' }),
+      );
+
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      const event = events[0]!;
+      expect(event.mode).toBe('pre');
+      expect(event.tool).toBe('Bash');
+      const toolInput = event.toolInput as { command?: string };
+      expect(toolInput.command).not.toContain('SECRET_ABC123XYZ');
+    });
+
+    it('afterShellExecution writes a post/Bash success event', () => {
+      processHook(makeCursorBeforeShellExecution());
+      processHook(makeCursorAfterShellExecution());
+
+      const events = readBufferEvents();
+      expect(events).toHaveLength(2);
+      const post = events[1]!;
+      expect(post.mode).toBe('post');
+      expect(post.tool).toBe('Bash');
+      expect(post.success).toBe(true);
+    });
+
+    it('beforeMCPExecution writes a pre event using the raw MCP tool_name (no mapping applied)', () => {
+      processHook(makeCursorBeforeMCPExecution());
+
+      const event = readBufferEvents()[0]!;
+      expect(event.mode).toBe('pre');
+      expect(event.tool).toBe('gitbutler_update_branches');
+    });
+
+    it('afterMCPExecution writes a post success event using the raw MCP tool_name', () => {
+      processHook(makeCursorBeforeMCPExecution());
+      processHook(makeCursorAfterMCPExecution());
+
+      const post = readBufferEvents()[1]!;
+      expect(post.mode).toBe('post');
+      expect(post.tool).toBe('gitbutler_update_branches');
+      expect(post.success).toBe(true);
+    });
+
+    it('beforeReadFile writes a completed post/Read event (no matching after-event exists)', () => {
+      processHook(makeCursorBeforeReadFile());
+
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      const event = events[0]!;
+      expect(event.mode).toBe('post');
+      expect(event.tool).toBe('Read');
+      expect(event.success).toBe(true);
+    });
+
+    it('beforeReadFile never writes raw file content to the buffer by default', () => {
+      processHook(makeCursorBeforeReadFile({ content: 'super-secret-file-contents' }));
+
+      const raw = readFileSync(bufferPath, 'utf-8');
+      expect(raw).not.toContain('super-secret-file-contents');
+    });
+
+    it('afterFileEdit writes a completed post/Edit event (no matching before-event exists)', () => {
+      processHook(makeCursorAfterFileEdit());
+
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      const event = events[0]!;
+      expect(event.mode).toBe('post');
+      expect(event.tool).toBe('Edit');
+      expect(event.success).toBe(true);
+    });
+
+    it('uses conversation_id as the session identifier when session_id is absent', () => {
+      processHook(makeCursorBeforeShellExecution({ conversation_id: 'conv-abc-123' }));
+
+      const event = readBufferEvents()[0]!;
+      expect(event.sessionId).toBe('conv-abc-123');
+    });
+
+    it('routes events with different conversation_id values to different buffer files', () => {
+      delete process.env.NEW_RELIC_AI_MCP_BUFFER_PATH;
+      process.env.NEW_RELIC_AI_MCP_STORAGE_PATH = tmpDir;
+
+      processHook(makeCursorBeforeShellExecution({ conversation_id: 'conv-aaa' }));
+      processHook(makeCursorBeforeShellExecution({ conversation_id: 'conv-bbb' }));
+
+      expect(existsSync(resolve(tmpDir, 'buffer-conv-aaa.jsonl'))).toBe(true);
+      expect(existsSync(resolve(tmpDir, 'buffer-conv-bbb.jsonl'))).toBe(true);
+    });
+  });
+
   describe('helper functions', () => {
     it('redact() replaces API keys', () => {
       expect(redact('API_KEY = my-secret-key')).toContain('[REDACTED]');

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -455,6 +455,17 @@ interface HookInput {
   transcript_path?: string;
   error?: string;
   is_interrupt?: boolean;
+  // Cursor (https://cursor.com/docs/agent/hooks) sends a different field
+  // vocabulary per hook type instead of the uniform tool_name/tool_input
+  // Claude Code and Kiro use. conversation_id is Cursor's closest analog to
+  // session_id — Cursor never sends session_id. command/file_path/content/
+  // edits are confirmed via a real JSON example from Cursor's own team:
+  // https://blog.gitbutler.com/cursor-hooks-deep-dive
+  conversation_id?: string;
+  command?: string;
+  file_path?: string;
+  content?: string;
+  edits?: { old_string?: string; new_string?: string }[];
   [key: string]: unknown;
 }
 
@@ -619,10 +630,20 @@ function processHook(raw: string): void {
     return; // Malformed JSON — skip silently
   }
 
+  // Cursor (https://cursor.com/docs/agent/hooks) never sends session_id —
+  // conversation_id is its closest analog (one per chat, like a Claude Code
+  // session). Claude Code and Kiro always send session_id, so this only
+  // takes effect for Cursor events.
+  const sessionId = data.session_id ?? data.conversation_id;
+
   // Drop a PPID breadcrumb at the very top so the MCP server can resolve its
   // Claude Code session_id without an env-var or initialize-payload extension.
   // The function itself is a no-op when sessionId is missing or invalid, and
-  // short-circuits if the breadcrumb is already current.
+  // short-circuits if the breadcrumb is already current. Cursor's
+  // conversation_id is deliberately excluded here — there is no confirmed
+  // evidence that Cursor's own MCP-server child process shares Claude Code's
+  // ancestry-based session-resolution model, so extending this to
+  // conversation_id would be a guess, not a fix.
   if (typeof data.session_id === 'string' && data.session_id.length > 0) {
     writePpidBreadcrumb(data.session_id);
   }
@@ -691,6 +712,85 @@ function processHook(raw: string): void {
       error: redact(data.error ?? 'unknown error'),
       isInterrupt: data.is_interrupt ?? false,
     };
+  } else if (eventName === 'beforeshellexecution') {
+    // Cursor's shell hooks carry no tool_name field — the event name itself
+    // identifies the tool. Confirmed payload shape:
+    // https://blog.gitbutler.com/cursor-hooks-deep-dive
+    const command = data.command ?? '';
+    event = {
+      mode: 'pre' as const,
+      tool: 'Bash',
+      timestamp,
+      inputSize: sizeOf(command),
+      inputHash: hashInput(command),
+      toolInput: { command: redact(command) },
+    };
+  } else if (eventName === 'aftershellexecution') {
+    // Cursor doesn't document a distinct failure event for shell (unlike
+    // Claude Code's PostToolUseFailure) and no source confirms afterShellExecution's
+    // exact payload fields — treat as success absent any failure signal, same
+    // convention as Claude Code's PostToolUse-without-PostToolUseFailure.
+    event = {
+      mode: 'post' as const,
+      tool: 'Bash',
+      timestamp,
+      success: true,
+    };
+  } else if (eventName === 'beforemcpexecution') {
+    // tool_name here is an arbitrary third-party MCP tool name, not one of
+    // Preflight's canonical built-in tool names — passed through as-is
+    // (identity), matching how src/platforms/generic-mcp-adapter.ts already
+    // treats third-party MCP tool names.
+    const mcpTool = data.tool_name ?? 'unknown';
+    event = {
+      mode: 'pre' as const,
+      tool: mcpTool,
+      timestamp,
+      inputSize: sizeOf(data.tool_input),
+      inputHash: hashInput(data.tool_input),
+    };
+  } else if (eventName === 'aftermcpexecution') {
+    // Same identity tool-name treatment and success-by-default convention as
+    // aftershellexecution above — no source confirms this event's exact
+    // success/output fields.
+    const mcpTool = data.tool_name ?? 'unknown';
+    event = {
+      mode: 'post' as const,
+      tool: mcpTool,
+      timestamp,
+      success: true,
+    };
+  } else if (eventName === 'beforereadfile') {
+    // Cursor has no "afterReadFile" event — beforeReadFile is the only file-read
+    // hook that exists (confirmed: https://blog.gitbutler.com/cursor-hooks-deep-dive
+    // documents 6 original hooks, none pair with beforeReadFile). Emitted directly
+    // as a completed post event — the same code path event-processor.ts already
+    // uses for an orphaned PostToolUse with no matching pre-event — rather than
+    // inventing new pairing semantics for a "pre-only" tool call.
+    event = {
+      mode: 'post' as const,
+      tool: 'Read',
+      timestamp,
+      success: true,
+      ...(data.file_path !== undefined && { toolInput: { file_path: data.file_path } }),
+    };
+    // data.content carries the actual file contents — never write it to the
+    // buffer unless recordContent is enabled, same as Claude Code's existing
+    // tool_response/tool_input content handling.
+    if (recordContent && data.content !== undefined) {
+      event.outputContent = redact(truncate(data.content, maxContentLen));
+    }
+  } else if (eventName === 'afterfileedit') {
+    // Cursor has no "beforeFileEdit" event — afterFileEdit is post-only,
+    // mirror image of beforeReadFile above: emitted directly as a completed
+    // post event via the same orphaned-post code path.
+    event = {
+      mode: 'post' as const,
+      tool: 'Edit',
+      timestamp,
+      success: true,
+      ...(data.file_path !== undefined && { toolInput: { file_path: data.file_path } }),
+    };
   } else {
     // Unknown hook event — ignore silently
     return;
@@ -699,12 +799,12 @@ function processHook(raw: string): void {
   // Attach session metadata
   if (data.cwd) event.cwd = data.cwd;
   if (data.permission_mode) event.permissionMode = data.permission_mode;
-  if (data.session_id) event.sessionId = data.session_id;
+  if (sessionId) event.sessionId = sessionId;
   if (data.tool_use_id) event.toolUseId = data.tool_use_id;
 
   // Write to buffer — wrapped in try/catch for resilience.
   try {
-    const bufferPath = getBufferPath(data.session_id);
+    const bufferPath = getBufferPath(sessionId);
     const bufferDir = dirname(bufferPath);
     if (!existsSync(bufferDir)) {
       mkdirSync(bufferDir, { recursive: true, mode: 0o700 });

--- a/src/platforms/cursor-adapter.test.ts
+++ b/src/platforms/cursor-adapter.test.ts
@@ -187,6 +187,13 @@ describe('CursorAdapter', () => {
       expect(instructions.length).toBeGreaterThan(0);
       expect(instructions).toContain('Cursor');
     });
+
+    it('documents the real .cursor/hooks.json setup, not a file watcher', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions).toContain('.cursor/hooks.json');
+      expect(instructions).toContain('preflight-collector');
+      expect(instructions).not.toContain('file watcher');
+    });
   });
 
   describe('initialize', () => {
@@ -202,6 +209,22 @@ describe('CursorAdapter', () => {
 
     it('returns "Unknown" for an unrecognized tool name', () => {
       expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+
+    it('maps the generic preToolUse/postToolUse "Shell" category to "Bash"', () => {
+      expect(adapter.mapToolName('Shell')).toBe('Bash');
+    });
+
+    it('maps the generic preToolUse/postToolUse "Task" category to "Agent"', () => {
+      expect(adapter.mapToolName('Task')).toBe('Agent');
+    });
+
+    it('maps the generic preToolUse/postToolUse "Read" category to "Read"', () => {
+      expect(adapter.mapToolName('Read')).toBe('Read');
+    });
+
+    it('maps the generic preToolUse/postToolUse "Write" category to "Write"', () => {
+      expect(adapter.mapToolName('Write')).toBe('Write');
     });
   });
 });

--- a/src/platforms/cursor-adapter.ts
+++ b/src/platforms/cursor-adapter.ts
@@ -5,6 +5,27 @@ import type {
   NormalizedToolCall,
 } from './types.js';
 
+/**
+ * Maps Cursor tool names to the normalized Claude Code tool vocabulary.
+ * Two distinct vocabularies coexist here, both confirmed against real Cursor
+ * documentation and a Cursor engineer's own forum replies
+ * (https://forum.cursor.com/t/cursor-cli-doesnt-send-all-events-defined-in-hooks/148316):
+ *
+ * 1. Cursor's per-action hook events (beforeShellExecution, beforeMCPExecution,
+ *    beforeReadFile, afterFileEdit) carry no generic tool_name field at all —
+ *    src/hooks/collector-script.ts derives the tool name directly from the
+ *    event name itself, so this map is never consulted for those events.
+ * 2. Cursor's generic preToolUse/postToolUse events (confirmed to exist, but
+ *    with a payload schema that is only partially documented) carry
+ *    tool_name as one of a small fixed vocabulary: Shell/Read/Write/Task/MCP.
+ *    Read/Write need no translation (Cursor's names already match Preflight's
+ *    canonical names). MCP is deliberately left unmapped — collapsing an
+ *    arbitrary downstream MCP tool call into the literal string "MCP" would
+ *    discard information no source confirms how to recover from this event
+ *    alone; mapToolName() correctly returns 'Unknown' for it, and the caller
+ *    (src/hooks/event-processor.ts's mapToolNameOrOriginal()) preserves "MCP"
+ *    as the original name rather than collapsing it further.
+ */
 const CURSOR_TOOL_MAP: Record<string, string> = {
   edit_file: 'Edit',
   read_file: 'Read',
@@ -16,6 +37,10 @@ const CURSOR_TOOL_MAP: Record<string, string> = {
   codebase_search: 'Grep',
   delete_file: 'Delete',
   create_file: 'Write',
+  Shell: 'Bash',
+  Task: 'Agent',
+  Read: 'Read',
+  Write: 'Write',
 };
 
 interface CursorToolCallEvent {
@@ -36,8 +61,12 @@ export class CursorAdapter implements PlatformAdapter {
   readonly platformName = 'cursor';
 
   async initialize(_config: PlatformConfig): Promise<void> {
-    // Cursor uses MCP natively — proxy captures MCP tool calls automatically.
-    // Built-in tool calls arrive via file watcher or extension API events.
+    // Cursor's built-in tool activity (shell commands, file reads/edits) is
+    // captured via its own hooks system (.cursor/hooks.json), a local
+    // process protocol unrelated to MCP — see getHookInstallInstructions().
+    // MCP tool calls Cursor makes to third-party servers also flow through
+    // that same hooks system (beforeMCPExecution/afterMCPExecution), not
+    // through a Preflight-side MCP proxy.
   }
 
   normalizeToolCall(raw: unknown): NormalizedToolCall {
@@ -75,11 +104,24 @@ export class CursorAdapter implements PlatformAdapter {
   getHookInstallInstructions(): string {
     return [
       'Cursor IDE Setup:',
-      '1. Open Cursor Settings > MCP',
-      '2. Add a new MCP server with command: npx preflight --stdio',
-      '3. Set the environment variables: NEW_RELIC_LICENSE_KEY, NEW_RELIC_ACCOUNT_ID',
-      '4. MCP tool calls are captured automatically via the proxy',
-      '5. Built-in tool calls (file edits, terminal) require the file watcher or Cursor extension',
+      '1. Register the preflight MCP server for nr_observe_* tools:',
+      '   Open Cursor Settings > MCP, add a new server with command: npx preflight --stdio',
+      '   Set the environment variables: NEW_RELIC_LICENSE_KEY, NEW_RELIC_ACCOUNT_ID',
+      '2. Configure Cursor hooks so tool-call activity (shell, file reads/edits, MCP) is',
+      '   captured — create .cursor/hooks.json (project) or ~/.cursor/hooks.json (global):',
+      '   {',
+      '     "version": 1,',
+      '     "hooks": {',
+      '       "beforeShellExecution": [{ "command": "preflight-collector" }],',
+      '       "afterShellExecution": [{ "command": "preflight-collector" }],',
+      '       "beforeMCPExecution": [{ "command": "preflight-collector" }],',
+      '       "afterMCPExecution": [{ "command": "preflight-collector" }],',
+      '       "beforeReadFile": [{ "command": "preflight-collector" }],',
+      '       "afterFileEdit": [{ "command": "preflight-collector" }]',
+      '     }',
+      '   }',
+      '3. Ensure preflight-collector is on your PATH (npm link, or npm install -g @newrelic/preflight)',
+      '4. Restart Cursor.',
     ].join('\n');
   }
 


### PR DESCRIPTION
## Summary
- Cursor IDE's real hooks system (`.cursor/hooks.json`) sends a different, per-action-type event vocabulary than Claude Code (`beforeShellExecution`/`afterShellExecution`, `beforeMCPExecution`/`afterMCPExecution`, `beforeReadFile`, `afterFileEdit`) — none of these were recognized, so every Cursor hook event was silently dropped. Added recognition and correct parsing for all six events.
- Corrected the Cursor platform adapter's tool-name map and setup instructions, which previously described a nonexistent "file watcher or Cursor extension" mechanism for capturing built-in tool calls. Instructions now document the real `.cursor/hooks.json` setup.
- Version bump 1.4.3 → 1.4.4.

Every hook payload field this fix consumes is sourced from a real, dated, cited primary source (Cursor's own changelog, a Cursor-team-collaborated blog deep dive, and a Cursor engineer's own forum replies) — no assumptions. Fields with no confirmed source (exact success/output payload for two of the six events) are handled conservatively rather than guessed.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — all passing
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] New unit tests cover all six Cursor hook events, shell-command redaction, file-content-never-leaks-without-recordContent, and session routing
- [x] Adapter tests cover the corrected tool-name map and setup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #90
