### PR TITLE
Fix: Windsurf hook events silently dropped + adapter integration claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.5] - 2026-07-09
+
+### Fixed
+
+- **Windsurf hook events were silently dropped** — `preflight-collector` only recognized `hook_event_name` (Claude Code/Kiro/Cursor's event-name field). Windsurf's real Cascade Hooks system (`.windsurf/hooks.json`, confirmed via https://docs.windsurf.com/windsurf/cascade/hooks) sends the event name as `agent_action_name` instead, with all event data nested under a `tool_info` object rather than flat fields — so every Windsurf hook event fell through to a silent no-op. The collector now recognizes and correctly parses `pre_read_code`/`post_read_code`, `pre_write_code`/`post_write_code`, `pre_run_command`/`post_run_command`, and `pre_mcp_tool_use`/`post_mcp_tool_use`.
+- **`WindsurfAdapter`'s setup instructions and `initialize()` comment described a nonexistent integration** — both claimed built-in tool calls (file edits, terminal) were captured via "extension API or file watcher events"; no such mechanism exists anywhere in this codebase. Instructions now document the real `.windsurf/hooks.json` Cascade Hooks setup.
+
 ## [1.4.4] - 2026-07-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -1,6 +1,6 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import {
@@ -89,6 +89,22 @@ function makePostToolUseFailure(overrides?: Record<string, unknown>): string {
 function readBufferEvents(): Record<string, unknown>[] {
   if (!existsSync(bufferPath)) return [];
   const raw = readFileSync(bufferPath, 'utf-8').trim();
+  if (!raw) return [];
+  return raw.split('\n').map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+/**
+ * Helper to read buffer events from a session-specific buffer file.
+ * When sessionId is provided, reads from buffer-{sessionId}.jsonl instead of the default.
+ * Used for testing platforms like Cursor and Windsurf that route by conversation_id/trajectory_id.
+ */
+function readBufferLines(sessionId?: string): Record<string, unknown>[] {
+  let path = bufferPath;
+  if (sessionId) {
+    path = resolve(dirname(bufferPath), `buffer-${sessionId}.jsonl`);
+  }
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, 'utf-8').trim();
   if (!raw) return [];
   return raw.split('\n').map((line) => JSON.parse(line) as Record<string, unknown>);
 }
@@ -600,6 +616,218 @@ describe('collector-script', () => {
 
       expect(existsSync(resolve(tmpDir, 'buffer-conv-aaa.jsonl'))).toBe(true);
       expect(existsSync(resolve(tmpDir, 'buffer-conv-bbb.jsonl'))).toBe(true);
+    });
+  });
+
+  describe('Windsurf hook events', () => {
+    function makeWindsurfPreReadCode(overrides: Record<string, unknown> = {}): string {
+      return JSON.stringify({
+        agent_action_name: 'pre_read_code',
+        trajectory_id: 'traj-abc123',
+        execution_id: 'exec-1',
+        timestamp: '2026-07-09T12:00:00Z',
+        model_name: 'Claude Sonnet 4',
+        tool_info: { file_path: '/Users/dev/project/file.py' },
+        ...overrides,
+      });
+    }
+
+    function makeWindsurfPostReadCode(overrides: Record<string, unknown> = {}): string {
+      return JSON.stringify({
+        agent_action_name: 'post_read_code',
+        trajectory_id: 'traj-abc123',
+        tool_info: { file_path: '/Users/dev/project/file.py' },
+        ...overrides,
+      });
+    }
+
+    function makeWindsurfPreWriteCode(overrides: Record<string, unknown> = {}): string {
+      return JSON.stringify({
+        agent_action_name: 'pre_write_code',
+        trajectory_id: 'traj-abc123',
+        tool_info: {
+          file_path: '/Users/dev/project/file.py',
+          edits: [
+            { old_string: 'def old():\n    pass', new_string: 'def new():\n    return True' },
+          ],
+        },
+        ...overrides,
+      });
+    }
+
+    function makeWindsurfPostWriteCode(overrides: Record<string, unknown> = {}): string {
+      return JSON.stringify({
+        agent_action_name: 'post_write_code',
+        trajectory_id: 'traj-abc123',
+        tool_info: {
+          file_path: '/Users/dev/project/file.py',
+          edits: [{ old_string: 'import os', new_string: 'import os\nimport sys' }],
+        },
+        ...overrides,
+      });
+    }
+
+    function makeWindsurfPreRunCommand(overrides: Record<string, unknown> = {}): string {
+      return JSON.stringify({
+        agent_action_name: 'pre_run_command',
+        trajectory_id: 'traj-abc123',
+        tool_info: { command_line: 'npm install left-pad', cwd: '/Users/dev/project' },
+        ...overrides,
+      });
+    }
+
+    function makeWindsurfPostRunCommand(overrides: Record<string, unknown> = {}): string {
+      return JSON.stringify({
+        agent_action_name: 'post_run_command',
+        trajectory_id: 'traj-abc123',
+        tool_info: { command_line: 'npm install left-pad', cwd: '/Users/dev/project' },
+        ...overrides,
+      });
+    }
+
+    function makeWindsurfPreMcpToolUse(overrides: Record<string, unknown> = {}): string {
+      return JSON.stringify({
+        agent_action_name: 'pre_mcp_tool_use',
+        trajectory_id: 'traj-abc123',
+        tool_info: {
+          mcp_server_name: 'github',
+          mcp_tool_name: 'create_issue',
+          mcp_tool_arguments: { owner: 'code-owner', repo: 'my-repo', title: 'Bug report' },
+        },
+        ...overrides,
+      });
+    }
+
+    function makeWindsurfPostMcpToolUse(overrides: Record<string, unknown> = {}): string {
+      return JSON.stringify({
+        agent_action_name: 'post_mcp_tool_use',
+        trajectory_id: 'traj-abc123',
+        tool_info: {
+          mcp_server_name: 'github',
+          mcp_tool_name: 'create_issue',
+          mcp_tool_arguments: { owner: 'code-owner', repo: 'my-repo', title: 'Bug report' },
+          mcp_result: 'issue #42 created',
+        },
+        ...overrides,
+      });
+    }
+
+    it('writes a pre event for pre_read_code with tool Read', () => {
+      processHook(makeWindsurfPreReadCode());
+      const lines = readBufferLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({
+        mode: 'pre',
+        tool: 'Read',
+        toolInput: { file_path: '/Users/dev/project/file.py' },
+      });
+    });
+
+    it('writes a post event for post_read_code with success true', () => {
+      processHook(makeWindsurfPostReadCode());
+      const lines = readBufferLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({
+        mode: 'post',
+        tool: 'Read',
+        success: true,
+        toolInput: { file_path: '/Users/dev/project/file.py' },
+      });
+    });
+
+    it('writes a pre event for pre_write_code with tool Edit', () => {
+      processHook(makeWindsurfPreWriteCode());
+      const lines = readBufferLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({
+        mode: 'pre',
+        tool: 'Edit',
+        toolInput: { file_path: '/Users/dev/project/file.py' },
+      });
+    });
+
+    it('writes a post event for post_write_code with success true', () => {
+      processHook(makeWindsurfPostWriteCode());
+      const lines = readBufferLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({
+        mode: 'post',
+        tool: 'Edit',
+        success: true,
+      });
+    });
+
+    it('writes a pre event for pre_run_command with tool Bash and redacts the command', () => {
+      processHook(
+        makeWindsurfPreRunCommand({
+          tool_info: {
+            command_line: 'API_KEY=sk-abcdefghijklmnopqrstuvwxyz012345 deploy',
+            cwd: '/x',
+          },
+        }),
+      );
+      const lines = readBufferLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0].mode).toBe('pre');
+      expect(lines[0].tool).toBe('Bash');
+      expect((lines[0].toolInput as { command: string }).command).toContain('[REDACTED]');
+      expect((lines[0].toolInput as { command: string }).command).not.toContain(
+        'sk-abcdefghijklmnopqrstuvwxyz012345',
+      );
+    });
+
+    it('writes a post event for post_run_command with success true', () => {
+      processHook(makeWindsurfPostRunCommand());
+      const lines = readBufferLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({ mode: 'post', tool: 'Bash', success: true });
+    });
+
+    it('writes a pre event for pre_mcp_tool_use with the raw MCP tool name', () => {
+      processHook(makeWindsurfPreMcpToolUse());
+      const lines = readBufferLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0].mode).toBe('pre');
+      expect(lines[0].tool).toBe('create_issue');
+    });
+
+    it('writes a post event for post_mcp_tool_use with success true', () => {
+      processHook(makeWindsurfPostMcpToolUse());
+      const lines = readBufferLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({ mode: 'post', tool: 'create_issue', success: true });
+    });
+
+    it('routes by trajectory_id when session_id is absent', () => {
+      delete process.env.NEW_RELIC_AI_MCP_BUFFER_PATH;
+      process.env.NEW_RELIC_AI_MCP_STORAGE_PATH = tmpDir;
+
+      processHook(makeWindsurfPreReadCode({ trajectory_id: 'traj-route-test' }));
+      const lines = readBufferLines('traj-route-test');
+      expect(lines).toHaveLength(1);
+      expect(lines[0].sessionId).toBe('traj-route-test');
+    });
+
+    it('silently ignores pre_user_prompt (not a tool-call event)', () => {
+      processHook(
+        JSON.stringify({
+          agent_action_name: 'pre_user_prompt',
+          trajectory_id: 'traj-abc123',
+          tool_info: { user_prompt: 'can you run echo hello' },
+        }),
+      );
+      expect(readBufferLines('traj-abc123')).toHaveLength(0);
+    });
+
+    it('silently ignores post_cascade_response (not a tool-call event)', () => {
+      processHook(
+        JSON.stringify({
+          agent_action_name: 'post_cascade_response',
+          trajectory_id: 'traj-abc123',
+          tool_info: { response: 'Done.' },
+        }),
+      );
+      expect(readBufferLines('traj-abc123')).toHaveLength(0);
     });
   });
 

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -466,6 +466,17 @@ interface HookInput {
   file_path?: string;
   content?: string;
   edits?: { old_string?: string; new_string?: string }[];
+  // Windsurf (https://docs.windsurf.com/windsurf/cascade/hooks) sends a
+  // completely different envelope from every other platform: the event name
+  // itself is `agent_action_name`, not `hook_event_name`, and all
+  // event-specific data lives nested under `tool_info` rather than flat
+  // fields. `trajectory_id` is Windsurf's closest analog to session_id
+  // ("Unique identifier for the overall Cascade conversation" per the docs
+  // above) — Windsurf never sends session_id, the same situation as Cursor's
+  // conversation_id.
+  agent_action_name?: string;
+  trajectory_id?: string;
+  tool_info?: Record<string, unknown>;
   [key: string]: unknown;
 }
 
@@ -622,6 +633,16 @@ function extractOutputMeta(toolName: string, output: unknown): Record<string, un
   return undefined;
 }
 
+/**
+ * Windsurf nests all event-specific data under `tool_info` instead of flat
+ * top-level fields (https://docs.windsurf.com/windsurf/cascade/hooks).
+ * Returns an empty object when tool_info is missing or malformed so callers
+ * can destructure without null checks.
+ */
+function getWindsurfToolInfo(data: HookInput): Record<string, unknown> {
+  return data.tool_info !== null && typeof data.tool_info === 'object' ? data.tool_info : {};
+}
+
 function processHook(raw: string): void {
   let data: HookInput;
   try {
@@ -634,7 +655,10 @@ function processHook(raw: string): void {
   // conversation_id is its closest analog (one per chat, like a Claude Code
   // session). Claude Code and Kiro always send session_id, so this only
   // takes effect for Cursor events.
-  const sessionId = data.session_id ?? data.conversation_id;
+  // Windsurf (https://docs.windsurf.com/windsurf/cascade/hooks) never sends
+  // session_id either — trajectory_id is its closest analog, the same role
+  // conversation_id plays for Cursor.
+  const sessionId = data.session_id ?? data.conversation_id ?? data.trajectory_id;
 
   // Drop a PPID breadcrumb at the very top so the MCP server can resolve its
   // Claude Code session_id without an env-var or initialize-payload extension.
@@ -653,7 +677,11 @@ function processHook(raw: string): void {
   // Normalize case so both are recognized without hard-coding per-platform
   // spellings here (this file intentionally has no platform-adapter import —
   // see the file's own "no heavy imports" design constraint).
-  const eventName = data.hook_event_name?.toLowerCase();
+  // Windsurf sends the event name as agent_action_name, not hook_event_name
+  // (https://docs.windsurf.com/windsurf/cascade/hooks) — already lowercase
+  // with underscores (e.g. "pre_read_code"), but .toLowerCase() is harmless
+  // and keeps this line uniform with every other platform's derivation.
+  const eventName = (data.hook_event_name ?? data.agent_action_name)?.toLowerCase();
   const toolName = data.tool_name ?? 'unknown';
   const timestamp = Date.now();
   const recordContent = getRecordContent();
@@ -790,6 +818,93 @@ function processHook(raw: string): void {
       timestamp,
       success: true,
       ...(data.file_path !== undefined && { toolInput: { file_path: data.file_path } }),
+    };
+  } else if (eventName === 'pre_read_code') {
+    // Confirmed payload: https://docs.windsurf.com/windsurf/cascade/hooks#pre_read_code
+    const filePath = getWindsurfToolInfo(data).file_path;
+    event = {
+      mode: 'pre' as const,
+      tool: 'Read',
+      timestamp,
+      inputSize: sizeOf(filePath),
+      inputHash: hashInput(filePath),
+      ...(typeof filePath === 'string' && { toolInput: { file_path: filePath } }),
+    };
+  } else if (eventName === 'post_read_code') {
+    // No source documents a failure signal for this event — success: true
+    // unconditionally, same convention as Cursor's afterShellExecution.
+    const filePath = getWindsurfToolInfo(data).file_path;
+    event = {
+      mode: 'post' as const,
+      tool: 'Read',
+      timestamp,
+      success: true,
+      ...(typeof filePath === 'string' && { toolInput: { file_path: filePath } }),
+    };
+  } else if (eventName === 'pre_write_code') {
+    // Maps to 'Edit' not 'Write' — tool_info carries an edits[] array of
+    // {old_string, new_string}, the same shape as Claude Code's Edit tool,
+    // not a full-file Write. Mirrors Cursor's afterFileEdit -> 'Edit'.
+    const filePath = getWindsurfToolInfo(data).file_path;
+    event = {
+      mode: 'pre' as const,
+      tool: 'Edit',
+      timestamp,
+      inputSize: sizeOf(filePath),
+      inputHash: hashInput(filePath),
+      ...(typeof filePath === 'string' && { toolInput: { file_path: filePath } }),
+    };
+  } else if (eventName === 'post_write_code') {
+    const filePath = getWindsurfToolInfo(data).file_path;
+    event = {
+      mode: 'post' as const,
+      tool: 'Edit',
+      timestamp,
+      success: true,
+      ...(typeof filePath === 'string' && { toolInput: { file_path: filePath } }),
+    };
+  } else if (eventName === 'pre_run_command') {
+    // Confirmed payload: https://docs.windsurf.com/windsurf/cascade/hooks#pre_run_command
+    const commandLineRaw = getWindsurfToolInfo(data).command_line;
+    const commandLine = typeof commandLineRaw === 'string' ? commandLineRaw : '';
+    event = {
+      mode: 'pre' as const,
+      tool: 'Bash',
+      timestamp,
+      inputSize: sizeOf(commandLine),
+      inputHash: hashInput(commandLine),
+      toolInput: { command: redact(commandLine) },
+    };
+  } else if (eventName === 'post_run_command') {
+    // No source documents an exit-code/output field for this event —
+    // success: true unconditionally, same gap as Cursor's afterShellExecution.
+    event = {
+      mode: 'post' as const,
+      tool: 'Bash',
+      timestamp,
+      success: true,
+    };
+  } else if (eventName === 'pre_mcp_tool_use') {
+    // mcp_tool_name is an arbitrary third-party MCP tool name, passed through
+    // as-is (identity) — same treatment as Cursor's beforeMCPExecution and
+    // src/platforms/generic-mcp-adapter.ts.
+    const toolInfo = getWindsurfToolInfo(data);
+    const mcpTool = typeof toolInfo.mcp_tool_name === 'string' ? toolInfo.mcp_tool_name : 'unknown';
+    event = {
+      mode: 'pre' as const,
+      tool: mcpTool,
+      timestamp,
+      inputSize: sizeOf(toolInfo.mcp_tool_arguments),
+      inputHash: hashInput(toolInfo.mcp_tool_arguments),
+    };
+  } else if (eventName === 'post_mcp_tool_use') {
+    const toolInfo = getWindsurfToolInfo(data);
+    const mcpTool = typeof toolInfo.mcp_tool_name === 'string' ? toolInfo.mcp_tool_name : 'unknown';
+    event = {
+      mode: 'post' as const,
+      tool: mcpTool,
+      timestamp,
+      success: true,
     };
   } else {
     // Unknown hook event — ignore silently

--- a/src/platforms/windsurf-adapter.test.ts
+++ b/src/platforms/windsurf-adapter.test.ts
@@ -207,6 +207,13 @@ describe('WindsurfAdapter', () => {
       expect(instructions).toContain('Windsurf');
       expect(instructions).toContain('MCP');
     });
+
+    it('documents the real .windsurf/hooks.json Cascade Hooks system for built-in tool calls', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions).toContain('hooks.json');
+      expect(instructions).not.toContain('file watcher');
+      expect(instructions).not.toContain('extension');
+    });
   });
 
   describe('initialize', () => {

--- a/src/platforms/windsurf-adapter.ts
+++ b/src/platforms/windsurf-adapter.ts
@@ -39,8 +39,11 @@ export class WindsurfAdapter implements PlatformAdapter {
   readonly platformName = 'windsurf';
 
   async initialize(_config: PlatformConfig): Promise<void> {
-    // Windsurf supports MCP natively — proxy captures MCP tool calls automatically.
-    // Built-in Cascade tool calls arrive via extension API or file watcher events.
+    // Windsurf supports MCP natively via its own mcp_config.json. Built-in
+    // Cascade tool calls (file reads/writes, terminal commands, MCP calls)
+    // arrive through Windsurf's real Cascade Hooks system (.windsurf/hooks.json),
+    // handled by src/hooks/collector-script.ts — not through a file watcher
+    // or extension API. See https://docs.windsurf.com/windsurf/cascade/hooks.
   }
 
   normalizeToolCall(raw: unknown): NormalizedToolCall {
@@ -81,8 +84,13 @@ export class WindsurfAdapter implements PlatformAdapter {
       '1. Open Windsurf Settings > MCP Servers',
       '2. Add a new MCP server with command: npx preflight --stdio',
       '3. Set the environment variables: NEW_RELIC_LICENSE_KEY, NEW_RELIC_ACCOUNT_ID',
-      '4. MCP tool calls via Cascade are captured automatically through the proxy',
-      '5. Built-in tool calls (file edits, terminal) require the file watcher or Windsurf extension',
+      '4. MCP tool calls via Cascade are captured automatically through the MCP connection',
+      '5. Built-in tool calls (file reads/writes, terminal commands) require Cascade Hooks:',
+      '   a. Create .windsurf/hooks.json in your workspace root (or use the user/system-level path)',
+      '   b. Register pre_read_code, post_read_code, pre_write_code, post_write_code,',
+      '      pre_run_command, and post_run_command hooks, each running:',
+      '      preflight-collector',
+      '   c. See https://docs.windsurf.com/windsurf/cascade/hooks for the full hooks.json schema',
     ].join('\n');
   }
 


### PR DESCRIPTION
Closes #92

## Summary
- `preflight-collector` never recognized Windsurf's real Cascade Hooks vocabulary (`.windsurf/hooks.json`, per https://docs.windsurf.com/windsurf/cascade/hooks). Windsurf sends the event name as `agent_action_name` (not `hook_event_name`) with all event data nested under `tool_info` — every Windsurf hook event silently fell through to a no-op. Added handling for `pre_read_code`/`post_read_code` → Read, `pre_write_code`/`post_write_code` → Edit, `pre_run_command`/`post_run_command` → Bash, and `pre_mcp_tool_use`/`post_mcp_tool_use` → identity-passthrough MCP tool name. Four conversation-lifecycle events (`pre_user_prompt`, `post_cascade_response`, `post_cascade_response_with_transcript`, `post_setup_worktree`) are intentionally left unhandled — no tool-call duration/success semantics.
- `WindsurfAdapter`'s setup instructions and internal comments claimed built-in tool calls were captured via "extension API or file watcher events" — no such mechanism exists. Both now document the real `.windsurf/hooks.json` setup.
- Version bump 1.4.4 → 1.4.5.

## Test plan
- [x] `npm test` — 128/128 suites passing
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
