### PR TITLE
Fix: v1.4.6 — Zed adapter correctness fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.6] - 2026-07-10
+
+### Fixed
+
+- **`ZedAdapter`'s tool-name map used invented tool names that don't match Zed's real built-in agent vocabulary** — `open_file`, `create_file`, `execute_command`, `search_files`, `find_in_files`, `search_in_file`, `run_command`, and `list_files` are not real Zed tool names (confirmed via https://zed.dev/docs/ai/tools.html). `ZED_TOOL_MAP` now covers Zed's confirmed real built-in tools (`read_file`, `find_path`, `grep`, `list_directory`, `fetch`, `search_web`, `edit_file`, `write_file`, `delete_path`, `terminal`, `spawn_agent`, `skill`).
+- **`ZedAdapter`'s setup instructions and `initialize()` comment described a nonexistent capture mechanism** — both claimed built-in tool calls "arrive via stdio" automatically; no such mechanism exists. Unlike the Kiro/Cursor/Windsurf fixes, Zed's native agent genuinely has no hook/callback system to document instead (confirmed: no "Hooks" page exists anywhere in Zed's documentation). Instructions now accurately state that Preflight can only observe calls made to its own MCP tools in Zed, and that full tool-call observability requires running an already-supported platform (e.g. Claude Code) as a Zed External Agent instead.
+
 ## [1.4.5] - 2026-07-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/platforms/zed-adapter.test.ts
+++ b/src/platforms/zed-adapter.test.ts
@@ -28,30 +28,40 @@ describe('ZedAdapter', () => {
   });
 
   describe('normalizeToolCall', () => {
-    it('maps "open_file" to "Read"', () => {
+    it('maps "read_file" to "Read"', () => {
       const normalized = adapter.normalizeToolCall({
-        tool: 'open_file',
+        tool: 'read_file',
         timestamp: 2000,
         success: true,
       });
       expect(normalized.toolName).toBe('Read');
-      expect(normalized.platformToolName).toBe('open_file');
+      expect(normalized.platformToolName).toBe('read_file');
       expect(normalized.platform).toBe('zed');
     });
 
-    it('maps "read_file" to "Read"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'read_file', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Read');
+    it('maps "find_path" to "Glob"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'find_path', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Glob');
     });
 
-    it('maps "create_file" to "Write"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'create_file', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Write');
+    it('maps "grep" to "Grep"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'grep', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Grep');
     });
 
-    it('maps "write_file" to "Write"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'write_file', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Write');
+    it('maps "list_directory" to "Glob"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'list_directory', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Glob');
+    });
+
+    it('maps "fetch" to "WebFetch"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'fetch', timestamp: 2000 });
+      expect(normalized.toolName).toBe('WebFetch');
+    });
+
+    it('maps "search_web" to "WebSearch"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'search_web', timestamp: 2000 });
+      expect(normalized.toolName).toBe('WebSearch');
     });
 
     it('maps "edit_file" to "Edit"', () => {
@@ -64,29 +74,19 @@ describe('ZedAdapter', () => {
       expect(normalized.filePath).toBe('/src/app.ts');
     });
 
-    it('maps "delete_file" to "Delete"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'delete_file', timestamp: 2000 });
+    it('maps "write_file" to "Write"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'write_file', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Write');
+    });
+
+    it('maps "delete_path" to "Delete"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'delete_path', timestamp: 2000 });
       expect(normalized.toolName).toBe('Delete');
     });
 
-    it('maps "search_files" to "Glob"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'search_files', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Glob');
-    });
-
-    it('maps "find_in_files" to "Grep"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'find_in_files', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Grep');
-    });
-
-    it('maps "search_in_file" to "Grep"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'search_in_file', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Grep');
-    });
-
-    it('maps "execute_command" to "Bash"', () => {
+    it('maps "terminal" to "Bash"', () => {
       const normalized = adapter.normalizeToolCall({
-        tool: 'execute_command',
+        tool: 'terminal',
         timestamp: 2000,
         command: 'npm test',
       });
@@ -94,19 +94,38 @@ describe('ZedAdapter', () => {
       expect(normalized.command).toBe('npm test');
     });
 
-    it('maps "run_command" to "Bash"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'run_command', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Bash');
+    it('maps "spawn_agent" to "Agent"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'spawn_agent', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Agent');
     });
 
-    it('maps "list_files" to "Glob"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'list_files', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Glob');
+    it('maps "skill" to "Skill"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'skill', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Skill');
     });
 
-    it('maps "list_directory" to "Glob"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'list_directory', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Glob');
+    it('leaves "diagnostics" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'diagnostics', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('diagnostics');
+    });
+
+    it('leaves "copy_path" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'copy_path', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('copy_path');
+    });
+
+    it('leaves "move_path" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'move_path', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('move_path');
+    });
+
+    it('leaves "create_directory" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'create_directory', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('create_directory');
     });
 
     it('maps unknown tool to "Unknown" with platformToolName preserved', () => {
@@ -224,6 +243,15 @@ describe('ZedAdapter', () => {
     it('mentions NEW_RELIC_ACCOUNT_ID', () => {
       expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
     });
+
+    it('states Zed has no hook mechanism instead of claiming automatic capture', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions).toContain('no hook mechanism');
+    });
+
+    it('documents the real context_servers settings key', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('context_servers');
+    });
   });
 
   describe('initialize', () => {
@@ -235,6 +263,14 @@ describe('ZedAdapter', () => {
   describe('mapToolName', () => {
     it('maps a known tool name', () => {
       expect(adapter.mapToolName('read_file')).toBe('Read');
+    });
+
+    it('maps "terminal" to "Bash"', () => {
+      expect(adapter.mapToolName('terminal')).toBe('Bash');
+    });
+
+    it('returns "Unknown" for a real Zed tool with no canonical equivalent', () => {
+      expect(adapter.mapToolName('diagnostics')).toBe('Unknown');
     });
 
     it('returns "Unknown" for an unrecognized tool name', () => {

--- a/src/platforms/zed-adapter.ts
+++ b/src/platforms/zed-adapter.ts
@@ -5,20 +5,28 @@ import type {
   NormalizedToolCall,
 } from './types.js';
 
+// Maps Zed's real built-in agent tool names (confirmed via
+// https://zed.dev/docs/ai/tools.html) to the normalized Claude Code tool
+// vocabulary. Zed's native agent has no hook/callback mechanism (see
+// initialize()'s comment below), so these entries are currently unreachable
+// from the real hook pipeline — this map exists for correctness and for any
+// future Zed hook capability, not because any Zed event reaches it today.
+// `diagnostics`, `copy_path`, `move_path`, and `create_directory` are real
+// Zed tools with no named Claude Code equivalent and are deliberately left
+// unmapped (they fall through to 'Unknown' with platformToolName preserved).
 const ZED_TOOL_MAP: Record<string, string> = {
-  open_file: 'Read',
   read_file: 'Read',
-  create_file: 'Write',
-  write_file: 'Write',
-  edit_file: 'Edit',
-  delete_file: 'Delete',
-  search_files: 'Glob',
-  find_in_files: 'Grep',
-  search_in_file: 'Grep',
-  execute_command: 'Bash',
-  run_command: 'Bash',
-  list_files: 'Glob',
+  find_path: 'Glob',
+  grep: 'Grep',
   list_directory: 'Glob',
+  fetch: 'WebFetch',
+  search_web: 'WebSearch',
+  edit_file: 'Edit',
+  write_file: 'Write',
+  delete_path: 'Delete',
+  terminal: 'Bash',
+  spawn_agent: 'Agent',
+  skill: 'Skill',
 };
 
 interface ZedToolCallEvent {
@@ -39,7 +47,16 @@ export class ZedAdapter implements PlatformAdapter {
   readonly platformName = 'zed';
 
   async initialize(_config: PlatformConfig): Promise<void> {
-    // Zed spawns MCP servers as child processes. Tool calls arrive via stdio.
+    // Zed's native agent has no hook/callback mechanism for tool-call
+    // interception (confirmed: https://zed.dev/docs/ai/mcp.html — Zed
+    // supports only MCP's Tools and Prompts features, with no notification
+    // for host-side tool calls). As a Zed MCP "context server", Preflight
+    // can only receive calls Zed's agent makes to Preflight's own exposed
+    // tools — it cannot observe Zed's built-in read_file/edit_file/terminal
+    // calls. When Zed runs another coding agent (Claude Code, Cursor, etc.)
+    // as an External Agent via the Agent Client Protocol
+    // (https://zed.dev/docs/ai/external-agents.html), that agent's own
+    // native hooks already capture its tool calls independently of Zed.
   }
 
   normalizeToolCall(raw: unknown): NormalizedToolCall {
@@ -79,18 +96,27 @@ export class ZedAdapter implements PlatformAdapter {
   getHookInstallInstructions(): string {
     return [
       'Zed Editor Setup:',
-      '1. Open Zed Settings (Cmd+,) and go to the "assistant" section',
-      '2. Add an MCP server entry:',
+      "1. Zed's native agent has no hook mechanism for tool-call capture —",
+      '   Preflight configured as a Zed MCP server only sees calls made to',
+      "   its own tools, not Zed's built-in read_file/edit_file/terminal calls.",
+      '2. To use Preflight as an MCP context server in Zed (for its own',
+      '   observability tools), open Settings -> AI -> MCP Servers, click',
+      '   "Add Server", and add:',
       '   {',
-      '     "name": "preflight",',
-      '     "command": "npx",',
-      '     "args": ["preflight", "--stdio"],',
-      '     "env": {',
-      '       "NEW_RELIC_LICENSE_KEY": "<your-key>",',
-      '       "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"',
+      '     "context_servers": {',
+      '       "preflight": {',
+      '         "command": "npx",',
+      '         "args": ["preflight", "--stdio"],',
+      '         "env": {',
+      '           "NEW_RELIC_LICENSE_KEY": "<your-key>",',
+      '           "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"',
+      '         }',
+      '       }',
       '     }',
       '   }',
-      '3. Restart Zed to activate.',
+      '3. For full tool-call observability, run Claude Code (or another',
+      '   already-supported platform) as a Zed External Agent instead —',
+      '   its own native hooks capture tool calls independently of Zed.',
     ].join('\n');
   }
 


### PR DESCRIPTION
Closes #94

## Summary
- `ZED_TOOL_MAP` used invented tool names (`open_file`, `create_file`, `execute_command`, `search_files`, `find_in_files`, `search_in_file`, `run_command`, `list_files`) that don't match Zed's real built-in agent vocabulary. Confirmed via https://zed.dev/docs/ai/tools.html — real tool names are `read_file`, `find_path`, `grep`, `list_directory`, `fetch`, `search_web`, `edit_file`, `write_file`, `delete_path`, `terminal`, `spawn_agent`, `skill`. Four real Zed tools with no named Claude Code equivalent (`diagnostics`, `copy_path`, `move_path`, `create_directory`) are deliberately left unmapped, falling through to `'Unknown'` with the raw name preserved.
- `initialize()`'s comment and `getHookInstallInstructions()` both claimed Zed automatically captures built-in tool calls — false. Unlike the Kiro/Cursor/Windsurf adapter fixes (which added real hook-event handling to `preflight-collector`), Zed's native agent has no hook/callback mechanism at all — no "Hooks" page exists anywhere in Zed's documentation, and Zed only supports MCP's Tools and Prompts features. This fix intentionally makes zero changes to the hook collector — there's no real Zed event to add. Instructions now honestly state Preflight can only observe calls made to its own MCP tools in Zed, and that full tool-call observability requires running an already-supported platform (e.g. Claude Code) as a Zed External Agent instead.
- Version bump 1.4.5 → 1.4.6.

## Test plan
- [x] `npm test` — 128/129 suites passing, 3876/3879 tests passing
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
