### PR TITLE
Fix: correct Continue adapter tool-map and setup instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.7] - 2026-07-09
+
+### Fixed
+
+- Continue adapter: replaced the entirely invented `CONTINUE_TOOL_MAP` (camelCase names that never matched Continue's real tool vocabulary) with Continue's actual snake_case built-in tool names, confirmed directly from Continue's own source (`core/tools/builtIn.ts`). Removed the incorrect `deleteFile: 'Delete'` mapping — Continue has no delete/remove built-in tool at all.
+- Continue adapter: corrected `getHookInstallInstructions()` to honestly state that Continue's native agent has no PreToolUse/PostToolUse-style hook mechanism, describe the real (non-deprecated) `.continue/mcpServers/*.yaml` MCP config format, and note that the upstream `continuedev/continue` repository is no longer actively maintained.
+
 ## [1.4.6] - 2026-07-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/platforms/continue-adapter.test.ts
+++ b/src/platforms/continue-adapter.test.ts
@@ -34,25 +34,33 @@ describe('ContinueAdapter', () => {
   });
 
   describe('normalizeToolCall', () => {
-    it('maps "readFile" to "Read"', () => {
+    it('maps "read_file" to "Read"', () => {
       const normalized = adapter.normalizeToolCall({
-        tool: 'readFile',
+        tool: 'read_file',
         timestamp: 2000,
         success: true,
       });
       expect(normalized.toolName).toBe('Read');
-      expect(normalized.platformToolName).toBe('readFile');
+      expect(normalized.platformToolName).toBe('read_file');
       expect(normalized.platform).toBe('continue');
     });
 
-    it('maps "writeFile" to "Write"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'writeFile', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Write');
+    it('maps "read_file_range" to "Read"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file_range', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Read');
     });
 
-    it('maps "editFile" to "Edit"', () => {
+    it('maps "read_currently_open_file" to "Read"', () => {
       const normalized = adapter.normalizeToolCall({
-        tool: 'editFile',
+        tool: 'read_currently_open_file',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Read');
+    });
+
+    it('maps "edit_existing_file" to "Edit"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'edit_existing_file',
         timestamp: 2000,
         filePath: '/src/app.ts',
       });
@@ -60,39 +68,27 @@ describe('ContinueAdapter', () => {
       expect(normalized.filePath).toBe('/src/app.ts');
     });
 
-    it('maps "createFile" to "Write"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'createFile', timestamp: 2000 });
+    it('maps "single_find_and_replace" to "Edit"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'single_find_and_replace',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Edit');
+    });
+
+    it('maps "multi_edit" to "MultiEdit"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'multi_edit', timestamp: 2000 });
+      expect(normalized.toolName).toBe('MultiEdit');
+    });
+
+    it('maps "create_new_file" to "Write"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'create_new_file', timestamp: 2000 });
       expect(normalized.toolName).toBe('Write');
     });
 
-    it('maps "deleteFile" to "Delete"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'deleteFile', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Delete');
-    });
-
-    it('maps "searchFiles" to "Glob"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'searchFiles', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Glob');
-    });
-
-    it('maps "grep" to "Grep"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'grep', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Grep');
-    });
-
-    it('maps "grepSearch" to "Grep"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'grepSearch', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Grep');
-    });
-
-    it('maps "fileSearch" to "Glob"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'fileSearch', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Glob');
-    });
-
-    it('maps "runTerminalCommand" to "Bash"', () => {
+    it('maps "run_terminal_command" to "Bash"', () => {
       const normalized = adapter.normalizeToolCall({
-        tool: 'runTerminalCommand',
+        tool: 'run_terminal_command',
         timestamp: 2000,
         command: 'npm test',
       });
@@ -100,29 +96,78 @@ describe('ContinueAdapter', () => {
       expect(normalized.command).toBe('npm test');
     });
 
-    it('maps "terminal" to "Bash"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'terminal', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Bash');
+    it('maps "grep_search" to "Grep"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'grep_search', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Grep');
     });
 
-    it('maps "viewSubdirectory" to "Glob"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'viewSubdirectory', timestamp: 2000 });
+    it('maps "file_glob_search" to "Glob"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'file_glob_search', timestamp: 2000 });
       expect(normalized.toolName).toBe('Glob');
     });
 
-    it('maps "viewRepoMap" to "Glob"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'viewRepoMap', timestamp: 2000 });
+    it('maps "ls" to "Glob"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'ls', timestamp: 2000 });
       expect(normalized.toolName).toBe('Glob');
+    });
+
+    it('maps "view_subdirectory" to "Glob"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'view_subdirectory', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Glob');
+    });
+
+    it('maps "view_repo_map" to "Glob"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'view_repo_map', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Glob');
+    });
+
+    it('maps "search_web" to "WebSearch"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'search_web', timestamp: 2000 });
+      expect(normalized.toolName).toBe('WebSearch');
+    });
+
+    it('maps "fetch_url_content" to "WebFetch"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'fetch_url_content', timestamp: 2000 });
+      expect(normalized.toolName).toBe('WebFetch');
+    });
+
+    it('maps "read_skill" to "Skill"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'read_skill', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Skill');
+    });
+
+    it('maps unmapped real tool "view_diff" to "Unknown" with platformToolName preserved', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'view_diff', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('view_diff');
+    });
+
+    it('maps unmapped real tool "create_rule_block" to "Unknown" with platformToolName preserved', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'create_rule_block', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('create_rule_block');
+    });
+
+    it('maps unmapped real tool "request_rule" to "Unknown" with platformToolName preserved', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'request_rule', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('request_rule');
+    });
+
+    it('maps unmapped real tool "codebase" to "Unknown" with platformToolName preserved', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'codebase', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('codebase');
     });
 
     it('accepts "toolName" field as an alternative to "tool"', () => {
-      const normalized = adapter.normalizeToolCall({ toolName: 'readFile', timestamp: 2000 });
+      const normalized = adapter.normalizeToolCall({ toolName: 'read_file', timestamp: 2000 });
       expect(normalized.toolName).toBe('Read');
-      expect(normalized.platformToolName).toBe('readFile');
+      expect(normalized.platformToolName).toBe('read_file');
     });
 
     it('normalizes filepath (lowercase p) to filePath', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'readFile', filepath: '/src/app.ts' });
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file', filepath: '/src/app.ts' });
       expect(normalized.filePath).toBe('/src/app.ts');
     });
 
@@ -142,13 +187,13 @@ describe('ContinueAdapter', () => {
     });
 
     it('defaults success to true when not provided', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'readFile', timestamp: 2000 });
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file', timestamp: 2000 });
       expect(normalized.success).toBe(true);
     });
 
     it('preserves error field', () => {
       const normalized = adapter.normalizeToolCall({
-        tool: 'editFile',
+        tool: 'edit_existing_file',
         timestamp: 2000,
         success: false,
         error: 'permission denied',
@@ -159,7 +204,7 @@ describe('ContinueAdapter', () => {
 
     it('uses current time when timestamp is missing', () => {
       const before = Date.now();
-      const normalized = adapter.normalizeToolCall({ tool: 'readFile' });
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file' });
       const after = Date.now();
       expect(normalized.timestamp).toBeGreaterThanOrEqual(before);
       expect(normalized.timestamp).toBeLessThanOrEqual(after);
@@ -167,7 +212,7 @@ describe('ContinueAdapter', () => {
 
     it('includes inputSizeBytes and outputSizeBytes when present', () => {
       const normalized = adapter.normalizeToolCall({
-        tool: 'readFile',
+        tool: 'read_file',
         timestamp: 2000,
         inputSizeBytes: 50,
         outputSizeBytes: 1000,
@@ -178,7 +223,7 @@ describe('ContinueAdapter', () => {
 
     it('includes sessionId when present', () => {
       const normalized = adapter.normalizeToolCall({
-        tool: 'readFile',
+        tool: 'read_file',
         timestamp: 2000,
         sessionId: 'cont-sess-001',
       });
@@ -237,12 +282,16 @@ describe('ContinueAdapter', () => {
       expect(instructions).toContain('Continue');
     });
 
-    it('mentions NEW_RELIC_LICENSE_KEY', () => {
-      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_LICENSE_KEY');
+    it('states that Continue has no hook mechanism', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('no hook mechanism');
     });
 
-    it('mentions NEW_RELIC_ACCOUNT_ID', () => {
-      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
+    it('describes the real MCP server config location', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('.continue/mcpServers');
+    });
+
+    it('mentions that Continue is no longer actively maintained', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('no longer actively maintained');
     });
   });
 
@@ -254,11 +303,15 @@ describe('ContinueAdapter', () => {
 
   describe('mapToolName', () => {
     it('maps a known tool name', () => {
-      expect(adapter.mapToolName('readFile')).toBe('Read');
+      expect(adapter.mapToolName('read_file')).toBe('Read');
     });
 
     it('returns "Unknown" for an unrecognized tool name', () => {
       expect(adapter.mapToolName('totallyMadeUpTool')).toBe('Unknown');
+    });
+
+    it('returns "Unknown" for a real but deliberately unmapped tool name', () => {
+      expect(adapter.mapToolName('view_diff')).toBe('Unknown');
     });
   });
 });

--- a/src/platforms/continue-adapter.ts
+++ b/src/platforms/continue-adapter.ts
@@ -6,19 +6,22 @@ import type {
 } from './types.js';
 
 const CONTINUE_TOOL_MAP: Record<string, string> = {
-  readFile: 'Read',
-  writeFile: 'Write',
-  editFile: 'Edit',
-  createFile: 'Write',
-  deleteFile: 'Delete',
-  searchFiles: 'Glob',
-  grep: 'Grep',
-  grepSearch: 'Grep',
-  fileSearch: 'Glob',
-  runTerminalCommand: 'Bash',
-  terminal: 'Bash',
-  viewSubdirectory: 'Glob',
-  viewRepoMap: 'Glob',
+  read_file: 'Read',
+  read_file_range: 'Read',
+  read_currently_open_file: 'Read',
+  edit_existing_file: 'Edit',
+  single_find_and_replace: 'Edit',
+  multi_edit: 'MultiEdit',
+  create_new_file: 'Write',
+  run_terminal_command: 'Bash',
+  grep_search: 'Grep',
+  file_glob_search: 'Glob',
+  ls: 'Glob',
+  view_subdirectory: 'Glob',
+  view_repo_map: 'Glob',
+  search_web: 'WebSearch',
+  fetch_url_content: 'WebFetch',
+  read_skill: 'Skill',
 };
 
 interface ContinueToolCallEvent {
@@ -41,7 +44,13 @@ export class ContinueAdapter implements PlatformAdapter {
   readonly platformName = 'continue';
 
   async initialize(_config: PlatformConfig): Promise<void> {
-    // Continue.dev communicates via MCP stdio or local HTTP server.
+    // Continue's native agent (VS Code/JetBrains extension and CLI) has no
+    // PreToolUse/PostToolUse-style hook mechanism for its built-in tools
+    // (read_file, edit_existing_file, run_terminal_command, etc.). Continue
+    // supports MCP only as a client: it can call out to an MCP server like
+    // Preflight, but that only surfaces calls Continue's agent chooses to make
+    // to Preflight's own tools, never a callback for Continue's built-in tool
+    // calls. See getHookInstallInstructions() for the real integration path.
   }
 
   normalizeToolCall(raw: unknown): NormalizedToolCall {
@@ -81,19 +90,30 @@ export class ContinueAdapter implements PlatformAdapter {
 
   getHookInstallInstructions(): string {
     return [
-      'Continue.dev Setup:',
-      '1. Open Continue config file (~/.continue/config.json)',
-      '2. Add to "mcpServers":',
-      '   {',
-      '     "name": "preflight",',
-      '     "command": "npx",',
-      '     "args": ["preflight", "--stdio"],',
-      '     "env": {',
-      '       "NEW_RELIC_LICENSE_KEY": "<your-key>",',
-      '       "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"',
-      '     }',
-      '   }',
-      '3. Reload the Continue extension.',
+      'Continue Setup:',
+      '',
+      "Continue's native agent has no hook mechanism — Preflight cannot",
+      'observe calls to built-in tools (read_file, edit_existing_file,',
+      'run_terminal_command, etc.) the way it does for Claude Code.',
+      '',
+      'What Preflight CAN see: calls Continue routes to its own MCP tools.',
+      '1. Create a folder .continue/mcpServers in your workspace root.',
+      '2. Add a file preflight.yaml with:',
+      '   name: Preflight mcpServer',
+      '   version: 0.0.1',
+      '   schema: v1',
+      '   mcpServers:',
+      '     - name: preflight',
+      '       command: npx',
+      '       args: ["preflight", "--stdio"]',
+      '       env:',
+      '         NEW_RELIC_LICENSE_KEY: <your-key>',
+      '         NEW_RELIC_ACCOUNT_ID: <your-account-id>',
+      '3. Reload Continue.',
+      '',
+      'Note: the continuedev/continue repository is no longer actively maintained',
+      'and is read-only for all users as of its final 2.0.0',
+      'release, so this integration path is unlikely to gain deeper hooks.',
     ].join('\n');
   }
 


### PR DESCRIPTION
Closes #96

## Summary

- `CONTINUE_TOOL_MAP` used entirely invented camelCase tool names (`readFile`, `writeFile`, `terminal`, `deleteFile`, ...) that never matched Continue's real built-in tool vocabulary. Replaced with Continue's actual snake_case tool names, confirmed directly from Continue's own source (`core/tools/builtIn.ts`): `read_file`, `edit_existing_file`, `create_new_file`, `run_terminal_command`, `grep_search`, `file_glob_search`, `search_web`, `fetch_url_content`, `ls`, `view_subdirectory`, `view_repo_map`, `read_skill`, `read_file_range`, `read_currently_open_file`, `single_find_and_replace`, `multi_edit`. Removed the incorrect `deleteFile: 'Delete'` mapping — Continue has no delete/remove built-in tool at all.
- `view_diff`, `create_rule_block`, `request_rule`, and `codebase` are real Continue tools with no genuine Claude Code equivalent — left deliberately unmapped (fall through to `'Unknown'` with the raw name preserved).
- Corrected `getHookInstallInstructions()`/`initialize()`: Continue's native agent has no PreToolUse/PostToolUse-style hook mechanism (confirmed via real docs — no such capability exists anywhere in Continue's documentation). Instructions now honestly state this, describe the real (non-deprecated) `.continue/mcpServers/*.yaml` MCP config format, and note that `continuedev/continue` is no longer actively maintained upstream (final v2.0.0 release, repo now read-only).
- No `src/hooks/collector-script.ts` changes — there is nothing to fix there for Continue, since no hook events are ever emitted by Continue's native agent.
- Version bump 1.4.6 → 1.4.7.

Fifth in an ongoing series auditing all platform adapters against real vendor documentation (Kiro, Cursor, Windsurf, Zed already shipped).

## Test plan

- [x] `npm run build && npm test` — 128/129 suites passed (1 pre-existing skip), 3885/3888 tests passed (3 pre-existing skips), 0 failures
- [x] `npm run lint` — clean, 0 errors/warnings
- [x] Manually verified all 16 mapped keys are real Continue tool names and all 4 deliberately-unmapped names are absent from the map
- [x] Diffstat matches the originating private-repo commit exactly (5 files, 163 insertions, 83 deletions)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>