### PR TITLE
Fix: correct Amazon Q Developer CLI adapter tool-map and hook wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.8] - 2026-07-09
+
+### Fixed
+
+- Amazon Q Developer CLI adapter: replaced an invented 15-entry tool-name map (only 3 entries were real) with the confirmed 9-tool built-in vocabulary, mapping the 4 with genuine Claude Code equivalents (`fs_read`, `fs_write`, `execute_bash`, `todo_list`) and leaving the rest (`introspect`, `report_issue`, `knowledge`, `thinking`, `use_aws`) unmapped rather than forced.
+- `collector-script.ts`: `postToolUse` events no longer hardcode `success: true` — they now read `tool_response.success` when present, fixing a cross-platform bug where failed Kiro and Amazon Q tool calls were silently recorded as successful.
+- Amazon Q Developer CLI adapter: `getHookInstallInstructions()` now documents the platform's real, genuine hook mechanism (`preToolUse`/`postToolUse` via the agent config `hooks` field) instead of only covering MCP server registration.
+
 ## [1.4.7] - 2026-07-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.7",
+      "version": "1.4.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -456,6 +456,108 @@ describe('collector-script', () => {
     });
   });
 
+  describe('collector-script — postToolUse tool_response.success (Kiro / Amazon Q)', () => {
+    it('marks the event unsuccessful when tool_response.success is false', () => {
+      processHook(
+        makeKiroPostToolUse({ tool_response: { success: false, result: ['permission denied'] } }),
+      );
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].success).toBe(false);
+    });
+
+    it('marks the event successful when tool_response.success is true', () => {
+      processHook(makeKiroPostToolUse({ tool_response: { success: true, result: ['ok'] } }));
+      const events = readBufferEvents();
+      expect(events[0].success).toBe(true);
+    });
+
+    it('defaults to successful when tool_response has no success field (Claude Code shape)', () => {
+      processHook(makePostToolUse({ tool_response: { exitCode: 0 } }));
+      const events = readBufferEvents();
+      expect(events[0].success).toBe(true);
+    });
+
+    it('defaults to successful when tool_response is a non-object', () => {
+      processHook(makePostToolUse({ tool_response: 'plain string output' }));
+      const events = readBufferEvents();
+      expect(events[0].success).toBe(true);
+    });
+
+    it("unifies top-level success with Edit's own tool_response.success (intentional — Claude Code's Edit tool is not exempt)", () => {
+      processHook(
+        makePostToolUse({
+          tool_name: 'Edit',
+          tool_response: { success: false, error: 'no match found' },
+        }),
+      );
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].success).toBe(false);
+    });
+  });
+
+  describe('collector-script — Amazon Q Developer CLI hook payloads (https://github.com/aws/amazon-q-developer-cli/blob/main/docs/hooks.md)', () => {
+    function makeAmazonQPreToolUse(overrides?: Record<string, unknown>): string {
+      return JSON.stringify({
+        hook_event_name: 'preToolUse',
+        cwd: '/current/working/directory',
+        tool_name: 'fs_read',
+        tool_input: {
+          operations: [{ mode: 'Line', path: '/current/working/directory/docs/hooks.md' }],
+        },
+        ...overrides,
+      });
+    }
+
+    function makeAmazonQPostToolUse(overrides?: Record<string, unknown>): string {
+      return JSON.stringify({
+        hook_event_name: 'postToolUse',
+        cwd: '/current/working/directory',
+        tool_name: 'fs_read',
+        tool_input: {
+          operations: [{ mode: 'Line', path: '/current/working/directory/docs/hooks.md' }],
+        },
+        tool_response: { success: true, result: ['# Hooks\n\nHooks allow you to execute...'] },
+        ...overrides,
+      });
+    }
+
+    it('writes a pre event for a real Amazon Q preToolUse payload', () => {
+      processHook(makeAmazonQPreToolUse());
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].mode).toBe('pre');
+      expect(events[0].tool).toBe('fs_read');
+    });
+
+    it('writes a successful post event for a real Amazon Q postToolUse payload', () => {
+      processHook(makeAmazonQPostToolUse());
+      const events = readBufferEvents();
+      expect(events[0].mode).toBe('post');
+      expect(events[0].success).toBe(true);
+    });
+
+    it('writes a failed post event when tool_response.success is false', () => {
+      processHook(
+        makeAmazonQPostToolUse({ tool_response: { success: false, result: ['Access denied'] } }),
+      );
+      const events = readBufferEvents();
+      expect(events[0].success).toBe(false);
+    });
+
+    it('has no session identifier field, unlike every other supported platform', () => {
+      processHook(makeAmazonQPreToolUse());
+      const events = readBufferEvents();
+      // Amazon Q hook events carry no session_id/conversation_id/trajectory_id —
+      // confirmed absent from the real payload shape in hooks.md. sessionId
+      // falls through to undefined, and getBufferPath() buckets it under
+      // buffer-unknown.jsonl (the same fallback bucket the storage layer
+      // already provides for any session-less platform).
+      expect(events[0].sessionId).toBeUndefined();
+    });
+  });
+
   function makeCursorBeforeShellExecution(overrides?: Record<string, unknown>): string {
     return JSON.stringify({
       hook_event_name: 'beforeShellExecution',

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -708,12 +708,34 @@ function processHook(raw: string): void {
       event.inputContent = redact(truncate(content, maxContentLen));
     }
   } else if (eventName === 'posttooluse') {
+    // Claude Code generally signals tool failure via a separate
+    // PostToolUseFailure event, so hardcoding true here was historically
+    // almost always safe — with one known exception: Claude Code's own Edit
+    // tool sets tool_response.success: false (see extractOutputMeta's Edit
+    // case below, which has always read this into toolOutput.editSuccess)
+    // when a find-and-replace doesn't match. Kiro and Amazon Q Developer CLI
+    // both use this single postToolUse event for both outcomes and set
+    // tool_response.success: false on failure (confirmed identical shape:
+    // https://kiro.dev/docs/cli/hooks and
+    // https://github.com/aws/amazon-q-developer-cli/blob/main/docs/hooks.md).
+    // Reading tool_response.success here (defaulting to true when absent)
+    // both fixes Kiro/Amazon Q and intentionally unifies the top-level
+    // success/ToolCallRecord.success signal with the existing
+    // toolOutput.editSuccess signal for Claude Code's own no-match Edit case
+    // — a no-match edit is a genuine failure worth surfacing to
+    // anti-pattern/task-completion metrics, not a behavior to special-case
+    // away.
+    const toolResponse = data.tool_response;
+    const responseSuccess =
+      toolResponse !== null && typeof toolResponse === 'object' && !Array.isArray(toolResponse)
+        ? (toolResponse as Record<string, unknown>).success
+        : undefined;
     event = {
       mode: 'post' as const,
       tool: toolName,
       timestamp,
       outputSize: sizeOf(data.tool_response),
-      success: true,
+      success: typeof responseSuccess === 'boolean' ? responseSuccess : true,
     };
 
     // Store input metadata as fallback for orphaned-post pairing (pre-event may be missing)

--- a/src/platforms/amazon-q-adapter.test.ts
+++ b/src/platforms/amazon-q-adapter.test.ts
@@ -50,46 +50,6 @@ describe('AmazonQAdapter', () => {
       expect(normalized.toolName).toBe('Write');
     });
 
-    it('maps "fs_edit" to "Edit"', () => {
-      const normalized = adapter.normalizeToolCall({
-        tool: 'fs_edit',
-        timestamp: 2000,
-        filePath: '/src/app.ts',
-      });
-      expect(normalized.toolName).toBe('Edit');
-      expect(normalized.filePath).toBe('/src/app.ts');
-    });
-
-    it('maps "fs_create" to "Write"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'fs_create', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Write');
-    });
-
-    it('maps "fs_delete" to "Delete"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'fs_delete', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Delete');
-    });
-
-    it('maps "fs_list" to "Glob"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'fs_list', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Glob');
-    });
-
-    it('maps "fs_find" to "Glob"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'fs_find', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Glob');
-    });
-
-    it('maps "grep" to "Grep"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'grep', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Grep');
-    });
-
-    it('maps "search_code" to "Grep"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'search_code', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Grep');
-    });
-
     it('maps "execute_bash" to "Bash"', () => {
       const normalized = adapter.normalizeToolCall({
         tool: 'execute_bash',
@@ -100,29 +60,35 @@ describe('AmazonQAdapter', () => {
       expect(normalized.command).toBe('npm test');
     });
 
-    it('maps "run_shell" to "Bash"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'run_shell', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Bash');
+    it('maps "todo_list" to "TaskCreate"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'todo_list', timestamp: 2000 });
+      expect(normalized.toolName).toBe('TaskCreate');
     });
 
-    it('maps "execute_command" to "Bash"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'execute_command', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Bash');
+    it('maps "introspect" to "Unknown" with platformToolName preserved (no real equivalent)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'introspect', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('introspect');
     });
 
-    it('maps "explain_code" to "Read"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'explain_code', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Read');
+    it('maps "report_issue" to "Unknown" (no real equivalent)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'report_issue', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
     });
 
-    it('maps "review_code" to "Read"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'review_code', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Read');
+    it('maps "knowledge" to "Unknown" (no real equivalent)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'knowledge', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
     });
 
-    it('maps "transform_code" to "Edit"', () => {
-      const normalized = adapter.normalizeToolCall({ tool: 'transform_code', timestamp: 2000 });
-      expect(normalized.toolName).toBe('Edit');
+    it('maps "thinking" to "Unknown" (no real equivalent)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'thinking', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+    });
+
+    it('maps "use_aws" to "Unknown" (no real equivalent)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'use_aws', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
     });
 
     it('accepts "toolName" field as an alternative to "tool"', () => {
@@ -155,7 +121,7 @@ describe('AmazonQAdapter', () => {
 
     it('preserves error field', () => {
       const normalized = adapter.normalizeToolCall({
-        tool: 'fs_edit',
+        tool: 'fs_write',
         timestamp: 2000,
         success: false,
         error: 'permission denied',
@@ -251,6 +217,22 @@ describe('AmazonQAdapter', () => {
     it('mentions NEW_RELIC_ACCOUNT_ID', () => {
       expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
     });
+
+    it('documents the real preToolUse/postToolUse hooks field', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions).toContain('preToolUse');
+      expect(instructions).toContain('postToolUse');
+      expect(instructions).toContain('preflight-collector');
+    });
+
+    it('documents the real agent config file location', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('cli-agents');
+    });
+
+    it('discloses the missing session identifier limitation', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions).toContain('no session identifier');
+    });
   });
 
   describe('initialize', () => {
@@ -262,6 +244,14 @@ describe('AmazonQAdapter', () => {
   describe('mapToolName', () => {
     it('maps a known tool name', () => {
       expect(adapter.mapToolName('fs_read')).toBe('Read');
+    });
+
+    it('maps "todo_list" to "TaskCreate"', () => {
+      expect(adapter.mapToolName('todo_list')).toBe('TaskCreate');
+    });
+
+    it('returns "Unknown" for a real Amazon Q tool with no equivalent', () => {
+      expect(adapter.mapToolName('use_aws')).toBe('Unknown');
     });
 
     it('returns "Unknown" for an unrecognized tool name', () => {

--- a/src/platforms/amazon-q-adapter.ts
+++ b/src/platforms/amazon-q-adapter.ts
@@ -5,22 +5,24 @@ import type {
   NormalizedToolCall,
 } from './types.js';
 
+/**
+ * Maps Amazon Q Developer CLI's real built-in tool names
+ * (https://aws.github.io/amazon-q-developer-cli/built-in-tools.html) to the
+ * normalized Claude Code tool vocabulary. Amazon Q CLI has exactly 9
+ * built-in tools; only 4 have a genuine Claude Code equivalent.
+ * `introspect` (CLI self-help), `report_issue` (opens a GitHub issue
+ * template), `knowledge` (cross-session semantic search — a persistent
+ * concept with no one-shot equivalent), `thinking` (internal reasoning, no
+ * observable side effect), and `use_aws` (a structured AWS API call, not a
+ * shell command) are deliberately left unmapped — they fall through to
+ * 'Unknown' via mapToolName()'s `?? 'Unknown'` default, with the raw name
+ * preserved via event-processor.ts's mapToolNameOrOriginal() fallback.
+ */
 const AMAZON_Q_TOOL_MAP: Record<string, string> = {
   fs_read: 'Read',
   fs_write: 'Write',
-  fs_edit: 'Edit',
-  fs_create: 'Write',
-  fs_delete: 'Delete',
-  fs_list: 'Glob',
-  fs_find: 'Glob',
-  grep: 'Grep',
-  search_code: 'Grep',
   execute_bash: 'Bash',
-  run_shell: 'Bash',
-  execute_command: 'Bash',
-  explain_code: 'Read',
-  review_code: 'Read',
-  transform_code: 'Edit',
+  todo_list: 'TaskCreate',
 };
 
 interface AmazonQToolCallEvent {
@@ -43,7 +45,15 @@ export class AmazonQAdapter implements PlatformAdapter {
   readonly platformName = 'amazon-q';
 
   async initialize(_config: PlatformConfig): Promise<void> {
-    // Amazon Q Developer connects via the MCP stdio protocol.
+    // Amazon Q Developer CLI supports MCP as a client (preflight can be
+    // registered as an MCP server for nr_observe_* tools, same as every
+    // other MCP-client platform in this series) and has a genuine hook
+    // mechanism — agentSpawn/userPromptSubmit/preToolUse/postToolUse/stop,
+    // configured per-agent (see getHookInstallInstructions()). Unlike Zed or
+    // Continue, there is no "hooks don't exist" caveat here: once wired,
+    // Amazon Q's preToolUse/postToolUse events are handled by the same
+    // generic branches in collector-script.ts that Claude Code and Kiro use
+    // — its hook_event_name/tool_name/tool_input field names are identical.
   }
 
   normalizeToolCall(raw: unknown): NormalizedToolCall {
@@ -81,7 +91,7 @@ export class AmazonQAdapter implements PlatformAdapter {
 
   getHookInstallInstructions(): string {
     return [
-      'Amazon Q Developer Setup:',
+      'Amazon Q Developer CLI Setup:',
       '1. Open your Amazon Q Developer MCP configuration file',
       '   (typically ~/.aws/amazonq/mcp.json or project-level .amazonq/mcp.json)',
       '2. Add to "mcpServers":',
@@ -95,7 +105,25 @@ export class AmazonQAdapter implements PlatformAdapter {
       '       }',
       '     }',
       '   }',
-      '3. Restart Amazon Q Developer.',
+      '3. Configure Amazon Q CLI hooks so built-in tool calls (fs_read,',
+      '   fs_write, execute_bash, etc.) are captured — edit your agent config',
+      '   file (~/.aws/amazonq/cli-agents/<agent-name>.json for a global',
+      '   agent, or .amazonq/cli-agents/<agent-name>.json for a workspace',
+      '   agent) and add:',
+      '   {',
+      '     "hooks": {',
+      '       "preToolUse": [{ "command": "preflight-collector" }],',
+      '       "postToolUse": [{ "command": "preflight-collector" }]',
+      '     }',
+      '   }',
+      '   See https://aws.github.io/amazon-q-developer-cli/agent-format.html#hooks-field',
+      '   for the full hooks schema.',
+      '4. Restart Amazon Q Developer CLI (or start a new `q chat` session).',
+      '',
+      'Note: Amazon Q hook events carry no session identifier (no session_id',
+      'or equivalent field), unlike Claude Code, Kiro, Cursor, or Windsurf.',
+      'Concurrent Amazon Q sessions on the same machine share a single',
+      'unscoped buffer.',
     ].join('\n');
   }
 


### PR DESCRIPTION
Closes #98

## Summary
- Replaced an invented 15-entry tool-name map (only 3 entries were real) with the confirmed 9-tool built-in vocabulary for Amazon Q Developer CLI, mapping the 4 with genuine Claude Code equivalents (`fs_read`, `fs_write`, `execute_bash`, `todo_list`) and leaving `introspect`, `report_issue`, `knowledge`, `thinking`, and `use_aws` unmapped rather than forced.
- Fixed a cross-platform bug in `collector-script.ts`: `postToolUse` events hardcoded `success: true` instead of reading `tool_response.success`, silently losing real failure signals from Kiro and Amazon Q (both encode tool failure this way, not via a separate failure event). This also corrects Claude Code's own `Edit` tool, which already sets this field on a no-match failure — unifying the top-level `success` signal with the existing `toolOutput.editSuccess` signal.
- Rewrote `getHookInstallInstructions()` to document Amazon Q Developer CLI's real, genuine hook mechanism (`preToolUse`/`postToolUse` via the agent config `hooks` field) instead of only covering MCP server registration.
- Version bump to 1.4.8.

## Test plan
- [x] `npm run build && npm test && npm run lint` — all tests passed, 0 lint errors/warnings
- [x] Verified real tool vocabulary against `https://aws.github.io/amazon-q-developer-cli/built-in-tools.html`
- [x] Verified hook payload shape and `tool_response.success` semantics against `https://github.com/aws/amazon-q-developer-cli/blob/main/docs/hooks.md` and `https://kiro.dev/docs/cli/hooks`
- [x] Confirmed backward compatibility for every existing Claude Code/Kiro/Cursor/Windsurf test fixture in `collector-script.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
