### PR TITLE
Docs: v1.4.9 — adapter documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.9] - 2026-07-10
+
+### Added
+
+- **`docs/ADAPTERS.md`** — canonical per-platform reference covering integration mechanism, detection env vars, tool-name mapping, known gaps, and setup steps for all 8 named platform adapters and the generic MCP fallback. Closes out the adapter-correctness series (v1.4.3–v1.4.8): the real behavior was already fixed in code, but was previously undocumented outside source comments and unit tests.
+
+### Fixed
+
+- **`CONTRIBUTING.md`'s "Platform Support" table was itself incorrect** — it claimed a shared `NEW_RELIC_AI_PLATFORM` env var drove auto-detection for Cursor, Windsurf, Zed, Continue.dev, and Amazon Q; in reality only the Kiro and Copilot adapters read that variable, and the other five each use distinct, undocumented env vars in `isSupported()`. Replaced with an accurate summary that points to `docs/ADAPTERS.md`.
+
+### Changed
+
+- `CLAUDE.md` — added a **Platform Adapter Pattern** section (mirroring the existing Metric Tracker Pattern / MCP Tool Registration sections) describing `PlatformAdapter`/`PlatformRegistry` and cross-referencing `docs/ADAPTERS.md`.
+- `docs/ARCHITECTURE.md` — added `PlatformRegistry` to the Component Reference table; it was missing despite normalizing every hook-sourced tool name since v1.4.3.
+- `README.md` — added `docs/ADAPTERS.md` to the Documentation list and noted under "Works With" that platform coverage isn't uniform (some platforms only observe calls made to Preflight's own MCP tools, not their built-in tools).
+
 ## [1.4.8] - 2026-07-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,12 @@ Each tracker:
 - Exposes a `getMetrics()` method returning a typed snapshot
 - Has a corresponding `*.test.ts` file with factory helpers
 
+## Platform Adapter Pattern
+
+Each adapter in `src/platforms/` implements `PlatformAdapter` (`types.ts`): `normalizeToolCall()`, `mapToolName()`, `getSessionMetadata()`, `getHookInstallInstructions()`, `isSupported()`. `PlatformRegistry.detect()` (`platform-registry.ts`) returns the first registered adapter whose `isSupported()` is `true` — registration order matters, and the generic MCP fallback is always registered last with `isSupported()` hardcoded `true`.
+
+Platform capabilities are not uniform: some platforms (Claude Code, Kiro, Amazon Q) expose real hook events that `src/hooks/collector-script.ts` parses into every built-in tool call; others (Zed, Continue.dev) only support MCP as a client, so Preflight can observe calls made to its own MCP tools but never the platform's built-in file/shell tools. Never invent a tool-name map or setup instructions — every entry must trace to the platform's own documentation or source, cited in a comment. See [ADAPTERS.md](./docs/ADAPTERS.md) for the full per-platform reference (mechanism, detection env vars, tool-map sourcing, known gaps, setup steps).
+
 ## MCP Tool Registration
 
 Tools are registered in `src/tools/session-stats.ts` via `registerTools()`, which receives all tracker instances and calls `server.tool()` for each MCP tool. Each tool handler:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,18 +296,11 @@ See [SECURITY.md](./SECURITY.md) for the full guidelines and code review checkli
 
 ## Platform Support
 
-The MCP server automatically detects and supports multiple AI coding platforms:
+The MCP server registers an adapter per AI coding platform and auto-detects the active one at startup — each adapter's `isSupported()` checks its own platform-specific env vars (most do **not** use a shared `NEW_RELIC_AI_PLATFORM` variable; only the Kiro and Copilot adapters read it).
 
-| Platform           | Setup                                     | Notes                                                  |
-| ------------------ | ----------------------------------------- | ------------------------------------------------------ |
-| **Claude Code**    | Built-in                                  | Default platform; install hook via `preflight install` |
-| **Cursor**         | Env var: `NEW_RELIC_AI_PLATFORM=cursor`   | Auto-detected if Cursor config present                 |
-| **Windsurf**       | Env var: `NEW_RELIC_AI_PLATFORM=windsurf` | Auto-detected if Windsurf config present               |
-| **GitHub Copilot** | Env var: `NEW_RELIC_AI_PLATFORM=copilot`  | Requires manual hook setup                             |
-| **Zed**            | Env var: `NEW_RELIC_AI_PLATFORM=zed`      | Auto-detected from Zed config directory                |
-| **Continue.dev**   | Env var: `NEW_RELIC_AI_PLATFORM=continue` | Auto-detected from Continue config                     |
-| **Amazon Q**       | Env var: `NEW_RELIC_AI_PLATFORM=amazonq`  | Requires AWS IDE plugin setup                          |
-| **Amazon Kiro**    | Env var: `NEW_RELIC_AI_PLATFORM=kiro`     | MCP-native; add server to `.kiro/settings/mcp.json`    |
+Platform capabilities vary: some platforms expose a real hook mechanism that captures every built-in tool call, others only support MCP as a client (so Preflight can only see calls routed to its own MCP tools, not the platform's built-in file/shell tools).
+
+See **[docs/ADAPTERS.md](./docs/ADAPTERS.md)** for the full per-platform reference — integration mechanism, detection env vars, tool-name mapping, known gaps, and setup steps.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Restart your AI tool — hooks and the MCP server load at session start. Every t
 
 **Claude Code** • **Cursor** • **Windsurf** • **GitHub Copilot** • **Zed** • **Continue.dev** • **Amazon Q Developer** • **Amazon Kiro**
 
+Coverage isn't uniform — some platforms capture every built-in tool call, others (Zed, Continue.dev) only see calls routed to Preflight's own MCP tools. See [ADAPTERS.md](docs/ADAPTERS.md) for what each platform can and can't observe, and per-platform setup steps.
+
 ---
 
 ## Connect New Relic (optional)
@@ -178,6 +180,7 @@ Add `--project` to `install`/`uninstall` to scope changes to the current directo
 
 - [**ADVANCED.md**](docs/ADVANCED.md) — Configuration, dashboards, alerts, Terraform
 - [**ARCHITECTURE.md**](docs/ARCHITECTURE.md) — Data flow, component reference, and operating modes
+- [**ADAPTERS.md**](docs/ADAPTERS.md) — Per-platform integration mechanism, setup steps, and known gaps
 - [**CONTRIBUTING.md**](CONTRIBUTING.md) — Development, testing, submitting PRs
 - [**SECURITY.md**](./SECURITY.md) — Security guidelines and best practices
 - [**PRIVACY.md**](./PRIVACY.md) — Data collection inventory and pre-cloud checklist

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,0 +1,267 @@
+# Platform Adapters
+
+Preflight supports 8 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
+
+This doc is the canonical reference for what each adapter can and can't observe, how detection and setup actually work, and where the gaps are. It mirrors `src/platforms/*.ts` and the hook-event handling in `src/hooks/collector-script.ts` — if you change either, update this doc in the same PR.
+
+> **Maintenance note:** every adapter implements `getHookInstallInstructions()`, which returns the setup text reproduced below. That method is not currently called from any CLI command (`preflight doctor --platform <x>` explicitly skips it and tells the user to verify manually) — this document is presently the only place that text is surfaced to a user. If a CLI surface is added later, keep this doc and the adapter methods in sync, or replace the relevant section here with a pointer to the command output.
+
+## Integration mechanisms
+
+| Mechanism                                                                                                      | Platforms                   | What's captured                                                                        |
+| -------------------------------------------------------------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------- |
+| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q | All built-in tool calls                                                                |
+| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf            | All built-in tool calls                                                                |
+| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev           | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools |
+| **HTTP push from an extension**                                                                                | GitHub Copilot              | Whatever the (user-supplied) extension forwards                                        |
+| **Self-report via MCP tools**                                                                                  | Generic MCP fallback        | Whatever the caller reports via `nr_observe_report_tool_call`                          |
+
+Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
+
+---
+
+## Claude Code (`claude-code`)
+
+**Mechanism:** Native `PreToolUse`/`PostToolUse`/`PostToolUseFailure` hooks, installed by Preflight itself.
+
+**Detection (`isSupported()`):** `CLAUDE_CODE` env var set, or `CLAUDE_CODE_VERSION` set, or `MCP_CLIENT === 'claude-code'`.
+
+**Setup:**
+
+1. Run `npx preflight install`
+2. This adds `PreToolUse`/`PostToolUse` hooks to `~/.claude/settings.json`
+3. Restart Claude Code to activate the hooks
+4. Add the MCP server to your `.mcp.json` configuration
+
+**Notes:** The default, first-class platform. Tool names pass through unmapped (`mapToolName()` is identity).
+
+---
+
+## Cursor (`cursor`)
+
+**Mechanism:** Cursor's own hooks system (`.cursor/hooks.json`), a local process protocol unrelated to MCP. Confirmed against Cursor's docs and a Cursor engineer's forum reply ([forum.cursor.com/t/cursor-cli-doesnt-send-all-events-defined-in-hooks/148316](https://forum.cursor.com/t/cursor-cli-doesnt-send-all-events-defined-in-hooks/148316)).
+
+**Detection (`isSupported()`):** `CURSOR_SESSION_ID` set, or `CURSOR_TRACE_ID` set, or `MCP_CLIENT === 'cursor'`.
+
+**Two distinct event vocabularies handled by `collector-script.ts`:**
+
+1. Per-action hook events — `beforeShellExecution`, `afterShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterFileEdit` — carry no generic `tool_name` field; the collector derives the tool name from the event name itself. `CURSOR_TOOL_MAP` is never consulted for these.
+2. Generic `preToolUse`/`postToolUse` events (confirmed to exist, payload only partially documented) — carry `tool_name` as one of `Shell`/`Read`/`Write`/`Task`/`MCP`. `MCP` is deliberately left unmapped (collapsing an arbitrary downstream MCP tool into the literal string "MCP" would discard information); it falls through to `'Unknown'` with the original name preserved.
+
+**Known gaps:** Cursor has no `afterReadFile` event (`beforeReadFile` is emitted as a completed read directly) and no `beforeFileEdit` event (`afterFileEdit` is post-only). `afterShellExecution`/`afterMCPExecution` have no documented failure-outcome field, so success is reported unconditionally `true`.
+
+**Setup:**
+
+1. Register the Preflight MCP server for `nr_observe_*` tools: Cursor Settings → MCP → add server, command `npx preflight --stdio`, env `NEW_RELIC_LICENSE_KEY`, `NEW_RELIC_ACCOUNT_ID`
+2. Configure Cursor hooks so tool-call activity is captured — create `.cursor/hooks.json` (project) or `~/.cursor/hooks.json` (global):
+   ```json
+   {
+     "version": 1,
+     "hooks": {
+       "beforeShellExecution": [{ "command": "preflight-collector" }],
+       "afterShellExecution": [{ "command": "preflight-collector" }],
+       "beforeMCPExecution": [{ "command": "preflight-collector" }],
+       "afterMCPExecution": [{ "command": "preflight-collector" }],
+       "beforeReadFile": [{ "command": "preflight-collector" }],
+       "afterFileEdit": [{ "command": "preflight-collector" }]
+     }
+   }
+   ```
+3. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`)
+4. Restart Cursor
+
+---
+
+## Windsurf (`windsurf`)
+
+**Mechanism:** Windsurf's real Cascade Hooks system (`.windsurf/hooks.json`) — [docs.windsurf.com/windsurf/cascade/hooks](https://docs.windsurf.com/windsurf/cascade/hooks). Not a file watcher or extension API. Windsurf also supports MCP natively via `mcp_config.json`.
+
+**Detection (`isSupported()`):** `WINDSURF_SESSION_ID` set, or `WINDSURF_CONTEXT_ID` set, or `MCP_CLIENT === 'windsurf'`.
+
+**Event vocabulary handled by `collector-script.ts`:** `pre_read_code`, `post_read_code`, `pre_write_code`, `post_write_code`, `pre_run_command`, `post_run_command`. Windsurf sends the event name as `agent_action_name`, not `hook_event_name` — the collector checks both.
+
+**Known gaps:** `post_read_code`/`post_run_command` report success `true` unconditionally, the same gap as Cursor's `afterShellExecution`. `pre_write_code` maps to `'Edit'` (it's typically a partial edit, not a full-file write).
+
+**Setup:**
+
+1. Windsurf Settings → MCP Servers → add server, command `npx preflight --stdio`, env `NEW_RELIC_LICENSE_KEY`, `NEW_RELIC_ACCOUNT_ID`
+2. MCP tool calls via Cascade are captured automatically through the MCP connection
+3. Built-in tool calls (file reads/writes, terminal commands) require Cascade Hooks — create `.windsurf/hooks.json` and register `pre_read_code`, `post_read_code`, `pre_write_code`, `post_write_code`, `pre_run_command`, `post_run_command`, each running `preflight-collector`
+4. See [docs.windsurf.com/windsurf/cascade/hooks](https://docs.windsurf.com/windsurf/cascade/hooks) for the full schema
+
+---
+
+## Zed (`zed`)
+
+**Mechanism:** None for built-in tools. Zed's native agent has no hook/callback mechanism for tool-call interception — confirmed via [zed.dev/docs/ai/mcp.html](https://zed.dev/docs/ai/mcp.html): Zed supports only MCP's Tools and Prompts features, with no notification for host-side tool calls. As a Zed MCP "context server," Preflight can only receive calls Zed's agent makes to Preflight's own exposed tools.
+
+**Detection (`isSupported()`):** `ZED_SESSION_ID` set, or `ZED_EXTENSION_API_VERSION` set, or `MCP_CLIENT === 'zed'`, or `ZED_ITEM_ID` set.
+
+**Tool-map status:** `ZED_TOOL_MAP` (real built-in agent tool names from [zed.dev/docs/ai/tools.html](https://zed.dev/docs/ai/tools.html)) exists for correctness and any future hook capability — it is currently **unreachable**, since no Zed event reaches it. `diagnostics`, `copy_path`, `move_path`, `create_directory` are real Zed tools deliberately left unmapped.
+
+**Workaround:** When Zed runs another already-supported platform (Claude Code, Cursor, etc.) as an [External Agent via the Agent Client Protocol](https://zed.dev/docs/ai/external-agents.html), that agent's own native hooks capture its tool calls independently of Zed.
+
+**Setup:**
+
+1. There is no hook mechanism for tool-call capture in Zed's native agent — Preflight only sees calls made to its own MCP tools.
+2. To use Preflight as an MCP context server (for its own observability tools): Settings → AI → MCP Servers → Add Server:
+   ```json
+   {
+     "context_servers": {
+       "preflight": {
+         "command": "npx",
+         "args": ["preflight", "--stdio"],
+         "env": {
+           "NEW_RELIC_LICENSE_KEY": "<your-key>",
+           "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"
+         }
+       }
+     }
+   }
+   ```
+3. For full tool-call observability, run an already-supported platform as a Zed External Agent instead.
+
+---
+
+## Continue.dev (`continue`)
+
+**Mechanism:** None for built-in tools. Continue's native agent (VS Code/JetBrains extension and CLI) has no `PreToolUse`/`PostToolUse`-style hook mechanism. Continue supports MCP only as a client.
+
+**Detection (`isSupported()`):** `CONTINUE_SESSION_ID` set, or `CONTINUE_SERVER_HOST` set, or `MCP_CLIENT === 'continue'`, or `MCP_CLIENT_NAME === 'continue'`.
+
+**Tool-map status:** `CONTINUE_TOOL_MAP` covers Continue's real built-in tool vocabulary (`read_file`, `edit_existing_file`, `run_terminal_command`, etc.) but, like Zed's map, is currently unreachable via any hook — it exists for the events that _would_ arrive if Continue ever exposed a callback.
+
+**Setup:**
+
+1. Continue cannot observe built-in tool calls the way Claude Code can — only calls Continue routes to its own MCP tools are visible.
+2. Create `.continue/mcpServers/preflight.yaml`:
+   ```yaml
+   name: Preflight mcpServer
+   version: 0.0.1
+   schema: v1
+   mcpServers:
+     - name: preflight
+       command: npx
+       args: ['preflight', '--stdio']
+       env:
+         NEW_RELIC_LICENSE_KEY: <your-key>
+         NEW_RELIC_ACCOUNT_ID: <your-account-id>
+   ```
+3. Reload Continue.
+
+**Note:** the `continuedev/continue` repository is no longer actively maintained and is read-only as of its final 2.0.0 release, so a deeper hook integration is unlikely to land upstream.
+
+---
+
+## Amazon Q Developer CLI (`amazon-q`)
+
+**Mechanism:** A genuine hook mechanism — `agentSpawn`/`userPromptSubmit`/`preToolUse`/`postToolUse`/`stop`, configured per-agent. Once wired, Amazon Q's `preToolUse`/`postToolUse` events are handled by the same generic branches in `collector-script.ts` that Claude Code and Kiro use (identical `hook_event_name`/`tool_name`/`tool_input` field names). Also supports MCP as a client.
+
+**Detection (`isSupported()`):** `AMAZON_Q_SESSION_ID` set, or `Q_DEVELOPER_SESSION` set, or `MCP_CLIENT === 'amazon-q'`, or `AWS_CODEWHISPERER_SESSION` set.
+
+**Tool-map:** Amazon Q CLI has exactly 9 built-in tools; only 4 have a genuine Claude Code equivalent (`fs_read`→Read, `fs_write`→Write, `execute_bash`→Bash, `todo_list`→TaskCreate). `introspect`, `report_issue`, `knowledge`, `thinking`, and `use_aws` are deliberately left unmapped and fall through to `'Unknown'` with the original name preserved.
+
+**Known gap:** Amazon Q hook events carry no session identifier at all (unlike Claude Code, Kiro, Cursor, or Windsurf) — concurrent Amazon Q sessions on the same machine share a single unscoped buffer.
+
+**Setup:**
+
+1. Open your Amazon Q MCP config (`~/.aws/amazonq/mcp.json` or project-level `.amazonq/mcp.json`), add to `mcpServers`:
+   ```json
+   {
+     "preflight": {
+       "command": "npx",
+       "args": ["preflight", "--stdio"],
+       "env": {
+         "NEW_RELIC_LICENSE_KEY": "<your-key>",
+         "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"
+       }
+     }
+   }
+   ```
+2. Configure hooks in your agent config (`~/.aws/amazonq/cli-agents/<agent-name>.json` global, or `.amazonq/cli-agents/<agent-name>.json` workspace):
+   ```json
+   {
+     "hooks": {
+       "preToolUse": [{ "command": "preflight-collector" }],
+       "postToolUse": [{ "command": "preflight-collector" }]
+     }
+   }
+   ```
+   See [aws.github.io/amazon-q-developer-cli/agent-format.html#hooks-field](https://aws.github.io/amazon-q-developer-cli/agent-format.html#hooks-field).
+3. Restart Amazon Q Developer CLI (or start a new `q chat` session).
+
+---
+
+## Amazon Kiro (`kiro`)
+
+**Mechanism:** MCP stdio protocol, plus real hook events — [kiro.dev/docs/cli/hooks](https://kiro.dev/docs/cli/hooks). Kiro sends the hook event name in lower-camelCase (`preToolUse`) rather than Claude Code's PascalCase (`PreToolUse`); `collector-script.ts` matches case-insensitively so both are handled by the same generic branches as Claude Code and Amazon Q.
+
+**Detection (`isSupported()`):** `KIRO_SESSION_ID` set, or `KIRO_IDE` set, or `MCP_CLIENT === 'kiro'`, or `NEW_RELIC_AI_PLATFORM === 'kiro'`.
+
+**Tool-map:** `tool_name` may arrive as either a tool's canonical name (`fs_read`) or a documented alias (`read`) — both forms are covered in `KIRO_TOOL_MAP`. Some entries (`fsRead`, `fsCreate`, etc.) have no confirmed source in Kiro's public docs and are kept as best-effort coverage for IDE-surface tool names — don't remove them without positive evidence they're wrong.
+
+**Setup:**
+
+1. Open your Kiro MCP config (`~/.kiro/settings/mcp.json` user-level, or `.kiro/settings/mcp.json` workspace-level), add to `mcpServers`:
+   ```json
+   {
+     "preflight": {
+       "command": "npx",
+       "args": ["preflight", "--stdio"],
+       "env": {
+         "NEW_RELIC_LICENSE_KEY": "<your-key>",
+         "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"
+       }
+     }
+   }
+   ```
+2. Restart Kiro (or reconnect MCP servers from the Kiro MCP panel).
+
+---
+
+## GitHub Copilot (`copilot`)
+
+**Mechanism:** Copilot does not use MCP natively. Data arrives from a Copilot-compatible VS Code extension via HTTP push to a local Preflight endpoint (`http://localhost:9847`). This adapter only consumes events — it doesn't ship the extension itself.
+
+**Detection (`isSupported()`):** `MCP_CLIENT === 'copilot'`, or `NEW_RELIC_AI_PLATFORM === 'copilot'` (the only adapter besides Kiro that actually reads `NEW_RELIC_AI_PLATFORM`).
+
+**Event vocabulary:** `file_edit`→Edit, `file_open`→Read, `file_create`→Write, `file_delete`→Delete, `terminal_command`→Bash, `task`→Bash.
+
+**Known gap:** tool-call timing is approximate — inferred from VS Code event timestamps, not a precise pre/post pair.
+
+**Setup:**
+
+1. Set `NEW_RELIC_AI_PLATFORM=copilot` in your environment
+2. Set `NEW_RELIC_LICENSE_KEY` and `NEW_RELIC_ACCOUNT_ID`
+3. Configure your Copilot extension to forward events to `http://localhost:9847` (`"preflight.endpoint": "http://localhost:9847"` in VS Code settings)
+
+Unlike every other adapter in this document, Copilot has no first-party extension that forwards tool-call events — Preflight only receives what a third-party or user-authored extension chooses to send to the endpoint above. Treat this integration's fidelity as bounded by that extension, not by this adapter's own code.
+
+---
+
+## Generic MCP fallback (`generic-mcp`)
+
+**Mechanism:** Self-report via MCP tools. Always registered last and always `isSupported() === true` — the catch-all for any MCP-speaking client not otherwise named above.
+
+**Tools exposed:**
+
+- `nr_observe_report_tool_call` — report a non-MCP tool call (file read/write/terminal command) manually
+- `nr_observe_report_session_start` / `nr_observe_report_session_end` — session lifecycle
+
+**Setup:**
+
+1. Add the Preflight MCP server to your client's MCP configuration: `npx preflight --stdio`
+2. Set `NEW_RELIC_LICENSE_KEY`, `NEW_RELIC_ACCOUNT_ID`
+3. MCP tool calls are captured automatically via the proxy
+4. Use `nr_observe_report_tool_call` for non-MCP tool activity
+5. Use `nr_observe_report_session_start` / `nr_observe_report_session_end` for session tracking
+
+---
+
+## Adding a new adapter
+
+1. Implement `PlatformAdapter` (`src/platforms/types.ts`) in a new `src/platforms/<name>-adapter.ts`.
+2. Source the tool-name map from the platform's own documentation — never invent entries. Every existing adapter's tool-map comment cites its source; do the same.
+3. If the platform has a real hook/callback mechanism, add its event vocabulary as new branches in `src/hooks/collector-script.ts` (see Cursor's or Windsurf's branches for the pattern) — don't assume the platform matches Claude Code's `tool_name`/`tool_input` shape.
+4. Register the adapter in `createDefaultRegistry()` (`src/platforms/platform-registry.ts`), before the generic MCP fallback.
+5. Add this platform's section to this document, following the structure above: mechanism, detection env vars, tool-map/event vocabulary, known gaps, setup steps.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,17 +93,18 @@ Proxy mode is a **separate, mutually exclusive** code path. It does not use hook
 
 ## Component Reference
 
-| Component              | File                           | Purpose                                                                                                              |
-| ---------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `collector-script.ts`  | `src/hooks/`                   | Spawned by Claude Code hooks; reads hook JSON from stdin, appends to buffer file. Must complete in < 5 ms.           |
-| `buffer-SESSION.jsonl` | `~/.newrelic-preflight/`       | Ring buffer of raw hook events. Written by collector, drained by `HookEventProcessor`.                               |
-| `HookEventProcessor`   | `src/hooks/event-processor.ts` | Polls buffer every 100 ms. Pairs `PreToolUse` and `PostToolUse` events into `ToolCallRecord` objects.                |
-| Metric trackers (~15)  | `src/metrics/`                 | Each tracker receives every `ToolCallRecord` and maintains a typed metrics snapshot.                                 |
-| `NrIngestManager`      | `src/transport/nr-ingest.ts`   | Wraps `HarvestScheduler`; flushes events (5 s), metrics (60 s), and logs (5 s) to New Relic.                         |
-| MCP tools              | `src/tools/`                   | Registered via `registerTools()`; read tracker state and return it as MCP tool responses. Active in `--stdio` mode.  |
-| Dashboard server       | `src/index.ts`                 | HTTP server on port 7777 serving the local web UI. Active in `--local` mode.                                         |
-| `ProxyManager`         | `src/proxy/proxy-manager.ts`   | HTTP proxy that forwards MCP traffic to upstream servers and intercepts it for telemetry. Active in proxy mode only. |
-| `OtlpReceiver`         | `src/proxy/`                   | Receives enriched OTLP payloads from `ProxyManager` and forwards to New Relic OTLP endpoint.                         |
+| Component              | File                           | Purpose                                                                                                                          |
+| ---------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `collector-script.ts`  | `src/hooks/`                   | Spawned by Claude Code hooks; reads hook JSON from stdin, appends to buffer file. Must complete in < 5 ms.                       |
+| `buffer-SESSION.jsonl` | `~/.newrelic-preflight/`       | Ring buffer of raw hook events. Written by collector, drained by `HookEventProcessor`.                                           |
+| `HookEventProcessor`   | `src/hooks/event-processor.ts` | Polls buffer every 100 ms. Pairs `PreToolUse` and `PostToolUse` events into `ToolCallRecord` objects.                            |
+| `PlatformRegistry`     | `src/platforms/`               | Detects the active AI coding platform and normalizes its tool names to Preflight's vocabulary. See [ADAPTERS.md](./ADAPTERS.md). |
+| Metric trackers (~15)  | `src/metrics/`                 | Each tracker receives every `ToolCallRecord` and maintains a typed metrics snapshot.                                             |
+| `NrIngestManager`      | `src/transport/nr-ingest.ts`   | Wraps `HarvestScheduler`; flushes events (5 s), metrics (60 s), and logs (5 s) to New Relic.                                     |
+| MCP tools              | `src/tools/`                   | Registered via `registerTools()`; read tracker state and return it as MCP tool responses. Active in `--stdio` mode.              |
+| Dashboard server       | `src/index.ts`                 | HTTP server on port 7777 serving the local web UI. Active in `--local` mode.                                                     |
+| `ProxyManager`         | `src/proxy/proxy-manager.ts`   | HTTP proxy that forwards MCP traffic to upstream servers and intercepts it for telemetry. Active in proxy mode only.             |
+| `OtlpReceiver`         | `src/proxy/`                   | Receives enriched OTLP payloads from `ProxyManager` and forwards to New Relic OTLP endpoint.                                     |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
Fixes #102

## Summary
- Adds `docs/ADAPTERS.md`: the canonical per-platform reference (integration mechanism, detection env vars, tool-name mapping, known gaps, setup steps) for all 8 named adapters + the generic MCP fallback.
- Fixes `CONTRIBUTING.md`'s "Platform Support" table, which claimed a shared `NEW_RELIC_AI_PLATFORM` env var drives auto-detection for Cursor, Windsurf, Zed, Continue.dev, and Amazon Q. Only the Kiro and Copilot adapters actually read that variable — the other five each use distinct env vars in `isSupported()`. Replaced with an accurate summary pointing to `docs/ADAPTERS.md`.
- Cross-references `docs/ADAPTERS.md` from `CLAUDE.md` (new "Platform Adapter Pattern" section), `docs/ARCHITECTURE.md` (added `PlatformRegistry` to the Component Reference table), and `README.md`.
- Version bump to v1.4.9 with a CHANGELOG entry.

## Test plan
- [x] `npm install && npm run build` passes
- [x] Full test suite passes (3893 passed, 3 skipped) via pre-push hook
- [x] `npm run lint` / `npm run format:check` pass (pre-commit hook)