### PR TITLE
Fix: v1.4.11 — /dev/stdin EACCES when running Preflight inside WSL via wsl.exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.11] - 2026-07-10
+
+### Fixed
+
+- **`EACCES` reading stdin when Claude Code runs on a Windows host and spawns Preflight inside WSL via `wsl.exe`** — the hook collector read stdin by opening `/dev/stdin`, a symlink to `/proc/self/fd/0`. On Linux that path is a fresh `open()` subject to a permission check, and the stdin pipe crossing the Windows/WSL boundary is created by WSL's root-owned init/relay (`root:root`, mode `0600`), so the re-open failed for a non-root user even though the already-inherited file descriptor was readable. Hook events were silently dropped for every Windows-host/WSL-guest Claude Code setup. The collector now falls back to reading the inherited stdin file descriptor directly when `/dev/stdin` specifically fails with `EACCES`, leaving the existing POSIX and Windows read paths unchanged otherwise. (#99)
+
 ## [1.4.10] - 2026-07-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.10",
+      "version": "1.4.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -1605,5 +1605,39 @@ describe('collector-script', () => {
       readStdinSync();
       expect(calls).toEqual([process.stdin.fd]);
     });
+
+    it('falls back to the inherited stdin fd when /dev/stdin re-open is denied (EACCES)', () => {
+      // Reproduces the WSL boundary case: a Windows-host Claude Code process
+      // spawns this script inside WSL via wsl.exe. The piped stdin's
+      // underlying inode is root-owned, so re-opening /dev/stdin
+      // (-> /proc/self/fd/0) fails permission checks even though the
+      // already-inherited fd 0 is readable.
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      const calls: Array<string | number> = [];
+      _stdinFs.readFileSync = (pathOrFd) => {
+        calls.push(pathOrFd);
+        if (pathOrFd === '/dev/stdin') {
+          const err = new Error("EACCES: permission denied, open '/dev/stdin'");
+          (err as NodeJS.ErrnoException).code = 'EACCES';
+          throw err;
+        }
+        return '{"hook_event_name":"PreToolUse"}';
+      };
+      expect(readStdinSync()).toBe('{"hook_event_name":"PreToolUse"}');
+      expect(calls).toEqual(['/dev/stdin', process.stdin.fd]);
+    });
+
+    it('re-throws non-EACCES /dev/stdin errors without falling back to the fd', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      const calls: Array<string | number> = [];
+      _stdinFs.readFileSync = (pathOrFd) => {
+        calls.push(pathOrFd);
+        const err = new Error("ENOENT: no such file or directory, open '/dev/stdin'");
+        (err as NodeJS.ErrnoException).code = 'ENOENT';
+        throw err;
+      };
+      expect(() => readStdinSync()).toThrow('ENOENT');
+      expect(calls).toEqual(['/dev/stdin']);
+    });
   });
 });

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -1028,11 +1028,30 @@ export const _stdinFs = {
  * threw instead of returning cleanly. package.json's `engines.node` floor
  * (>=22) is well past every Node release carrying that fix; don't lower it
  * without re-checking this. See nodejs/node#35997 and libuv/libuv#3043.
+ *
+ * `/dev/stdin` is a symlink to `/proc/self/fd/0`, so opening it is a fresh
+ * `open()` subject to a permission check against the pipe's current owner —
+ * unlike reading the already-inherited fd 0, which needs no such check. That
+ * distinction is invisible on a normal POSIX host, but surfaces when Claude
+ * Code runs on a Windows host and spawns this script inside WSL via
+ * `wsl.exe`: the piped stdin crossing that boundary is created by WSL's
+ * root-owned init/relay (root:root, mode 0600), so re-opening `/dev/stdin`
+ * fails with EACCES for the non-root user even though fd 0 is readable. Fall
+ * back to the fd only on that specific error so the common case keeps
+ * avoiding the EAGAIN risk above.
  */
 function readStdinSync(): string {
-  return process.platform === 'win32'
-    ? _stdinFs.readFileSync(process.stdin.fd)
-    : _stdinFs.readFileSync('/dev/stdin');
+  if (process.platform === 'win32') {
+    return _stdinFs.readFileSync(process.stdin.fd);
+  }
+  try {
+    return _stdinFs.readFileSync('/dev/stdin');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EACCES') {
+      return _stdinFs.readFileSync(process.stdin.fd);
+    }
+    throw err;
+  }
 }
 
 if (_isDirectExecution) {


### PR DESCRIPTION
## Summary
- Fixes #99. When Claude Code runs on a Windows host and spawns Preflight inside WSL via `wsl.exe`, the piped stdin crossing that boundary is created by WSL's root-owned init/relay (`root:root`, mode `0600`). The hook collector read stdin by opening `/dev/stdin` — a symlink to `/proc/self/fd/0` — which triggers a fresh `open()` subject to a permission check against that root-owned inode, failing with `EACCES` for the non-root user even though the already-inherited stdin file descriptor is readable. Hook events were silently dropped for every such setup.
- The collector now falls back to reading the inherited stdin file descriptor directly only when `/dev/stdin` fails specifically with `EACCES`, leaving the existing POSIX (EAGAIN-avoidant) and Windows read paths unchanged for every other case.
- Version bump to 1.4.11 + CHANGELOG entry.

## Test plan
- [x] New unit tests: fallback on `EACCES`, and non-`EACCES` errors still propagate unchanged (`src/hooks/collector-script.test.ts`)
- [x] Root cause independently verified with a local repro of the underlying Unix permission-check mechanic (an already-open fd bypasses the re-check; a fresh re-open of the same path re-triggers it)
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors/warnings
- [x] `npm test` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)