### PR TITLE
Fix: nr_observe_get_platform_comparison can't differentiate platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.12] - 2026-07-10
+
+### Fixed
+
+- `nr_observe_get_platform_comparison` could never differentiate platforms — `buildSessionSummary()` never set the `platform` field on persisted session summaries, so every session fell into the `'claude-code'` fallback bucket regardless of which of the 9 real platform adapters generated it. The active platform (already detected once per process by `PlatformRegistry`) is now threaded through `HookEventProcessor.activePlatform` into every persisted session summary. Found during the MCP tools audit. Does not address the related `nr_observe_get_collaboration_profile` bug (missing `userMessages`/`assistantMessages`/`userCorrections` data) — that's a separate, larger fix.
+
 ## [1.4.11] - 2026-07-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.11",
+      "version": "1.4.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -730,6 +730,33 @@ describe('HookEventProcessor', () => {
       expect(records[0]!.toolName).toBe('Read');
     });
 
+    it('activePlatform getter reflects the injected platform adapter', () => {
+      const fakeAdapter = {
+        platformName: 'fake',
+        initialize: async () => {},
+        normalizeToolCall: () => {
+          throw new Error('not used by this test');
+        },
+        mapToolName: (name: string) => name,
+        getSessionMetadata: () => ({ platform: 'fake' }),
+        getHookInstallInstructions: () => '',
+        isSupported: () => true,
+      };
+
+      const processor = new HookEventProcessor({ store, onRecord, platformAdapter: fakeAdapter });
+
+      expect(processor.activePlatform).toBe('fake');
+    });
+
+    it('activePlatform getter falls back to the process-detected platform when none is injected', () => {
+      // No platformAdapter option passed — falls back to createDefaultRegistry().getActive(),
+      // which resolves to GenericMcpAdapter (platformName 'generic-mcp') when no platform
+      // env vars are set, same default the tool-name-mapping test above relies on.
+      const processor = new HookEventProcessor({ store, onRecord });
+
+      expect(processor.activePlatform).toBe('generic-mcp');
+    });
+
     it('maps tool names correctly when pairing falls back to findOldestPendingKey (no toolUseId)', () => {
       const fakeAdapter = {
         platformName: 'fake',

--- a/src/hooks/event-processor.ts
+++ b/src/hooks/event-processor.ts
@@ -97,6 +97,15 @@ export class HookEventProcessor {
     };
   }
 
+  /**
+   * The platform name resolved for this process — either the explicitly
+   * injected `platformAdapter`, or the auto-detected default. Resolved
+   * once at construction time; this getter never re-detects.
+   */
+  get activePlatform(): string {
+    return this.platformAdapter.platformName;
+  }
+
   start(): void {
     if (this.running) {
       logger.warn('HookEventProcessor already running');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1471,6 +1471,7 @@ async function main(): Promise<void> {
           efficiencyScorer,
           developer: config.developer ?? 'unknown',
           repoName: currentRepoName,
+          platform: eventProcessor?.activePlatform,
         });
         // Skip persisting the synthetic session JSON written by --local /
         // proxy modes. These IDs (local-<ts>, proxy-<ts>) are MCP-internal

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -545,6 +545,23 @@ describe('buildSessionSummary', () => {
     expect(summary.cacheSavingsUsd).toBe(0.018);
   });
 
+  it('threads the platform field through when provided', () => {
+    const summary = buildSessionSummary({
+      sessionTracker: makeSessionTracker(),
+      developer: 'dev',
+      platform: 'cursor',
+    });
+    expect(summary.platform).toBe('cursor');
+  });
+
+  it('leaves platform undefined when not provided', () => {
+    const summary = buildSessionSummary({
+      sessionTracker: makeSessionTracker(),
+      developer: 'dev',
+    });
+    expect(summary.platform).toBeUndefined();
+  });
+
   it('deserializeFullSessionSummary round-trips cache fields', () => {
     const raw = {
       sessionId: 'sess-abc',

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -252,6 +252,7 @@ export interface BuildSessionSummarySources {
   efficiencyScorer?: EfficiencyScorer;
   developer: string;
   repoName?: string | null;
+  platform?: string;
 }
 
 export function buildSessionSummary(sources: BuildSessionSummarySources): FullSessionSummary {
@@ -379,6 +380,7 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     assistantMessages: 0,
     userCorrections: 0,
     outcome: 'completed',
+    platform: sources.platform,
     timeline: timeline.length > 0 ? timeline : undefined,
   };
 }


### PR DESCRIPTION
Closes #107

## Summary
- `nr_observe_get_platform_comparison` could never differentiate platforms — `buildSessionSummary()` never set the `platform` field on persisted session summaries, so every session fell into the `'claude-code'` fallback bucket regardless of which of the 9 real platform adapters generated it.
- The active platform is detected exactly once per process by `PlatformRegistry` (already happening, just never exposed). This threads that already-known value through: `HookEventProcessor.activePlatform` (new public getter) → `BuildSessionSummarySources.platform` (new optional field) → `FullSessionSummary.platform` (already-existing field, now populated) → `nr_observe_get_platform_comparison`'s grouping logic (already reads it, unchanged).
- No consumer-side changes needed. Found during an audit of every registered MCP tool's documented contract vs. its actual implementation.
- Does **not** fix `nr_observe_get_collaboration_profile` — that needs `userMessages`/`assistantMessages`/`userCorrections` data via new transcript-parsing logic, a separate, larger fix with its own design (deferred).
- Version bump 1.4.11 → 1.4.12 + CHANGELOG entry.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 3899 passed, 3 skipped (pre-existing, unrelated); 4 new tests
- [x] Diff scoped to exactly the 8 files this fix touches — no unrelated changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)