### PR TITLE
Fix: v1.4.14 — path.relative() containment check for CodeQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.14] - 2026-07-10
+
+### Fixed
+
+- **v1.4.13's path-containment fix did not actually clear the CodeQL `js/path-injection` findings it targeted** — that release replaced a runtime-derived separator check with two hardcoded literal checks combined with `||`, but that combination is never recognized by CodeQL as a sanitizer, regardless of whether the literals are hardcoded or the check is inlined. Confirmed by pushing several candidate shapes directly to a disposable test repository and inspecting the actual scan result rather than relying on pull-request-level checks (which don't reliably reflect whether a pre-existing finding was resolved). `isWithinRoot()`'s containment check is now `path.relative()`-based, inlined directly at the point of use, which is the shape confirmed to satisfy CodeQL's sanitizer recognition. Windows correctness is now handled by Node's own platform-aware `path.relative()`/`path.isAbsolute()` rather than hand-rolled separator matching.
+
 ## [1.4.13] - 2026-07-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.13",
+      "version": "1.4.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/static-handler.test.ts
+++ b/src/dashboard/routes/static-handler.test.ts
@@ -146,6 +146,15 @@ describe('static-handler', () => {
     expect(status()).toBe(403);
   });
 
+  it('rejects an empty/double-slash path with 403', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'static-'));
+    writeFileSync(join(dir, 'index.html'), '<!doctype html>');
+    const handler = createStaticHandler(dir);
+    const { req, res, status } = makeReqRes('//');
+    await handler(req, res);
+    expect(status()).toBe(403);
+  });
+
   // Regression guard: vite.config.ts must use base:'/' so the built
   // index.html references assets via absolute paths. With base:'./', a
   // direct refresh on /sessions resolves relative './assets/x.js' against

--- a/src/dashboard/routes/static-handler.ts
+++ b/src/dashboard/routes/static-handler.ts
@@ -1,5 +1,5 @@
 import { readFile, stat } from 'node:fs/promises';
-import { extname, join, resolve, sep } from 'node:path';
+import { extname, join, relative, isAbsolute, resolve, sep } from 'node:path';
 import { IncomingMessage, ServerResponse } from 'node:http';
 
 const MIME: Record<string, string> = {
@@ -22,24 +22,6 @@ const MIME: Record<string, string> = {
   '.avif': 'image/avif',
   '.txt': 'text/plain; charset=utf-8',
 };
-
-/**
- * True if `target` resolves to a path inside `root`. Both branches are
- * literal string checks ('/' and '\\') and must stay that way — never
- * replace either with a `path.sep`-derived value.
- *
- * Dropping the backslash branch breaks static asset serving on Windows,
- * where resolve()/join() produce backslash-joined paths that a '/'-only
- * check never matches. Making either branch non-literal (e.g. concatenating
- * a runtime `sep` variable instead of a quoted character) breaks static
- * analysis: CodeQL cannot statically prove that a runtime separator value
- * equals '/', so it stops recognising this as the standard
- * path-containment sanitizer pattern and flags the file reads below as
- * path injection.
- */
-export function isWithinRoot(root: string, target: string): boolean {
-  return target.startsWith(root + '/') || target.startsWith(root + '\\');
-}
 
 async function serveIndexFallback(root: string, res: ServerResponse): Promise<void> {
   try {
@@ -69,17 +51,31 @@ export function createStaticHandler(
     const reqPath = url.split('?')[0] ?? '/';
     const filename = reqPath === '/' ? 'index.html' : reqPath.replace(/^\/+/, '');
 
-    // Reject null bytes and explicit traversal components before path resolution.
-    // resolve() would eliminate these too, but the explicit check here makes the
-    // sanitization visible to static analysis (CodeQL js/path-injection).
-    if (filename.includes('\0') || filename.split('/').some((c) => c === '..')) {
+    // Reject an empty filename, null bytes, and explicit traversal
+    // components before path resolution. resolve() would eliminate '..'
+    // segments too, but the explicit check here makes the sanitization
+    // visible to static analysis (CodeQL js/path-injection), and rejecting
+    // an empty filename here — rather than letting it fall through to a
+    // directory stat() — keeps a malformed URL like `//` returning 403,
+    // not 404.
+    if (filename === '' || filename.includes('\0') || filename.split('/').some((c) => c === '..')) {
       res.writeHead(403);
       res.end();
       return;
     }
 
     const target = resolve(join(root, filename));
-    if (!isWithinRoot(root, target)) {
+    // path.relative() plus this escape check is the containment pattern
+    // CodeQL recognises as a path-injection sanitizer for the reads below.
+    // An `||` of two startsWith() checks (the previous approach, needed to
+    // handle both '/' and '\\') is never recognised — inlined or not — and
+    // a single-branch check can't cover Windows. This must stay inlined
+    // here, not delegated to a helper function: routing the identical
+    // check through a separate function also breaks CodeQL's recognition
+    // of it. Both of these were confirmed by pushing each shape to a real
+    // CodeQL-scanned branch and checking the analysis result directly.
+    const rel = relative(root, target);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
       res.writeHead(403);
       res.end();
       return;

--- a/src/dashboard/routes/static-handler.windows-sep.test.ts
+++ b/src/dashboard/routes/static-handler.windows-sep.test.ts
@@ -1,24 +1,20 @@
-import { isWithinRoot } from './static-handler.js';
+import { win32 } from 'node:path';
 
-// static-handler.ts resolves paths with node:path's `resolve`/`join`, which on
-// Windows produce backslash-joined paths — a '/'-only containment check
-// never matches them. isWithinRoot() checks both literal separators
-// unconditionally, so these Windows-path cases are exercised deterministically
-// regardless of the OS actually running this test.
-describe('isWithinRoot — Windows separator', () => {
-  it('accepts a child path joined with backslashes', () => {
-    expect(isWithinRoot('C:\\Users\\dev\\dist', 'C:\\Users\\dev\\dist\\index.html')).toBe(true);
+// static-handler.ts's containment check now delegates entirely to
+// path.relative()/path.isAbsolute() rather than hand-rolled separator
+// matching, so there's no callable function of ours left to unit-test in
+// isolation for the Windows case. This pins Node's own path.win32 behavior
+// for the exact inputs that check relies on, so a future Node behavior
+// change here would be caught rather than silently relied upon.
+describe('path.win32 containment behavior (pins Node, not our code)', () => {
+  it('produces a plain relative path for a child of root', () => {
+    const rel = win32.relative('C:\\Users\\dev\\dist', 'C:\\Users\\dev\\dist\\index.html');
+    expect(rel.startsWith('..')).toBe(false);
+    expect(win32.isAbsolute(rel)).toBe(false);
   });
 
-  it('rejects a sibling path that merely shares a prefix', () => {
-    expect(isWithinRoot('C:\\Users\\dev\\dist', 'C:\\Users\\dev\\dist-evil\\secret')).toBe(false);
-  });
-
-  it('still accepts POSIX-style child paths using the default separator', () => {
-    expect(isWithinRoot('/app/dist', '/app/dist/index.html')).toBe(true);
-  });
-
-  it('still rejects POSIX-style sibling paths using the default separator', () => {
-    expect(isWithinRoot('/app/dist', '/app/dist-evil/secret')).toBe(false);
+  it('produces a parent-escaping relative path for a sibling that merely shares a prefix', () => {
+    const rel = win32.relative('C:\\Users\\dev\\dist', 'C:\\Users\\dev\\dist-evil\\secret');
+    expect(rel.startsWith('..')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- v1.4.13's fix (two hardcoded literal separator checks OR'd together) did
  not actually clear CodeQL's `js/path-injection` findings despite passing
  every check available at merge time.
- Root cause: CodeQL never recognizes an `||` of two `startsWith()` calls
  as a sanitizer, regardless of whether the literals are hardcoded or the
  check is inlined. It does recognize a `path.relative()`-based
  containment check, but only when inlined directly at the point of use.
- `isWithinRoot()` is now deleted; the containment check is inlined
  directly using `path.relative()`/`path.isAbsolute()`. Windows
  correctness is now handled by Node's own platform-aware path module
  rather than hand-rolled separator matching.
- Preserves the exact current 403 for an empty/double-slash request path.
- Confirmed clean against a real push-triggered CodeQL analysis on a
  disposable scratch repo before this PR was opened.

Fixes #110

## Test plan

- [x] `npm run build && npm test && npm run lint` — all pass
- [x] New `path.win32`-behavior-pinning test replaces the old
  `isWithinRoot()` unit tests
- [x] New end-to-end test for the empty/double-slash edge case
- [x] Confirmed clean against a real push-triggered CodeQL analysis before
  opening this PR