### PR TITLE
Fix: nr_observe_report_feedback never emitted ai.feedback.count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.15] - 2026-07-10
+
+### Fixed
+
+- `nr_observe_report_feedback` recorded user quality feedback but never emitted it — `FeedbackCollector.emitMetrics()` was never called from the harvest flush, so `ai.feedback.count` never reached New Relic. Fixed by wiring `emitMetrics()` into the harvest flush alongside the existing `costTracker`/`efficiencyScorer` metrics. Also fixed a latent double-counting bug found while wiring this in: `emitMetrics()` had no cursor, so calling it on every harvest flush (as this fix now does) would have re-emitted every historical feedback record on every subsequent flush; it now tracks a `lastEmittedIndex` cursor, mirroring `EfficiencyScorer`'s existing pattern. Found during the MCP tools audit. Does not implement an actual correlation between feedback and efficiency scores — that remains a separate, larger fix.
+
 ## [1.4.14] - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `nr_observe_report_feedback` recorded user quality feedback but never emitted it — `FeedbackCollector.emitMetrics()` was never called from the harvest flush, so `ai.feedback.count` never reached New Relic. Fixed by wiring `emitMetrics()` into the harvest flush alongside the existing `costTracker`/`efficiencyScorer` metrics. Also fixed a latent double-counting bug found while wiring this in: `emitMetrics()` had no cursor, so calling it on every harvest flush (as this fix now does) would have re-emitted every historical feedback record on every subsequent flush; it now tracks a `lastEmittedIndex` cursor, mirroring `EfficiencyScorer`'s existing pattern. Found during the MCP tools audit. Does not implement an actual correlation between feedback and efficiency scores — that remains a separate, larger fix.
+- `nr_observe_report_feedback` recorded user quality feedback but never emitted it — `FeedbackCollector.emitMetrics()` was never called from the harvest flush, so `ai.feedback.count` never reached New Relic. Fixed by wiring `emitMetrics()` into the harvest flush alongside the existing `costTracker`/`efficiencyScorer` metrics. Also fixed a latent double-counting bug found while wiring this in: `emitMetrics()` had no cursor, so calling it on every harvest flush (as this fix now does) would have re-emitted every historical feedback record on every subsequent flush; it now tracks a `lastEmittedIndex` cursor, mirroring `EfficiencyScorer`'s existing pattern. Does not implement an actual correlation between feedback and efficiency scores — that remains a separate, larger fix.
 
 ## [1.4.14] - 2026-07-10
 
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `nr_observe_get_platform_comparison` could never differentiate platforms — `buildSessionSummary()` never set the `platform` field on persisted session summaries, so every session fell into the `'claude-code'` fallback bucket regardless of which of the 9 real platform adapters generated it. The active platform (already detected once per process by `PlatformRegistry`) is now threaded through `HookEventProcessor.activePlatform` into every persisted session summary. Found during the MCP tools audit. Does not address the related `nr_observe_get_collaboration_profile` bug (missing `userMessages`/`assistantMessages`/`userCorrections` data) — that's a separate, larger fix.
+- `nr_observe_get_platform_comparison` could never differentiate platforms — `buildSessionSummary()` never set the `platform` field on persisted session summaries, so every session fell into the `'claude-code'` fallback bucket regardless of which of the 9 real platform adapters generated it. The active platform (already detected once per process by `PlatformRegistry`) is now threaded through `HookEventProcessor.activePlatform` into every persisted session summary. Does not address the related `nr_observe_get_collaboration_profile` bug (missing `userMessages`/`assistantMessages`/`userCorrections` data) — that's a separate, larger fix.
 
 ## [1.4.11] - 2026-07-10
 
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `CLAUDE.md`'s MCP Tools list and `docs/COMMANDS_TABLE.md` were missing 5 fully-implemented, registered MCP tools: `nr_observe_get_config`, `nr_observe_get_cost_per_tool`, `nr_observe_get_turn_analysis`, and `nr_observe_get_git_efficiency` (all present in `COMMANDS_TABLE.md` but absent from `CLAUDE.md`'s summary list), and `nr_observe_get_context_tracking` (missing from both docs, and even from `analytics-tools.ts`'s own header comment). All 5 are now documented in both files. Found during an audit of every registered MCP tool's documented contract vs. its actual implementation.
+- `CLAUDE.md`'s MCP Tools list and `docs/COMMANDS_TABLE.md` were missing 5 fully-implemented, registered MCP tools: `nr_observe_get_config`, `nr_observe_get_cost_per_tool`, `nr_observe_get_turn_analysis`, and `nr_observe_get_git_efficiency` (all present in `COMMANDS_TABLE.md` but absent from `CLAUDE.md`'s summary list), and `nr_observe_get_context_tracking` (missing from both docs, and even from `analytics-tools.ts`'s own header comment). All 5 are now documented in both files.
 
 ## [1.4.9] - 2026-07-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.14",
+      "version": "1.4.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1167,6 +1167,7 @@ async function main(): Promise<void> {
         metricHarvestIntervalMs: config.harvestIntervalMs.metrics,
         costTracker,
         efficiencyScorer,
+        feedbackCollector,
         turnCostAttributor,
         sessionTraceId,
       });
@@ -1589,6 +1590,7 @@ async function main(): Promise<void> {
                 metricHarvestIntervalMs: config!.harvestIntervalMs.metrics,
                 costTracker,
                 efficiencyScorer,
+                feedbackCollector,
                 turnCostAttributor,
                 sessionTraceId: realId,
               });

--- a/src/tools/workflow-tools.test.ts
+++ b/src/tools/workflow-tools.test.ts
@@ -634,6 +634,40 @@ describe('FeedbackCollector.emitMetrics()', () => {
     });
     expect(recorded[1]).toEqual({ name: 'ai.feedback.count', value: 1, attrs: { quality: 'bad' } });
   });
+
+  it('does not re-emit records already emitted on a previous call', () => {
+    const collector = new FeedbackCollector();
+    collector.record({ quality: 'good' });
+
+    const agg1 = { record: jest.fn() } as unknown as import('../shared/index.js').MetricAggregator;
+    collector.emitMetrics(agg1);
+    expect(agg1.record).toHaveBeenCalledTimes(1);
+
+    const agg2 = { record: jest.fn() } as unknown as import('../shared/index.js').MetricAggregator;
+    collector.emitMetrics(agg2);
+    expect(agg2.record).not.toHaveBeenCalled();
+  });
+
+  it('emits only the new record when called again after another record() call', () => {
+    const collector = new FeedbackCollector();
+    collector.record({ quality: 'good' });
+
+    const agg1 = { record: jest.fn() } as unknown as import('../shared/index.js').MetricAggregator;
+    collector.emitMetrics(agg1);
+
+    collector.record({ quality: 'bad' });
+
+    const recorded2: Array<{ attrs: Record<string, string | number> }> = [];
+    const agg2 = {
+      record(_name: string, _value: number, attrs: Record<string, string | number> = {}) {
+        recorded2.push({ attrs });
+      },
+    } as unknown as import('../shared/index.js').MetricAggregator;
+    collector.emitMetrics(agg2);
+
+    expect(recorded2).toHaveLength(1);
+    expect(recorded2[0]!.attrs).toEqual({ quality: 'bad' });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -30,6 +30,7 @@ export interface FeedbackRecord {
 
 export class FeedbackCollector {
   private records: FeedbackRecord[] = [];
+  private lastEmittedIndex = 0;
 
   record(feedback: Omit<FeedbackRecord, 'timestamp'>): FeedbackRecord {
     const entry: FeedbackRecord = { ...feedback, timestamp: Date.now() };
@@ -42,13 +43,16 @@ export class FeedbackCollector {
   }
 
   emitMetrics(aggregator: MetricAggregator): void {
-    for (const record of this.records) {
+    for (let i = this.lastEmittedIndex; i < this.records.length; i++) {
+      const record = this.records[i]!;
       aggregator.record('ai.feedback.count', 1, { quality: record.quality });
     }
+    this.lastEmittedIndex = this.records.length;
   }
 
   reset(): void {
     this.records = [];
+    this.lastEmittedIndex = 0;
   }
 }
 

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -13,6 +13,7 @@ import type { ProxyToolCallRecord } from '../proxy/types.js';
 import type { AiCodingTask } from '../metrics/task-detector.js';
 import type { AntiPattern } from '../metrics/anti-patterns.js';
 import { SessionTracker } from '../metrics/session-tracker.js';
+import { FeedbackCollector } from '../tools/workflow-tools.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -427,6 +428,24 @@ describe('NrIngestManager', () => {
       expect(metricNames).toContain('ai.session.duration_ms');
       expect(metricNames).toContain('ai.session.unique_files_read');
       expect(metricNames).toContain('ai.session.unique_files_written');
+    });
+
+    it('emits ai.feedback.count on stop when a feedbackCollector is provided', async () => {
+      const sessionTracker = new SessionTracker('feedback-session');
+      const feedbackCollector = new FeedbackCollector();
+      feedbackCollector.record({ quality: 'good' });
+
+      const manager = new NrIngestManager(makeIngestOptions({ sessionTracker, feedbackCollector }));
+
+      manager.start();
+      await manager.stop();
+
+      expect(mockSendMetrics).toHaveBeenCalled();
+      const sentMetrics = (mockSendMetrics.mock.calls[0] as unknown[])[0] as Array<
+        Record<string, unknown>
+      >;
+      const feedbackMetrics = sentMetrics.filter((m) => m.name === 'ai.feedback.count');
+      expect(feedbackMetrics).toHaveLength(1);
     });
 
     it('emitSessionGauges is a no-op after stop()', async () => {

--- a/src/transport/nr-ingest.ts
+++ b/src/transport/nr-ingest.ts
@@ -30,6 +30,7 @@ import type { AntiPattern } from '../metrics/anti-patterns.js';
 import type { SessionTracker } from '../metrics/session-tracker.js';
 import type { CostTracker } from '../metrics/cost-tracker.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
+import type { FeedbackCollector } from '../tools/workflow-tools.js';
 import type { BudgetThresholdEvent } from '../metrics/budget-tracker.js';
 import type { ContextTurnSnapshot, ToolContextContribution } from '../metrics/context-tracker.js';
 import { ProxyMetricsTracker } from '../metrics/proxy-metrics.js';
@@ -97,6 +98,8 @@ export interface NrIngestOptions {
   costTracker?: CostTracker;
   /** Efficiency scorer for emitting ai.efficiency.* metrics. */
   efficiencyScorer?: EfficiencyScorer;
+  /** Feedback collector for emitting ai.feedback.count metrics. */
+  feedbackCollector?: FeedbackCollector;
   teamId?: string | null;
   projectId?: string | null;
   orgId?: string | null;
@@ -430,6 +433,7 @@ export class NrIngestManager {
   private readonly proxyMetrics: ProxyMetricsTracker;
   private readonly costTracker?: CostTracker;
   private readonly efficiencyScorer?: EfficiencyScorer;
+  private readonly feedbackCollector?: FeedbackCollector;
   readonly auditTrail: AuditTrailManager;
   private readonly developer: string;
   private readonly appName: string;
@@ -455,6 +459,7 @@ export class NrIngestManager {
     this.proxyMetrics = new ProxyMetricsTracker();
     this.costTracker = options.costTracker;
     this.efficiencyScorer = options.efficiencyScorer;
+    this.feedbackCollector = options.feedbackCollector;
     this.turnCostAttributor = options.turnCostAttributor;
     this.auditTrail =
       options.auditTrail ??
@@ -800,7 +805,7 @@ export class NrIngestManager {
 
     // Emit cost and efficiency metrics with developer dimension so Team View
     // FACET developer queries return per-developer breakdowns.
-    if (this.costTracker || this.efficiencyScorer) {
+    if (this.costTracker || this.efficiencyScorer || this.feedbackCollector) {
       const developer = this.developer;
       const scheduler = this.scheduler;
       const devAggregator = new MetricAggregator();
@@ -823,6 +828,7 @@ export class NrIngestManager {
       };
       this.costTracker?.emitMetrics(devAggregator);
       this.efficiencyScorer?.emitMetrics(devAggregator);
+      this.feedbackCollector?.emitMetrics(devAggregator);
     }
 
     // Emit aggregated proxy metrics


### PR DESCRIPTION
Closes #114

## Summary
- `nr_observe_report_feedback` recorded user quality feedback correctly, but nothing ever read the records back or emitted them — `FeedbackCollector.emitMetrics()` was never called from the harvest flush, so `ai.feedback.count` never reached New Relic.
- Fixed by wiring `emitMetrics()` into the harvest flush alongside the existing `costTracker`/`efficiencyScorer` metrics.
- **Also fixed a latent bug found during design:** `emitMetrics()` had no cursor, so calling it on every harvest flush (as this fix now does) would have re-emitted every historical feedback record on every subsequent flush, inflating the count. It now tracks a `lastEmittedIndex` cursor, mirroring `EfficiencyScorer`'s existing pattern.
- Does **not** implement an actual correlation between feedback and efficiency scores/`task_id` — that's a separate, larger fix, deferred. Tool description kept as-is per explicit decision.
- Found during the MCP tools audit.
- Version bump 1.4.14 → 1.4.15 + CHANGELOG entry.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 3901 passed, 3 skipped (pre-existing, unrelated); 3 new tests
- [x] Diff scoped to exactly the 8 files this fix touches

🤖 Generated with [Claude Code](https://claude.com/claude-code)