### PR TITLE
Fix: nr_observe_get_instruction_drift always reports empty data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.16] - 2026-07-10
+
+### Fixed
+
+- `nr_observe_get_instruction_drift` always reported an empty dataset — `InstructionDriftTracker.recordSessionOutcome()` and `.loadRecords()` had zero call sites in production. Fixing this required cross-session persistence, not just in-process wiring: each MCP server process is scoped to one Claude Code session, so recording an outcome right before shutdown alone would be lost immediately and never enable the cross-session correlation the tool exists to provide. The session's prompt hash is now persisted on the saved session summary, the last 7 days of prior sessions are reloaded into the tracker at startup, and the current session's own outcome is recorded at shutdown. Note: correlation is currently keyed on the hash of the `Read` tool's arguments (file path/offset/limit), not the file's content, so this detects read/path drift rather than CLAUDE.md content changes — hashing actual content remains a separate, larger fix.
+
 ## [1.4.15] - 2026-07-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.15",
+      "version": "1.4.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,11 @@ import { loadMcpConfig, DEFAULT_STORAGE_PATH } from './config.js';
 import type { McpServerConfig } from './config.js';
 import { ProxyManager } from './proxy/index.js';
 import { LocalStore } from './storage/index.js';
-import { SessionStore, buildSessionSummary } from './storage/session-store.js';
+import {
+  SessionStore,
+  buildSessionSummary,
+  sessionSummaryToDriftRecord,
+} from './storage/session-store.js';
 import { WeeklySummaryGenerator } from './storage/weekly-summary.js';
 import { HookEventProcessor } from './hooks/index.js';
 import { SessionTracker } from './metrics/session-tracker.js';
@@ -38,6 +42,7 @@ import { ContextTrackerRegistry } from './metrics/context-tracker.js';
 import { LatencyDecompositionTracker } from './metrics/latency-decomposition.js';
 import { DecisionTracker } from './metrics/decision-tracker.js';
 import { InstructionDriftTracker } from './metrics/instruction-drift-tracker.js';
+import type { SessionOutcomeRecord } from './metrics/instruction-drift-tracker.js';
 import { ToolSelectionScorer } from './metrics/tool-selection-scorer.js';
 import { QualityProxyTracker } from './metrics/quality-proxy-tracker.js';
 import { ApiFailureTracker } from './metrics/api-failure-tracker.js';
@@ -781,6 +786,21 @@ async function main(): Promise<void> {
       }
     }
 
+    // Hydrate instruction-drift tracker with the last 7 days of prior
+    // sessions so cross-session prompt-variant correlation has real data
+    // from the moment this session starts (mirrors computeHistoricalCosts'
+    // weekAgo window below). Sessions persisted before this field existed
+    // have instructionPromptHash === null and are naturally excluded.
+    const weekAgoForDrift = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const historicalDriftSessions = sessionStore.loadAllSessions({ since: weekAgoForDrift });
+    const driftRecords: SessionOutcomeRecord[] = [];
+    for (const session of historicalDriftSessions) {
+      if (session.sessionId === currentSessionId) continue;
+      const record = sessionSummaryToDriftRecord(session);
+      if (record) driftRecords.push(record);
+    }
+    instructionDriftTracker.loadRecords(driftRecords);
+
     // Also hydrate from git log — commit commands often aren't captured by
     // tool hooks (Claude Code commits internally), so we read the actual
     // repo history to get an accurate commit count for today.
@@ -1473,7 +1493,12 @@ async function main(): Promise<void> {
           developer: config.developer ?? 'unknown',
           repoName: currentRepoName,
           platform: eventProcessor?.activePlatform,
+          instructionPromptHash: instructionDriftTracker.promptHash,
         });
+        const driftRecord = sessionSummaryToDriftRecord(summary);
+        if (driftRecord) {
+          instructionDriftTracker.recordSessionOutcome(driftRecord);
+        }
         // Skip persisting the synthetic session JSON written by --local /
         // proxy modes. These IDs (local-<ts>, proxy-<ts>) are MCP-internal
         // bookkeeping; they don't correspond to a real Claude Code session

--- a/src/metrics/instruction-drift-tracker.test.ts
+++ b/src/metrics/instruction-drift-tracker.test.ts
@@ -245,4 +245,15 @@ describe('InstructionDriftTracker', () => {
     expect(metrics.currentPromptHash).toBeNull();
     expect(metrics.uniquePromptVariants).toBe(0);
   });
+
+  it('promptHash getter reflects the current prompt hash', () => {
+    const tracker = new InstructionDriftTracker();
+    expect(tracker.promptHash).toBeNull();
+
+    tracker.setPromptHash('abc123');
+    expect(tracker.promptHash).toBe('abc123');
+
+    tracker.setPromptHash('def456');
+    expect(tracker.promptHash).toBe('def456');
+  });
 });

--- a/src/metrics/instruction-drift-tracker.ts
+++ b/src/metrics/instruction-drift-tracker.ts
@@ -77,6 +77,10 @@ export class InstructionDriftTracker {
     this.minSessionsForComparison = options?.minSessionsForComparison ?? DEFAULT_MIN_SESSIONS;
   }
 
+  get promptHash(): string | null {
+    return this.currentPromptHash;
+  }
+
   recordToolCall(record: ToolCallRecord): void {
     if (record.toolName !== 'Read') return;
 

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -6,6 +6,7 @@ import {
   SessionStore,
   buildSessionSummary,
   deserializeFullSessionSummary,
+  sessionSummaryToDriftRecord,
 } from './session-store.js';
 import type { FullSessionSummary } from './session-store.js';
 import type { SessionTracker } from '../metrics/session-tracker.js';
@@ -13,6 +14,7 @@ import { CostTracker } from '../metrics/cost-tracker.js';
 import type { CostMetrics } from '../metrics/cost-tracker.js';
 import type { TaskDetector } from '../metrics/task-detector.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
+import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -76,6 +78,107 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     ...overrides,
   };
 }
+
+describe('instructionPromptHash field', () => {
+  it('buildSessionSummary sets instructionPromptHash from sources', () => {
+    const sessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'sess-1',
+        sessionName: null,
+        sessionStartTime: Date.now(),
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        bashCommandsRun: 0,
+        toolSuccessRate: null,
+      }),
+    } as unknown as SessionTracker;
+
+    const summary = buildSessionSummary({
+      sessionTracker,
+      developer: 'dev1',
+      instructionPromptHash: 'hash-abc',
+    });
+
+    expect(summary.instructionPromptHash).toBe('hash-abc');
+  });
+
+  it('buildSessionSummary defaults instructionPromptHash to null when not provided', () => {
+    const sessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'sess-2',
+        sessionName: null,
+        sessionStartTime: Date.now(),
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        bashCommandsRun: 0,
+        toolSuccessRate: null,
+      }),
+    } as unknown as SessionTracker;
+
+    const summary = buildSessionSummary({ sessionTracker, developer: 'dev1' });
+
+    expect(summary.instructionPromptHash).toBeNull();
+  });
+
+  it('deserializeFullSessionSummary round-trips instructionPromptHash', () => {
+    const summary = makeSummary({ instructionPromptHash: 'hash-xyz' });
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(JSON.stringify(summary)) as Record<string, unknown>,
+    );
+    expect(roundTripped.instructionPromptHash).toBe('hash-xyz');
+  });
+
+  it('deserializeFullSessionSummary defaults instructionPromptHash to null when field is missing (pre-fix session files)', () => {
+    const summary = makeSummary();
+    const raw = JSON.parse(JSON.stringify(summary)) as Record<string, unknown>;
+    delete raw.instructionPromptHash;
+    const roundTripped = deserializeFullSessionSummary(raw);
+    expect(roundTripped.instructionPromptHash).toBeNull();
+  });
+});
+
+describe('sessionSummaryToDriftRecord', () => {
+  it('returns null when instructionPromptHash is null', () => {
+    const summary = makeSummary({ instructionPromptHash: null });
+    expect(sessionSummaryToDriftRecord(summary)).toBeNull();
+  });
+
+  it('maps a summary with a prompt hash into a SessionOutcomeRecord', () => {
+    const summary = makeSummary({
+      sessionId: 'sess-3',
+      instructionPromptHash: 'hash-123',
+      endTime: 1_700_000_000_000,
+      taskSuccessRate: 0.8,
+      tokensInput: 1000,
+      tokensOutput: 500,
+      taskCount: 4,
+      efficiencyScore: 0.9,
+      antiPatterns: [{ type: 'thrashing', count: 3 }],
+    });
+
+    const record = sessionSummaryToDriftRecord(summary) as SessionOutcomeRecord;
+
+    expect(record).not.toBeNull();
+    expect(record.sessionId).toBe('sess-3');
+    expect(record.promptHash).toBe('hash-123');
+    expect(record.timestamp).toBe(1_700_000_000_000);
+    expect(record.successRate).toBe(0.8);
+    expect(record.totalTokens).toBe(1500);
+    expect(record.thrashingIncidents).toBe(3);
+    expect(record.taskCount).toBe(4);
+    expect(record.avgEfficiency).toBe(0.9);
+  });
+
+  it('defaults thrashingIncidents to 0 when no thrashing anti-pattern is present', () => {
+    const summary = makeSummary({
+      instructionPromptHash: 'hash-456',
+      antiPatterns: [{ type: 're_reading', count: 2 }],
+    });
+
+    const record = sessionSummaryToDriftRecord(summary) as SessionOutcomeRecord;
+    expect(record.thrashingIncidents).toBe(0);
+  });
+});
 
 function makeSessionTracker(): SessionTracker {
   return {

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -22,6 +22,7 @@ import type { CostTracker } from '../metrics/cost-tracker.js';
 import type { TaskDetector } from '../metrics/task-detector.js';
 import type { AntiPatternDetector } from '../metrics/anti-patterns.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
+import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
 
 const logger = createLogger('session-store');
 
@@ -62,6 +63,7 @@ export interface FullSessionSummary extends SessionSummary {
   readonly userCorrections: number;
   readonly outcome: string;
   readonly platform?: string;
+  readonly instructionPromptHash?: string | null;
   readonly timeline?: ReplayTimelineEntry[];
 }
 
@@ -253,6 +255,7 @@ export interface BuildSessionSummarySources {
   developer: string;
   repoName?: string | null;
   platform?: string;
+  instructionPromptHash?: string | null;
 }
 
 export function buildSessionSummary(sources: BuildSessionSummarySources): FullSessionSummary {
@@ -381,7 +384,35 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     userCorrections: 0,
     outcome: 'completed',
     platform: sources.platform,
+    instructionPromptHash: sources.instructionPromptHash ?? null,
     timeline: timeline.length > 0 ? timeline : undefined,
+  };
+}
+
+/**
+ * Maps a persisted session summary into the shape InstructionDriftTracker
+ * consumes, for both startup hydration (loadRecords) and shutdown recording
+ * (recordSessionOutcome, which only uses the outcome fields and ignores
+ * promptHash/timestamp). Returns null when the session never had a prompt
+ * hash captured (no CLAUDE.md read that session, or the session predates
+ * this field's introduction).
+ */
+export function sessionSummaryToDriftRecord(
+  summary: FullSessionSummary,
+): SessionOutcomeRecord | null {
+  if (summary.instructionPromptHash === null || summary.instructionPromptHash === undefined) {
+    return null;
+  }
+
+  return {
+    sessionId: summary.sessionId,
+    promptHash: summary.instructionPromptHash,
+    timestamp: summary.endTime,
+    successRate: summary.taskSuccessRate,
+    totalTokens: summary.tokensInput + summary.tokensOutput,
+    thrashingIncidents: summary.antiPatterns.find((p) => p.type === 'thrashing')?.count ?? 0,
+    taskCount: summary.taskCount,
+    avgEfficiency: summary.efficiencyScore,
   };
 }
 
@@ -462,6 +493,8 @@ export function deserializeFullSessionSummary(obj: Record<string, unknown>): Ful
     userCorrections: typeof obj.userCorrections === 'number' ? obj.userCorrections : 0,
     outcome: typeof obj.outcome === 'string' ? obj.outcome : 'unknown',
     platform: typeof obj.platform === 'string' ? obj.platform : undefined,
+    instructionPromptHash:
+      typeof obj.instructionPromptHash === 'string' ? obj.instructionPromptHash : null,
     timeline: Array.isArray(obj.timeline)
       ? (obj.timeline as unknown[])
           .filter(


### PR DESCRIPTION
Closes #116

## Summary

- `InstructionDriftTracker.recordSessionOutcome()` and `.loadRecords()` had zero call sites in production — the tracker's read path worked, but nothing fed it session outcomes, so `nr_observe_get_instruction_drift` always reported an empty dataset.
- Fixing this requires cross-session persistence, not just in-process wiring: each MCP server process is scoped to one Claude Code session, so recording an outcome right before shutdown alone would be immediately lost and never enable the cross-session correlation that's the tool's entire purpose.
- The session's prompt hash is now persisted on the saved session summary, the last 7 days of prior sessions are reloaded into the tracker at startup, and the current session's own outcome is recorded at shutdown.
- Note: correlation is currently keyed on the hash of a `Read` tool call's *arguments* (file path/offset/limit), not the file's *content* — so this detects read/path drift rather than CLAUDE.md content drift. That's a pre-existing gap in the shared hashing utility, not introduced here; hashing actual content remains a separate, larger fix.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 3909 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
