### PR TITLE
Fix: nr_observe_get_api_failures silently reports zero instead of disclosing the gap (v1.4.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.17] - 2026-07-10
+
+### Fixed
+
+- `nr_observe_get_api_failures` always silently reported zero API failures — `ApiFailureTracker.recordRequest()`/`.recordFailure()` had zero call sites in production. Investigating this one further than the others: model-API-level failure data (rate limits, timeouts, auth errors from the LLM provider itself) is not observable anywhere in Preflight's current architecture, in either mode. Claude Code hook events only see Claude Code's own tool calls, not the underlying model-API traffic, and Preflight's proxy mode forwards requests to MCP servers, not to the model API itself — there is no LLM-facing proxy in this codebase today. Rather than fabricate a substitute signal, the tool's response now carries an explicit `dataAvailable: false` field and an explanatory `note` on every call, so a caller can no longer mistake the permanent all-zero output for "no failures occurred." Building a real LLM-facing proxy to make this data genuinely observable remains a separate, much larger effort.
+
 ## [1.4.16] - 2026-07-10
 
 ### Fixed

--- a/docs/COMMANDS_TABLE.md
+++ b/docs/COMMANDS_TABLE.md
@@ -1586,7 +1586,7 @@ Source: `src/tools/extended-analytics-tools.ts`, `src/metrics/quality-proxy-trac
 
 ### `nr_observe_get_api_failures`
 
-API failure tracking: per-model reliability scorecards, tokens lost, throttle alerts, and mean time to recovery.
+API failure tracking: per-model reliability scorecards, tokens lost, throttle alerts, and mean time to recovery. **Limitation:** model-API-level failure data is not observable in Preflight's current architecture (neither Claude Code hook events nor proxy mode see raw model-API traffic) — this tool currently always returns empty/zero metrics, with `dataAvailable: false` and a `note` field explaining why.
 
 **Parameters:** None
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.16",
+      "version": "1.4.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -760,6 +760,11 @@ async function main(): Promise<void> {
     const instructionDriftTracker = new InstructionDriftTracker();
     const toolSelectionScorer = new ToolSelectionScorer();
     const qualityProxyTracker = new QualityProxyTracker();
+    // ApiFailureTracker is instantiated but never fed: recordRequest()/recordFailure()
+    // require visibility into model-API-level traffic (LLM provider rate limits,
+    // timeouts, auth errors), which is not observable in either stdio mode (hooks
+    // only see Claude Code's own tool calls) or proxy mode (which forwards to MCP
+    // servers, not the model API). Kept dormant for a future LLM-facing proxy.
     const apiFailureTracker = new ApiFailureTracker();
     liveSessionRegistry = new LiveSessionRegistry();
     liveSessionRegistry.startSampling();

--- a/src/metrics/api-failure-tracker.test.ts
+++ b/src/metrics/api-failure-tracker.test.ts
@@ -254,4 +254,25 @@ describe('ApiFailureTracker', () => {
     expect(metrics.totalFailures).toBe(0);
     expect(metrics.totalTokensLost).toBe(0);
   });
+
+  it('always reports dataAvailable false with an explanatory note', () => {
+    const tracker = new ApiFailureTracker();
+    const metrics = tracker.getMetrics();
+    expect(metrics.dataAvailable).toBe(false);
+    expect(metrics.note).toBe(
+      "Model-API-level failure data (rate limits, timeouts, auth errors from the LLM provider itself) is not observable in Preflight's current architecture. Neither Claude Code hook events nor proxy mode see raw model-API traffic — proxy mode forwards requests to MCP servers, not to the model API. All-zero fields below reflect this limitation, not an absence of real failures.",
+    );
+
+    // Recording real events must not change either field — the limitation is
+    // architectural, not a function of whether any failure was ever recorded.
+    tracker.recordFailure({
+      errorType: 'rate_limit',
+      model: 'claude-opus-4',
+      turnNumber: 1,
+      tokensInFlight: 100,
+    });
+    const metricsAfter = tracker.getMetrics();
+    expect(metricsAfter.dataAvailable).toBe(false);
+    expect(metricsAfter.note).toBe(metrics.note);
+  });
 });

--- a/src/metrics/api-failure-tracker.ts
+++ b/src/metrics/api-failure-tracker.ts
@@ -62,6 +62,8 @@ export interface ApiFailureMetrics {
   readonly meanTimeToRecoveryMs: number | null;
   readonly throttleAlerts: readonly ThrottleAlert[];
   readonly recentFailures: readonly ApiFailureEvent[];
+  readonly dataAvailable: boolean;
+  readonly note: string;
 }
 
 export interface ApiFailureTrackerOptions {
@@ -80,6 +82,9 @@ const DEFAULT_THROTTLE_THRESHOLD = 3;
 const DEFAULT_THROTTLE_WINDOW_MINUTES = 10;
 const DEFAULT_MAX_EVENTS = 500;
 const DEFAULT_COST_PER_TOKEN_USD = 0.000003;
+
+const API_FAILURE_DATA_UNAVAILABLE_NOTE =
+  "Model-API-level failure data (rate limits, timeouts, auth errors from the LLM provider itself) is not observable in Preflight's current architecture. Neither Claude Code hook events nor proxy mode see raw model-API traffic — proxy mode forwards requests to MCP servers, not to the model API. All-zero fields below reflect this limitation, not an absence of real failures.";
 
 // ---------------------------------------------------------------------------
 // ApiFailureTracker
@@ -195,6 +200,8 @@ export class ApiFailureTracker {
       meanTimeToRecoveryMs: meanRecovery,
       throttleAlerts: this.throttleAlerts,
       recentFailures: this.events.slice(-20),
+      dataAvailable: false,
+      note: API_FAILURE_DATA_UNAVAILABLE_NOTE,
     };
   }
 

--- a/src/tools/extended-analytics-tools.ts
+++ b/src/tools/extended-analytics-tools.ts
@@ -93,7 +93,7 @@ export const QUALITY_PROXY_TOOL = {
 export const API_FAILURES_TOOL = {
   name: 'nr_observe_get_api_failures',
   description:
-    'Get API failure tracking: per-model reliability scorecards, tokens lost, cost impact, throttle alerts, and mean time to recovery.',
+    "Get API failure tracking: per-model reliability scorecards, tokens lost, cost impact, throttle alerts, and mean time to recovery. LIMITATION: model-API-level failure data is not observable in Preflight's current architecture (see the note field in the response) — this tool currently always returns empty/zero metrics.",
   inputSchema: { type: 'object' as const, properties: {} },
   annotations: { readOnlyHint: true },
 };


### PR DESCRIPTION
Closes #119

## Summary

- `nr_observe_get_api_failures` always silently reported zero API failures because `ApiFailureTracker.recordRequest()`/`.recordFailure()` had zero call sites in production.
- Model-API-level failure data (rate limits, timeouts, auth errors from the LLM provider itself) is not observable in Preflight's current architecture in either mode: Claude Code hook events only see Claude Code's own tool calls, and proxy mode forwards requests to MCP servers, not to the model API itself — there's no LLM-facing proxy in this codebase today.
- Rather than fabricate a substitute signal, the tool's actual response now carries an explicit `dataAvailable: false` field and an explanatory `note` on every call, plus an updated tool description, `index.ts` comment, and `COMMANDS_TABLE.md` entry — so a caller can no longer mistake the permanent all-zero output for "no failures occurred."
- Ships as v1.4.17 with a CHANGELOG entry.

## Test plan

- [x] `npm run build && npm test && npm run lint && npm run format:check` — all pass, 0 failures, 0 lint errors/warnings
- [x] New test asserts `dataAvailable`/`note` are always present and unaffected by recording a real failure

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>