### PR TITLE
Fix: nr_observe_get_latency_decomposition falsely claimed a proxy-mode fix path (v1.4.18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 .env*
 !.env.example
 .superpowers/
+docs/superpowers/
 .claude/
 test-results/
 playwright-report/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.18] - 2026-07-10
+
+### Fixed
+
+- `nr_observe_get_latency_decomposition`'s code comment and documentation both falsely claimed the tool "only" needs proxy-mode instrumentation to work. Verified false: Preflight's proxy mode forwards requests to MCP servers, not to the model API, so its visible latency is MCP-server latency, not model-API latency — the same architectural gap found in the `nr_observe_get_api_failures` fix above. Unlike that tool, this one's runtime behavior was already safe (it's never listed in `tools/list`, and a direct call already returns an explicit error rather than misleading data), so this fix corrects the false claims in the code comment, the direct-call error message, and the docs table — no runtime behavior, registration, or data shape change beyond adding an explanatory `note` field to the existing error response.
+
 ## [1.4.17] - 2026-07-10
 
 ### Fixed

--- a/docs/COMMANDS_TABLE.md
+++ b/docs/COMMANDS_TABLE.md
@@ -1421,28 +1421,11 @@ Source: `src/tools/extended-analytics-tools.ts`, `src/metrics/context-compositio
 
 Time split between LLM API calls, tool execution, and overhead — with p50/p95 percentiles for each component.
 
+**Status: not currently functional.** Neither Claude Code hook events nor proxy mode observe the model-API-level timing this tool needs. It is not registered in `tools/list`; calling it directly by name returns an explanatory error.
+
 **Parameters:** None
 
-**Returns:**
-
-```json
-{
-  "turnCount": 8,
-  "llmApi": { "p50": 1200, "p95": 3500 },
-  "toolExecution": { "p50": 45, "p95": 280 },
-  "overhead": { "p50": 12, "p95": 60 },
-  "avgComposition": { "llmApi": 0.7, "toolExecution": 0.25, "overhead": 0.05 },
-  "recentTurns": []
-}
-```
-
-**Data source:** `LatencyDecompositionTracker`
-
-**How it works:** Receives per-turn timing reports with `llmApiMs`, `toolExecutionMs`, and computes overhead as the remainder. Aggregates into p50/p95 percentiles per component and a fractional composition showing how each component contributes to overall turn latency.
-
-**Requires:** `LatencyDecompositionTracker`
-
-Source: `src/tools/extended-analytics-tools.ts`, `src/metrics/latency-decomposition.ts`
+**Data source:** `LatencyDecompositionTracker` (implemented, correctly, but never fed — see `src/index.ts` for why)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.17",
+      "version": "1.4.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -752,9 +752,13 @@ async function main(): Promise<void> {
     const retryDetector = new RetryDetector();
     const contextCompositionTracker = new ContextCompositionTracker();
     const contextTracker = new ContextTrackerRegistry();
-    // LatencyDecompositionTracker requires turn-level LLM vs tool timing that is
-    // only available in proxy mode (where we see upstream response latency). In
-    // stdio mode the data cannot be auto-populated so we skip instantiation.
+    // LatencyDecompositionTracker requires a true LLM-API-vs-tool-execution split.
+    // Neither mode observes this: stdio hooks only see Claude Code's own tool
+    // calls, and proxy mode's visible "upstream" latency is MCP-server latency
+    // (see ApiFailureTracker's comment below), not model-API latency. There is
+    // no turn-boundary hook (UserPromptSubmit/Stop) wired either, so even a
+    // coarse tool-execution-vs-everything-else split isn't currently derivable.
+    // Kept dormant; would need new hook wiring or an LLM-facing proxy to fix for real.
     const latencyDecompositionTracker: LatencyDecompositionTracker | undefined = undefined;
     const decisionTracker = new DecisionTracker();
     const instructionDriftTracker = new InstructionDriftTracker();

--- a/src/tools/session-stats.test.ts
+++ b/src/tools/session-stats.test.ts
@@ -484,6 +484,21 @@ describe('MCP protocol integration', () => {
     expect(JSON.parse(content[0]!.text)).toMatchObject({ error: 'tracker exploded' });
   });
 
+  it('calling nr_observe_get_latency_decomposition returns an explanatory error', async () => {
+    const result = await client.callTool({
+      name: 'nr_observe_get_latency_decomposition',
+      arguments: {},
+    });
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(content).toHaveLength(1);
+    const data = JSON.parse(content[0]!.text);
+    expect(data.error).toBe('nr_observe_get_latency_decomposition is not currently functional');
+    expect(data.note).toBe(
+      "Preflight cannot observe a true LLM-API-vs-tool-execution split in either stdio or proxy mode -- see the comment above the tracker's instantiation in index.ts for the full explanation. This tool is intentionally not registered in tools/list.",
+    );
+  });
+
   it('MCP initialize response includes transparency disclosure', () => {
     const info = client.getServerVersion();
     expect(info?.name).toBe('test-mcp');

--- a/src/tools/session-stats.ts
+++ b/src/tools/session-stats.ts
@@ -1316,7 +1316,10 @@ export function registerTools(server: Server, options: ToolRegistrationOptions):
               content: [
                 {
                   type: 'text' as const,
-                  text: JSON.stringify({ error: 'LatencyDecompositionTracker not available' }),
+                  text: JSON.stringify({
+                    error: 'nr_observe_get_latency_decomposition is not currently functional',
+                    note: "Preflight cannot observe a true LLM-API-vs-tool-execution split in either stdio or proxy mode -- see the comment above the tracker's instantiation in index.ts for the full explanation. This tool is intentionally not registered in tools/list.",
+                  }),
                 },
               ],
               isError: true,


### PR DESCRIPTION
Closes #121

## Summary

- `nr_observe_get_latency_decomposition`'s code comment and public docs both falsely claimed the tool "only" needs proxy-mode instrumentation to work.
- Verified false by tracing the actual code: Preflight's proxy mode forwards requests to MCP servers, not to the model API, so its visible latency (`upstreamLatencyMs`) is MCP-server latency, not model-API latency — the same architectural gap found in the `nr_observe_get_api_failures` fix. There's also no turn-boundary hook (`UserPromptSubmit`/`Stop`) wired anywhere, so even stdio mode can't cleanly separate LLM thinking time from overhead.
- Unlike `nr_observe_get_api_failures`, this tool's runtime behavior was already safe — it's never listed in `tools/list` (tracker hardcoded `undefined`), and a direct call by name already returns an explicit `isError: true` response rather than misleading data. So this fix corrects the false claims rather than changing any registration, data shape, or tracker interface.
- Adds an explanatory `note` field to the existing error response, corrects the `src/index.ts` comment, and replaces the fabricated example response in `docs/COMMANDS_TABLE.md` with an accurate "not currently functional" status.
- Incidental: added `docs/superpowers/` to `.gitignore` — closes a gap where a sibling planning-docs directory wasn't covered by the existing ignore rule.

## Test plan

- [x] New test: `calling nr_observe_get_latency_decomposition returns an explanatory error` (session-stats.test.ts)
- [x] Full suite: 3914 tests, 3911 passed / 3 skipped, 0 failures
- [x] `npm run build && npm test` clean
- [x] `npm run lint` — 0 errors, 0 warnings

🤖 Generated with assistance from Claude Sonnet 5

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
