### PR TITLE
Fix: nr_observe_get_context_composition and nr_observe_get_decision_tree overclaims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.19] - 2026-07-10
+
+### Fixed
+
+- `nr_observe_get_context_composition`'s per-turn token breakdown claims 4 categories (system prompt, conversation history, tool results, injected files), but two of them — `system_prompt` and `injected_file_content` — are always 0: the model API's usage response only reports aggregate input/cache-read/cache-creation token counts, with no breakdown by content category, so Preflight has no way to separate those two categories from the rest. `fillPercent` and the dominance alerts are unaffected and reflect real totals. The tool's response now carries an explanatory `note` field on every call, and the registered description now discloses the limitation.
+- `nr_observe_get_decision_tree`'s `reasoning` field reads like extracted reasoning but is always one of 3 fixed rule-based labels (e.g. "recovery after X failure") — `DecisionTracker.recordToolCall()` has no parameter carrying actual model reasoning text. Branches are also only recorded on 3 narrow triggers, not on every turn, so `totalBranches` undercounts ordinary turns relative to a literal "per turn" reading. The tool's response (including the `post_mortem: true` path) now carries an explanatory `note` field, and the registered description no longer claims "reasoning...extraction."
+
 ## [1.4.18] - 2026-07-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.18",
+      "version": "1.4.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/metrics/context-composition-tracker.test.ts
+++ b/src/metrics/context-composition-tracker.test.ts
@@ -32,6 +32,20 @@ describe('ContextCompositionTracker', () => {
     expect(metrics.currentFillPercent).toBe(7);
   });
 
+  it('always reports an explanatory note about the two dead categories', () => {
+    const tracker = new ContextCompositionTracker();
+    const metrics = tracker.getMetrics();
+    expect(metrics.note).toBe(
+      "system_prompt and injected_file_content are always 0 in currentBreakdown/history -- the model API's usage response only reports aggregate input/cache-read/cache-creation token counts, with no breakdown by content category, so these two categories can't be separated from conversation_history/tool_results. fillPercent and dominanceAlerts are unaffected and reflect real totals.",
+    );
+
+    // Recording a real turn must not change the note -- the limitation is
+    // architectural, not a function of whether any turn was ever recorded.
+    tracker.recordTurn(makeReport());
+    const metricsAfter = tracker.getMetrics();
+    expect(metricsAfter.note).toBe(metrics.note);
+  });
+
   it('fires threshold alert at 50%', () => {
     const alerts: ContextThresholdAlert[] = [];
     const tracker = new ContextCompositionTracker({

--- a/src/metrics/context-composition-tracker.ts
+++ b/src/metrics/context-composition-tracker.ts
@@ -43,6 +43,7 @@ export interface ContextCompositionMetrics {
   readonly thresholdAlerts: readonly ContextThresholdAlert[];
   readonly dominanceAlerts: readonly CategoryDominanceAlert[];
   readonly history: readonly TurnComposition[];
+  readonly note: string;
 }
 
 export interface ContextCompositionOptions {
@@ -71,6 +72,9 @@ const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_FILL_THRESHOLDS = [50, 75, 90] as const;
 const DEFAULT_DOMINANCE_THRESHOLD = 60;
 const DEFAULT_MAX_HISTORY = 500;
+
+const CONTEXT_COMPOSITION_NOTE =
+  "system_prompt and injected_file_content are always 0 in currentBreakdown/history -- the model API's usage response only reports aggregate input/cache-read/cache-creation token counts, with no breakdown by content category, so these two categories can't be separated from conversation_history/tool_results. fillPercent and dominanceAlerts are unaffected and reflect real totals.";
 
 // ---------------------------------------------------------------------------
 // ContextCompositionTracker
@@ -179,6 +183,7 @@ export class ContextCompositionTracker {
       thresholdAlerts: this.thresholdAlerts,
       dominanceAlerts: this.dominanceAlerts,
       history: this.history,
+      note: CONTEXT_COMPOSITION_NOTE,
     };
   }
 

--- a/src/metrics/decision-tracker.test.ts
+++ b/src/metrics/decision-tracker.test.ts
@@ -18,6 +18,25 @@ describe('DecisionTracker', () => {
     expect(metrics.successRate).toBeNull(); // no outcomes yet
   });
 
+  it('always reports an explanatory note about the templated reasoning field', () => {
+    const tracker = new DecisionTracker();
+    const metrics = tracker.getMetrics();
+    expect(metrics.note).toBe(
+      "reasoning fields above are rule-based labels (e.g. 'recovery after X failure', 'retrying Y on Z'), not extracted model chain-of-thought -- recordToolCall() has no access to actual reasoning text. Branches are only recorded on 3 narrow triggers (failure recovery, AskUserQuestion, 3rd+ same-tool-same-file retry), not on every turn, so totalBranches undercounts ordinary turns.",
+    );
+
+    // Recording a real decision must not change the note -- the limitation
+    // is architectural, not a function of whether any branch was ever recorded.
+    tracker.recordDecision({
+      turnNumber: 1,
+      reasoning: 'test reasoning',
+      chosenAction: 'read file',
+      toolName: 'Read',
+    });
+    const metricsAfter = tracker.getMetrics();
+    expect(metricsAfter.note).toBe(metrics.note);
+  });
+
   it('tags branches with outcomes', () => {
     const tracker = new DecisionTracker();
     tracker.recordDecision({

--- a/src/metrics/decision-tracker.ts
+++ b/src/metrics/decision-tracker.ts
@@ -23,6 +23,7 @@ export interface DecisionTreeMetrics {
   readonly failurePoints: readonly DecisionBranch[];
   readonly longestFailureStreak: number;
   readonly firstFailureIndex: number | null;
+  readonly note: string;
 }
 
 export interface DecisionTrackerOptions {
@@ -36,6 +37,9 @@ export interface DecisionTrackerOptions {
 
 const DEFAULT_MAX_BRANCHES = 500;
 const DEFAULT_REASONING_MAX_LENGTH = 500;
+
+export const DECISION_TREE_REASONING_NOTE =
+  "reasoning fields above are rule-based labels (e.g. 'recovery after X failure', 'retrying Y on Z'), not extracted model chain-of-thought -- recordToolCall() has no access to actual reasoning text. Branches are only recorded on 3 narrow triggers (failure recovery, AskUserQuestion, 3rd+ same-tool-same-file retry), not on every turn, so totalBranches undercounts ordinary turns.";
 
 // ---------------------------------------------------------------------------
 // DecisionTracker
@@ -162,6 +166,7 @@ export class DecisionTracker {
       failurePoints,
       longestFailureStreak: this.computeLongestFailureStreak(),
       firstFailureIndex: this.findFirstFailureIndex(),
+      note: DECISION_TREE_REASONING_NOTE,
     };
   }
 

--- a/src/tools/extended-analytics-tools.test.ts
+++ b/src/tools/extended-analytics-tools.test.ts
@@ -34,6 +34,9 @@ describe('extended-analytics-tools handlers', () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.turnCount).toBe(0);
     expect(parsed.currentFillPercent).toBe(0);
+    expect(parsed.note).toBe(
+      "system_prompt and injected_file_content are always 0 in currentBreakdown/history -- the model API's usage response only reports aggregate input/cache-read/cache-creation token counts, with no breakdown by content category, so these two categories can't be separated from conversation_history/tool_results. fillPercent and dominanceAlerts are unaffected and reflect real totals.",
+    );
   });
 
   it('handleGetLatencyDecomposition returns metrics JSON', () => {
@@ -58,10 +61,14 @@ describe('extended-analytics-tools handlers', () => {
     const metrics = JSON.parse(metricsResult.content[0].text);
     expect(metrics.totalBranches).toBe(1);
     expect(metrics.longestFailureStreak).toBe(1);
+    expect(metrics.note).toBe(
+      "reasoning fields above are rule-based labels (e.g. 'recovery after X failure', 'retrying Y on Z'), not extracted model chain-of-thought -- recordToolCall() has no access to actual reasoning text. Branches are only recorded on 3 narrow triggers (failure recovery, AskUserQuestion, 3rd+ same-tool-same-file retry), not on every turn, so totalBranches undercounts ordinary turns.",
+    );
 
     const pmResult = handleGetDecisionTree(tracker, true);
     const pm = JSON.parse(pmResult.content[0].text);
     expect(pm.postMortem).toHaveLength(1);
+    expect(pm.note).toBe(metrics.note);
   });
 
   it('handleGetInstructionDrift returns metrics JSON', () => {

--- a/src/tools/extended-analytics-tools.ts
+++ b/src/tools/extended-analytics-tools.ts
@@ -17,6 +17,7 @@ import type { RetryDetector } from '../metrics/retry-detector.js';
 import type { ContextCompositionTracker } from '../metrics/context-composition-tracker.js';
 import type { LatencyDecompositionTracker } from '../metrics/latency-decomposition.js';
 import type { DecisionTracker } from '../metrics/decision-tracker.js';
+import { DECISION_TREE_REASONING_NOTE } from '../metrics/decision-tracker.js';
 import type { InstructionDriftTracker } from '../metrics/instruction-drift-tracker.js';
 import type { ToolSelectionScorer } from '../metrics/tool-selection-scorer.js';
 import type { QualityProxyTracker } from '../metrics/quality-proxy-tracker.js';
@@ -37,7 +38,7 @@ export const RETRY_ALERTS_TOOL = {
 export const CONTEXT_COMPOSITION_TOOL = {
   name: 'nr_observe_get_context_composition',
   description:
-    'Get per-turn token breakdown by category (system prompt, conversation history, tool results, injected files). Shows context window fill percentage and dominance alerts.',
+    "Get per-turn token breakdown by category (system prompt, conversation history, tool results, injected files). Shows context window fill percentage and dominance alerts. LIMITATION: system_prompt and injected_file_content are always 0 -- the model API's aggregate usage counts have no breakdown by content category (see the note field in the response).",
   inputSchema: { type: 'object' as const, properties: {} },
   annotations: { readOnlyHint: true },
 };
@@ -53,7 +54,7 @@ export const LATENCY_DECOMPOSITION_TOOL = {
 export const DECISION_TREE_TOOL = {
   name: 'nr_observe_get_decision_tree',
   description:
-    'Get decision branch analysis: reasoning and action extraction per turn with outcome tagging. Includes post-mortem of failure chains and longest failure streak.',
+    'Get decision branch analysis: rule-based decision labeling and action tagging for triggered branches (recovery, retry, delegation), with outcome tagging. Includes post-mortem of failure chains and longest failure streak. LIMITATION: the reasoning field is a fixed rule-based label, not extracted model chain-of-thought, and branches are only recorded on 3 narrow triggers rather than every turn (see the note field in the response).',
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -133,7 +134,16 @@ export function handleGetDecisionTree(
   if (postMortem) {
     const branches = tracker.getPostMortem();
     return {
-      content: [{ type: 'text' as const, text: JSON.stringify({ postMortem: branches }, null, 2) }],
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(
+            { postMortem: branches, note: DECISION_TREE_REASONING_NOTE },
+            null,
+            2,
+          ),
+        },
+      ],
     };
   }
   return {


### PR DESCRIPTION
Closes #126
Closes #127

## Summary

Fixes the final 2 tools left over from the MCP tools audit fix series (see #104, #107, #114, #116, #119, #121). Unlike those prior fixes, these two tools aren't wiring bugs — both are registered, working, and return partially-real data, but each silently substitutes a fake/templated value for a specific field without disclosing it.

- **`nr_observe_get_context_composition`**: `system_prompt` and `injected_file_content` token categories are always 0 — architecturally unknowable, since the model API's usage response only reports aggregate input/cache-read/cache-creation counts with no per-category breakdown. `fillPercent`/dominance alerts are genuinely correct and unaffected.
- **`nr_observe_get_decision_tree`**: the `reasoning` field is always one of 3 hardcoded rule-based templates, not extracted model chain-of-thought — `DecisionTracker.recordToolCall()` has no parameter carrying reasoning text. Branches are also only recorded on 3 narrow triggers, not every turn.

Both fixes apply the same `dataAvailable`/`note` payload-disclosure pattern already established in this codebase by `nr_observe_get_api_failures` (#119): an unconditional `note` field on every response (including `decision_tree`'s `post_mortem: true` path, which bypasses `getMetrics()` entirely), plus a `LIMITATION:` clause on each tool's registered description. No tracker computation logic changed — purely disclosure.

A real fix for `decision_tree`'s reasoning extraction is technically feasible (verified against a real transcript JSONL — `thinking`/`text` blocks precede each `tool_use` entry) but is real design work, tracked separately. `context_composition`'s `system_prompt` gap is a hard architectural block with nothing further to design.

## Test plan

- [x] New unit tests for both trackers' unconditional `note` field (stable across real recordings)
- [x] Extended existing handler tests in `extended-analytics-tools.test.ts` for both tools, including `decision_tree`'s post-mortem path
- [x] `npm run build && npm test` — 3913 passed, 3 skipped (unrelated)
- [x] `npm run lint` — 0 errors, 0 warnings

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>