### PR TITLE
Fix: storage crash-recovery data-loss race, non-atomic writes, and week-53 validation (v1.4.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.20] - 2026-07-11
+
+### Fixed
+
+- `LocalStore`'s crash-recovery drain merge could silently drop a hook event that `preflight-collector` wrote in the narrow window between the merge's read of the live buffer and its overwrite of that buffer with the merged content. Recovery now extracts the leftover `.drain` file's events in memory and lets the buffer's own already-atomic claim-and-drain path (rename, not read-then-overwrite) handle the live buffer, so a concurrent append can never be clobbered.
+- `WeeklySummaryGenerator.generate()`'s write was a single non-atomic `writeFileSync`; a crash mid-write (SIGKILL, OOM, host crash) left a truncated/invalid JSON file that still passed the shutdown handler's `existsSync()` check, permanently corrupting that week's backfill slot. The write now goes through a temp file plus atomic rename.
+- `getLatest()` returned `null` outright if the single lexicographically-latest weekly summary file was corrupt, blinding every caller (including `nr_observe_get_weekly_summary`'s no-arg/`"latest"` path) to all older, still-valid summaries. It now falls back to the next-most-recent valid file.
+- Requesting a nonexistent ISO week (e.g. `"2025-W53"` — 2025 only has 52 weeks) silently returned a real-looking but wrong date range that actually overlapped the following year's week 1. `getWeekDateRange()` now rejects such inputs, and `nr_observe_get_weekly_summary` returns a clean error instead of a misleading result.
+
 ## [1.4.19] - 2026-07-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.19",
+      "version": "1.4.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -25,6 +25,22 @@ const SESSION_ID_RE = /^[a-zA-Z0-9_-]{1,128}$/;
  */
 const ORPHAN_BUFFER_MTIME_MS = 5 * 60 * 1000;
 
+function parseHookEvents(raw: string): HookEvent[] {
+  if (!raw.trim()) {
+    return [];
+  }
+  const events: HookEvent[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line) as HookEvent);
+    } catch {
+      logger.warn('Skipping malformed buffer line', { line: line.slice(0, 100) });
+    }
+  }
+  return events;
+}
+
 /**
  * Liveness probe via signal 0 — POSIX sends no signal but performs the
  * permission/existence checks. Returns true iff the PID names a live process
@@ -819,57 +835,38 @@ export class LocalStore {
     const tmpPath = bufferPath + '.drain';
 
     // Recover from a previous failed drain — the .drain file has events that
-    // were never processed.
+    // were never processed. Extracted in memory (never merged back into
+    // bufferPath) so a concurrent preflight-collector append can never be
+    // silently clobbered: any append that lands after the claim-rename below
+    // creates a fresh bufferPath, which the next poll drains normally.
+    let recoveredEvents: HookEvent[] = [];
     if (existsSync(tmpPath)) {
       try {
-        if (existsSync(bufferPath)) {
-          const drainData = readFileSync(tmpPath, 'utf-8');
-          const bufferData = readFileSync(bufferPath, 'utf-8');
-          writeFileSync(
-            bufferPath,
-            drainData + (drainData.endsWith('\n') ? '' : '\n') + bufferData,
-            { mode: 0o600 },
-          );
-          unlinkSync(tmpPath);
-        } else {
-          renameSync(tmpPath, bufferPath);
-        }
+        const drainData = readFileSync(tmpPath, 'utf-8');
+        recoveredEvents = parseHookEvents(drainData);
+        unlinkSync(tmpPath);
       } catch {
         logger.warn('Failed to recover .drain file — will retry next poll');
       }
     }
 
     if (!existsSync(bufferPath)) {
-      return [];
+      return recoveredEvents;
     }
 
     try {
       renameSync(bufferPath, tmpPath);
     } catch {
-      return [];
+      return recoveredEvents;
     }
 
     try {
       const raw = readFileSync(tmpPath, 'utf-8');
       unlinkSync(tmpPath);
-
-      if (!raw.trim()) {
-        return [];
-      }
-
-      const events: HookEvent[] = [];
-      for (const line of raw.split('\n')) {
-        if (!line.trim()) continue;
-        try {
-          events.push(JSON.parse(line) as HookEvent);
-        } catch {
-          logger.warn('Skipping malformed buffer line', { line: line.slice(0, 100) });
-        }
-      }
-      return events;
+      return [...recoveredEvents, ...parseHookEvents(raw)];
     } catch (err) {
       logger.warn('Failed to drain buffer — will retry next poll', { error: String(err) });
-      return [];
+      return recoveredEvents;
     }
   }
 

--- a/src/storage/weekly-summary.test.ts
+++ b/src/storage/weekly-summary.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SessionStore } from './session-store.js';
@@ -92,6 +92,26 @@ describe('aggregateSessions prototype-pollution resistance', () => {
     expect(summary.toolBreakdown['Read']).toBe(5);
     // Object.prototype must be unmodified — no pollution of enumerable properties
     expect(Object.keys(Object.prototype)).toEqual([]);
+  });
+});
+
+describe('getWeekDateRange() nonexistent-week validation', () => {
+  it('throws for "2025-W53" (2025 has no 53rd ISO week)', () => {
+    expect(() => getWeekDateRange('2025-W53')).toThrow(/no such ISO week/);
+  });
+
+  it('throws for "2024-W53" and "2027-W53" (also no 53rd week)', () => {
+    expect(() => getWeekDateRange('2024-W53')).toThrow(/no such ISO week/);
+    expect(() => getWeekDateRange('2027-W53')).toThrow(/no such ISO week/);
+  });
+
+  it('does not throw for "2026-W53" (a genuine 53rd ISO week)', () => {
+    expect(() => getWeekDateRange('2026-W53')).not.toThrow();
+  });
+
+  it('does not throw for ordinary weeks', () => {
+    expect(() => getWeekDateRange('2026-W01')).not.toThrow();
+    expect(() => getWeekDateRange('2026-W52')).not.toThrow();
   });
 });
 
@@ -216,6 +236,37 @@ describe('WeeklySummaryGenerator', () => {
     expect(() => generator.generate('2026-W16')).not.toThrow();
   });
 
+  it('generate() leaves no stray .tmp file behind after a successful write', () => {
+    const store = new SessionStore({ storagePath: tmpDir });
+    const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+    const { start } = getWeekDateRange('2026-W16');
+    store.saveSession(makeSummary({ sessionId: 'n04-sess', startTime: start.getTime() + 1000 }));
+
+    generator.generate('2026-W16');
+
+    const summariesDir = join(tmpDir, 'weekly_summaries');
+    const leftovers = readdirSync(summariesDir).filter((f) => f.includes('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('generate() called twice for the same week fully replaces the file (no corruption)', () => {
+    const store = new SessionStore({ storagePath: tmpDir });
+    const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+    const { start } = getWeekDateRange('2026-W16');
+
+    store.saveSession(makeSummary({ sessionId: 'n05-a', startTime: start.getTime() + 1000 }));
+    const first = generator.generate('2026-W16');
+    expect(first.sessionCount).toBe(1);
+
+    store.saveSession(makeSummary({ sessionId: 'n05-b', startTime: start.getTime() + 2000 }));
+    const second = generator.generate('2026-W16');
+    expect(second.sessionCount).toBe(2);
+
+    const filepath = join(tmpDir, 'weekly_summaries', '2026-W16.json');
+    const onDisk = JSON.parse(readFileSync(filepath, 'utf-8')) as { sessionCount: number };
+    expect(onDisk.sessionCount).toBe(2);
+  });
+
   it('auto-generation: generates last week summary if missing', () => {
     const store = new SessionStore({ storagePath: tmpDir });
     const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
@@ -275,5 +326,31 @@ describe('WeeklySummaryGenerator', () => {
     const latest = generator.getLatest();
     expect(latest).not.toBeNull();
     expect(latest!.week).toBe('2026-W16');
+  });
+
+  it('getLatest() falls back to the next-most-recent valid summary when the latest file is corrupt', () => {
+    const store = new SessionStore({ storagePath: tmpDir });
+    const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+
+    const { start } = getWeekDateRange('2026-W15');
+    store.saveSession(makeSummary({ sessionId: 'valid-w15', startTime: start.getTime() + 1000 }));
+    generator.generate('2026-W15');
+
+    // W16 is lexicographically later but corrupt — simulates a crash-truncated write.
+    const corruptPath = join(tmpDir, 'weekly_summaries', '2026-W16.json');
+    writeFileSync(corruptPath, '{"week": "2026-W16", "sessionCount":');
+
+    const latest = generator.getLatest();
+    expect(latest).not.toBeNull();
+    expect(latest!.week).toBe('2026-W15');
+  });
+
+  it('getLatest() returns null when every summary file is corrupt', () => {
+    const store = new SessionStore({ storagePath: tmpDir });
+    const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+
+    writeFileSync(join(tmpDir, 'weekly_summaries', '2026-W16.json'), 'NOT VALID JSON');
+
+    expect(generator.getLatest()).toBeNull();
   });
 });

--- a/src/storage/weekly-summary.ts
+++ b/src/storage/weekly-summary.ts
@@ -8,7 +8,15 @@
  * ISO week helpers use Monday as the first day of the week.
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { createLogger } from '../shared/index.js';
 import type { SessionStore } from './session-store.js';
@@ -65,6 +73,20 @@ export function getIsoWeekId(date: Date): string {
   return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`;
 }
 
+// UTC-safe mirror of getIsoWeekId(), used only to validate dates already
+// computed via UTC arithmetic below. getIsoWeekId() itself intentionally
+// reads local calendar fields (correct for the caller-supplied wall-clock
+// dates it's used with elsewhere in this file) — reusing it here would make
+// this validation depend on the server's local timezone.
+function getUtcIsoWeekId(date: Date): string {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`;
+}
+
 /**
  * Compute the date range for an ISO week.
  * Returns Monday 00:00:00 UTC to Sunday 23:59:59.999 UTC.
@@ -86,6 +108,13 @@ export function getWeekDateRange(weekId: string): { start: Date; end: Date } {
   // Monday of target week
   const targetMonday = new Date(week1Monday.getTime());
   targetMonday.setUTCDate(week1Monday.getUTCDate() + (week - 1) * 7);
+
+  // Reject week IDs whose year has no such ISO week (e.g. "2025-W53" when
+  // 2025 only has 52) by round-tripping the computed Monday back through
+  // the ISO week calculation — a genuine week reproduces the ID it was given.
+  if (getUtcIsoWeekId(targetMonday) !== weekId) {
+    throw new Error(`Invalid week ID: ${weekId} (year ${year} has no such ISO week)`);
+  }
 
   // Exclusive upper bound: Monday 00:00:00.000 of the following week.
   // Use half-open interval [start, end) to avoid the 23:59:59.999 boundary edge case.
@@ -132,11 +161,18 @@ export class WeeklySummaryGenerator {
     }
 
     const filepath = join(this.summariesDir, `${weekId}.json`);
+    const tmpFilepath = `${filepath}.tmp-${process.pid}`;
     try {
-      writeFileSync(filepath, JSON.stringify(summary, null, 2) + '\n', { mode: 0o600 });
+      writeFileSync(tmpFilepath, JSON.stringify(summary, null, 2) + '\n', { mode: 0o600 });
+      renameSync(tmpFilepath, filepath);
       logger.debug('Weekly summary generated', { weekId, sessions: weekSessions.length });
     } catch (err) {
       logger.error('Failed to write weekly summary to disk', { weekId, error: String(err) });
+      try {
+        unlinkSync(tmpFilepath);
+      } catch {
+        // tmp file may not have been created yet — nothing to clean up
+      }
       // Return the in-memory summary even if the write fails so callers still get data
     }
 
@@ -152,16 +188,19 @@ export class WeeklySummaryGenerator {
       .filter((f) => /^\d{4}-W\d{2}\.json$/.test(f))
       .sort();
 
-    if (files.length === 0) return null;
-
-    const latestFile = files[files.length - 1]!;
-    try {
-      const raw = readFileSync(join(this.summariesDir, latestFile), 'utf-8');
-      return JSON.parse(raw) as WeeklySummary;
-    } catch {
-      logger.warn('Failed to read latest weekly summary', { file: latestFile });
-      return null;
+    // Try newest-first; a single corrupted "latest" file shouldn't blind
+    // callers to every older, still-valid summary.
+    for (let i = files.length - 1; i >= 0; i--) {
+      const file = files[i]!;
+      try {
+        const raw = readFileSync(join(this.summariesDir, file), 'utf-8');
+        return JSON.parse(raw) as WeeklySummary;
+      } catch {
+        logger.warn('Failed to read weekly summary; trying next-most-recent', { file });
+      }
     }
+
+    return null;
   }
 
   checkAndGenerateLastWeek(): WeeklySummary | null {

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -189,6 +189,14 @@ describe('Cross-session tool handlers', () => {
     expect(parsed.week).toBe('2026-W16');
   });
 
+  it('handleGetWeeklySummary returns a clean error for a nonexistent ISO week 53', () => {
+    const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+    const result = handleGetWeeklySummary(generator, { week: '2025-W53' });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.error).toMatch(/no such ISO week/);
+  });
+
   // -------------------------------------------------------------------------
   // 3. get_trends for "efficiency"
   // -------------------------------------------------------------------------

--- a/src/tools/cross-session-tools.ts
+++ b/src/tools/cross-session-tools.ts
@@ -17,7 +17,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import type { SessionStore } from '../storage/session-store.js';
 import { formatSlackDigest } from '../digest/digest-formatter.js';
 import { sendSlackDigest } from '../digest/digest-sender.js';
-import type { WeeklySummaryGenerator } from '../storage/weekly-summary.js';
+import type { WeeklySummaryGenerator, WeeklySummary } from '../storage/weekly-summary.js';
 import { getIsoWeekId } from '../storage/weekly-summary.js';
 import type { TrendAnalyzer } from '../metrics/trend-analyzer.js';
 import type { CollaborationProfiler } from '../metrics/collaboration-profile.js';
@@ -365,7 +365,22 @@ export function handleGetWeeklySummary(
     };
   }
 
-  const summary = weeklySummaryGenerator.generate(args.week);
+  let summary: WeeklySummary;
+  try {
+    summary = weeklySummaryGenerator.generate(args.week);
+  } catch (err) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            error: err instanceof Error ? err.message : 'Invalid week',
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
   return {
     content: [
       {


### PR DESCRIPTION
## Summary

Three storage-subsystem correctness bugs found during an internal audit:

- `LocalStore`'s crash-recovery drain merge could silently drop a hook event `preflight-collector` wrote in the narrow window between the merge's read of the live buffer and its overwrite of that buffer with the merged content. Recovery now extracts the leftover `.drain` file's events in memory and lets the buffer's own already-atomic claim-and-drain path (rename, not read-then-overwrite) handle the live buffer, so a concurrent append can never be clobbered.
- `WeeklySummaryGenerator.generate()`'s write was a single non-atomic `writeFileSync`; a crash mid-write left a truncated/invalid JSON file that still passed the shutdown handler's `existsSync()` check, permanently corrupting that week's backfill slot. The write now goes through a temp file plus atomic rename.
- `getLatest()` returned `null` outright if the single lexicographically-latest weekly summary file was corrupt, blinding every caller (including `nr_observe_get_weekly_summary`'s no-arg/`"latest"` path) to all older, still-valid summaries. It now falls back to the next-most-recent valid file.
- Requesting a nonexistent ISO week (e.g. `"2025-W53"` — 2025 only has 52 weeks) silently returned a real-looking but wrong date range that actually overlapped the following year's week 1. `getWeekDateRange()` now rejects such inputs, and `nr_observe_get_weekly_summary` returns a clean error instead of a misleading result.

This is a routine incremental sync per `docs/PUBLIC_RELEASE_PLAN.md` — the version bump and release tag will follow as a separate step once this merges.

Fixes #149
Fixes #154
Fixes #153

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 3922 passed, 3 skipped (pre-existing), 0 failed
- [x] `npm run lint && npm run format:check` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)