### PR TITLE
Fix proxy telemetry integrity in standalone mode (v1.4.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.21] - 2026-07-11
+
+### Fixed
+
+- Standalone HTTP-proxy mode sent zero telemetry to New Relic — `ProxyManager`'s `onToolCall`/`onRequest` callbacks were wired to `logger.debug()` only, and `NrIngestManager` was never constructed on that code path, so `AiMcpToolCall`/`AiProxyRequest` events, the `ai.mcp.*` proxy gauges, and audit-trail security recording for proxied tool calls never fired. Proxy mode now constructs and starts an `NrIngestManager` (gated on `mode !== 'local'`, matching the existing `--stdio`/`--local` behavior) and feeds it from the proxy callbacks.
+- If the local OTLP/HTTP receiver failed to start (e.g. port already in use), proxy mode continued reporting itself healthy with the receiver silently absent, with no signal beyond a log line. `ProxyManager` now tracks OTLP receiver status (`disabled` / `running` / `failed`) and surfaces it in the `GET /health` response whenever the receiver is enabled, and the failure is now logged at `error` level.
+
 ## [1.4.20] - 2026-07-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.20",
+      "version": "1.4.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,6 +5,7 @@ import { resolve, join } from 'node:path';
 import {
   parseArgs,
   maskCredential,
+  buildProxyTelemetryCallbacks,
   classifyDashboardStartError,
   startDashboardRepoll,
   setupDashboardPostBind,
@@ -13,6 +14,8 @@ import {
 } from './index.js';
 import type { DashboardServer } from './dashboard/dashboard-server.js';
 import type { LocalStore } from './storage/index.js';
+import type { ProxyToolCallRecord, ProxyRequestRecord } from './proxy/index.js';
+import type { NrIngestManager } from './transport/nr-ingest.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 
@@ -213,6 +216,74 @@ describe('classifyDashboardStartError()', () => {
   });
 });
 
+// buildProxyTelemetryCallbacks() — proxy-mode telemetry wiring
+// ---------------------------------------------------------------------------
+
+describe('buildProxyTelemetryCallbacks()', () => {
+  function makeToolCallRecord(): ProxyToolCallRecord {
+    return {
+      id: 'call-1',
+      sessionId: null,
+      toolName: 'search',
+      toolUseId: 'use-1',
+      timestamp: Date.now(),
+      durationMs: 12,
+      success: true,
+      serverName: 'github',
+      upstreamLatencyMs: 8,
+    };
+  }
+
+  function makeRequestRecord(): ProxyRequestRecord {
+    return {
+      id: 'req-1',
+      serverName: 'github',
+      method: 'tools/list',
+      timestamp: Date.now(),
+      durationMs: 5,
+      upstreamLatencyMs: 3,
+      success: true,
+    };
+  }
+
+  it('forwards tool-call records to nrIngest.ingestToolCall when nrIngest is provided', () => {
+    const ingestToolCall = jest.fn();
+    const ingestProxyRequest = jest.fn();
+    const { onToolCall } = buildProxyTelemetryCallbacks({
+      ingestToolCall,
+      ingestProxyRequest,
+    } as unknown as NrIngestManager);
+
+    const record = makeToolCallRecord();
+    onToolCall(record);
+
+    expect(ingestToolCall).toHaveBeenCalledTimes(1);
+    expect(ingestToolCall).toHaveBeenCalledWith(record);
+  });
+
+  it('forwards request records to nrIngest.ingestProxyRequest when nrIngest is provided', () => {
+    const ingestToolCall = jest.fn();
+    const ingestProxyRequest = jest.fn();
+    const { onRequest } = buildProxyTelemetryCallbacks({
+      ingestToolCall,
+      ingestProxyRequest,
+    } as unknown as NrIngestManager);
+
+    const record = makeRequestRecord();
+    onRequest(record);
+
+    expect(ingestProxyRequest).toHaveBeenCalledTimes(1);
+    expect(ingestProxyRequest).toHaveBeenCalledWith(record);
+  });
+
+  it('does not throw when nrIngest is undefined (local-mode proxy)', () => {
+    const { onToolCall, onRequest } = buildProxyTelemetryCallbacks(undefined);
+
+    expect(() => onToolCall(makeToolCallRecord())).not.toThrow();
+    expect(() => onRequest(makeRequestRecord())).not.toThrow();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // CLI argument edge cases
 // ---------------------------------------------------------------------------
@@ -284,7 +355,7 @@ describe('CLI argument edge cases', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Task #13: dashboard ownership re-poll — startDashboardRepoll() +
+// Dashboard ownership re-poll — startDashboardRepoll() +
 // setupDashboardPostBind() + getDashboardRepollIntervalMs()
 // ---------------------------------------------------------------------------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { createServer } from './server.js';
 import { loadMcpConfig, DEFAULT_STORAGE_PATH } from './config.js';
 import type { McpServerConfig } from './config.js';
 import { ProxyManager } from './proxy/index.js';
+import type { ProxyToolCallRecord, ProxyRequestRecord } from './proxy/index.js';
 import { LocalStore } from './storage/index.js';
 import {
   SessionStore,
@@ -133,6 +134,44 @@ function loadConfigOrDie(options: Partial<CliOptions>): Readonly<McpServerConfig
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(`${msg}\n\nRun 'preflight doctor' to diagnose.`);
   }
+}
+
+/**
+ * Structural subset of NrIngestManager consumed by the proxy-mode telemetry
+ * callbacks. Declared separately (rather than importing the class type
+ * directly into the callback signature) so tests can pass a plain object of
+ * jest.fn()s without constructing a real NrIngestManager.
+ */
+type ProxyTelemetrySink = Pick<NrIngestManager, 'ingestToolCall' | 'ingestProxyRequest'>;
+
+/**
+ * Builds the ProxyManager onToolCall/onRequest callbacks for standalone proxy
+ * mode. When nrIngest is undefined (proxy running with mode: 'local', i.e. no
+ * cloud egress configured), the callbacks still log locally but do not
+ * attempt telemetry ingestion.
+ */
+export function buildProxyTelemetryCallbacks(nrIngest: ProxyTelemetrySink | undefined): {
+  onToolCall: (record: ProxyToolCallRecord) => void;
+  onRequest: (record: ProxyRequestRecord) => void;
+} {
+  return {
+    onToolCall: (record) => {
+      logger.debug('Proxy tool call', {
+        server: record.serverName,
+        tool: record.toolName,
+        durationMs: record.durationMs,
+      });
+      nrIngest?.ingestToolCall(record);
+    },
+    onRequest: (record) => {
+      logger.debug('Proxy request', {
+        server: record.serverName,
+        method: record.method,
+        durationMs: record.durationMs,
+      });
+      nrIngest?.ingestProxyRequest(record);
+    },
+  };
 }
 
 /**
@@ -1793,22 +1832,45 @@ async function main(): Promise<void> {
     // looks like a real session id.
     const sessionTraceId = `proxy-${Date.now()}`;
 
+    // Mirror the --stdio/--local gate above: mode: 'local' means no cloud
+    // egress by design, so no NrIngestManager is constructed and the proxy
+    // callbacks stay local-log-only. For 'cloud'/'both', loadConfigOrDie()
+    // has already guaranteed licenseKey/accountId are set (config.ts's
+    // load-time validation), so this mirrors that guard rather than
+    // re-deriving it.
+    if (config.mode !== 'local') {
+      if (!config.licenseKey || !config.accountId) {
+        throw new Error(
+          'licenseKey and accountId must be defined. ' +
+            'This should have been caught by config validation. ' +
+            'Check that mode is not "local" or that cloud credentials are configured.',
+        );
+      }
+      nrIngest = new NrIngestManager({
+        licenseKey: config.licenseKey,
+        transportOptions: {
+          accountId: config.accountId,
+          collectorHost: config.collectorHost,
+        },
+        developer: config.developer,
+        appName: config.appName,
+        teamId: config.teamId,
+        projectId: config.projectId,
+        orgId: config.orgId,
+        sessionTracker: new SessionTracker(sessionTraceId),
+        eventHarvestIntervalMs: config.harvestIntervalMs.events,
+        metricHarvestIntervalMs: config.harvestIntervalMs.metrics,
+        sessionTraceId,
+      });
+      nrIngest.start();
+    }
+
+    const { onToolCall, onRequest } = buildProxyTelemetryCallbacks(nrIngest);
+
     proxyManager = new ProxyManager({
       port: config.port,
-      onToolCall: (record) => {
-        logger.debug('Proxy tool call', {
-          server: record.serverName,
-          tool: record.toolName,
-          durationMs: record.durationMs,
-        });
-      },
-      onRequest: (record) => {
-        logger.debug('Proxy request', {
-          server: record.serverName,
-          method: record.method,
-          durationMs: record.durationMs,
-        });
-      },
+      onToolCall,
+      onRequest,
       otlpReceiverEnabled: config.otlpReceiverEnabled,
       otlpReceiverPort: config.otlpReceiverPort,
       otlpReceiverBindAddress: config.otlpReceiverBindAddress,

--- a/src/proxy/proxy-manager.test.ts
+++ b/src/proxy/proxy-manager.test.ts
@@ -236,6 +236,86 @@ describe('ProxyManager HTTP server', () => {
     expect(body.upstreams).toEqual(['server-a', 'server-b']);
   });
 
+  it('reports otlpReceiverStatus as disabled in /health when otlpReceiverEnabled is not set', async () => {
+    ({ server: mockServer, port: proxyPort } = await createMockMcpServer());
+    const mockPort = proxyPort;
+
+    manager = new ProxyManager({ port: 0 });
+    manager.registerUpstream({
+      name: 'test-server',
+      url: `http://127.0.0.1:${mockPort}`,
+      transportType: 'http',
+      allowPrivateHosts: true,
+    });
+    await manager.start();
+    const addr = (
+      manager as unknown as { httpServer: { address: () => { port: number } } }
+    ).httpServer?.address();
+    proxyPort = typeof addr === 'object' && addr ? addr.port : 0;
+
+    const response = await httpRequest(`http://127.0.0.1:${proxyPort}/health`, { method: 'GET' });
+    const body = JSON.parse(response.body) as { otlpReceiverStatus?: string };
+    expect(body.otlpReceiverStatus).toBeUndefined();
+    expect(manager.getOtlpReceiverStatus()).toBe('disabled');
+  });
+
+  it('reports otlpReceiverStatus as running in /health when the OTLP receiver starts successfully', async () => {
+    ({ server: mockServer, port: proxyPort } = await createMockMcpServer());
+    const mockPort = proxyPort;
+
+    manager = new ProxyManager({ port: 0, otlpReceiverEnabled: true, otlpReceiverPort: 0 });
+    manager.registerUpstream({
+      name: 'test-server',
+      url: `http://127.0.0.1:${mockPort}`,
+      transportType: 'http',
+      allowPrivateHosts: true,
+    });
+    await manager.start();
+    const addr = (
+      manager as unknown as { httpServer: { address: () => { port: number } } }
+    ).httpServer?.address();
+    proxyPort = typeof addr === 'object' && addr ? addr.port : 0;
+
+    const response = await httpRequest(`http://127.0.0.1:${proxyPort}/health`, { method: 'GET' });
+    const body = JSON.parse(response.body) as { otlpReceiverStatus?: string };
+    expect(body.otlpReceiverStatus).toBe('running');
+    expect(manager.getOtlpReceiverStatus()).toBe('running');
+  });
+
+  it('reports otlpReceiverStatus as failed in /health when the OTLP receiver port is already in use', async () => {
+    ({ server: mockServer, port: proxyPort } = await createMockMcpServer());
+    const mockPort = proxyPort;
+
+    // Bind a blocker server to a free port first, then reuse that exact port
+    // as the OTLP receiver's port so its own listen() call hits EADDRINUSE.
+    const blocker = createHttpServer((_req, res) => res.end());
+    await new Promise<void>((resolve) => blocker.listen(0, '127.0.0.1', resolve));
+    const blockerAddr = blocker.address();
+    const otlpPort = typeof blockerAddr === 'object' && blockerAddr ? blockerAddr.port : 0;
+
+    manager = new ProxyManager({ port: 0, otlpReceiverEnabled: true, otlpReceiverPort: otlpPort });
+    manager.registerUpstream({
+      name: 'test-server',
+      url: `http://127.0.0.1:${mockPort}`,
+      transportType: 'http',
+      allowPrivateHosts: true,
+    });
+    await manager.start();
+    const addr = (
+      manager as unknown as { httpServer: { address: () => { port: number } } }
+    ).httpServer?.address();
+    proxyPort = typeof addr === 'object' && addr ? addr.port : 0;
+
+    try {
+      const response = await httpRequest(`http://127.0.0.1:${proxyPort}/health`, { method: 'GET' });
+      const body = JSON.parse(response.body) as { otlpReceiverStatus?: string };
+      expect(body.otlpReceiverStatus).toBe('failed');
+      expect(manager.getOtlpReceiverStatus()).toBe('failed');
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
+  });
+
   it('returns 404 for unknown upstream', async () => {
     ({ server: mockServer, port: proxyPort } = await createMockMcpServer());
     await setupProxy(proxyPort);

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -41,6 +41,8 @@ export interface ProxyManagerOptions {
   readonly otlpEnrichmentAttributes?: Record<string, string>;
 }
 
+export type OtlpReceiverStatus = 'disabled' | 'running' | 'failed';
+
 const DEFAULT_BODY_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
 
@@ -80,6 +82,7 @@ export class ProxyManager {
   private readonly upstreams = new Map<string, ProxyUpstream>();
   private httpServer: Server | null = null;
   private otlpReceiver: OtlpReceiver | null = null;
+  private otlpReceiverStatus: OtlpReceiverStatus = 'disabled';
   private readonly options: ProxyManagerOptions;
   private readonly port: number;
   private readonly onToolCall: ((record: ProxyToolCallRecord) => void) | undefined;
@@ -111,6 +114,15 @@ export class ProxyManager {
   /** Get a registered upstream by name (for testing). */
   getUpstream(name: string): ProxyUpstream | undefined {
     return this.upstreams.get(name);
+  }
+
+  /**
+   * Current state of the local OTLP/HTTP receiver. Only meaningful when
+   * otlpReceiverEnabled was set on the constructor options — otherwise always
+   * 'disabled'. Also surfaced in the GET /health response.
+   */
+  getOtlpReceiverStatus(): OtlpReceiverStatus {
+    return this.otlpReceiverStatus;
   }
 
   /** Connect all upstreams and start the HTTP proxy server. */
@@ -186,8 +198,12 @@ export class ProxyManager {
         });
         await receiver.start();
         this.otlpReceiver = receiver;
+        this.otlpReceiverStatus = 'running';
       } catch (err) {
-        logger.warn('OTLP receiver failed to start — disabled', { error: String(err) });
+        this.otlpReceiverStatus = 'failed';
+        logger.error('OTLP receiver failed to start — proxy continuing without it', {
+          error: String(err),
+        });
       }
     }
   }
@@ -210,6 +226,7 @@ export class ProxyManager {
     if (this.otlpReceiver) {
       await this.otlpReceiver.stop();
       this.otlpReceiver = null;
+      this.otlpReceiverStatus = 'disabled';
     }
 
     // Disconnect all upstreams
@@ -230,6 +247,9 @@ export class ProxyManager {
       const body = JSON.stringify({
         status: 'ok',
         upstreams: this.getUpstreamNames(),
+        ...(this.options.otlpReceiverEnabled
+          ? { otlpReceiverStatus: this.otlpReceiverStatus }
+          : {}),
       });
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(body);


### PR DESCRIPTION
## Summary

- Fixes #142: standalone HTTP-proxy mode sent zero telemetry to New Relic. `ProxyManager`'s `onToolCall`/`onRequest` callbacks were wired to `logger.debug()` only, and `NrIngestManager` was never constructed on that code path. Proxy mode now constructs and starts an `NrIngestManager` (gated on `mode !== 'local'`, mirroring the existing `--stdio`/`--local` behavior) and feeds it from the proxy callbacks via a new, independently-tested `buildProxyTelemetryCallbacks()` helper in `src/index.ts`.
- Fixes #145: if the local OTLP/HTTP receiver failed to start (e.g. port already in use), proxy mode continued reporting itself healthy with the receiver silently absent, with no signal beyond a log line. `ProxyManager` now tracks OTLP receiver status (`disabled`/`running`/`failed`) and surfaces it in the `GET /health` response whenever the receiver is enabled; the failure is now logged at `error` level instead of `warn`.
- Bumps version to 1.4.21 (`package.json` + `package-lock.json`) and adds a CHANGELOG entry.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 3928 passed, 3 pre-existing skips, 0 failures
- [x] `npm run lint` — clean
- [x] New unit tests for `buildProxyTelemetryCallbacks()` (src/index.test.ts): forwards tool-call/request records to `NrIngestManager` when present, no-op-safe when absent (local mode)
- [x] New unit tests for OTLP receiver status (src/proxy/proxy-manager.test.ts): `disabled` when not enabled, `running` on successful start, `failed` on a genuine `EADDRINUSE` (real bound socket, not mocked)