### PR TITLE
Fix install verification gaps (v1.4.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.22] - 2026-07-11
+
+### Fixed
+
+- `setup-wizard.ts`'s background-dashboard-daemon install step reported success right after `launchctl load` returned without throwing, which only confirms the plist loaded, not that the daemon process actually came up healthy — a plist can load successfully while the spawned process immediately crashes. It now polls the dashboard's `/api/health` endpoint via the same `getDashboardAddress()`/`waitForHealthyDashboard()` helpers `cli.ts`'s `update` command already uses, and downgrades the success message to a warning (with `launchctl list` / log-file pointers) when the health check fails.
+- `checkStorageWritable()` used `accessSync(W_OK)` alone, which succeeds identically for a writable file and a writable directory — a corrupted install with a plain file sitting at the storage path would falsely report "ok" while `LocalStore`'s downstream `mkdirSync()` calls would fail with `ENOTDIR`. It now also calls `statSync().isDirectory()` and reports a distinct "exists but is not a directory" failure (with a `rm && mkdir` fix suggestion) when the path exists but isn't a directory.
+
 ## [1.4.21] - 2026-07-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.21",
+      "version": "1.4.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -23,12 +23,7 @@ import {
   generateNrConfig,
 } from './install-helper.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
-import {
-  validateConfigFile,
-  DEFAULT_STORAGE_PATH,
-  ConfigFileSchema,
-  loadMcpConfig,
-} from '../config.js';
+import { validateConfigFile, DEFAULT_STORAGE_PATH, ConfigFileSchema } from '../config.js';
 import type { PlatformTarget } from '../config.js';
 import { migrateStoragePath } from './migrate.js';
 import {
@@ -42,6 +37,7 @@ import {
 } from './schedule.js';
 import { readJsonFileStrict, writeJsonFile, errMsg } from './json-utils.js';
 import { LocalStore } from '../storage/index.js';
+import { getDashboardAddress, waitForHealthyDashboard } from './dashboard-health.js';
 
 const logger = createLogger('cli');
 
@@ -266,54 +262,6 @@ function readLocalPackageVersion(repoRoot: string): string | null {
     return typeof parsed.version === 'string' ? parsed.version : null;
   } catch {
     return null;
-  }
-}
-
-/**
- * Resolves the dashboard's configured host/port, or null if the config
- * can't be loaded (e.g. a cloud-mode config missing credentials). Callers
- * treat null as "skip verification" rather than a hard failure — restart
- * verification is a best-effort enhancement, never a new way for `update`
- * to fail.
- */
-function getDashboardAddress(): { host: string; port: number } | null {
-  try {
-    const config = loadMcpConfig();
-    return { host: config.dashboard.host, port: config.dashboard.port };
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Polls `GET /api/health` until it reports a healthy, current-version
- * response or `timeoutMs` elapses. Connection errors (server not listening
- * yet) and malformed responses are treated as "not yet" and retried, not as
- * failures. When `expectedVersion` is null, the version check is skipped —
- * any healthy response counts.
- */
-async function waitForHealthyDashboard(
-  host: string,
-  port: number,
-  expectedVersion: string | null,
-  timeoutMs = 5000,
-  intervalMs = 300,
-): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    try {
-      const res = await fetch(`http://${host}:${port}/api/health`);
-      if (res.ok) {
-        const body = (await res.json()) as { ok?: unknown; version?: unknown };
-        if (body.ok === true && (expectedVersion === null || body.version === expectedVersion)) {
-          return true;
-        }
-      }
-    } catch {
-      // Not listening yet, or a malformed response — keep polling.
-    }
-    if (Date.now() >= deadline) return false;
-    await sleep(intervalMs);
   }
 }
 

--- a/src/install/dashboard-health.ts
+++ b/src/install/dashboard-health.ts
@@ -1,0 +1,53 @@
+import { loadMcpConfig } from '../config.js';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+/**
+ * Resolves the dashboard's configured host/port, or null if the config
+ * can't be loaded (e.g. a cloud-mode config missing credentials). Callers
+ * treat null as "skip verification" rather than a hard failure — health
+ * verification is a best-effort enhancement, never a new way for a caller
+ * to fail.
+ */
+export function getDashboardAddress(): { host: string; port: number } | null {
+  try {
+    const config = loadMcpConfig();
+    return { host: config.dashboard.host, port: config.dashboard.port };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Polls `GET /api/health` until it reports a healthy, current-version
+ * response or `timeoutMs` elapses. Connection errors (server not listening
+ * yet) and malformed responses are treated as "not yet" and retried, not as
+ * failures. When `expectedVersion` is null, the version check is skipped —
+ * any healthy response counts.
+ */
+export async function waitForHealthyDashboard(
+  host: string,
+  port: number,
+  expectedVersion: string | null,
+  timeoutMs = 5000,
+  intervalMs = 300,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const res = await fetch(`http://${host}:${port}/api/health`);
+      if (res.ok) {
+        const body = (await res.json()) as { ok?: unknown; version?: unknown };
+        if (body.ok === true && (expectedVersion === null || body.version === expectedVersion)) {
+          return true;
+        }
+      }
+    } catch {
+      // Not listening yet, or a malformed response — keep polling.
+    }
+    if (Date.now() >= deadline) return false;
+    await sleep(intervalMs);
+  }
+}

--- a/src/install/diagnostics.test.ts
+++ b/src/install/diagnostics.test.ts
@@ -497,24 +497,36 @@ describe('runDiagnostics', () => {
   describe('Check 5: Storage writable', () => {
     it('returns fail when directory does not exist', async () => {
       mockedExistSync.mockImplementation((p) => p !== '/test-home/.newrelic-preflight');
-      mockedAccessSync.mockImplementation(() => {
-        throw new Error('ENOENT');
-      });
       const checks = await runDiagnostics(makeOpts());
-      expect(checks.find((x) => x.check === 'Storage writable')?.status).toBe('fail');
+      const check = checks.find((x) => x.check === 'Storage writable');
+      expect(check?.status).toBe('fail');
+      expect(check?.detail).toContain('Directory not found');
+    });
+
+    it('returns fail with a distinct message when the path exists but is a file, not a directory', async () => {
+      mockedExistSync.mockReturnValue(true);
+      mockedStatSync.mockImplementation(() => ({ isDirectory: () => false }));
+      const checks = await runDiagnostics(makeOpts());
+      const check = checks.find((x) => x.check === 'Storage writable');
+      expect(check?.status).toBe('fail');
+      expect(check?.detail).toContain('exists but is not a directory');
     });
 
     it('returns fail when directory is not writable', async () => {
       mockedExistSync.mockReturnValue(true);
+      mockedStatSync.mockImplementation(() => ({ isDirectory: () => true }));
       mockedAccessSync.mockImplementation(() => {
         throw new Error('EACCES');
       });
       const checks = await runDiagnostics(makeOpts());
-      expect(checks.find((x) => x.check === 'Storage writable')?.status).toBe('fail');
+      const check = checks.find((x) => x.check === 'Storage writable');
+      expect(check?.status).toBe('fail');
+      expect(check?.detail).toContain('is not writable');
     });
 
     it('returns ok when directory is writable', async () => {
       mockedExistSync.mockReturnValue(true);
+      mockedStatSync.mockImplementation(() => ({ isDirectory: () => true }));
       mockedAccessSync.mockImplementation(() => undefined);
       const checks = await runDiagnostics(makeOpts());
       expect(checks.find((x) => x.check === 'Storage writable')?.status).toBe('ok');

--- a/src/install/diagnostics.ts
+++ b/src/install/diagnostics.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants, existsSync, readFileSync } from 'node:fs';
+import { accessSync, constants, existsSync, readFileSync, statSync } from 'node:fs';
 import { platform } from 'node:os';
 import { resolve } from 'node:path';
 
@@ -309,18 +309,38 @@ function checkHooksWired(settingsPaths: string[], platform: string | undefined):
 }
 
 function checkStorageWritable(storagePath: string): DiagnosticCheck {
+  if (!existsSync(storagePath)) {
+    return {
+      check: 'Storage writable',
+      status: 'fail',
+      detail: `Directory not found: ${storagePath}`,
+      fix: `mkdir -p ${storagePath} && chmod 700 ${storagePath}`,
+    };
+  }
+
+  // accessSync(W_OK) alone can't distinguish a writable file from a writable
+  // directory — it succeeds for both. A file here (e.g. from a corrupted
+  // install or a race during a prior partial install) would otherwise report
+  // 'ok' while LocalStore's mkdirSync() calls fail downstream with ENOTDIR.
+  let isDirectory: boolean;
+  try {
+    isDirectory = statSync(storagePath).isDirectory();
+  } catch {
+    isDirectory = false;
+  }
+  if (!isDirectory) {
+    return {
+      check: 'Storage writable',
+      status: 'fail',
+      detail: `Storage path exists but is not a directory: ${storagePath}`,
+      fix: `rm ${storagePath} && mkdir -p ${storagePath} && chmod 700 ${storagePath}`,
+    };
+  }
+
   try {
     accessSync(storagePath, constants.W_OK);
     return { check: 'Storage writable', status: 'ok', detail: `${storagePath} is writable` };
   } catch {
-    if (!existsSync(storagePath)) {
-      return {
-        check: 'Storage writable',
-        status: 'fail',
-        detail: `Directory not found: ${storagePath}`,
-        fix: `mkdir -p ${storagePath} && chmod 700 ${storagePath}`,
-      };
-    }
     return {
       check: 'Storage writable',
       status: 'fail',

--- a/src/install/schedule.test.ts
+++ b/src/install/schedule.test.ts
@@ -113,6 +113,17 @@ describe('installSchedule', () => {
       .mockImplementation(() => Buffer.from('') as unknown as string);
     expect(() => installSchedule('/usr/local/bin/preflight', 8, 0)).not.toThrow();
   });
+
+  it('throws a wrapped error when launchctl load fails', () => {
+    mockedExecFileSync
+      .mockImplementationOnce(() => Buffer.from('') as unknown as string) // unload succeeds
+      .mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+    expect(() => installSchedule('/usr/local/bin/preflight', 8, 0)).toThrow(
+      'launchctl load failed: boom',
+    );
+  });
 });
 
 describe('removeSchedule', () => {
@@ -305,6 +316,17 @@ describe('installDashboardDaemon', () => {
       })
       .mockImplementation(() => Buffer.from('') as unknown as string);
     expect(() => installDashboardDaemon('/usr/local/bin/preflight')).not.toThrow();
+  });
+
+  it('throws a wrapped error when launchctl load fails', () => {
+    mockedExecFileSync
+      .mockImplementationOnce(() => Buffer.from('') as unknown as string) // unload succeeds
+      .mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+    expect(() => installDashboardDaemon('/usr/local/bin/preflight')).toThrow(
+      'launchctl load failed: boom',
+    );
   });
 });
 

--- a/src/install/setup-wizard.test.ts
+++ b/src/install/setup-wizard.test.ts
@@ -7,6 +7,7 @@ import * as scheduleMod from './schedule.js';
 import * as keyValidator from './key-validator.js';
 import * as cliMod from './cli.js';
 import * as platformMod from './platform.js';
+import * as dashboardHealthMod from './dashboard-health.js';
 
 // ---------------------------------------------------------------------------
 // Module-level mocks (hoisted above imports by jest at runtime).
@@ -43,6 +44,11 @@ jest.mock('./schedule.js', () => ({
   removeSchedule: jest.fn(),
   getScheduleStatus: jest.fn(() => ({ installed: false, readable: false })),
   resolveBinaryPath: jest.fn(() => null),
+  installDashboardDaemon: jest.fn(),
+}));
+jest.mock('./dashboard-health.js', () => ({
+  getDashboardAddress: jest.fn(),
+  waitForHealthyDashboard: jest.fn(),
 }));
 
 // Typed handles to the mocked module functions.
@@ -66,6 +72,15 @@ const mockedRl = rlMod as unknown as { createInterface: jest.Mock };
 const mockedSchedule = scheduleMod as unknown as {
   installSchedule: jest.Mock;
   resolveBinaryPath: jest.Mock;
+  installDashboardDaemon: jest.Mock;
+};
+const mockedDashboardHealth = {
+  getDashboardAddress: dashboardHealthMod.getDashboardAddress as jest.MockedFunction<
+    typeof dashboardHealthMod.getDashboardAddress
+  >,
+  waitForHealthyDashboard: dashboardHealthMod.waitForHealthyDashboard as jest.MockedFunction<
+    typeof dashboardHealthMod.waitForHealthyDashboard
+  >,
 };
 const mockedCli = cliMod as unknown as {
   runInstallCli: jest.Mock;
@@ -872,6 +887,105 @@ describe('setupWizard auto-update step', () => {
     await runSetupWizard();
 
     expect(mockedSchedule.installSchedule).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 6b: Always-on background dashboard daemon (macOS only)
+// ---------------------------------------------------------------------------
+describe('setupWizard daemon install step', () => {
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let mockRl: { question: jest.Mock; close: jest.Mock };
+  const savedPlatform = process.platform;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockRl = { question: jest.fn(), close: jest.fn() };
+    mockedRl.createInterface.mockReturnValue(mockRl);
+    mockedFs.mkdirSync.mockReturnValue(undefined);
+    mockedFs.writeFileSync.mockReturnValue(undefined);
+    mockedFs.readFileSync.mockReturnValue('{}');
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    mockedDashboardHealth.getDashboardAddress.mockReturnValue({ host: '127.0.0.1', port: 7777 });
+    mockedDashboardHealth.waitForHealthyDashboard.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    Object.defineProperty(process, 'platform', { value: savedPlatform, configurable: true });
+  });
+
+  // Local mode answer order up through Step 6b, then Step 7 (auto-update, darwin-only):
+  // mode, developer, teamId, projectId, sessionBudget, dashboardPort, copyStarterRules,
+  // installHooks, daemonAnswer, autoUpdate
+  function answers(...values: string[]): void {
+    let i = 0;
+    mockRl.question.mockImplementation(async () => values[i++] ?? '');
+  }
+
+  it('reports success and calls waitForHealthyDashboard when the daemon health-checks OK', async () => {
+    mockedSchedule.resolveBinaryPath.mockReturnValue('/usr/local/bin/preflight');
+    answers('local', 'tester', '', '', '', '', 'n', 'n', 'y', 'n');
+
+    await runSetupWizard();
+
+    expect(mockedSchedule.installDashboardDaemon).toHaveBeenCalledWith('/usr/local/bin/preflight');
+    expect(mockedDashboardHealth.waitForHealthyDashboard).toHaveBeenCalledWith(
+      '127.0.0.1',
+      7777,
+      null,
+    );
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Background dashboard daemon installed');
+    expect(output).not.toContain('could not be verified');
+  });
+
+  it('downgrades to a warning when the daemon health-check fails', async () => {
+    mockedSchedule.resolveBinaryPath.mockReturnValue('/usr/local/bin/preflight');
+    mockedDashboardHealth.waitForHealthyDashboard.mockResolvedValue(false);
+    answers('local', 'tester', '', '', '', '', 'n', 'n', 'y', 'n');
+
+    await runSetupWizard();
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('could not be verified as healthy');
+    expect(output).not.toContain('✓ Background dashboard daemon installed');
+  });
+
+  it('skips verification and keeps the success message when dashboard config cannot be loaded', async () => {
+    mockedSchedule.resolveBinaryPath.mockReturnValue('/usr/local/bin/preflight');
+    mockedDashboardHealth.getDashboardAddress.mockReturnValue(null);
+    answers('local', 'tester', '', '', '', '', 'n', 'n', 'y', 'n');
+
+    await runSetupWizard();
+
+    expect(mockedDashboardHealth.waitForHealthyDashboard).not.toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Background dashboard daemon installed');
+  });
+
+  it('does not install the daemon when the user declines', async () => {
+    mockedSchedule.resolveBinaryPath.mockReturnValue('/usr/local/bin/preflight');
+    answers('local', 'tester', '', '', '', '', 'n', 'n', 'n', 'n');
+
+    await runSetupWizard();
+
+    expect(mockedSchedule.installDashboardDaemon).not.toHaveBeenCalled();
+  });
+
+  it('warns without installing when preflight is not on PATH', async () => {
+    mockedSchedule.resolveBinaryPath.mockReturnValue(null);
+    answers('local', 'tester', '', '', '', '', 'n', 'n', 'y', 'n');
+
+    await runSetupWizard();
+
+    expect(mockedSchedule.installDashboardDaemon).not.toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Cannot install dashboard daemon');
   });
 });
 

--- a/src/install/setup-wizard.ts
+++ b/src/install/setup-wizard.ts
@@ -15,6 +15,7 @@ import { writeJsonFile } from './json-utils.js';
 import { installSchedule, installDashboardDaemon, resolveBinaryPath } from './schedule.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
 import { validateLicenseKey, validateApiKey } from './key-validator.js';
+import { getDashboardAddress, waitForHealthyDashboard } from './dashboard-health.js';
 
 const CONFIG_PATH = resolve(DEFAULT_STORAGE_PATH, 'config.json');
 const ALERT_RULES_DEST = resolve(DEFAULT_STORAGE_PATH, 'alerts', 'rules.json');
@@ -594,9 +595,22 @@ export async function runSetupWizard(): Promise<void> {
             // Removing before installing would leave the user with no daemon if
             // the install step fails.
             installDashboardDaemon(binaryPath);
-            print(
-              `✓ Background dashboard daemon installed — dashboard will be available at http://127.0.0.1:${dashboardPort ?? 7777} after login.`,
-            );
+            // Verify the daemon actually came up healthy rather than just that
+            // `launchctl load` didn't throw — a plist can load successfully while
+            // the spawned process immediately crashes. Matches the verification
+            // cli.ts's `update` command already does for this same call.
+            const address = getDashboardAddress();
+            const healthy =
+              address === null || (await waitForHealthyDashboard(address.host, address.port, null));
+            if (healthy) {
+              print(
+                `✓ Background dashboard daemon installed — dashboard will be available at http://127.0.0.1:${dashboardPort ?? 7777} after login.`,
+              );
+            } else {
+              print(
+                '⚠ Background dashboard daemon installed but could not be verified as healthy — it may still be starting up, or may have failed silently. Check `launchctl list | grep com.preflight.dashboard` and `~/.newrelic-preflight/dashboard.log`.',
+              );
+            }
             print(
               '  To stop: preflight uninstall  (or: launchctl unload ~/Library/LaunchAgents/com.preflight.dashboard.plist)',
             );


### PR DESCRIPTION
## Summary

- `setup-wizard.ts`'s background-dashboard-daemon install step reported success right after `launchctl load` returned without throwing, which only confirms the plist loaded, not that the daemon process actually came up healthy — a plist can load successfully while the spawned process immediately crashes. It now polls the dashboard's `/api/health` endpoint via the same `getDashboardAddress()`/`waitForHealthyDashboard()` helpers `cli.ts`'s `update` command already uses, and downgrades the success message to a warning (with `launchctl list` / log-file pointers) when the health check fails. Also adds regression tests for the `launchctl load`-failure path in both `installSchedule` and `installDashboardDaemon`.
- `checkStorageWritable()` used `accessSync(W_OK)` alone, which succeeds identically for a writable file and a writable directory — a corrupted install with a plain file sitting at the storage path would falsely report "ok" while `LocalStore`'s downstream `mkdirSync()` calls would fail with `ENOTDIR`. It now also calls `statSync().isDirectory()` and reports a distinct "exists but is not a directory" failure when the path exists but isn't a directory.
- Bumps version to 1.4.22 and adds a CHANGELOG entry.

Fixes #155. Fixes #156.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 3936 passed, 3 pre-existing skips, 0 failures
- [x] `npm run lint` — clean
