### PR TITLE
Fix replay-timeline bug + dashboard routing hygiene (v1.4.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.23] - 2026-07-12
+
+### Fixed
+
+- `buildReplayResponse()`'s main persisted-session path passed its timeline straight to `analyzeReplayTimeline()` with no sort, unlike its two fallback branches which both sort before analysis. Nothing upstream guarantees a persisted timeline is chronological (session persistence is append-only), so an out-of-order timeline could silently produce wrong anti-pattern segment boundaries and iteration counts with no error raised. The persisted-session path now sorts before analysis, matching the fallback branches.
+- `static-handler.ts`'s explicit path-traversal pre-check only split incoming paths on `/`, so a request built entirely from backslash-delimited `..` segments (no forward slashes at all) passed this specific check unchecked. The check now also splits on `\`, closing the gap in the primary sanitizer.
+- Removed `DashboardServer.registerRoute()`, a public method with no callers and no test coverage. Corrected a stale comment on `LiveEventBus`'s `setMaxListeners(200)` call that understated both the per-connection listener count (5, not 4) and the resulting connection headroom (200 concurrent connections, not 40 or 50 — `setMaxListeners` caps per event name, not in aggregate).
+
 ## [1.4.22] - 2026-07-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.22",
+      "version": "1.4.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/dashboard-server.ts
+++ b/src/dashboard/dashboard-server.ts
@@ -127,10 +127,6 @@ export class DashboardServer {
     });
   }
 
-  registerRoute(method: 'GET' | 'POST', path: string, handler: RouteHandler): void {
-    this.routes.set(`${method} ${path}`, handler);
-  }
-
   /** Phase 1 hook for tests + Phase 3 API route wiring. */
   getAlertEngine(): LocalAlertEngine | undefined {
     return this.opts.alertEngine;

--- a/src/dashboard/live-event-bus.ts
+++ b/src/dashboard/live-event-bus.ts
@@ -119,10 +119,11 @@ export class LiveEventBus {
 
   constructor(opts: LiveEventBusOptions = {}) {
     this.bufferSize = opts.replayBufferSize ?? DEFAULT_BUFFER_SIZE;
-    // Each SSE connection adds 4 listeners (tool-call, cost-update,
-    // anti-pattern, alert). 200 ÷ 4 = 50 concurrent connections before
-    // Node emits MaxListenersExceededWarning, which is comfortable
-    // headroom for parallel test runs and bursty client reconnects.
+    // Each SSE connection adds 5 listeners (tool-call, cost-update,
+    // anti-pattern, context-update, alert), each registered under its own
+    // event name. setMaxListeners() caps the count per event name, not in
+    // aggregate, so the real headroom is 200 concurrent connections —
+    // comfortable margin for parallel test runs and bursty client reconnects.
     this.emitter.setMaxListeners(200);
   }
 

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -312,6 +312,30 @@ describe('api-handler GET /api/sessions/:id', () => {
   });
 });
 
+describe('api-handler GET /api/sessions/:id/replay', () => {
+  it('sorts an out-of-order persisted timeline chronologically before returning it', async () => {
+    const outOfOrderTimeline = [
+      { timestamp: 300, toolName: 'Read', durationMs: 10, success: true },
+      { timestamp: 100, toolName: 'Edit', durationMs: 20, success: true },
+      { timestamp: 200, toolName: 'Bash', durationMs: 30, success: true },
+    ];
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: (id: string) =>
+          id === 'sess-replay' ? { sessionId: 'sess-replay', timeline: outOfOrderTimeline } : null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-replay/replay' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { timeline: Array<{ timestamp: number }> };
+    expect(parsed.timeline.map((e) => e.timestamp)).toEqual([100, 200, 300]);
+  });
+});
+
 describe('api-handler GET /api/cost', () => {
   it('returns cost and forecast as JSON', async () => {
     const fakeCost = { sessionTotalCostUsd: 0.25, costByModel: { 'claude-sonnet': 0.25 } };

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -542,6 +542,13 @@ function buildReplayResponse(sessionId: string, deps: ApiHandlerDeps): unknown |
         filePath: e.filePath ? redactSensitive(String(e.filePath)) : undefined,
         command: e.command ? redactSensitive(String(e.command)) : undefined,
       }));
+      // Persisted timelines are built append-only (session-store.ts iterates
+      // tasks and tool calls in array order, not sorted order) — nothing
+      // upstream guarantees chronological order. The two fallback branches
+      // below already sort before analysis; this main path (every
+      // completed/historical session) didn't, so every anti-pattern/segment
+      // detector inside analyzeReplayTimeline() silently trusted input order.
+      timeline.sort((a, b) => a.timestamp - b.timestamp);
       const analysis = analyzeReplayTimeline(timeline);
       return {
         sessionId,

--- a/src/dashboard/routes/static-handler.test.ts
+++ b/src/dashboard/routes/static-handler.test.ts
@@ -155,6 +155,19 @@ describe('static-handler', () => {
     expect(status()).toBe(403);
   });
 
+  it('rejects a backslash-delimited traversal payload the forward-slash-only check would miss', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'static-'));
+    writeFileSync(join(dir, 'index.html'), '<!doctype html>');
+    const handler = createStaticHandler(dir);
+    // The .js extension is load-bearing: without it, extname() would resolve to
+    // a bogus pseudo-extension (from the last '.' inside the '..' segments) that
+    // the MIME allow-list check rejects on its own, masking whether this test is
+    // actually exercising the traversal check being fixed here.
+    const { req, res, status } = makeReqRes('/assets\\..\\..\\secret.js');
+    await handler(req, res);
+    expect(status()).toBe(403);
+  });
+
   // Regression guard: vite.config.ts must use base:'/' so the built
   // index.html references assets via absolute paths. With base:'./', a
   // direct refresh on /sessions resolves relative './assets/x.js' against

--- a/src/dashboard/routes/static-handler.ts
+++ b/src/dashboard/routes/static-handler.ts
@@ -58,7 +58,11 @@ export function createStaticHandler(
     // an empty filename here — rather than letting it fall through to a
     // directory stat() — keeps a malformed URL like `//` returning 403,
     // not 404.
-    if (filename === '' || filename.includes('\0') || filename.split('/').some((c) => c === '..')) {
+    if (
+      filename === '' ||
+      filename.includes('\0') ||
+      filename.split(/[/\\]/).some((c) => c === '..')
+    ) {
       res.writeHead(403);
       res.end();
       return;


### PR DESCRIPTION
## Summary

- `buildReplayResponse()`'s main persisted-session path (serves every completed/historical session's replay view) passed its timeline straight to `analyzeReplayTimeline()` with no sort, unlike its two fallback branches which both sort first. Nothing upstream guarantees a persisted timeline is chronological, so an out-of-order timeline could silently produce wrong anti-pattern segment boundaries with no error raised. The persisted-session path now sorts before analysis, matching the fallback branches.
- `static-handler.ts`'s explicit path-traversal pre-check only split incoming paths on `/`, so a request built entirely from backslash-delimited `..` segments passed that specific check unchecked. The check now also splits on `\`, closing the gap in the primary sanitizer. A second, independent containment layer already made the handler safe in practice; this fix closes the gap in the explicit, static-analysis-visible check without touching that second layer.
- Removed `DashboardServer.registerRoute()`, a public method with no callers and no test coverage. Corrected a stale comment on `LiveEventBus`'s `setMaxListeners(200)` call that understated both the per-connection listener count (5, not 4) and the resulting connection headroom (200 concurrent connections, not 40 or 50).
- Bumps version to 1.4.23 and adds a CHANGELOG entry.

Fixes #162. Fixes #165. Fixes #166.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 3938 passed, 3 pre-existing skips, 0 failures
- [x] `npm run lint` — clean