### PR TITLE
Fix proxy SSRF/DNS-rebinding gap + error-message leakage (v1.4.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.24] - 2026-07-12
+
+### Fixed
+
+- Standalone proxy mode's SSRF protection validated the literal hostname string of a configured upstream/forward URL, but re-checked the exact same unchanged string a second time immediately before every network call — providing no real protection against DNS rebinding (a hostname resolving to a safe address when first validated, then to `127.0.0.1` or a cloud metadata address before the connection is actually made). Both `HttpUpstream` (proxy forwarding) and `OtlpReceiver` (OTLP forward endpoint) now resolve the hostname exactly once at connection time via a custom DNS lookup, validate every resolved address against the same blocklist rules, and pin the actual connection to that validated address.
+- Two proxy upstream transports returned raw error detail to HTTP clients on failure: `HttpUpstream` included the literal connection-error text (which can contain the upstream's host:port) in its JSON error body, and `StdioUpstream` forwarded a failed child process's raw error message (which can include file paths or tool-echoed arguments) straight through as the JSON-RPC error message. Both now return only a generic error code/message to the client; the full detail is still logged server-side.
+
 ## [1.4.23] - 2026-07-12
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -147,7 +147,9 @@ if (!ALLOWED_SCHEMES.has(this.url.protocol)) throw new Error('…scheme not allo
 if (BLOCKED_HOST_RE.test(this.url.hostname)) throw new Error('…private addresses not allowed');
 ```
 
-This is used by both `HttpUpstream` (MCP proxy forwarding) and `OtlpReceiver` (`otlpForwardEndpoint` config). Any new network client that takes a URL from config or user input should call `validateSsrfUrl()` at construction time.
+Checking the literal hostname string is not sufficient on its own — DNS can be repointed between the time a URL is validated and the time it's actually connected to (DNS rebinding). `createSsrfSafeLookup()` closes that gap: it resolves the hostname exactly once, validates every resolved address against the same rules above, and hands that validated address to the actual HTTP client as a custom `lookup` function, so the socket that gets opened is guaranteed to be an address that was just checked. `HttpUpstream.forward()` passes it as `http.request`'s/`https.request`'s `lookup` option; `OtlpReceiver` passes it via an `undici.Agent`'s `connect.lookup` option. A one-time `validateSsrfUrl()` call at construction is still worth keeping as a cheap fail-fast for an obviously-blocked literal host, but it is not itself the thing preventing rebinding — do not rely on a second same-string check immediately before a network call; it re-checks nothing new.
+
+This is used by both `HttpUpstream` (MCP proxy forwarding) and `OtlpReceiver` (`otlpForwardEndpoint` config). Any new network client that takes a URL from config or user input should call `validateSsrfUrl()` at construction time, and — if it makes its own outbound connections rather than delegating to `HttpUpstream`/`OtlpReceiver` — should also use `createSsrfSafeLookup()` as its connection-time resolver.
 
 ### Proxy body limits — `proxy-manager.ts`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.23",
+      "version": "1.4.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/proxy/otlp-receiver.test.ts
+++ b/src/proxy/otlp-receiver.test.ts
@@ -1,4 +1,17 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+// `jest.spyOn(dns, 'lookup')` cannot redefine `node:dns`'s export under this
+// ESM/ts-jest setup (the module namespace object is non-configurable), so — as in
+// src/security/ssrf.test.ts — the module must be replaced wholesale via jest.mock()
+// before anything else imports it. The default implementation delegates to the real
+// dns.lookup so every pre-existing test is unaffected (the `describe('forward', ...)`
+// tests mock globalThis.fetch directly, so undici's Agent — and its connect.lookup —
+// is never reached there); only the DNS-rebinding test below overrides it per-call.
+jest.mock('node:dns', () => {
+  const actual = jest.requireActual<typeof import('node:dns')>('node:dns');
+  return { lookup: jest.fn(actual.lookup) };
+});
+
 import { request as nodeRequest } from 'node:http';
 import type { Server } from 'node:http';
 import { createConnection, type AddressInfo } from 'node:net';
@@ -245,6 +258,63 @@ describe('forward', () => {
       // Verify only forwardHeaders and Content-Type are present
       expect(headers).toHaveProperty('api-key', 'test-key');
       expect(headers).toHaveProperty('Content-Type', 'application/json');
+    } finally {
+      await receiver.stop();
+    }
+  });
+});
+
+describe('forward — DNS rebinding protection', () => {
+  // This describe block is a sibling of describe('forward', ...), not nested inside it,
+  // so that block's own beforeEach (which sets globalThis.fetch = mockFetch) never runs
+  // here. However, describe('forward', ...)'s afterEach (and the unrelated 'error
+  // message sanitization' describe block, further below) resets globalThis.fetch to
+  // `undefined` rather than restoring the original native implementation — so by the
+  // time this block's test runs, globalThis.fetch is left undefined by that earlier
+  // block's cleanup, regardless of nesting. Save the real fetch once at module load
+  // (before any test has run) and restore it around this block's own test so the
+  // Agent's connect.lookup gets a genuine, unmocked fetch to actually run through.
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('rejects the forward when the forwardEndpoint hostname resolves to a private address', async () => {
+    const dnsMod = await import('node:dns');
+    const mockedLookup = dnsMod.lookup as unknown as jest.Mock<(...args: unknown[]) => void>;
+    mockedLookup.mockImplementationOnce((..._args: unknown[]) => {
+      const cb = _args[_args.length - 1] as (
+        err: NodeJS.ErrnoException | null,
+        addresses: { address: string; family: number }[],
+      ) => void;
+      cb(null, [{ address: '169.254.169.254', family: 4 }]);
+    });
+
+    const receiver = makeReceiver({
+      forwardEndpoint: 'https://looks-public-but-rebinds.example',
+    });
+    await receiver.start();
+    try {
+      const port = getBoundPort(receiver);
+      const res = await httpRequest(
+        port,
+        'POST',
+        '/v1/traces',
+        JSON.stringify({ resourceSpans: [] }),
+      );
+      // Without a dispatcher wired in, fetch never consults the mocked dns.lookup at
+      // all — it fails via its own resolver (real ENOTFOUND for this nonexistent
+      // domain), which the generic error handler also maps to 500. That coincidence
+      // would let this test pass even with no SSRF protection wired up. Asserting the
+      // mock was actually invoked proves the rejection came from the resolved-address
+      // check, not from an unrelated real DNS failure.
+      expect(mockedLookup).toHaveBeenCalled();
+      expect(res.statusCode).toBe(500);
     } finally {
       await receiver.stop();
     }

--- a/src/proxy/otlp-receiver.ts
+++ b/src/proxy/otlp-receiver.ts
@@ -1,8 +1,9 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createGunzip, createInflate, createBrotliDecompress } from 'node:zlib';
 import { timingSafeEqual } from 'node:crypto';
+import { Agent } from 'undici';
 import { createLogger } from '../shared/index.js';
-import { validateSsrfUrl } from '../security/ssrf.js';
+import { validateSsrfUrl, createSsrfSafeLookup } from '../security/ssrf.js';
 
 const logger = createLogger('otlp-receiver');
 
@@ -38,10 +39,17 @@ export class OtlpReceiver {
   private readonly options: OtlpReceiverOptions;
   private server: ReturnType<typeof createServer> | null = null;
   private readonly rateLimiter = new Map<string, number[]>();
+  // Built once and reused for every forward() call. Its connect.lookup resolves and
+  // validates the address actually connected to — see createSsrfSafeLookup()'s doc
+  // comment. undefined when forwarding is disabled (nothing to protect).
+  private readonly forwardDispatcher: Agent | undefined;
 
   constructor(options: OtlpReceiverOptions) {
     if (options.forwardEndpoint !== null) {
       validateSsrfUrl('OtlpReceiver forwardEndpoint', new URL(options.forwardEndpoint));
+      this.forwardDispatcher = new Agent({
+        connect: { lookup: createSsrfSafeLookup('OtlpReceiver forward endpoint (resolved)') },
+      });
     }
     this.options = Object.freeze(options);
   }
@@ -348,19 +356,26 @@ export class OtlpReceiver {
     if (this.options.forwardEndpoint === null) {
       throw new Error('forward() called with no forwardEndpoint configured');
     }
-    validateSsrfUrl('OtlpReceiver forward endpoint', new URL(this.options.forwardEndpoint));
     const url = `${this.options.forwardEndpoint}${path}`;
     // SECURITY: client request headers are deliberately NOT propagated to upstream — only forwardHeaders + Content-Type.
     // This prevents header injection attacks where a malicious client could inject headers into the upstream NR API call.
     // Do not change without security review.
-    const response = await globalThis.fetch(url, {
+    //
+    // The dispatcher's connect.lookup (set in the constructor) is what actually
+    // enforces SSRF protection here — resolving and validating the address this
+    // fetch connects to, not just the hostname string. Do not add back a
+    // validateSsrfUrl(...) call on the string here; re-checking the same
+    // unvalidated string provides no real protection against DNS rebinding.
+    const init: RequestInit & { dispatcher?: Agent } = {
       method: 'POST',
       headers: {
         'Content-Type': contentType,
         ...this.options.forwardHeaders,
       },
       body: body as unknown as BodyInit,
-    });
+      dispatcher: this.forwardDispatcher,
+    };
+    const response = await globalThis.fetch(url, init);
     const responseBody = await response.text();
     return { statusCode: response.status, body: responseBody };
   }

--- a/src/proxy/upstream-http.test.ts
+++ b/src/proxy/upstream-http.test.ts
@@ -1,4 +1,17 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+// `jest.spyOn(dns, 'lookup')` cannot redefine `node:dns`'s export under this
+// ESM/ts-jest setup (the module namespace object is non-configurable), so — as in
+// src/security/ssrf.test.ts — the module must be replaced wholesale via jest.mock()
+// before anything else imports it. The default implementation delegates to the real
+// dns.lookup so every pre-existing test (which never exercises a real hostname lookup —
+// they use literal IPs, which node:http/https resolve without calling `lookup` at all)
+// is unaffected; only the DNS-rebinding test below overrides it per-call.
+jest.mock('node:dns', () => {
+  const actual = jest.requireActual<typeof import('node:dns')>('node:dns');
+  return { lookup: jest.fn(actual.lookup) };
+});
+
 import {
   createServer,
   request as nodeRequest,
@@ -791,7 +804,9 @@ describe('HttpUpstream.forward()', () => {
 
     expect(result.statusCode).toBe(502);
     expect(result.isStreaming).toBe(false);
-    expect(Buffer.concat(fakeRes._body).toString()).toContain('timed out');
+    const body = JSON.parse(Buffer.concat(fakeRes._body).toString());
+    expect(body.error).toBe('upstream_unavailable');
+    expect(body.message).toBeUndefined();
   });
 
   it('returns upstream status and JSON error body when upstream errors before sending data', async () => {
@@ -819,6 +834,32 @@ describe('HttpUpstream.forward()', () => {
     expect(fakeRes._headers['content-type']).toBe('application/json');
     const body = JSON.parse(Buffer.concat(fakeRes._body).toString());
     expect(body.error).toBe('upstream_error');
+    expect(body.message).toBeUndefined();
+  });
+
+  it('does not leak raw connection-error detail (host:port) to the HTTP client', async () => {
+    ({ server: mockServer, port } = await createMockServer((_req, res) => {
+      res.end();
+    }));
+    await closeServer(mockServer);
+    mockServer = undefined as unknown as Server; // already closed; afterEach's guard checks truthiness
+
+    const upstream = new HttpUpstream(makeConfig(port));
+    const fakeReq = makeFakeRequest();
+    const fakeRes = makeFakeResponse();
+
+    const result = await upstream.forward(
+      fakeReq,
+      fakeRes as unknown as ServerResponse,
+      Buffer.from('{}'),
+    );
+
+    expect(result.statusCode).toBe(502);
+    expect(fakeRes._statusCode).toBe(502);
+    const body = JSON.parse(Buffer.concat(fakeRes._body).toString());
+    expect(body.error).toBe('upstream_unavailable');
+    expect(body.message).toBeUndefined();
+    expect(JSON.stringify(body)).not.toContain(String(port));
   });
 
   it('default timeout is 30 seconds', () => {
@@ -1004,6 +1045,42 @@ describe('HttpUpstream.forward()', () => {
       // Should return 502 (unreachable) not because of SSRF, but because DNS fails
       // or connection refused. The re-validation in forward() should complete
       // without throwing (since my-mcp-server.example.com is a public hostname).
+      expect(result.statusCode).toBe(502);
+    });
+
+    it('rejects the connection when the hostname resolves to a private address (real DNS-rebinding closure)', async () => {
+      const dnsMod = await import('node:dns');
+      const mockedLookup = dnsMod.lookup as unknown as jest.Mock<(...args: unknown[]) => void>;
+      mockedLookup.mockImplementationOnce((..._args: unknown[]) => {
+        const cb = _args[_args.length - 1] as (
+          err: NodeJS.ErrnoException | null,
+          addresses: { address: string; family: number }[],
+        ) => void;
+        cb(null, [{ address: '127.0.0.1', family: 4 }]);
+      });
+
+      const upstream = new HttpUpstream({
+        name: 'rebind-target',
+        url: 'https://looks-public-but-rebinds.example',
+        transportType: 'http',
+      });
+      const fakeReq = makeFakeRequest();
+      const fakeRes = makeFakeResponse();
+
+      const result = await upstream.forward(
+        fakeReq,
+        fakeRes as unknown as ServerResponse,
+        Buffer.from('{}'),
+      );
+
+      // Without a custom `lookup` option wired into the request, https.request never
+      // consults the mocked dns.lookup at all — it fails via its own internal resolver
+      // (real ENOTFOUND for this nonexistent domain), which also produces 502. That
+      // coincidence would let this test pass even with no SSRF protection wired up.
+      // Asserting the mock was actually invoked proves the rejection came from the
+      // resolved-address check, not from an unrelated real DNS failure.
+      expect(mockedLookup).toHaveBeenCalled();
+      // The connection must fail (502) — it must NOT actually reach 127.0.0.1.
       expect(result.statusCode).toBe(502);
     });
   });

--- a/src/proxy/upstream-http.ts
+++ b/src/proxy/upstream-http.ts
@@ -13,7 +13,7 @@ import { performance } from 'node:perf_hooks';
 import { createLogger } from '../shared/index.js';
 import type { ForwardResult, ProxyUpstream, UpstreamConfig } from './types.js';
 import { shouldForwardHeader } from './types.js';
-import { validateSsrfUrl } from '../security/ssrf.js';
+import { validateSsrfUrl, createSsrfSafeLookup } from '../security/ssrf.js';
 
 const logger = createLogger('proxy-http');
 
@@ -77,11 +77,6 @@ export class HttpUpstream implements ProxyUpstream {
   async forward(req: IncomingMessage, res: ServerResponse, body: Buffer): Promise<ForwardResult> {
     const requestFn = this.url.protocol === 'https:' ? httpsRequest : httpRequest;
 
-    // Re-validate URL against SSRF rules immediately before fetch to prevent DNS rebinding
-    if (!this.allowPrivateHosts) {
-      validateSsrfUrl(`HttpUpstream "${this.name}" (pre-fetch)`, this.url);
-    }
-
     // Build forwarded headers
     const headers: Record<string, string> = {};
     if (req.headers) {
@@ -104,6 +99,12 @@ export class HttpUpstream implements ProxyUpstream {
           method: req.method ?? 'POST',
           headers,
           timeout: this.timeoutMs,
+          // Resolves and validates the address actually connected to — not just the
+          // hostname string — closing the gap a same-string re-check (removed above)
+          // could not close. See createSsrfSafeLookup()'s doc comment for why.
+          ...(this.allowPrivateHosts
+            ? {}
+            : { lookup: createSsrfSafeLookup(`HttpUpstream "${this.name}" (resolved)`) }),
         },
         (upstreamRes) => {
           const upstreamLatencyMs = performance.now() - start;
@@ -192,7 +193,7 @@ export class HttpUpstream implements ProxyUpstream {
                 // Write 502 rather than re-using the upstream's statusCode (which may
                 // be 200) — that would fool callers into treating an error body as success.
                 res.writeHead(502, { 'content-type': 'application/json' });
-                res.end(JSON.stringify({ error: 'upstream_error', message: String(err) }));
+                res.end(JSON.stringify({ error: 'upstream_error' }));
               }
               resolve({
                 statusCode,
@@ -218,7 +219,7 @@ export class HttpUpstream implements ProxyUpstream {
           res.writeHead(502, { 'content-type': 'application/json' });
         }
         if (!res.writableEnded) {
-          res.end(JSON.stringify({ error: 'upstream_unavailable', message: String(err) }));
+          res.end(JSON.stringify({ error: 'upstream_unavailable' }));
         }
         resolve({
           statusCode: 502,

--- a/src/proxy/upstream-stdio.test.ts
+++ b/src/proxy/upstream-stdio.test.ts
@@ -277,7 +277,8 @@ describe('StdioUpstream.forward() with mock client', () => {
     expect(getStatus()).toBe(500);
     const parsed = JSON.parse(getBody());
     expect(parsed.error.code).toBe(-32603);
-    expect(parsed.error.message).toBe('Process crashed');
+    expect(parsed.error.message).toBe('Internal error');
+    expect(parsed.error.message).not.toContain('Process crashed');
     expect(result.upstreamLatencyMs).toBeGreaterThanOrEqual(0);
   });
 

--- a/src/proxy/upstream-stdio.ts
+++ b/src/proxy/upstream-stdio.ts
@@ -272,7 +272,10 @@ export class StdioUpstream implements ProxyUpstream {
         error: message,
       });
 
-      const size = writeJsonRpcError(res, rpc.id, -32603, message);
+      // -32603 is JSON-RPC's standard "Internal error" code — reuse its own name as the
+      // generic client-facing message. The real detail (child-process error text, which
+      // may contain file paths or tool-echoed arguments) stays in the logger call above.
+      const size = writeJsonRpcError(res, rpc.id, -32603, 'Internal error');
       return {
         statusCode: 500,
         isStreaming: false,

--- a/src/security/ssrf.test.ts
+++ b/src/security/ssrf.test.ts
@@ -1,0 +1,110 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+jest.mock('node:dns', () => ({ lookup: jest.fn() }));
+
+import * as dns from 'node:dns';
+import { createSsrfSafeLookup } from './ssrf.js';
+
+// `dns.lookup` is a 5-overload union with no single callable type, so it can't
+// flow into `jest.Mock`'s generic directly. Naming the one overload shape this
+// suite's `mockImplementation` calls actually use (a 3-arg callback-style lookup)
+// keeps `mockedLookup` concretely typed instead of falling back to jest's
+// default `UnknownFunction`, which would reject the typed `(_hostname: string, ...)`
+// implementations below.
+type LookupCallback = (
+  hostname: string,
+  options: unknown,
+  callback: (...args: unknown[]) => void,
+) => void;
+const mockedLookup = dns.lookup as unknown as jest.Mock<LookupCallback>;
+
+// Mirrors the callback shape node:http and undici's Agent actually use when
+// invoking a custom `lookup` option — both pass { all: true } in practice.
+function callLookup(
+  fn: ReturnType<typeof createSsrfSafeLookup>,
+  hostname: string,
+  all: boolean,
+): Promise<{ err: NodeJS.ErrnoException | null; address: unknown; family?: number }> {
+  return new Promise((resolve) => {
+    fn(hostname, { all }, (err, address, family) => resolve({ err, address, family }));
+  });
+}
+
+describe('createSsrfSafeLookup', () => {
+  beforeEach(() => {
+    mockedLookup.mockReset();
+  });
+
+  it('resolves and returns the array of addresses when the caller asked for all:true, given a safe hostname', async () => {
+    mockedLookup.mockImplementation(
+      (_hostname: string, _opts: unknown, cb: (...args: unknown[]) => void) => {
+        cb(null, [{ address: '93.184.216.34', family: 4 }]);
+      },
+    );
+
+    const lookup = createSsrfSafeLookup('test');
+    const result = await callLookup(lookup, 'example.com', true);
+
+    expect(result.err).toBeNull();
+    expect(result.address).toEqual([{ address: '93.184.216.34', family: 4 }]);
+  });
+
+  it('returns a single address+family when the caller asked for all:false, given a safe hostname', async () => {
+    mockedLookup.mockImplementation(
+      (_hostname: string, _opts: unknown, cb: (...args: unknown[]) => void) => {
+        cb(null, [{ address: '93.184.216.34', family: 4 }]);
+      },
+    );
+
+    const lookup = createSsrfSafeLookup('test');
+    const result = await callLookup(lookup, 'example.com', false);
+
+    expect(result.err).toBeNull();
+    expect(result.address).toBe('93.184.216.34');
+    expect(result.family).toBe(4);
+  });
+
+  it('rejects when DNS resolves the hostname to a loopback address (the rebind scenario)', async () => {
+    mockedLookup.mockImplementation(
+      (_hostname: string, _opts: unknown, cb: (...args: unknown[]) => void) => {
+        cb(null, [{ address: '127.0.0.1', family: 4 }]);
+      },
+    );
+
+    const lookup = createSsrfSafeLookup('test');
+    const result = await callLookup(lookup, 'attacker-controlled.example', true);
+
+    expect(result.err).not.toBeNull();
+    expect(result.err?.message).toContain('private or loopback');
+  });
+
+  it('rejects when ANY resolved address is blocked, even if another is safe', async () => {
+    mockedLookup.mockImplementation(
+      (_hostname: string, _opts: unknown, cb: (...args: unknown[]) => void) => {
+        cb(null, [
+          { address: '93.184.216.34', family: 4 },
+          { address: '169.254.169.254', family: 4 },
+        ]);
+      },
+    );
+
+    const lookup = createSsrfSafeLookup('test');
+    const result = await callLookup(lookup, 'mixed-resolution.example', true);
+
+    expect(result.err).not.toBeNull();
+  });
+
+  it('propagates a real DNS failure (e.g. ENOTFOUND) as-is', async () => {
+    const dnsError = Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' });
+    mockedLookup.mockImplementation(
+      (_hostname: string, _opts: unknown, cb: (...args: unknown[]) => void) => {
+        cb(dnsError);
+      },
+    );
+
+    const lookup = createSsrfSafeLookup('test');
+    const result = await callLookup(lookup, 'nonexistent.example', true);
+
+    expect(result.err).toBe(dnsError);
+  });
+});

--- a/src/security/ssrf.ts
+++ b/src/security/ssrf.ts
@@ -1,3 +1,6 @@
+import { lookup as dnsLookup } from 'node:dns';
+import type { LookupFunction } from 'node:net';
+
 const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
 
 // Cloud metadata service FQDNs that resolve to internal addresses within cloud accounts.
@@ -143,4 +146,55 @@ export function validateSsrfUrl(label: string, url: URL): void {
   if (embeddedIPv4 && BLOCKED_HOST_RE.test(embeddedIPv4)) {
     throw new Error(`${label}: host "${url.hostname}" contains a private or loopback IPv4 address`);
   }
+}
+
+/**
+ * Builds a drop-in replacement for the `lookup` option accepted by
+ * `http.request`/`https.request` (`node:net`'s `LookupFunction` type) and by
+ * `undici`'s `Agent`'s `connect.lookup` option. Resolves the hostname exactly
+ * once via `dns.lookup()`, validates every resolved address against the same
+ * rules `validateSsrfUrl` applies to literal hostnames, and only then hands
+ * the address(es) back to the caller — which then opens its TCP/TLS
+ * connection to exactly that address, with no further DNS resolution of its
+ * own. This is what actually closes the DNS-rebinding gap: checking a
+ * hostname string and later letting the OS resolve it again independently
+ * leaves a window for the DNS record to change between the two steps.
+ *
+ * Both known callers (node:http's internals and undici's connector) invoke
+ * a custom lookup with `options.all: true`, expecting an address array back
+ * — confirmed empirically. This still honors `options.all: false` for
+ * correctness against any other caller of the `LookupFunction` contract.
+ */
+export function createSsrfSafeLookup(label: string): LookupFunction {
+  return (hostname, options, callback) => {
+    dnsLookup(
+      hostname,
+      { family: options.family, hints: options.hints, all: true },
+      (err, addresses) => {
+        if (err) {
+          callback(err, '');
+          return;
+        }
+        if (addresses.length === 0) {
+          callback(new Error(`${label}: DNS lookup for "${hostname}" returned no addresses`), '');
+          return;
+        }
+        for (const { address, family } of addresses) {
+          const hostForCheck = family === 6 ? `[${address}]` : address;
+          try {
+            validateSsrfUrl(label, new URL(`http://${hostForCheck}`));
+          } catch (validationErr) {
+            callback(validationErr as Error, '');
+            return;
+          }
+        }
+        if (options.all) {
+          callback(null, addresses);
+        } else {
+          const chosen = addresses[0]!;
+          callback(null, chosen.address, chosen.family);
+        }
+      },
+    );
+  };
 }


### PR DESCRIPTION
## Summary

- SSRF protection validated the literal hostname string of a configured upstream/forward URL, but re-checked the exact same unchanged string a second time immediately before every network call, providing no real protection against DNS rebinding (a hostname resolving to a safe address when first validated, then to `127.0.0.1` or a cloud metadata address before the connection is actually made). Both `HttpUpstream` (proxy forwarding) and `OtlpReceiver` (OTLP forward endpoint) now resolve the hostname exactly once at connection time via a custom DNS lookup, validate every resolved address against the same blocklist rules, and pin the actual connection to that validated address.
- Two proxy upstream transports returned raw error detail to HTTP clients on failure: `HttpUpstream` included the literal connection-error text (which can contain the upstream's host:port) in its JSON error body, and `StdioUpstream` forwarded a failed child process's raw error message (which can include file paths or tool-echoed arguments) straight through as the JSON-RPC error message. Both now return only a generic error code/message to the client; the full detail is still logged server-side.
- Bumps version to 1.4.24 and adds a CHANGELOG entry.

Fixes #143. Fixes #144.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 3946 passed, 3 pre-existing skips, 0 failures
- [x] `npm run lint` — clean