### PR TITLE
Fix #151, #152: Storage cleanup — dead code + redaction consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.27] - 2026-07-12
+
+### Fixed
+
+- `LocalStore.saveSession()` and `loadRecentSessions()` were a parallel, unused session-persistence implementation with zero non-test call sites — every real session-persistence path goes through the separate `SessionStore` class instead. Removed both methods and their tests.
+- `buildSessionSummary()` redacted `timeline[].filePath` via `redactSensitive()` but persisted `filesRead`/`filesModified`/`sessionName`/`repoName` unredacted, even though they're sourced from the same underlying task data. All four now go through the same redaction call for consistency.
+- `SessionStore.saveSession()` now logs a warning when it's about to overwrite an existing session file for the same `sessionId`+date — the scenario a resumed/forked session running two MCP processes against one real session ID would produce. The overwrite behavior (last-write-wins) is unchanged; this only makes a previously-silent collision visible.
+
 ## [1.4.26] - 2026-07-12
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.26",
+      "version": "1.4.27",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -13,7 +13,7 @@ import {
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { LocalStore } from './local-store.js';
-import type { HookEvent, SessionSummary, AuditEntry } from './types.js';
+import type { HookEvent, AuditEntry } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -41,19 +41,6 @@ function makeEvent(overrides?: Partial<HookEvent>): HookEvent {
     inputSize: 42,
     outputSize: 100,
     success: true,
-    ...overrides,
-  };
-}
-
-function makeSession(overrides?: Partial<SessionSummary>): SessionSummary {
-  const now = Date.now();
-  return {
-    sessionId: `sess-${now}`,
-    startTime: now - 60_000,
-    endTime: now,
-    durationMs: 60_000,
-    toolCallCount: 5,
-    developer: 'test-user',
     ...overrides,
   };
 }
@@ -230,95 +217,6 @@ describe('LocalStore', () => {
       const drained = store.drainBuffer();
       expect(drained).toHaveLength(1);
       expect(drained[0]!.tool).toBe('Valid');
-    });
-  });
-
-  describe('saveSession() + loadRecentSessions()', () => {
-    it('saves a session and loads it back', () => {
-      const store = new LocalStore(tmpDir);
-      store.initialize();
-
-      const session = makeSession();
-      store.saveSession(session);
-
-      const loaded = store.loadRecentSessions(7);
-      expect(loaded).toHaveLength(1);
-      expect(loaded[0]).toEqual(session);
-    });
-
-    it('filters out sessions older than the cutoff', () => {
-      const store = new LocalStore(tmpDir);
-      store.initialize();
-
-      const now = Date.now();
-      const recent = makeSession({ sessionId: 'recent', startTime: now - 1000, endTime: now });
-      const old = makeSession({
-        sessionId: 'old',
-        startTime: now - 30 * 86_400_000,
-        endTime: now - 30 * 86_400_000 + 1000,
-      });
-
-      store.saveSession(recent);
-      store.saveSession(old);
-
-      // Touch the old file to make its mtime old
-      const oldPath = resolve(tmpDir, 'sessions', 'old.json');
-      const pastDate = new Date(now - 30 * 86_400_000);
-      utimesSync(oldPath, pastDate, pastDate);
-
-      const loaded = store.loadRecentSessions(7);
-      expect(loaded).toHaveLength(1);
-      expect(loaded[0]!.sessionId).toBe('recent');
-    });
-
-    it('returns empty array when sessions directory does not exist', () => {
-      const store = new LocalStore(tmpDir);
-      // Do NOT call initialize()
-      expect(store.loadRecentSessions(7)).toEqual([]);
-    });
-
-    it('rejects sessionId containing path traversal and writes no file', () => {
-      const store = new LocalStore(tmpDir);
-      store.initialize();
-
-      store.saveSession(makeSession({ sessionId: '../../etc/passwd' }));
-
-      expect(readdirSync(resolve(tmpDir, 'sessions'))).toHaveLength(0);
-    });
-
-    it('rejects sessionId containing a forward slash', () => {
-      const store = new LocalStore(tmpDir);
-      store.initialize();
-
-      store.saveSession(makeSession({ sessionId: 'a/b' }));
-
-      expect(readdirSync(resolve(tmpDir, 'sessions'))).toHaveLength(0);
-    });
-
-    it('accepts a valid UUID-style sessionId', () => {
-      const store = new LocalStore(tmpDir);
-      store.initialize();
-
-      store.saveSession(makeSession({ sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }));
-
-      expect(readdirSync(resolve(tmpDir, 'sessions'))).toHaveLength(1);
-    });
-
-    it('sorts sessions by startTime', () => {
-      const store = new LocalStore(tmpDir);
-      store.initialize();
-
-      const now = Date.now();
-      const s1 = makeSession({ sessionId: 's1', startTime: now - 3000 });
-      const s2 = makeSession({ sessionId: 's2', startTime: now - 1000 });
-      const s3 = makeSession({ sessionId: 's3', startTime: now - 2000 });
-
-      store.saveSession(s2);
-      store.saveSession(s3);
-      store.saveSession(s1);
-
-      const loaded = store.loadRecentSessions(7);
-      expect(loaded.map((s) => s.sessionId)).toEqual(['s1', 's3', 's2']);
     });
   });
 

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -9,9 +9,9 @@ import {
   readdirSync,
   statSync,
 } from 'node:fs';
-import { resolve, join, sep } from 'node:path';
+import { resolve, sep } from 'node:path';
 import { createLogger } from '../shared/index.js';
-import type { HookEvent, SessionSummary, AuditEntry } from './types.js';
+import type { HookEvent, AuditEntry } from './types.js';
 
 const logger = createLogger('local-store');
 
@@ -878,52 +878,6 @@ export class LocalStore {
   /** The sessionId this store was scoped to, if any (test helper). */
   getSessionId(): string | null {
     return this.sessionId;
-  }
-
-  saveSession(session: SessionSummary): void {
-    if (!SESSION_ID_RE.test(session.sessionId)) {
-      logger.warn('Rejecting invalid sessionId for file path', { sessionId: session.sessionId });
-      return;
-    }
-    const sessionsDir = resolve(this.storagePath, 'sessions');
-    const filepath = resolve(sessionsDir, `${session.sessionId}.json`);
-    if (!filepath.startsWith(sessionsDir + sep)) {
-      throw new Error(`Session path escaped storage directory: ${filepath}`);
-    }
-    writeFileSync(filepath, JSON.stringify(session, null, 2) + '\n', { mode: 0o600 });
-    logger.debug('Session saved', { sessionId: session.sessionId });
-  }
-
-  loadRecentSessions(days: number): SessionSummary[] {
-    const sessionsDir = resolve(this.storagePath, 'sessions');
-    if (!existsSync(sessionsDir)) {
-      return [];
-    }
-
-    const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
-    const sessions: SessionSummary[] = [];
-
-    for (const file of readdirSync(sessionsDir)) {
-      if (!file.endsWith('.json')) continue;
-      const filepath = join(sessionsDir, file);
-
-      try {
-        const stat = statSync(filepath);
-        if (stat.mtimeMs < cutoff) continue;
-
-        const raw = readFileSync(filepath, 'utf-8');
-        const parsed = JSON.parse(raw) as unknown;
-        // Guard against corrupted files (null, numbers, arrays) that would crash
-        // the downstream sort on .startTime.
-        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-          sessions.push(parsed as SessionSummary);
-        }
-      } catch {
-        logger.warn('Skipping unreadable session file', { file });
-      }
-    }
-
-    return sessions.sort((a, b) => a.startTime - b.startTime);
   }
 
   appendAuditLog(entry: AuditEntry): void {

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -540,6 +540,140 @@ describe('buildSessionSummary', () => {
     expect(summary.outcome).toBe('completed');
   });
 
+  it('redacts secret-shaped substrings in filesRead and filesModified', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'redact-test',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 1,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: 1,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+
+    const mockTaskDetector = {
+      getCurrentTask: () => null,
+      getMetrics: () => ({
+        totalTasksCompleted: 1,
+        currentTaskActive: false,
+        currentTaskToolCalls: 0,
+        averageTaskDurationMs: 0,
+        averageToolCallsPerTask: 0,
+        completedTasks: [
+          {
+            taskId: 't1',
+            startTime: 1700000000000,
+            endTime: 1700000060000,
+            durationMs: 60_000,
+            toolCallCount: 1,
+            toolCallsByType: {},
+            filesRead: ['/repo/config-API_KEY=abc123def456secretvalue.ts'],
+            filesModified: ['/repo/README.md'],
+            linesChanged: 0,
+            linesAdded: 0,
+            linesRemoved: 0,
+            bashCommandsRun: 0,
+            testsRun: 0,
+            testsPassed: 0,
+            buildRun: 0,
+            buildPassed: 0,
+            estimatedCostUsd: 0,
+            tokensUsed: 0,
+            askedUserQuestions: 0,
+            subAgentsSpawned: 0,
+            toolCalls: [],
+          },
+        ],
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      taskDetector: mockTaskDetector as unknown as TaskDetector,
+      developer: 'alice',
+    });
+
+    expect(summary.filesRead).toEqual(['/repo/config-[REDACTED]']);
+    expect(summary.filesRead[0]).not.toContain('abc123def456secretvalue');
+    expect(summary.filesModified).toEqual(['/repo/README.md']);
+  });
+
+  it('redacts secret-shaped substrings in sessionName and repoName', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'redact-test-2',
+        sessionName: 'API_KEY=abc123def456secretvalue',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: 1,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      developer: 'alice',
+      repoName: 'API_KEY=abc123def456secretvalue',
+    });
+
+    expect(summary.sessionName).toBe('[REDACTED]');
+    expect(summary.repoName).toBe('[REDACTED]');
+  });
+
+  it('leaves sessionName and repoName as null when not provided', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'redact-test-3',
+        sessionName: null,
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: 1,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      developer: 'alice',
+    });
+
+    expect(summary.sessionName).toBeNull();
+    expect(summary.repoName).toBeNull();
+  });
+
   it('includes active task data in the summary', () => {
     const mockSessionTracker = {
       getMetrics: () => ({
@@ -831,7 +965,7 @@ describe('SessionStore corruption-recovery', () => {
     }
   });
 
-  it('two saveSession calls with the same sessionId result in last-write-wins', () => {
+  it('two saveSession calls with the same sessionId result in last-write-wins, and logs a warning on the second write', () => {
     const store = new SessionStore({ storagePath: tmpDir });
     const startTime = new Date('2026-03-01T00:00:00Z').getTime();
 
@@ -844,6 +978,13 @@ describe('SessionStore corruption-recovery', () => {
     const loaded = store.loadSession('dup-id');
     expect(loaded).not.toBeNull();
     expect(loaded!.developer).toBe('bob');
+
+    const logged = stderrSpy.mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(
+      logged.some(
+        (l: string) => l.includes('"warn"') && l.includes('Overwriting existing session file'),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -114,6 +114,21 @@ export class SessionStore {
       throw new Error(`Session path escaped storage directory: ${filepath}`);
     }
 
+    // A second process saving under the same sessionId+date (e.g. two MCP
+    // servers both resumed/forked against one real session ID) would
+    // otherwise silently overwrite the first save with no error. This
+    // warning makes that cross-process collision visible instead of a
+    // silent last-write-wins; the overwrite itself is unchanged.
+    if (existsSync(filepath)) {
+      logger.warn(
+        'Overwriting existing session file — possible cross-process sessionId collision',
+        {
+          sessionId: summary.sessionId,
+          filename,
+        },
+      );
+    }
+
     try {
       writeFileSync(filepath, JSON.stringify(summary, null, 2) + '\n', { mode: 0o600 });
       logger.debug('Session saved', { sessionId: summary.sessionId, filename });
@@ -345,8 +360,8 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
 
   return {
     sessionId: sessionMetrics.sessionId,
-    sessionName: sessionMetrics.sessionName,
-    repoName: sources.repoName ?? null,
+    sessionName: sessionMetrics.sessionName ? redactSensitive(sessionMetrics.sessionName) : null,
+    repoName: sources.repoName ? redactSensitive(sources.repoName) : null,
     startTime: sessionMetrics.sessionStartTime,
     endTime: now,
     // Recalculate durationMs from wall-clock times rather than trusting the
@@ -356,8 +371,8 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     developer,
     model: costMetrics?.model ?? null,
     toolBreakdown: { ...sessionMetrics.toolCallCountByTool },
-    filesRead: [...allFilesRead].sort(),
-    filesModified: [...allFilesModified].sort(),
+    filesRead: [...allFilesRead].sort().map((f) => redactSensitive(f)),
+    filesModified: [...allFilesModified].sort().map((f) => redactSensitive(f)),
     linesAdded: totalLinesAdded,
     linesRemoved: totalLinesRemoved,
     bashCommandCount: sessionMetrics.bashCommandsRun,


### PR DESCRIPTION
## Summary

- Removes `LocalStore.saveSession()` / `loadRecentSessions()`, a parallel session-persistence implementation with zero non-test callers — real persistence goes through `SessionStore` instead. Fixes #151.
- `buildSessionSummary()` redacted `timeline[].filePath`/`.command` via `redactSensitive()` but persisted `filesRead`/`filesModified`/`sessionName`/`repoName` unredacted, despite being sourced from the same underlying task data. All four now route through the same redaction call. Fixes #152.
- `SessionStore.saveSession()` now logs a warning before overwriting an existing session file for the same `sessionId`+date — the scenario a resumed/forked session running two MCP processes against one real session ID would produce. Overwrite behavior (last-write-wins) is unchanged; this is visibility-only, no locking mechanism. Fixes #152.
- Version bump to 1.4.27.

## Test plan

- [x] `npm run build` — succeeds
- [x] `npm test` — 3947/3950 passing (3 pre-existing skips), 0 failures
- [x] `npm run lint` — 0 errors/warnings
- [x] New tests added for redaction consistency and the overwrite-warning log

🤖 Generated with [Claude Code](https://claude.com/claude-code)