### PR TITLE
Fix #164, #168: Security/redaction accuracy — SECURITY.md + REDACT_FIELD_KEYS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.29] - 2026-07-12
+
+### Fixed
+
+- `SECURITY.md`'s audit-trail network-request pattern list said `curl`, `wget`, `fetch`; the real pattern list is `curl`, `wget`, `nc`, `ssh`. Docs corrected.
+- `REDACT_FIELD_KEYS` (the allowlist controlling which extra `AiToolCall` string fields get redacted before reaching New Relic) was missing five fields that `src/hooks/tool-parsers.ts` produces: `commandDescription`, `taskSubject`, `grepPath`, `globPath`, and `agentTeamName`. These now pass through `redactSensitive()` like every other tool-specific string field.
+
 ## [1.4.28] - 2026-07-12
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -245,7 +245,7 @@ Both `AgentConfig` and `McpServerConfig` are frozen with `Object.freeze()` immed
 
 - **Sensitive file access** — `.env`, `.pem`, `.key`, credential and password files — severity: `high`
 - **Destructive commands** — `rm -rf`, `DROP TABLE`, pipe-to-shell patterns — severity: `critical`
-- **External network requests** — `curl`, `wget`, `fetch` — severity: `medium`
+- **External network requests** — `curl`, `wget`, `nc`, `ssh` — severity: `medium`
 
 Records are persisted to disk in real time via `LocalStore.appendAuditLog()`, so the trail survives unclean shutdowns.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.28",
+  "version": "1.4.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.28",
+      "version": "1.4.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.28",
+  "version": "1.4.29",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -298,6 +298,24 @@ describe('toolCallToNrEvent()', () => {
       expect(event.detail as string).not.toContain(SECRET_TOKEN);
     });
 
+    it('redacts secrets in commandDescription / taskSubject / grepPath / globPath / agentTeamName', () => {
+      const record = makeRecord({
+        commandDescription: `Run curl with token ${SECRET_TOKEN}`,
+        taskSubject: `Rotate token ${SECRET_TOKEN}`,
+        grepPath: `/tmp/${SECRET_TOKEN}/src`,
+        globPath: `/tmp/${SECRET_TOKEN}/**/*.ts`,
+        agentTeamName: `team-${SECRET_TOKEN}`,
+      } as unknown as Partial<ToolCallRecord>);
+
+      const event = toolCallToNrEvent(record, { developer: 'd', appName: 'a' });
+
+      expect(event.commandDescription as string).not.toContain(SECRET_TOKEN);
+      expect(event.taskSubject as string).not.toContain(SECRET_TOKEN);
+      expect(event.grepPath as string).not.toContain(SECRET_TOKEN);
+      expect(event.globPath as string).not.toContain(SECRET_TOKEN);
+      expect(event.agentTeamName as string).not.toContain(SECRET_TOKEN);
+    });
+
     it('does not redact non-sensitive string fields', () => {
       const record = makeRecord({
         toolName: 'Bash',

--- a/src/transport/nr-ingest.ts
+++ b/src/transport/nr-ingest.ts
@@ -150,6 +150,11 @@ const REDACT_FIELD_KEYS = new Set([
   'agent_description',
   'detail',
   'cwd',
+  'commandDescription',
+  'taskSubject',
+  'grepPath',
+  'globPath',
+  'agentTeamName',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Fixes #164. Fixes #168.

- `SECURITY.md`'s audit-trail network-request pattern list said `curl`, `wget`, `fetch`. The real pattern list (`DEFAULT_NETWORK_COMMAND_PATTERNS` in `src/security/audit-trail.ts`) is `curl`, `wget`, `nc`, `ssh`. Docs corrected to match.
- `REDACT_FIELD_KEYS` (the allowlist in `src/transport/nr-ingest.ts` controlling which extra `AiToolCall` string fields get redacted before reaching New Relic) was missing five fields that `src/hooks/tool-parsers.ts` actually produces: `commandDescription`, `taskSubject`, `grepPath`, `globPath`, `agentTeamName`. These passed through unredacted. Added all five, with a new test.
- Version bump to 1.4.29.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (3948/3951)
- [x] `npm run lint` — 0 new issues (repo's pre-existing lint gap in `scripts/*.ts` is unrelated to this change and predates it)
- [x] New test in `src/transport/nr-ingest.test.ts` exercises the real `toolCallToNrEvent()` redaction path (not mocked) for all five newly-added keys