### PR TITLE
Fix web-dashboard high-visibility bugs (v1.4.30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.30] - 2026-07-12
+
+### Fixed
+
+- The "Alert Thresholds" card claimed these five values feed "the local alert engine" and require a server restart. Neither is true — the real (and only) consumer is the separate `deploy-alerts` CLI, which templates cloud alert conditions and reads config fresh on every invocation. Subtitle and save-confirmation copy corrected.
+- Clicking "Unsubscribe" on the Slack digest webhook left an unsaved, stale edit visible in the input box even though the adjacent status Pill correctly flipped to "Not configured." The input now resets to server truth immediately.
+- The session detail page's "Outcome" card always showed one of exactly two hardcoded values (`completed`/`in progress`) — no real outcome classification exists. Relabeled as "Status" to accurately reflect it as a running-state indicator, not a quality/outcome classification.
+- The session detail page's "Session Quality" and "Tool Selection" cards were fully built but never rendered: the backing tracker data was never attached to any of the three `/api/sessions/:id` response branches. Now attached to the branches where the data is actually available (the live session and, for quality, persisted sessions via their own stored timeline).
+- The Today view's anti-pattern banner rendered a literal `?` instead of a real count for `stuck_loop`, `blind_editing`, and `over_delegation` patterns when reached via its non-SSE API-fallback path — the fallback chain only checked 3 of the 6 possible count fields. Extended to check all of them.
+
 ## [1.4.29] - 2026-07-12
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.29",
+  "version": "1.4.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.29",
+      "version": "1.4.30",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.29",
+  "version": "1.4.30",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -310,6 +310,183 @@ describe('api-handler GET /api/sessions/:id', () => {
     await handler(req, res);
     expect(status()).toBe(404);
   });
+
+  it('attaches qualityProxy (derived from timeline) to a persisted session with real signals', async () => {
+    const fakeSession = {
+      sessionId: 'sess-quality-1',
+      testRunCount: 4,
+      testPassCount: 3,
+      timeline: [
+        { timestamp: 1, toolName: 'Edit', durationMs: 10, success: true, filePath: 'a.ts' },
+        { timestamp: 2, toolName: 'Edit', durationMs: 10, success: false, filePath: 'b.ts' },
+      ],
+    };
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: (id: string) => (id === 'sess-quality-1' ? fakeSession : null),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-quality-1' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { qualityProxy?: { diffApplyRate: number | null } };
+    expect(parsed.qualityProxy).toBeDefined();
+    expect(parsed.qualityProxy?.diffApplyRate).toBeCloseTo(0.5);
+  });
+
+  it('does not attach qualityProxy to a persisted session with zero signals (regression guard)', async () => {
+    const fakeSession = {
+      sessionId: 'sess-abc-999',
+      startTime: Date.now() - 5000,
+      toolCallCount: 10,
+    };
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: (id: string) => (id === 'sess-abc-999' ? fakeSession : null),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-abc-999' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(JSON.parse(body())).toEqual(fakeSession);
+  });
+
+  it('attaches qualityProxy and session-filtered toolSelectionScore to the own-live-session branch', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({
+          sessionId: 'live1',
+          sessionName: null,
+          sessionStartTime: 1000,
+          sessionDurationMs: 500,
+          toolCallCount: 2,
+          toolCallCountByTool: { Read: 2 },
+          uniqueFilesRead: 1,
+          uniqueFilesWritten: 0,
+          toolCallTimeline: [],
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+      qualityProxyTracker: {
+        getMetrics: () => ({
+          totalSignals: 3,
+          diffApplyRate: 1,
+          testPassRate: null,
+          backtrackCount: 0,
+          selfCorrectionCount: 0,
+        }),
+      },
+      toolSelectionScorer: {
+        scoreSession: (calls: readonly unknown[]) => ({
+          score: 0.9,
+          redundantReadCount: calls.length,
+          repeatedFailureCount: 0,
+          unusedOutputCount: 0,
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['toolSelectionScorer'],
+      toolCallBuffer: {
+        getRecords: () => [
+          {
+            id: '1',
+            sessionId: 'live1',
+            toolName: 'Read',
+            toolUseId: 'u1',
+            timestamp: 1,
+            durationMs: 1,
+            success: true,
+          },
+          {
+            id: '2',
+            sessionId: 'other',
+            toolName: 'Read',
+            toolUseId: 'u2',
+            timestamp: 2,
+            durationMs: 1,
+            success: true,
+          },
+        ],
+      } as unknown as Parameters<typeof createApiHandler>[0]['toolCallBuffer'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/live1' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      qualityProxy?: { diffApplyRate: number | null };
+      toolSelectionScore?: { score: number; redundantReadCount: number };
+    };
+    expect(parsed.qualityProxy?.diffApplyRate).toBe(1);
+    // Only the 1 record belonging to 'live1' should have been scored, not the 'other' session's record.
+    expect(parsed.toolSelectionScore?.redundantReadCount).toBe(1);
+  });
+
+  it('attaches toolSelectionScore (but not qualityProxy) to the registry-synthesized branch', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({
+          sessionId: 'mine',
+          sessionName: null,
+          sessionStartTime: 0,
+          sessionDurationMs: 0,
+          toolCallCount: 0,
+          toolCallCountByTool: {},
+          uniqueFilesRead: 0,
+          uniqueFilesWritten: 0,
+          toolCallTimeline: [],
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+      liveSessionRegistry: {
+        getLiveSessions: () => ['concurrent1'],
+        getSessionName: () => null,
+      },
+      toolSelectionScorer: {
+        scoreSession: (calls: readonly unknown[]) => ({
+          score: 0.5,
+          redundantReadCount: 0,
+          repeatedFailureCount: calls.length,
+          unusedOutputCount: 0,
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['toolSelectionScorer'],
+      toolCallBuffer: {
+        getRecords: () => [
+          {
+            id: '1',
+            sessionId: 'concurrent1',
+            toolName: 'Bash',
+            toolUseId: 'u1',
+            timestamp: 1,
+            durationMs: 1,
+            success: false,
+          },
+        ],
+      } as unknown as Parameters<typeof createApiHandler>[0]['toolCallBuffer'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/concurrent1' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      qualityProxy?: unknown;
+      toolSelectionScore?: { repeatedFailureCount: number };
+    };
+    expect(parsed.qualityProxy).toBeUndefined();
+    expect(parsed.toolSelectionScore?.repeatedFailureCount).toBe(1);
+  });
 });
 
 describe('api-handler GET /api/sessions/:id/replay', () => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1644,7 +1644,10 @@ export function createApiHandler(
         if (!deps.sessionStore) return unavailable(res, 'sessionStore');
         const session = deps.sessionStore.loadSession(sessionId);
         if (session != null) {
-          jsonOk(res, session);
+          const quality = aggregateQualityFromHistory([session]);
+          const responseBody: Record<string, unknown> = { ...(session as Record<string, unknown>) };
+          if (quality.totalSignals > 0) responseBody.qualityProxy = quality;
+          jsonOk(res, responseBody);
           return;
         }
         // Not persisted — check if it's the current live session
@@ -1660,6 +1663,11 @@ export function createApiHandler(
                   count: number;
                 }>)
               : [];
+            const ownSessionRecords = (deps.toolCallBuffer?.getRecords() ?? []).filter(
+              (r) => r.sessionId === sessionId,
+            );
+            const quality = deps.qualityProxyTracker?.getMetrics() as
+              { totalSignals: number } | undefined;
             jsonOk(res, {
               sessionId: live.sessionId,
               sessionName: live.sessionName ?? null,
@@ -1671,6 +1679,11 @@ export function createApiHandler(
               outcome: 'in progress',
               toolBreakdown: live.toolCallCountByTool,
               antiPatterns,
+              qualityProxy: quality && quality.totalSignals > 0 ? quality : undefined,
+              toolSelectionScore:
+                ownSessionRecords.length > 0
+                  ? deps.toolSelectionScorer?.scoreSession(ownSessionRecords)
+                  : undefined,
               // Use the same `timeline` shape as persisted sessions so the
               // Sessions and Replay views can consume one type. See
               // src/storage/types.ts ReplayTimelineEntry.
@@ -1718,6 +1731,8 @@ export function createApiHandler(
             outcome: 'in progress',
             toolBreakdown: breakdown,
             antiPatterns: [],
+            toolSelectionScore:
+              records.length > 0 ? deps.toolSelectionScorer?.scoreSession(records) : undefined,
             timeline,
           });
           return;

--- a/src/web/views/Alerts.test.tsx
+++ b/src/web/views/Alerts.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+import { Alerts } from './Alerts';
+
+const DEFAULT_BUDGET = {
+  session: { budgetUsd: null, spentUsd: 0, pctUsed: null, exceeded: false },
+  daily: { budgetUsd: null, spentUsd: 0, pctUsed: null, exceeded: false },
+  weekly: { budgetUsd: null, spentUsd: 0, pctUsed: null, exceeded: false },
+  alerts: [],
+};
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function renderAlerts(initialSettings: {
+  digestWebhookUrl: string | null;
+  digestSchedule: string;
+  alerts: { personal: Record<string, number> };
+}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+  let settings = initialSettings;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    if (url === '/api/budget') return jsonResponse(DEFAULT_BUDGET);
+    if (url === '/api/settings' && (!init || init.method === undefined)) {
+      return jsonResponse(settings);
+    }
+    if (url === '/api/settings' && init?.method === 'PATCH') {
+      const patch = JSON.parse(String(init.body)) as Record<string, unknown>;
+      settings = { ...settings, ...patch } as typeof settings;
+      return jsonResponse({ ok: true, restartRequired: false });
+    }
+    return jsonResponse({});
+  }) as typeof fetch;
+  return render(
+    <QueryClientProvider client={qc}>
+      <Alerts />
+    </QueryClientProvider>,
+  );
+}
+
+const BASE_SETTINGS = {
+  digestWebhookUrl: 'https://hooks.slack.com/services/original',
+  digestSchedule: '0 9 * * 1',
+  alerts: {
+    personal: {
+      dailyCostUsd: 10,
+      sessionCostUsd: 5,
+      efficiencyScoreMin: 0.5,
+      stuckLoopCountMax: 3,
+      antiPatternCountMax: 5,
+    },
+  },
+};
+
+describe('Alerts view', () => {
+  it('does not claim these thresholds feed a local alert engine or need a server restart', async () => {
+    renderAlerts(BASE_SETTINGS);
+    await waitFor(() => expect(screen.getByText(/Alert Thresholds/)).toBeInTheDocument());
+    expect(screen.queryByText(/local alert engine/i)).toBeNull();
+    expect(screen.queryByText(/require a server restart/i)).toBeNull();
+  });
+
+  it('resets the webhook input to server truth after clicking Unsubscribe', async () => {
+    renderAlerts(BASE_SETTINGS);
+    const input = await screen.findByPlaceholderText('https://hooks.slack.com/...');
+    fireEvent.change(input, { target: { value: 'https://hooks.slack.com/unsaved-edit' } });
+    expect(input).toHaveValue('https://hooks.slack.com/unsaved-edit');
+
+    const unsubscribeButton = screen.getByRole('button', { name: 'Unsubscribe' });
+    fireEvent.click(unsubscribeButton);
+
+    await waitFor(() => expect(screen.getByText('Not configured')).toBeInTheDocument());
+    expect(input).toHaveValue('');
+  });
+});

--- a/src/web/views/Alerts.tsx
+++ b/src/web/views/Alerts.tsx
@@ -236,7 +236,7 @@ export function Alerts(): JSX.Element {
       <Card padding="md" className="mb-4">
         <SectionHeader
           title="Alert Thresholds"
-          subtitle="Thresholds for the local alert engine. Require a server restart to take effect."
+          subtitle="Thresholds used by the `deploy-alerts` CLI (`npm run deploy:alerts`) when templating cloud alert conditions. Have no effect on this dashboard or any running session."
         />
 
         {settingsQ.isLoading && <EmptyState icon="clock" variant="loading" title="Loading..." />}
@@ -264,7 +264,7 @@ export function Alerts(): JSX.Element {
               </Button>
               {thresholdSaved && (
                 <span className="text-xs text-accent-amber">
-                  Saved. Restart server for changes to take effect.
+                  Saved. Run `npm run deploy:alerts` to apply these to your cloud alert conditions.
                 </span>
               )}
             </div>
@@ -331,7 +331,12 @@ export function Alerts(): JSX.Element {
                 <Button
                   variant="danger"
                   size="md"
-                  onClick={() => saveMutation.mutate({ digestWebhookUrl: null })}
+                  onClick={() =>
+                    saveMutation.mutate(
+                      { digestWebhookUrl: null },
+                      { onSuccess: () => setWebhookUrl(undefined) },
+                    )
+                  }
                   disabled={saveMutation.isPending}
                 >
                   Unsubscribe

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -161,6 +161,23 @@ describe('Sessions view', () => {
     expect(screen.getAllByText('Read').length).toBeGreaterThanOrEqual(2);
   });
 
+  it('labels the outcome field as Status, not Outcome', async () => {
+    const detailWithOutcome = {
+      sessionId: 's1',
+      durationMs: 5000,
+      toolCallCount: 1,
+      outcome: 'completed',
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+    };
+    renderSessions(SAMPLE_LIST, { s1: detailWithOutcome });
+    // Auto-selects s1, so just wait for it to load
+    await waitFor(() => expect(screen.getAllByText('Read').length).toBeGreaterThanOrEqual(1));
+    // Verify the label is now "Status" instead of "Outcome"
+    expect(screen.queryByText('Outcome')).toBeNull();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('completed')).toBeInTheDocument();
+  });
+
   it('shows the timeline header with session ID and call count', async () => {
     const detail = {
       sessionId: 's1-abcdef',
@@ -282,5 +299,31 @@ describe('Sessions view — real API shapes', () => {
     await waitFor(() => expect(screen.getByText(/abc-123/)).toBeInTheDocument());
     fireEvent.click(screen.getAllByText(/abc-123/)[0]);
     await waitFor(() => expect(screen.getByText(/no tool calls/i)).toBeInTheDocument());
+  });
+
+  it('renders the Session Quality and Tool Selection cards when the API attaches them', async () => {
+    renderSessions(SAMPLE_LIST, {
+      s1: {
+        sessionId: 's1',
+        timeline: [],
+        toolBreakdown: { Edit: 2 },
+        qualityProxy: {
+          diffApplyRate: 0.8,
+          testPassRate: 0.6,
+          backtrackCount: 2,
+          selfCorrectionCount: 1,
+        },
+        toolSelectionScore: {
+          score: 0.75,
+          redundantReadCount: 3,
+          repeatedFailureCount: 1,
+          unusedOutputCount: 0,
+        },
+      },
+    });
+    await waitFor(() => expect(screen.getByText('Session Quality')).toBeInTheDocument());
+    expect(screen.getByText('Tool Selection')).toBeInTheDocument();
+    expect(screen.getByText('80%')).toBeInTheDocument();
+    expect(screen.getByText('0.75')).toBeInTheDocument();
   });
 });

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -403,8 +403,8 @@ function SessionTimeline({ data, isLive }: { data: SessionDetail; isLive: boolea
         )}
         {data.outcome && (
           <div className="bg-surface-3 rounded-lg p-2.5">
-            <Eyebrow>Outcome</Eyebrow>
-            <div>{data.outcome}</div>
+            <Eyebrow>Status</Eyebrow>
+            <div className="capitalize">{data.outcome}</div>
           </div>
         )}
       </div>

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -79,6 +79,63 @@ describe('Today view', () => {
     expect(screen.queryByText(/thrashing/i)).toBeNull();
   });
 
+  it('renders a real count for stuck_loop via the API-fallback path, not "?"', async () => {
+    useLiveStore.setState({ antiPatterns: [] });
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (url === '/api/anti-patterns') {
+        return new Response(
+          JSON.stringify([{ type: 'stuck_loop', command: 'npm test', repeatCount: 5 }]),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    renderToday();
+    await waitFor(() => expect(screen.getByText(/5× on/)).toBeInTheDocument());
+    expect(screen.queryByText(/\?× on/)).toBeNull();
+  });
+
+  it('renders a real count for blind_editing via the API-fallback path, not "?"', async () => {
+    useLiveStore.setState({ antiPatterns: [] });
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (url === '/api/anti-patterns') {
+        return new Response(
+          JSON.stringify([{ type: 'blind_editing', file: 'app.ts', editCount: 3 }]),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    renderToday();
+    await waitFor(() => expect(screen.getByText(/3× on/)).toBeInTheDocument());
+    expect(screen.queryByText(/\?× on/)).toBeNull();
+  });
+
+  it('renders a real count for over_delegation via the API-fallback path, not "?"', async () => {
+    useLiveStore.setState({ antiPatterns: [] });
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (url === '/api/anti-patterns') {
+        return new Response(JSON.stringify([{ type: 'over_delegation', agentCount: 7 }]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    renderToday();
+    await waitFor(() => expect(screen.getByText(/7× on/)).toBeInTheDocument());
+    expect(screen.queryByText(/\?× on/)).toBeNull();
+  });
+
   it('renders the forecast-EOD card with the projected end-of-day spend', () => {
     renderToday();
     expect(screen.getByText(/forecast/i)).toBeInTheDocument();

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -87,6 +87,7 @@ interface SessionAntiPattern {
   readonly readCount?: number;
   readonly repeatCount?: number;
   readonly editCount?: number;
+  readonly agentCount?: number;
 }
 
 interface SessionSummary {
@@ -393,6 +394,9 @@ export function Today(): JSX.Element {
                         {apiAntiPatterns[0].count ??
                           apiAntiPatterns[0].iterations ??
                           apiAntiPatterns[0].readCount ??
+                          apiAntiPatterns[0].repeatCount ??
+                          apiAntiPatterns[0].editCount ??
+                          apiAntiPatterns[0].agentCount ??
                           '?'}
                         × on{' '}
                       </span>


### PR DESCRIPTION
## Summary

Five high-visibility dashboard bug fixes in `src/web/`, plus a version bump to 1.4.30.

- Fixes #128. Alerts.tsx's "Alert Thresholds" card wrongly claimed to feed "the local alert engine" and require a server restart. Corrected to describe the real consumer (the separate `deploy-alerts` CLI, which templates cloud alert conditions and reads config fresh on every run — no restart involved).
- Fixes #129. Sessions.tsx's "Outcome" card always showed one of exactly two hardcoded values (`completed`/`in progress`) with no real classification logic anywhere in the codebase. Relabeled as "Status" to accurately reflect it as a running-state indicator rather than a quality/outcome classification.
- Fixes #130. Sessions.tsx's "Session Quality" and "Tool Selection" cards were fully built but never rendered because the backend never attached the tracker data to any of the three `/api/sessions/:id` response branches. Now attached to the branches where the data is actually and correctly available: `qualityProxy` on the persisted branch (derived from the session's own stored timeline) and the own-live branch (via the live tracker), both gated on having a real signal; `toolSelectionScore` on the own-live and registry-synthesized branches, both correctly scoped to that session's own records (not the shared cross-session buffer) to avoid leaking another concurrent session's data.
- Fixes #131. Today.tsx's anti-pattern banner rendered a literal `?` instead of a real count for `stuck_loop`, `blind_editing`, and `over_delegation` patterns on its non-SSE API-fallback path; the fallback chain only checked 3 of 6 possible count fields. Extended to check all of them.
- Fixes #132. Alerts.tsx's Unsubscribe button left a stale, unsaved webhook-URL edit visible in the input even though the adjacent status Pill correctly flipped to "Not configured." The input now resets to server truth immediately on that path.

## Test plan

- [x] Full suite: `npm run build && npm test && npm run lint` — clean (3952/3955 passing here)
- [x] New/updated tests: `Today.test.tsx`, `Alerts.test.tsx` (new file), `Sessions.test.tsx`, `api-handler.test.ts`
- [x] Manual browser verification against a running local dashboard for #128, #129, #130, #132