### PR TITLE
Fix web-dashboard lower-visibility bugs (v1.4.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.31] - 2026-07-13
+
+### Fixed
+
+- The Audit view's classification Pill rendered every entry with the same neutral gray tone, even for `destructive_command`/`sensitive_file` entries with a genuinely critical or high severity. The backend now forwards the computed severity, and the Pill is color-coded accordingly (red for critical, amber for high).
+- Four labels in the History view had drifted from the real fetch parameters they describe: "Weekly Efficiency · Last 8" (the real default is 12 weeks), the activity heatmap's screen-reader label claiming "last 4 weeks" (it's 12), "Peak Concurrent Sessions · All-Time" (the underlying fetch is always 30-day-bounded, never all-time), and "Daily Spend"/"Top Tools" panels that could silently understate their scope for very high-volume users due to an underlying 200-session fetch cap — both now carry a clarifying label.
+- The Git Efficiency view's "Today's activity across all sessions" silently excluded a session that started before local midnight and crossed into today — hydration now uses the overlap-aware session lookup already used elsewhere in the codebase for the same cross-midnight gap. Separately, the "Verified before push" indicator couldn't see a build/test that ran in an earlier session today when replaying that session's history, always showing "no build/test detected" in that case even when verification genuinely happened; the replay path now carries that signal through correctly.
+
 ## [1.4.30] - 2026-07-12
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.30",
+  "version": "1.4.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.30",
+      "version": "1.4.31",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.30",
+  "version": "1.4.31",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -628,6 +628,7 @@ describe('api-handler GET /api/audit', () => {
         tool: 'Read',
         target: 'Read /etc/passwd',
         classification: 'sensitive_file',
+        severity: 'high',
       },
       {
         ts: ts2,
@@ -635,6 +636,7 @@ describe('api-handler GET /api/audit', () => {
         tool: 'Bash',
         target: 'rm -rf /tmp/foo',
         classification: 'destructive_command',
+        severity: 'critical',
       },
     ]);
   });
@@ -662,6 +664,30 @@ describe('api-handler GET /api/audit', () => {
     const parsed = JSON.parse(body()) as Array<Record<string, unknown>>;
     expect(parsed[0]!.classification).toBe('other');
     expect(parsed[0]!.target).toBe('/some/normal/file.ts');
+  });
+
+  it('omits severity when there is no securityAlert', async () => {
+    const fakeAuditLog = [
+      {
+        timestamp: 1700000000000,
+        sessionId: null,
+        action: 'FileRead',
+        tool: 'Read',
+        detail: '/some/normal/file.ts',
+        developer: 'alice',
+      },
+    ];
+    const handler = createApiHandler({
+      auditTrailManager: { getAuditLog: () => fakeAuditLog } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['auditTrailManager'],
+    });
+    const req = { method: 'GET', url: '/api/audit' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as Array<Record<string, unknown>>;
+    expect(parsed[0]!.severity).toBeUndefined();
   });
 
   it('returns 503 when auditTrailManager is missing', async () => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -130,6 +130,7 @@ interface AuditEntryDto {
   readonly tool: string;
   readonly target: string;
   readonly classification: string;
+  readonly severity?: string;
 }
 
 function toAuditEntry(entry: unknown): AuditEntryDto {
@@ -146,6 +147,7 @@ function toAuditEntry(entry: unknown): AuditEntryDto {
     tool: r.tool,
     target,
     classification,
+    severity: r.securityAlert?.severity,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -826,7 +826,7 @@ async function main(): Promise<void> {
 
     // Hydrate git efficiency tracker with today's prior sessions so the
     // dashboard shows all-day git activity, not just the current session.
-    const todaySessions = sessionStore.loadTodaySessions();
+    const todaySessions = sessionStore.loadSessionsOverlappingToday();
     for (const session of todaySessions) {
       if (session.sessionId === currentSessionId) continue;
       if (session.timeline && session.timeline.length > 0) {

--- a/src/metrics/git-efficiency-tracker.test.ts
+++ b/src/metrics/git-efficiency-tracker.test.ts
@@ -538,6 +538,41 @@ describe('GitEfficiencyTracker', () => {
       expect(metrics.totalGitCommands).toBe(3);
     });
 
+    it('carries isTestCommand/isBuildCommand through to buildBeforePush detection', () => {
+      const t = Date.now() - 3600_000;
+      // Commit precedes test/push (not the more intuitive test-then-commit):
+      // buildBeforePush only latches true when the build/test timestamp is
+      // strictly after the last commit (see the staleness guard in the
+      // 'push' case of processEvent), so an earlier test wouldn't count.
+      const timeline: ReplayTimelineEntry[] = [
+        {
+          timestamp: t,
+          toolName: 'Bash',
+          durationMs: 100,
+          success: true,
+          command: 'git commit -m "verified change"',
+        },
+        {
+          timestamp: t + 1000,
+          toolName: 'Bash',
+          durationMs: 500,
+          success: true,
+          command: 'npm test',
+          isTestCommand: true,
+        },
+        {
+          timestamp: t + 2000,
+          toolName: 'Bash',
+          durationMs: 200,
+          success: true,
+          command: 'git push origin feature',
+        },
+      ];
+      tracker.replayTimeline(timeline);
+      const metrics = tracker.getMetrics();
+      expect(metrics.velocityMetrics.buildBeforePush).toBe(true);
+    });
+
     it('replays file edits for sync-before-edit detection', () => {
       const t = Date.now() - 3600_000;
       const timeline: ReplayTimelineEntry[] = [

--- a/src/metrics/git-efficiency-tracker.ts
+++ b/src/metrics/git-efficiency-tracker.ts
@@ -381,6 +381,8 @@ export class GitEfficiencyTracker {
         command: entry.command,
         filePath: entry.filePath,
         errorType: entry.errorType,
+        isTestCommand: entry.isTestCommand,
+        isBuildCommand: entry.isBuildCommand,
       };
       this.recordToolCall(syntheticRecord);
     }

--- a/src/web/views/Audit.test.tsx
+++ b/src/web/views/Audit.test.tsx
@@ -46,6 +46,39 @@ describe('Audit view', () => {
     expect(screen.getByText('curl evil.com')).toBeInTheDocument();
   });
 
+  it('colors the classification Pill by severity instead of always neutral', async () => {
+    const withSeverity = [
+      {
+        ts: 1,
+        tool: 'Bash',
+        target: 'rm -rf /tmp/x',
+        classification: 'destructive_command',
+        severity: 'critical',
+        sessionId: 's1',
+      },
+      {
+        ts: 2,
+        tool: 'Read',
+        target: '/etc/hosts',
+        classification: 'sensitive_file',
+        severity: 'high',
+        sessionId: 's1',
+      },
+      {
+        ts: 3,
+        tool: 'Read',
+        target: '/home/alice/notes.txt',
+        classification: 'other',
+        sessionId: 's2',
+      },
+    ];
+    renderAudit(withSeverity);
+    await waitFor(() => expect(screen.getByText('destructive_command')).toBeInTheDocument());
+    expect(screen.getByText('destructive_command').className).toMatch(/bg-accent-red/);
+    expect(screen.getByText('sensitive_file').className).toMatch(/bg-accent-amber/);
+    expect(screen.getByText('other').className).toMatch(/bg-surface-5/);
+  });
+
   it('filters by classification when a chip is clicked', async () => {
     const user = userEvent.setup();
     renderAudit(SAMPLE);

--- a/src/web/views/Audit.tsx
+++ b/src/web/views/Audit.tsx
@@ -10,6 +10,7 @@ interface AuditEntry {
   readonly tool: string;
   readonly target: string;
   readonly classification: string;
+  readonly severity?: string;
   readonly sessionId?: string;
 }
 
@@ -21,6 +22,12 @@ const FILTERS = [
 ] as const;
 
 type FilterKey = (typeof FILTERS)[number]['key'];
+
+const SEVERITY_TONE: Record<string, 'danger' | 'warning' | 'info'> = {
+  critical: 'danger',
+  high: 'warning',
+  medium: 'info',
+};
 
 export function downloadJsonl(rows: AuditEntry[]): void {
   const text = rows.map((r) => JSON.stringify(r)).join('\n');
@@ -124,7 +131,10 @@ export function Audit(): JSX.Element {
                   <td className="p-2">{r.tool}</td>
                   <td className="p-2 font-mono text-[11px]">{r.target}</td>
                   <td className="p-2">
-                    <Pill tone="neutral" size="sm">
+                    <Pill
+                      tone={r.severity ? (SEVERITY_TONE[r.severity] ?? 'neutral') : 'neutral'}
+                      size="sm"
+                    >
                       {r.classification}
                     </Pill>
                   </td>

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -157,6 +157,22 @@ function renderHistory(overrides: FetchOverrides = {}) {
         }),
       );
     }
+    if (url.startsWith('/api/activity-heatmap')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ days: [{ date: '2026-05-26', count: 3 }], maxCount: 3 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }
+    if (url.startsWith('/api/concurrency')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ dailyPeaks: [{ date: '2026-05-26', peak: 2 }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }
     return Promise.resolve(new Response('null', { status: 200 }));
   }) as typeof globalThis.fetch;
   return render(
@@ -199,6 +215,42 @@ describe('History view', () => {
   it('renders the top tools panel title', async () => {
     renderHistory();
     await waitFor(() => expect(screen.getByText(/top tools/i)).toBeInTheDocument());
+  });
+
+  it('titles the weekly efficiency panel to match the real 12-week fetch default', async () => {
+    renderHistory();
+    await waitFor(() =>
+      expect(screen.getByText('Weekly Efficiency · Last 12')).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('Weekly Efficiency · Last 8')).toBeNull();
+  });
+
+  it('labels the daily spend panel with the 200-session-cap clarification', async () => {
+    renderHistory();
+    await waitFor(() =>
+      expect(screen.getByText('Daily Spend · Last 30 Days (most recent 200)')).toBeInTheDocument(),
+    );
+  });
+
+  it('titles the top tools panel to disclose the 200-session cap instead of claiming "All Sessions"', async () => {
+    renderHistory();
+    await waitFor(() =>
+      expect(screen.getByText('Top Tools · Most Recent 200 Sessions')).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('Top Tools · All Sessions')).toBeNull();
+  });
+
+  it('uses the real 12-week window in the activity heatmap aria-label', async () => {
+    renderHistory();
+    await waitFor(() =>
+      expect(screen.getByLabelText('Daily activity heatmap for the last 12 weeks')).toBeTruthy(),
+    );
+  });
+
+  it('labels Peak Concurrent Sessions with the real 30-day fetch window, not "All-Time"', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText(/Peak Concurrent Sessions/)).toBeInTheDocument());
+    expect(screen.queryByText(/All-Time/)).toBeNull();
   });
 
   it('renders the personal coach panel and shows the top recommendation', async () => {

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -180,7 +180,7 @@ export function History(): JSX.Element {
       <h1 className="text-xl font-semibold gradient-text mb-4">History</h1>
 
       <div className="grid grid-cols-2 gap-3">
-        <Panel title="Weekly Efficiency · Last 8">
+        <Panel title="Weekly Efficiency · Last 12">
           <div className="h-44 min-w-0">
             <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
               <AreaChart data={weeklyData}>
@@ -212,7 +212,7 @@ export function History(): JSX.Element {
           </div>
         </Panel>
 
-        <Panel title="Daily Spend · Last 30 Days">
+        <Panel title="Daily Spend · Last 30 Days (most recent 200)">
           <div className="h-44 min-w-0">
             <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
               <BarChart data={dailyData}>
@@ -371,7 +371,7 @@ export function History(): JSX.Element {
           )}
         </Panel>
 
-        <Panel title="Top Tools · All Sessions">
+        <Panel title="Top Tools · Most Recent 200 Sessions">
           {topTools.length === 0 ? (
             <EmptyState
               icon="code"
@@ -420,7 +420,7 @@ export function History(): JSX.Element {
               buckets={[]}
               maxCount={activityGrid.data.maxCount}
               days={activityGrid.data.days}
-              ariaLabel="Daily activity heatmap for the last 4 weeks"
+              ariaLabel="Daily activity heatmap for the last 12 weeks"
             />
           </Panel>
         )}
@@ -431,10 +431,8 @@ export function History(): JSX.Element {
             day's peak was 0, which read as a missing feature. */}
         <Card padding="md" className="flex flex-col">
           <Eyebrow className="mb-3">
-            Peak Concurrent Sessions ·{' '}
-            {hasConcurrencyData
-              ? `All-Time: ${Math.max(...concurrencyData.map((d) => d.peak))}`
-              : 'Last 30 Days'}
+            Peak Concurrent Sessions · Last 30 Days
+            {hasConcurrencyData && `: ${Math.max(...concurrencyData.map((d) => d.peak))}`}
           </Eyebrow>
           {hasConcurrencyData ? (
             <div className="flex-1 flex items-end justify-center">


### PR DESCRIPTION
## Summary

Three lower-visibility dashboard bug fixes in `src/web/,, plus a version bump to 1.4.31.

- Fixes #133. Audit.tsx's classification Pill always rendered neutral gray regardless of how severe the flagged action actually was. `securityAlert.severity` was genuinely computed server-side but never forwarded to the DTO the frontend consumes. Now forwarded, and the Pill is color-coded (red for critical, amber for high, blue for medium) matching the pattern already used correctly elsewhere in the codebase.
- Fixes #134. Four labels in History.tsx had drifted from the real fetch parameters they describe: "Weekly Efficiency · Last 8" (the real default is 12 weeks), the activity heatmap's screen-reader label claiming "last 4 weeks" (it's 12), "Peak Concurrent Sessions · All-Time" (the underlying fetch is always 30-day-bounded, never all-time — the old logic had the label backwards), and two panels ("Daily Spend"/"Top Tools") that could silently understate their scope for very high-volume users due to an underlying 200-session fetch cap — all four now carry accurate labels.
- Fixes #135. Two related gaps where a session that started before local midnight wasn't fully carried into "today's" Git Efficiency view: session hydration used a same-day-only lookup instead of the overlap-aware one already used elsewhere in the codebase for this exact cross-midnight gap, and `replayTimeline()`'s synthetic tool-call records dropped `isTestCommand`/`isBuildCommand`, hiding "verified before push" signal from a build/test that ran in an earlier session today.

## Test plan

- [x] Full suite: `npm run build && npm test && npm run lint` — clean (3954/3957 passing here; lint fully clean, no issues at all)
- [x] New/updated tests: `Audit.test.tsx`, `History.test.tsx`, `git-efficiency-tracker.test.ts`, `api-handler.test.ts`
- [x] Manual browser verification against a running local dashboard for #134 (all four corrected labels, including the aria-label) and the Git Efficiency view itself