### PR TITLE
v1.4.33: Web dashboard API/behavior fixes + diagnostics platform-param feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.33] - 2026-07-13
+
+### Fixed
+
+- Audit view's "Export JSONL" button exported every audit entry regardless of the active classification filter or the 200-row display cap. Now exports exactly what's shown on screen.
+- Sessions view never rendered the `filesRead` or `antiPatterns` data the backend already computes for each session. Now shows a "Files Read" list and "Anti-Patterns" pills (reusing the same taxonomy labels used elsewhere in the session replay view) when present.
+- Dashboard's System Health diagnostics panel always ran the Claude-Code-specific hooks-wired check, regardless of which coding platform was actually detected — non-Claude-Code users (Cursor, Windsurf, etc.) saw a false "Hooks wired: fail" result. Now forwards the detected platform, which the existing check already knew how to handle correctly.
+
 ## [1.4.32] - 2026-07-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.32",
+  "version": "1.4.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.32",
+      "version": "1.4.33",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.32",
+  "version": "1.4.33",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1814,3 +1814,27 @@ describe('GET /api/diagnostics', () => {
     expect(JSON.parse(body())).toEqual(expected);
   });
 });
+
+describe('GET /api/diagnostics platform forwarding', () => {
+  it("forwards getActivePlatform()'s return value as the platform option to runDiagnostics", async () => {
+    mockedRunDiagnostics.mockResolvedValue([]);
+    const handler = createApiHandler({ getActivePlatform: () => 'cursor' });
+    const req = { method: 'GET', url: '/api/diagnostics' } as IncomingMessage;
+    const { res } = fakeRes();
+    await handler(req, res);
+    expect(mockedRunDiagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: 'cursor' }),
+    );
+  });
+
+  it('passes platform: undefined when getActivePlatform is not provided (no change to existing Claude Code behavior)', async () => {
+    mockedRunDiagnostics.mockResolvedValue([]);
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/diagnostics' } as IncomingMessage;
+    const { res } = fakeRes();
+    await handler(req, res);
+    expect(mockedRunDiagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: undefined }),
+    );
+  });
+});

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -242,6 +242,10 @@ export interface ApiHandlerDeps {
   readonly contextTracker?: { getMetrics: (sessionId?: string) => unknown };
   readonly config?: McpServerConfig;
   readonly configFilePath?: string;
+  // Resolved lazily (not captured as a plain value) because the platform
+  // adapter isn't assigned until after this deps object is constructed —
+  // see index.ts's eventProcessor initialization order.
+  readonly getActivePlatform?: () => string | undefined;
   // The dashboard owner reads every per-session buffer file in read-only
   // mode for the cross-session aggregate endpoint.
   // `peekAllBuffers()` does NOT drain — only the owning MCP's own
@@ -1356,6 +1360,7 @@ export function createApiHandler(
       // captured. diagnostics.ts prioritises this value over the file-validated
       // storagePath, so the same path the MCP server writes to is always checked.
       storagePath: deps.config?.storagePath,
+      platform: deps.getActivePlatform?.(),
     });
     jsonOk(res, checks);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1129,6 +1129,10 @@ async function main(): Promise<void> {
           contextTracker,
           config,
           configFilePath: options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json'),
+          // eventProcessor isn't assigned until after this object is built —
+          // resolve lazily so the diagnostics route sees the real platform
+          // once eventProcessor exists, not undefined forever.
+          getActivePlatform: () => eventProcessor?.activePlatform,
           // The dashboard owner reads every per-session buffer file in
           // read-only mode for the Today aggregate endpoint.
           // peekAllBuffers() returns HookEvent[] — widen at the boundary

--- a/src/web/views/Audit.test.tsx
+++ b/src/web/views/Audit.test.tsx
@@ -115,6 +115,58 @@ describe('Audit view', () => {
     await waitFor(() => expect(screen.getByText('/etc/hosts')).toBeInTheDocument());
     expect(screen.queryByText(/showing first/i)).toBeNull();
   });
+
+  it('exports only the filtered and capped rows, not the full unfiltered set', async () => {
+    const user = userEvent.setup();
+    const sensitiveRows = Array.from({ length: 250 }, (_, i) => ({
+      ts: 1_000_000 + i,
+      tool: 'Read',
+      target: `/sensitive/${i}`,
+      classification: 'sensitive_file',
+      sessionId: `s-${i}`,
+    }));
+    const destructiveRow = {
+      ts: 1,
+      tool: 'Bash',
+      target: 'rm -rf /tmp/x',
+      classification: 'destructive_command',
+      sessionId: 'x1',
+    };
+    renderAudit([destructiveRow, ...sensitiveRows]);
+    await waitFor(() => expect(screen.getByText('/sensitive/0')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /sensitive files/i }));
+    await waitFor(() => expect(screen.queryByText('rm -rf /tmp/x')).toBeNull());
+
+    let capturedBlob: Blob | null = null;
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = vi.fn((blob: Blob) => {
+      capturedBlob = blob;
+      return 'blob:test/export';
+    }) as typeof URL.createObjectURL;
+    URL.revokeObjectURL = vi.fn() as typeof URL.revokeObjectURL;
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    try {
+      await user.click(screen.getByRole('button', { name: /export jsonl/i }));
+      expect(capturedBlob).not.toBeNull();
+      const text = await capturedBlob!.text();
+      const lines = text.split('\n').filter(Boolean);
+      // Capped at 200, not the full 250 matching rows.
+      expect(lines).toHaveLength(200);
+      // Filtered out — destructive_command doesn't match the active "Sensitive files" filter.
+      expect(text).not.toMatch(/rm -rf \/tmp\/x/);
+      expect(text).toMatch(/\/sensitive\/0"/);
+      expect(text).toMatch(/\/sensitive\/199"/);
+      // Beyond the 200-row cap.
+      expect(text).not.toMatch(/\/sensitive\/200"/);
+    } finally {
+      URL.createObjectURL = origCreate;
+      URL.revokeObjectURL = origRevoke;
+      clickSpy.mockRestore();
+    }
+  });
 });
 
 describe('Audit downloadJsonl', () => {

--- a/src/web/views/Audit.tsx
+++ b/src/web/views/Audit.tsx
@@ -71,7 +71,7 @@ export function Audit(): JSX.Element {
       <GeoBanner theme="audit" />
       <header className="flex items-baseline justify-between mb-4">
         <h1 className="text-xl font-semibold gradient-text">Audit</h1>
-        <Button variant="secondary" size="md" onClick={() => downloadJsonl(rows)}>
+        <Button variant="secondary" size="md" onClick={() => downloadJsonl(visibleSlice)}>
           Export JSONL
         </Button>
       </header>

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -178,6 +178,55 @@ describe('Sessions view', () => {
     expect(screen.getByText('completed')).toBeInTheDocument();
   });
 
+  it('renders a Files Read list from data.filesRead, truncated to the last two path segments', async () => {
+    const detail = {
+      sessionId: 's1',
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+      filesRead: ['src/deep/nested/path/foo.ts', 'src/bar.ts'],
+    };
+    renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(screen.getByText('Files Read')).toBeInTheDocument());
+    expect(screen.getByText('path/foo.ts')).toBeInTheDocument();
+    expect(screen.getByText('src/bar.ts')).toBeInTheDocument();
+  });
+
+  it('does not render the Files Read section when filesRead is absent or empty', async () => {
+    const detail = {
+      sessionId: 's1',
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+    };
+    renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(screen.getAllByText('Read').length).toBeGreaterThanOrEqual(1));
+    expect(screen.queryByText('Files Read')).toBeNull();
+  });
+
+  it('renders antiPatterns pills reusing the SEGMENT_LABELS taxonomy, falling back to the raw type for unmapped values', async () => {
+    const detail = {
+      sessionId: 's1',
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+      antiPatterns: [
+        { type: 'thrashing', count: 3 },
+        { type: 'over_delegation', count: 1 },
+      ],
+    };
+    const { container } = renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(container.textContent).toContain('Edit/Test Thrashing'));
+    expect(container.textContent).toContain('× 3');
+    // over_delegation has no SEGMENT_LABELS entry — falls back to the raw type string.
+    expect(container.textContent).toContain('over_delegation');
+    expect(container.textContent).toContain('× 1');
+  });
+
+  it('does not render the Anti-Patterns section when antiPatterns is absent or empty', async () => {
+    const detail = {
+      sessionId: 's1',
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+    };
+    renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(screen.getAllByText('Read').length).toBeGreaterThanOrEqual(1));
+    expect(screen.queryByText('Anti-Patterns')).toBeNull();
+  });
+
   it('shows the timeline header with session ID and call count', async () => {
     const detail = {
       sessionId: 's1-abcdef',

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -409,6 +409,20 @@ function SessionTimeline({ data, isLive }: { data: SessionDetail; isLive: boolea
         )}
       </div>
 
+      {(data.antiPatterns?.length ?? 0) > 0 && (
+        <div className="mb-4">
+          <Eyebrow className="mb-1">Anti-Patterns</Eyebrow>
+          <div className="flex flex-wrap gap-1.5">
+            {data.antiPatterns!.map(({ type, count }) => (
+              <Pill key={type} tone="warning" size="sm" bordered>
+                {SEGMENT_LABELS[type] ?? type}
+                <span className="opacity-70">× {count}</span>
+              </Pill>
+            ))}
+          </div>
+        </div>
+      )}
+
       {(data.qualityProxy || data.toolSelectionScore) && (
         <div className="grid grid-cols-2 gap-3 mb-4">
           {data.qualityProxy && (
@@ -475,6 +489,19 @@ function SessionTimeline({ data, isLive }: { data: SessionDetail; isLive: boolea
           isLive={isLive}
           sessionId={data.sessionId}
         />
+      )}
+
+      {(data.filesRead?.length ?? 0) > 0 && (
+        <div className="mb-4">
+          <Eyebrow className="mb-1">Files Read</Eyebrow>
+          <ul className="text-[11px] text-ink-subtle space-y-0.5">
+            {data.filesRead!.map((f) => (
+              <li key={f} className="font-mono truncate">
+                {f.split('/').slice(-2).join('/')}
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
 
       {(data.filesModified?.length ?? 0) > 0 && (


### PR DESCRIPTION
## Summary

Three independent fixes:

- Audit view's "Export JSONL" button exported every entry regardless of the active classification filter or the 200-row display cap. Now exports exactly the filtered+capped set shown on screen.
- Sessions view never rendered the `filesRead`/`antiPatterns` fields the backend already computes for each session. Now shows a "Files Read" list (mirroring the existing "Files Modified" pattern) and "Anti-Patterns" pills (reusing the existing `SEGMENT_LABELS` taxonomy/`Pill` styling already used elsewhere in the same file).
- Dashboard's diagnostics panel always assumed Claude Code, so non-Claude-Code users (Cursor, Windsurf, etc.) got a false "Hooks wired: fail". `/api/diagnostics` now forwards the already-detected platform into `runDiagnostics()`, which already knew how to handle it correctly — it just never received the value. Backward compatible: Claude Code's `platformName` is literally `'claude-code'`, the exact string the existing check special-cases, so real Claude Code users see zero behavior change.

Fixes #139. Fixes #140. Fixes #157.

Version bumped to 1.4.33.

## Test plan

- [x] `npm run build && npm test && npm run lint` — build clean, tests 3956/3959 passing
- [x] Manually verified live against an isolated instance: Anti-Patterns pills + Files Read list render correctly, and `/api/diagnostics` correctly reports "not applicable to \"generic-mcp\"" instead of a false hooks-wired failure