### PR TITLE
v1.4.34: client.ts typed response contracts — Today.tsx cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.34] - 2026-07-13
+
+### Fixed
+
+- The Today view's dashboard API client now returns fully typed response interfaces for 15 API functions (`fetchCost`, `fetchSessionCurrent`, `fetchSessionsList`, `fetchTodayAggregate`, `fetchAntiPatterns`, `fetchConcurrency`, `fetchActivityHeatmap`, `fetchLiveSessions`, `fetchQualityProxy`, `fetchToolSelectionScore`, `fetchLatency`, `fetchModelUsage`, `fetchCacheHealth`, `fetchSessionReplay`, and `fetchRecentAlerts`) instead of the previous `Promise<unknown>`, eliminating the matching type-cast assertions at their call sites. This enables compile-time type checking to catch backend/frontend field mismatches before deployment. Part of an ongoing effort to type the rest of the dashboard's API layer (#141).
+
 ## [1.4.33] - 2026-07-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.33",
+  "version": "1.4.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.33",
+      "version": "1.4.34",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.33",
+  "version": "1.4.34",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -27,43 +27,349 @@ export interface HealthResponse {
 
 export const fetchHealth = (): Promise<HealthResponse> => getJson<HealthResponse>('/api/health');
 
-export const fetchSessionCurrent = (): Promise<unknown> => getJson<unknown>('/api/session/current');
+export interface AntiPattern {
+  readonly type: 'thrashing' | 're_reading' | 'stuck_loop' | 'blind_editing' | 'over_delegation';
+  readonly file?: string;
+  readonly command?: string;
+  readonly bashCategory?: string;
+  readonly iterations?: number;
+  readonly readCount?: number;
+  readonly repeatCount?: number;
+  readonly editCount?: number;
+  readonly agentCount?: number;
+  readonly suggestion: string;
+}
+
+// Real server type also has `sessionId`/`sessionName`/`liveSessions`/many more
+// counters (see SessionTracker.getMetrics() + efficiencyScore/liveSessions
+// added by the route). Declared fully so every current and future consumer
+// gets full field access without re-casting.
+export interface SessionCurrentResponse {
+  readonly sessionId: string;
+  readonly sessionName: string | null;
+  readonly sessionStartTime: number;
+  readonly sessionDurationMs: number;
+  readonly toolCallCount: number;
+  readonly toolCallCountByTool: Record<string, number>;
+  readonly toolDurationMsByTool: Record<
+    string,
+    { count: number; sum: number; min: number; max: number; p95: number }
+  >;
+  readonly toolSuccessRate: number | null;
+  readonly toolSuccessRateByTool: Record<string, number>;
+  readonly toolErrorCount: number;
+  readonly toolErrorsByType: Record<string, number>;
+  readonly uniqueFilesRead: number;
+  readonly uniqueFilesWritten: number;
+  readonly bashCommandsRun: number;
+  readonly bashExitCodes: Record<string, number>;
+  readonly bashCallsByCategory: Record<string, number>;
+  readonly searchQueries: number;
+  readonly toolCallTimeline: ReadonlyArray<{
+    timestamp: number;
+    toolName: string;
+    durationMs: number | null;
+    success: boolean;
+  }>;
+  readonly timelineTruncated: boolean;
+  readonly timelineEntryCount: number;
+  readonly efficiencyScore: number | null;
+  readonly liveSessions: string[];
+}
+
+export interface LatencyPercentiles {
+  readonly p50: number;
+  readonly p95: number;
+  readonly p99: number;
+  readonly min: number;
+  readonly max: number;
+  readonly count: number;
+}
+
+export interface LatencyMetrics {
+  readonly overall: LatencyPercentiles | null;
+  readonly byTool: Readonly<Record<string, LatencyPercentiles | null>>;
+  readonly slowestCalls: ReadonlyArray<{
+    readonly toolName: string;
+    readonly durationMs: number;
+    readonly timestamp: number;
+    readonly filePath?: string;
+  }>;
+}
+
+export interface ReplayTimelineEntry {
+  readonly timestamp: number;
+  readonly toolName: string;
+  readonly durationMs: number | null;
+  readonly success: boolean;
+  readonly filePath?: string;
+  readonly command?: string;
+  readonly isTestCommand?: boolean;
+  readonly isBuildCommand?: boolean;
+  readonly isLintCommand?: boolean;
+  readonly errorType?: string;
+}
+
+export interface AntiPatternSegment {
+  readonly type: string;
+  readonly startIndex: number;
+  readonly endIndex: number;
+  readonly iterations: number;
+  readonly target: string;
+  readonly severity: 'warning' | 'critical';
+}
+
+export interface SessionReplayResponse {
+  readonly sessionId: string;
+  readonly timeline: ReplayTimelineEntry[];
+  readonly segments: AntiPatternSegment[];
+  readonly worstSegment: AntiPatternSegment | null;
+}
+
+export interface TodayAggregateResponse {
+  readonly toolCallCount: number;
+  readonly totalCostUsd: number;
+  readonly antiPatternCount: number;
+  readonly avgDurationMs: number;
+  readonly sessionCount: number;
+  readonly sparkline: {
+    readonly startTimestamp: number;
+    readonly bucketSizeMs: number;
+    readonly points: readonly number[];
+  };
+}
+
+// /api/sessions returns a heterogeneous mix of full persisted session
+// summaries and small live-session stub objects (see the route handler at
+// api-handler.ts:641) — only sessionId is guaranteed present on every item.
+export interface SessionListEntry {
+  readonly sessionId: string;
+  readonly sessionName?: string | null;
+  readonly startTime?: number;
+  readonly endTime?: number;
+  readonly durationMs?: number;
+  readonly toolCallCount?: number;
+  readonly estimatedCostUsd?: number | null;
+  readonly antiPatterns?: Array<{ type: string; count: number }>;
+  readonly model?: string | null;
+  readonly toolSuccessRate?: number | null;
+  readonly efficiencyScore?: number | null;
+}
+
+export interface LiveSessionEntry {
+  readonly sessionId: string;
+  readonly sessionName: string | null;
+  readonly startTime: number;
+  readonly lastActivity: number;
+}
+
+export interface CostBreakdown {
+  readonly inputUsd: number;
+  readonly outputUsd: number;
+  readonly thinkingUsd: number;
+  readonly cacheReadUsd: number;
+  readonly cacheCreationUsd: number;
+  readonly totalUsd: number;
+  readonly savingsFromCacheUsd: number;
+}
+
+export interface CostMetrics {
+  readonly sessionTotalCostUsd: number | null;
+  readonly costByTask: null;
+  readonly costByModel: Record<string, number>;
+  readonly costPerLineOfCode: number | null;
+  readonly costPerFileModified: number | null;
+  readonly model: string | null;
+  readonly totalInputTokens: number;
+  readonly totalOutputTokens: number;
+  readonly totalThinkingTokens: number;
+  readonly totalCacheReadTokens: number;
+  readonly totalCacheCreationTokens: number;
+  readonly cacheHitRate: number | null;
+  readonly totalCacheSavingsUsd: number;
+  readonly reportCount: number;
+  readonly estimationCount: number;
+  readonly latestCostBreakdown: CostBreakdown | null;
+}
+
+export interface CostForecast {
+  readonly elapsedMs: number;
+  readonly spentUsd: number;
+  readonly rateUsdPerMs: number;
+  readonly forecastEndOfDayUsd: number | null;
+  readonly forecastEndOfWeekUsd: number | null;
+  readonly forecastSessionEndUsd: number | null;
+  readonly confidenceNote: string;
+}
+
+export interface CostResponse {
+  readonly cost: CostMetrics;
+  readonly forecast: CostForecast | null;
+  readonly sessionTodayUsd: number | null;
+}
+
+export const fetchSessionCurrent = (): Promise<SessionCurrentResponse> =>
+  getJson<SessionCurrentResponse>('/api/session/current');
 export const fetchSessionToday = (): Promise<unknown> => getJson<unknown>('/api/session/today');
-export const fetchSessionsList = (limit = 50): Promise<unknown> =>
-  getJson<unknown>(`/api/sessions?limit=${limit}`);
+export const fetchSessionsList = (limit = 50): Promise<SessionListEntry[]> =>
+  getJson<SessionListEntry[]>(`/api/sessions?limit=${limit}`);
 // Cross-session aggregate KPIs for the Today view.
-export const fetchTodayAggregate = (): Promise<unknown> =>
-  getJson<unknown>('/api/sessions/today/aggregate');
+export const fetchTodayAggregate = (): Promise<TodayAggregateResponse> =>
+  getJson<TodayAggregateResponse>('/api/sessions/today/aggregate');
 // Currently-live session list (for the Today selector to default to the
 // most-recently-active session).
-export const fetchLiveSessions = (): Promise<unknown> => getJson<unknown>('/api/sessions/live');
+export const fetchLiveSessions = (): Promise<LiveSessionEntry[]> =>
+  getJson<LiveSessionEntry[]>('/api/sessions/live');
 export const fetchSessionDetail = (id: string): Promise<unknown> =>
   getJson<unknown>(`/api/sessions/${encodeURIComponent(id)}`);
-export const fetchCost = (): Promise<unknown> => getJson<unknown>('/api/cost');
-export const fetchAntiPatterns = (): Promise<unknown> => getJson<unknown>('/api/anti-patterns');
+export const fetchCost = (): Promise<CostResponse> => getJson<CostResponse>('/api/cost');
+export const fetchAntiPatterns = (): Promise<AntiPattern[]> =>
+  getJson<AntiPattern[]>('/api/anti-patterns');
+export interface QualityEvent {
+  readonly signal:
+    | 'diff_applied_clean'
+    | 'diff_failed'
+    | 'test_pass'
+    | 'test_fail'
+    | 'backtrack'
+    | 'self_correction';
+  readonly turnNumber: number;
+  readonly timestamp: number;
+  readonly toolName: string;
+}
+
+export interface TurnQualityBucket {
+  readonly turnRange: string;
+  readonly totalSignals: number;
+  readonly positiveSignals: number;
+  readonly negativeSignals: number;
+  readonly qualityRatio: number | null;
+}
+
+export interface QualityProxyMetrics {
+  readonly totalSignals: number;
+  readonly diffApplyRate: number | null;
+  readonly testPassRate: number | null;
+  readonly backtrackCount: number;
+  readonly selfCorrectionCount: number;
+  readonly qualityByTurnBucket: readonly TurnQualityBucket[];
+  readonly degradationDetected: boolean;
+  readonly events: readonly QualityEvent[];
+}
+
+export interface ToolSelectionPenalty {
+  readonly callId: string;
+  readonly toolName: string;
+  readonly reason: 'redundant_read' | 'repeated_failure' | 'unused_output';
+  readonly penaltyScore: number;
+  readonly detail: string;
+}
+
+export interface ToolSelectionMetrics {
+  readonly score: number;
+  readonly totalCalls: number;
+  readonly penalizedCalls: number;
+  readonly penalties: readonly ToolSelectionPenalty[];
+  readonly worstOffenders: readonly ToolSelectionPenalty[];
+  readonly redundantReadCount: number;
+  readonly repeatedFailureCount: number;
+  readonly unusedOutputCount: number;
+}
+
 export const fetchAuditLog = (): Promise<unknown> => getJson<unknown>('/api/audit');
 export const fetchWeekly = (): Promise<unknown> => getJson<unknown>('/api/weekly');
 export const fetchBudget = (): Promise<unknown> => getJson<unknown>('/api/budget');
-export const fetchLatency = (): Promise<unknown> => getJson<unknown>('/api/latency');
+export const fetchLatency = (): Promise<LatencyMetrics> => getJson<LatencyMetrics>('/api/latency');
 export const fetchCostPerOutcome = (days = 30): Promise<unknown> =>
   getJson<unknown>(`/api/cost-per-outcome?days=${days}`);
 export const fetchPersonalCoach = (): Promise<unknown> => getJson<unknown>('/api/personal-coach');
-export const fetchRecentAlerts = (): Promise<unknown> => getJson<unknown>('/api/alerts/recent');
-export const fetchSessionReplay = (id: string): Promise<unknown> =>
-  getJson<unknown>(`/api/sessions/${encodeURIComponent(id)}/replay`);
-export const fetchQualityProxy = (): Promise<unknown> => getJson<unknown>('/api/quality-proxy');
-export const fetchToolSelectionScore = (): Promise<unknown> =>
-  getJson<unknown>('/api/tool-selection-score');
+export const fetchRecentAlerts = (): Promise<AlertEvent[]> =>
+  getJson<AlertEvent[]>('/api/alerts/recent');
+export const fetchSessionReplay = (id: string): Promise<SessionReplayResponse> =>
+  getJson<SessionReplayResponse>(`/api/sessions/${encodeURIComponent(id)}/replay`);
+export const fetchQualityProxy = (): Promise<QualityProxyMetrics> =>
+  getJson<QualityProxyMetrics>('/api/quality-proxy');
+export const fetchToolSelectionScore = (): Promise<ToolSelectionMetrics> =>
+  getJson<ToolSelectionMetrics>('/api/tool-selection-score');
 export const fetchGitEfficiency = (): Promise<unknown> => getJson<unknown>('/api/git-efficiency');
 export const fetchGitEfficiencyRepos = (): Promise<unknown> =>
   getJson<unknown>('/api/git-efficiency/repos');
-export const fetchConcurrency = (): Promise<unknown> => getJson<unknown>('/api/concurrency');
+
+export interface ModelStats {
+  readonly requestCount: number;
+  readonly totalInputTokens: number;
+  readonly totalOutputTokens: number;
+  readonly totalCostUsd: number;
+  readonly costPerOutputToken: number | null;
+  readonly avgOutputTokensPerRequest: number | null;
+}
+
+export interface ModelUsageMetrics {
+  readonly byModel: Readonly<Record<string, ModelStats>>;
+  readonly mostUsedModel: string | null;
+  readonly mostEfficientModel: string | null;
+  readonly totalModelsUsed: number;
+}
+
+export interface CacheHealthResponse {
+  readonly status: 'no_cache_activity' | 'needs_attention' | 'can_improve' | 'excellent';
+  readonly cache_hit_rate_pct: number | null;
+  readonly total_cache_read_tokens: number;
+  readonly total_cache_creation_tokens: number;
+  readonly total_savings_usd: number;
+  readonly week_over_week_delta_pts: number | null;
+}
+
+export interface AlertEvent {
+  readonly id: string;
+  readonly sessionId?: string;
+  readonly state: 'firing' | 'cleared';
+  readonly severity: 'info' | 'warning' | 'critical';
+  readonly title: string;
+  readonly description: string;
+  readonly value: number;
+  readonly threshold: number;
+  readonly firedAt: number;
+}
+
+export interface ConcurrencyResponse {
+  readonly current: number;
+  readonly peak: number;
+  readonly allTimePeak: number;
+  readonly bucketSizeMs: number;
+  readonly startTimestamp: number;
+  readonly buckets: ReadonlyArray<{ readonly timestamp: number; readonly count: number }>;
+}
+
+export interface ActivityHeatmapTodayResponse {
+  readonly buckets: number[];
+  readonly bucketSizeMs: number;
+  readonly startTimestamp: number;
+  readonly maxCount: number;
+}
+
+export interface ActivityHeatmapHistoryResponse {
+  readonly days: ReadonlyArray<{ readonly date: string; readonly count: number }>;
+  readonly maxCount: number;
+}
+
+export const fetchConcurrency = (): Promise<ConcurrencyResponse> =>
+  getJson<ConcurrencyResponse>('/api/concurrency');
 export const fetchConcurrencyHistory = (days = 30): Promise<unknown> =>
   getJson<unknown>(`/api/concurrency?view=history&days=${days}`);
-export const fetchActivityHeatmap = (view: string, weeks?: number): Promise<unknown> =>
-  getJson<unknown>(
+export function fetchActivityHeatmap(view: 'today'): Promise<ActivityHeatmapTodayResponse>;
+export function fetchActivityHeatmap(
+  view: 'history',
+  weeks?: number,
+): Promise<ActivityHeatmapHistoryResponse>;
+export function fetchActivityHeatmap(
+  view: string,
+  weeks?: number,
+): Promise<ActivityHeatmapTodayResponse | ActivityHeatmapHistoryResponse> {
+  return getJson<ActivityHeatmapTodayResponse | ActivityHeatmapHistoryResponse>(
     `/api/activity-heatmap?view=${encodeURIComponent(view)}${weeks ? `&weeks=${weeks}` : ''}`,
   );
+}
 export const fetchContext = (sessionId?: string): Promise<unknown> =>
   getJson<unknown>(
     sessionId ? `/api/context?sessionId=${encodeURIComponent(sessionId)}` : '/api/context',
@@ -89,8 +395,10 @@ export interface SettingsPatch {
   };
 }
 
-export const fetchModelUsage = (): Promise<unknown> => getJson<unknown>('/api/model-usage');
-export const fetchCacheHealth = (): Promise<unknown> => getJson<unknown>('/api/cache-health');
+export const fetchModelUsage = (): Promise<ModelUsageMetrics> =>
+  getJson<ModelUsageMetrics>('/api/model-usage');
+export const fetchCacheHealth = (): Promise<CacheHealthResponse> =>
+  getJson<CacheHealthResponse>('/api/cache-health');
 
 export const fetchSettings = (): Promise<unknown> => getJson<unknown>('/api/settings');
 export const fetchDiagnostics = (): Promise<unknown> => getJson<unknown>('/api/diagnostics');

--- a/src/web/hooks/useLiveEvents.ts
+++ b/src/web/hooks/useLiveEvents.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useLiveStore } from '../store/liveStore';
+import type { SessionCurrentResponse, AntiPattern } from '../api/client';
 
 // Liveness contract: the SSE handler emits an `event: heartbeat` frame
 // every 30s (sse-handler.ts: HEARTBEAT_MS) regardless of activity. That
@@ -14,17 +15,6 @@ import { useLiveStore } from '../store/liveStore';
 // jitter and one missed frame.
 const STALE_AFTER_MS = 75_000;
 const WATCHDOG_TICK_MS = 10_000;
-
-interface SessionCurrentResponse {
-  readonly sessionId?: string;
-  readonly toolCallCount?: number;
-  readonly toolCallTimeline?: ReadonlyArray<{
-    readonly timestamp: number;
-    readonly toolName: string;
-    readonly durationMs: number | null;
-    readonly success: boolean;
-  }>;
-}
 
 function hydrateFromApi(signal: AbortSignal): void {
   const store = useLiveStore.getState();
@@ -54,12 +44,12 @@ function hydrateFromApi(signal: AbortSignal): void {
   // window correctly.
 
   fetch('/api/anti-patterns', { signal })
-    .then((r) => (r.ok ? (r.json() as Promise<unknown>) : null))
+    .then((r) => (r.ok ? (r.json() as Promise<AntiPattern[]>) : null))
     .then((data) => {
       if (!Array.isArray(data)) return;
       for (const ap of data) {
         if (ap && typeof ap === 'object' && 'type' in ap) {
-          store.pushAntiPattern(ap as { type: string; target: string; count: number });
+          store.pushAntiPattern(ap as unknown as { type: string; target: string; count: number });
         }
       }
     })

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -28,7 +28,11 @@ import {
   fetchModelUsage,
   fetchLiveSessions,
   fetchTodayAggregate,
+  TodayAggregateResponse,
+  ActivityHeatmapTodayResponse,
+  LiveSessionEntry,
   NotFoundError,
+  CacheHealthResponse,
   qk,
 } from '../api/client';
 import {
@@ -63,13 +67,6 @@ interface CostApiResponse {
   readonly sessionTodayUsd?: number | null;
 }
 
-interface HeatmapApiResponse {
-  readonly buckets: number[];
-  readonly bucketSizeMs: number;
-  readonly startTimestamp: number;
-  readonly maxCount: number;
-}
-
 // Minimal view of the /api/session/current payload. F-050 added efficiencyScore.
 interface SessionCurrentApiResponse {
   readonly efficiencyScore?: number | null;
@@ -101,31 +98,6 @@ interface SessionSummary {
   readonly antiPatterns?: SessionAntiPattern[];
   readonly model?: string | null;
   readonly toolSuccessRate?: number | null;
-}
-
-// Task #17 (D3): cross-session aggregate KPI shape returned by
-// /api/sessions/today/aggregate. The dashboard owner reads every per-session
-// buffer file plus persisted today sessions to produce one global view.
-interface TodayAggregateApiResponse {
-  readonly toolCallCount: number;
-  readonly totalCostUsd: number;
-  readonly antiPatternCount: number;
-  readonly avgDurationMs: number;
-  readonly sessionCount: number;
-  readonly sparkline: {
-    readonly startTimestamp: number;
-    readonly bucketSizeMs: number;
-    readonly points: readonly number[];
-  };
-}
-
-// Task #17 (D3): /api/sessions/live response — currently-live sessions sorted
-// most-recently-active first.
-interface LiveSessionApiEntry {
-  readonly sessionId: string;
-  readonly sessionName: string | null;
-  readonly startTime: number;
-  readonly lastActivity: number;
 }
 
 interface QualityProxyMetrics {
@@ -162,7 +134,7 @@ export function Today(): JSX.Element {
 
   const { data: costApi, isPending: costPending } = useQuery<CostApiResponse>({
     queryKey: qk.cost,
-    queryFn: () => fetchCost() as Promise<CostApiResponse>,
+    queryFn: fetchCost,
   });
   // Task #17 (D3): the dashboard owner's session_current is arbitrary across
   // N concurrent sessions, so we keep the call only for the efficiencyScore
@@ -171,38 +143,38 @@ export function Today(): JSX.Element {
   // per-session buffer + persisted session.
   const { data: sessionCurrent } = useQuery<SessionCurrentApiResponse>({
     queryKey: qk.sessionCurrent,
-    queryFn: () => fetchSessionCurrent() as Promise<SessionCurrentApiResponse>,
+    queryFn: fetchSessionCurrent,
     refetchInterval: 10_000,
   });
-  const { data: aggregate, isPending: aggregatePending } = useQuery<TodayAggregateApiResponse>({
+  const { data: aggregate, isPending: aggregatePending } = useQuery<TodayAggregateResponse>({
     queryKey: qk.sessionsTodayAggregate,
-    queryFn: () => fetchTodayAggregate() as Promise<TodayAggregateApiResponse>,
+    queryFn: fetchTodayAggregate,
     refetchInterval: 10_000,
   });
   const { data: todaySessions, isPending: sessionsPending } = useQuery<SessionSummary[]>({
     queryKey: qk.sessionsList(200),
-    queryFn: () => fetchSessionsList(200) as Promise<SessionSummary[]>,
+    queryFn: () => fetchSessionsList(200),
     refetchInterval: 10_000,
   });
   const { data: apiAntiPatterns, isPending: antiPatternsPending } = useQuery<SessionAntiPattern[]>({
     queryKey: qk.antiPatterns,
-    queryFn: () => fetchAntiPatterns() as Promise<SessionAntiPattern[]>,
+    queryFn: fetchAntiPatterns,
   });
   const { data: concurrency } = useQuery<ConcurrencyData>({
     queryKey: qk.concurrency,
-    queryFn: () => fetchConcurrency() as Promise<ConcurrencyData>,
+    queryFn: fetchConcurrency,
     refetchInterval: 10_000,
   });
-  const { data: todayHeatmap } = useQuery<HeatmapApiResponse>({
+  const { data: todayHeatmap } = useQuery<ActivityHeatmapTodayResponse>({
     queryKey: qk.activityHeatmap('today'),
-    queryFn: () => fetchActivityHeatmap('today') as Promise<HeatmapApiResponse>,
+    queryFn: () => fetchActivityHeatmap('today'),
     refetchInterval: 30_000,
   });
   // Task #17 (D3): live-session list — drives the selector default and the
   // "Session ended" badge logic when the selected session goes stale.
-  const { data: liveSessions } = useQuery<LiveSessionApiEntry[]>({
+  const { data: liveSessions } = useQuery<LiveSessionEntry[]>({
     queryKey: qk.sessionsLive,
-    queryFn: () => fetchLiveSessions() as Promise<LiveSessionApiEntry[]>,
+    queryFn: fetchLiveSessions,
     refetchInterval: 10_000,
   });
 
@@ -449,7 +421,7 @@ export function Today(): JSX.Element {
 function QualityProxyPanel(): JSX.Element {
   const { data } = useQuery<QualityProxyMetrics>({
     queryKey: qk.qualityProxy,
-    queryFn: () => fetchQualityProxy() as Promise<QualityProxyMetrics>,
+    queryFn: fetchQualityProxy,
     refetchInterval: QUALITY_REFETCH_MS,
   });
 
@@ -500,7 +472,7 @@ function QualityProxyPanel(): JSX.Element {
 function ToolSelectionPanel(): JSX.Element {
   const { data } = useQuery<ToolSelectionMetrics>({
     queryKey: qk.toolSelectionScore,
-    queryFn: () => fetchToolSelectionScore() as Promise<ToolSelectionMetrics>,
+    queryFn: fetchToolSelectionScore,
     refetchInterval: QUALITY_REFETCH_MS,
   });
 
@@ -563,7 +535,7 @@ interface LatencyMetrics {
 function LatencyPanel(): JSX.Element {
   const { data } = useQuery<LatencyMetrics>({
     queryKey: qk.latency,
-    queryFn: () => fetchLatency() as Promise<LatencyMetrics>,
+    queryFn: fetchLatency,
     refetchInterval: QUALITY_REFETCH_MS,
   });
 
@@ -637,19 +609,10 @@ interface ModelUsageMetrics {
   readonly mostEfficientModel: string | null;
 }
 
-interface CacheHealthApiResponse {
-  readonly status: 'no_cache_activity' | 'needs_attention' | 'can_improve' | 'excellent';
-  readonly cache_hit_rate_pct: number | null;
-  readonly total_cache_read_tokens: number;
-  readonly total_cache_creation_tokens: number;
-  readonly total_savings_usd: number;
-  readonly week_over_week_delta_pts: number | null;
-}
-
 function ModelUsagePanel(): JSX.Element {
   const { data } = useQuery<ModelUsageMetrics>({
     queryKey: qk.modelUsage,
-    queryFn: () => fetchModelUsage() as Promise<ModelUsageMetrics>,
+    queryFn: fetchModelUsage,
     refetchInterval: QUALITY_REFETCH_MS,
   });
 
@@ -694,7 +657,7 @@ function ModelUsagePanel(): JSX.Element {
 }
 
 function cacheRecommendationText(
-  status: CacheHealthApiResponse['status'],
+  status: CacheHealthResponse['status'],
   hitRatePct: number | null,
 ): string {
   const pct = hitRatePct !== null ? `${hitRatePct}%` : null;
@@ -712,9 +675,9 @@ function cacheRecommendationText(
 }
 
 function CacheHealthPanel(): JSX.Element {
-  const { data } = useQuery<CacheHealthApiResponse>({
+  const { data } = useQuery<CacheHealthResponse>({
     queryKey: qk.cacheHealth,
-    queryFn: () => fetchCacheHealth() as Promise<CacheHealthApiResponse>,
+    queryFn: fetchCacheHealth,
     refetchInterval: QUALITY_REFETCH_MS,
   });
 
@@ -814,7 +777,7 @@ function LiveSessionPane({
   liveSessions,
 }: {
   sessions: SessionSummary[];
-  liveSessions: LiveSessionApiEntry[];
+  liveSessions: LiveSessionEntry[];
 }): JSX.Element {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'gantt' | 'list'>('list');
@@ -827,7 +790,7 @@ function LiveSessionPane({
   // populates immediately on first paint instead of waiting an interval.
   const { data: current } = useQuery<{ sessionId: string; liveSessions?: string[] }>({
     queryKey: qk.sessionCurrent,
-    queryFn: () => fetchSessionCurrent() as Promise<{ sessionId: string; liveSessions?: string[] }>,
+    queryFn: fetchSessionCurrent,
   });
 
   const liveSessionIds = useMemo(() => {
@@ -869,7 +832,7 @@ function LiveSessionPane({
 
   const { data: replay } = useQuery<ReplayData>({
     queryKey: activeId ? qk.sessionReplay(activeId) : ['replay', 'none'],
-    queryFn: () => fetchSessionReplay(activeId!) as Promise<ReplayData>,
+    queryFn: () => fetchSessionReplay(activeId!),
     enabled: activeId !== null,
     retry: false,
     refetchInterval: isLive ? LIVE_TAIL_REFETCH_MS : false,
@@ -900,7 +863,7 @@ function LiveSessionPane({
   const todaySessions = useMemo(() => {
     const RECENT_ACTIVITY_MS = 6 * 60 * 60 * 1000; // 6 hours
     const recentCutoff = Date.now() - RECENT_ACTIVITY_MS;
-    const liveById = new Map<string, LiveSessionApiEntry>();
+    const liveById = new Map<string, LiveSessionEntry>();
     for (const ls of liveSessions) liveById.set(ls.sessionId, ls);
 
     const byId = new Map<string, SessionSummary>();
@@ -1113,7 +1076,7 @@ function LiveSessionPane({
 // alerts. Falls back to the truncated session id when no friendly name is
 // known yet — sessionName is only set after the live registry has seen a
 // `cwd` from the first hook event.
-function sessionPillLabel(sessionId: string, liveSessions: LiveSessionApiEntry[]): string {
+function sessionPillLabel(sessionId: string, liveSessions: LiveSessionEntry[]): string {
   const match = liveSessions.find((ls) => ls.sessionId === sessionId);
   if (match?.sessionName) return match.sessionName;
   return sessionId.slice(0, 8);
@@ -1128,7 +1091,7 @@ function RecentAlertsPanel(): JSX.Element | null {
     queryKey: qk.alertsRecent,
     queryFn: async () => {
       try {
-        return (await fetchRecentAlerts()) as readonly AlertEvent[];
+        return await fetchRecentAlerts();
       } catch (err) {
         if (err instanceof NotFoundError) return null;
         throw err;


### PR DESCRIPTION
## Summary

Progress on #141: gives `src/web/api/client.ts`'s dashboard API functions real TypeScript response interfaces instead of `Promise<unknown>`, removing the matching `as Promise<T>` casts at call sites. This release covers the 15 functions consumed by `src/web/views/Today.tsx`, plus reconciling two duplicate/undertyped response shapes in `src/web/hooks/useLiveEvents.ts`. Part of an ongoing effort to type the rest of the dashboard's API layer — #141 stays open until the remaining views are covered.

- All 15 interfaces were derived by reading the real route handlers in `src/dashboard/routes/api-handler.ts` and the underlying tracker classes (`src/metrics/*.ts`), not guessed.
- Every interface is declared locally in `client.ts` (matching the existing `HealthResponse` precedent), since `src/web` builds under a separate `tsconfig.web.json` that excludes server-side source.
- View-local interfaces that were exact duplicates of the new canonical types were deleted in favor of importing the canonical type; narrower view-local projections were left in place.
- `fetchActivityHeatmap` became an overloaded function (`'today'`/`'history'` literal args each resolve to their own concrete response type) since it returns one of two shapes depending on its argument.

**Also discovered, filed as #186, not fixed here (behavior change, out of scope for a type-only release):** `useLiveEvents.ts`'s `/api/anti-patterns` REST hydration path pushes `target: undefined`/`count: undefined` into the live store, since the real server `AntiPattern` type has no such fields. Invisible before this release because the code cast from `unknown`; now visible as a forced `as unknown as` double-cast.

**Tooling note for future `src/web/` work:** `npm run build` (Vite/esbuild, no type-checking) and `npm run lint` (no `parserOptions.project`) don't catch TypeScript errors in `src/web/**`. Use `npx tsc --noEmit -p tsconfig.web.json` to actually type-check that directory.

## Test plan

- [x] `npm run build && npm test && npm run lint` clean
- [x] `npx tsc --noEmit -p tsconfig.web.json` — zero new errors vs. base
- [x] Zero remaining `as Promise<` casts in `Today.tsx`; all 15 target functions no longer `Promise<unknown>`
- [x] `scripts/verify-public-diff.sh` passed clean