### PR TITLE
v1.4.36: client.ts typed response contracts — Settings/Alerts/ContextBar/Audit cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.36] - 2026-07-13
+
+- Typed the last 7 `client.ts` response contracts, consumed by the Settings, Alerts, ContextBar, and Audit views (`fetchAuditLog`, `fetchContext`, `fetchSettings`, `fetchDiagnostics`, `patchSettings`, `postDigestSend`), removing the `as Promise<T>` casts these views previously needed. Also removed the unused `fetchSessionToday` export, which had zero consumers. This closes the effort to type the rest of the dashboard's API layer (#141) — every exported function in `client.ts` now has a real response interface instead of `Promise<unknown>`.
+
 ## [1.4.35] - 2026-07-13
 
 - Typed 7 more `client.ts` response contracts consumed by the History, Sessions, and Git Efficiency views (`fetchWeekly`, `fetchCostPerOutcome`, `fetchPersonalCoach`, `fetchConcurrencyHistory`, `fetchSessionDetail`, `fetchGitEfficiency`, `fetchGitEfficiencyRepos`), removing the `as Promise<T>` casts these views previously needed. Part of an ongoing effort to type the rest of the dashboard's API layer (#141).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.35",
+  "version": "1.4.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.35",
+      "version": "1.4.36",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.35",
+  "version": "1.4.36",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -210,7 +210,6 @@ export interface CostResponse {
 
 export const fetchSessionCurrent = (): Promise<SessionCurrentResponse> =>
   getJson<SessionCurrentResponse>('/api/session/current');
-export const fetchSessionToday = (): Promise<unknown> => getJson<unknown>('/api/session/today');
 export const fetchSessionsList = (limit = 50): Promise<SessionListEntry[]> =>
   getJson<SessionListEntry[]>(`/api/sessions?limit=${limit}`);
 // Cross-session aggregate KPIs for the Today view.
@@ -309,7 +308,20 @@ export interface ToolSelectionMetrics {
   readonly unusedOutputCount: number;
 }
 
-export const fetchAuditLog = (): Promise<unknown> => getJson<unknown>('/api/audit');
+// Mirrors AuditEntryDto in src/dashboard/routes/api-handler.ts (not importable —
+// tsconfig.web.json excludes server source). sessionId is `string | null` at
+// runtime (never `undefined`) — the real handler's toAuditEntry() always sets it,
+// falling back to null when the underlying audit record has none.
+export interface AuditEntry {
+  readonly ts: number;
+  readonly sessionId: string | null;
+  readonly tool: string;
+  readonly target: string;
+  readonly classification: string;
+  readonly severity?: string;
+}
+
+export const fetchAuditLog = (): Promise<AuditEntry[]> => getJson<AuditEntry[]>('/api/audit');
 
 // Mirrors WeeklySummary in src/storage/weekly-summary.ts (not importable —
 // tsconfig.web.json excludes server source). Only the fields the History
@@ -324,7 +336,33 @@ export interface WeeklyRow {
 }
 
 export const fetchWeekly = (): Promise<WeeklyRow[]> => getJson<WeeklyRow[]>('/api/weekly');
-export const fetchBudget = (): Promise<unknown> => getJson<unknown>('/api/budget');
+
+// Mirrors BudgetStatus in src/metrics/budget-tracker.ts (not importable —
+// tsconfig.web.json excludes server source). Alerts.tsx never reads
+// `remainingUsd`, so it's omitted here to match the one real consumer exactly.
+export interface BudgetPeriod {
+  readonly budgetUsd: number | null;
+  readonly spentUsd: number;
+  readonly pctUsed: number | null;
+  readonly exceeded: boolean;
+}
+
+export interface BudgetAlert {
+  readonly period: string;
+  readonly thresholdPct: number;
+  readonly spentUsd: number;
+  readonly budgetUsd: number;
+  readonly timestamp: number;
+}
+
+export interface BudgetStatus {
+  readonly session: BudgetPeriod;
+  readonly daily: BudgetPeriod;
+  readonly weekly: BudgetPeriod;
+  readonly alerts: readonly BudgetAlert[];
+}
+
+export const fetchBudget = (): Promise<BudgetStatus> => getJson<BudgetStatus>('/api/budget');
 export const fetchLatency = (): Promise<LatencyMetrics> => getJson<LatencyMetrics>('/api/latency');
 
 // Mirrors CostAttribution in src/metrics/cost-per-outcome.ts (not importable).
@@ -572,8 +610,58 @@ export function fetchActivityHeatmap(
     `/api/activity-heatmap?view=${encodeURIComponent(view)}${weeks ? `&weeks=${weeks}` : ''}`,
   );
 }
-export const fetchContext = (sessionId?: string): Promise<unknown> =>
-  getJson<unknown>(
+// Mirrors ContextTrackerMetrics in src/metrics/context-tracker.ts (not
+// importable — tsconfig.web.json excludes server source). Includes `history`
+// for full accuracy even though no current consumer reads it.
+export interface ContextBreakdown {
+  readonly system: number;
+  readonly tools: number;
+  readonly user: number;
+  readonly assistant: number;
+}
+
+export interface ContextGrowthSummary {
+  readonly startTokens: number;
+  readonly currentTokens: number;
+  readonly deltaTokens: number;
+}
+
+export interface ToolContextContribution {
+  readonly tool: string;
+  readonly totalBytes: number;
+  readonly estimatedTokens: number;
+  readonly percentOfToolOutput: number;
+}
+
+export interface ContextTurnSnapshot {
+  readonly turnNumber: number;
+  readonly timestamp: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheCreationTokens: number;
+  readonly fillPercent: number;
+  readonly breakdown: ContextBreakdown;
+}
+
+export interface ContextResponse {
+  readonly turnCount: number;
+  readonly growth: ContextGrowthSummary;
+  readonly currentBreakdown: ContextBreakdown;
+  readonly fillPercent: number;
+  /**
+   * Per-model context window cap (tokens). Resolved from the model in the
+   * Anthropic usage metadata — claude-opus-4-7 → 1_000_000, claude-haiku-4-5 →
+   * 200_000, etc. UI formats this as "X / Y" so a 250K Opus session reads as
+   * "250K / 1M (25%)" instead of "250K (125%)".
+   */
+  readonly contextWindow: number;
+  readonly toolContributions: readonly ToolContextContribution[];
+  readonly history: readonly ContextTurnSnapshot[];
+}
+
+export const fetchContext = (sessionId?: string): Promise<ContextResponse> =>
+  getJson<ContextResponse>(
     sessionId ? `/api/context?sessionId=${encodeURIComponent(sessionId)}` : '/api/context',
   );
 
@@ -602,28 +690,80 @@ export const fetchModelUsage = (): Promise<ModelUsageMetrics> =>
 export const fetchCacheHealth = (): Promise<CacheHealthResponse> =>
   getJson<CacheHealthResponse>('/api/cache-health');
 
-export const fetchSettings = (): Promise<unknown> => getJson<unknown>('/api/settings');
-export const fetchDiagnostics = (): Promise<unknown> => getJson<unknown>('/api/diagnostics');
+// Mirrors the real GET /api/settings handler response in
+// src/dashboard/routes/api-handler.ts (not importable — tsconfig.web.json
+// excludes server source). This is the full superset shape; Settings.tsx and
+// Alerts.tsx each keep their own narrower local `SettingsData` interface
+// covering only the fields they use — both are structurally assignable from
+// this type without a cast, since neither declares a field this type lacks.
+export interface SettingsResponse {
+  readonly developer: string;
+  readonly teamId: string | null;
+  readonly accountId: string | null;
+  readonly appName: string;
+  readonly mode: string;
+  readonly storagePath: string;
+  readonly highSecurity: boolean;
+  readonly licenseKey: string | null;
+  readonly sessionBudgetUsd: number | null;
+  readonly dailyBudgetUsd: number | null;
+  readonly weeklyBudgetUsd: number | null;
+  readonly retainSessionsDays: number | null;
+  readonly digestWebhookUrl: string | null;
+  readonly digestSchedule: string;
+  readonly alerts: {
+    readonly personal: {
+      readonly dailyCostUsd: number;
+      readonly sessionCostUsd: number;
+      readonly efficiencyScoreMin: number;
+      readonly stuckLoopCountMax: number;
+      readonly antiPatternCountMax: number;
+    };
+  };
+}
 
-export const patchSettings = (body: SettingsPatch): Promise<unknown> =>
+export const fetchSettings = (): Promise<SettingsResponse> =>
+  getJson<SettingsResponse>('/api/settings');
+
+// Mirrors the real exported DiagnosticCheck in src/install/diagnostics.ts
+// (not importable — tsconfig.web.json excludes server source).
+export interface DiagnosticCheck {
+  readonly check: string;
+  readonly status: 'ok' | 'warn' | 'fail' | 'skip';
+  readonly detail: string;
+  readonly fix?: string;
+}
+
+export const fetchDiagnostics = (): Promise<DiagnosticCheck[]> =>
+  getJson<DiagnosticCheck[]>('/api/diagnostics');
+
+export interface PatchSettingsResponse {
+  readonly ok: boolean;
+  readonly restartRequired: boolean;
+}
+
+export const patchSettings = (body: SettingsPatch): Promise<PatchSettingsResponse> =>
   fetch('/api/settings', {
     method: 'PATCH',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   }).then(async (r) => {
     if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
-    return (await r.json()) as unknown;
+    return (await r.json()) as PatchSettingsResponse;
   });
 
-export const postDigestSend = (): Promise<unknown> =>
+export interface DigestSendResponse {
+  readonly content: Array<{ readonly type: 'text'; readonly text: string }>;
+}
+
+export const postDigestSend = (): Promise<DigestSendResponse> =>
   fetch('/api/digest/send', { method: 'POST' }).then(async (r) => {
     if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
-    return (await r.json()) as unknown;
+    return (await r.json()) as DigestSendResponse;
   });
 
 export const qk = {
   sessionCurrent: ['session', 'current'] as const,
-  sessionToday: ['session', 'today'] as const,
   sessionsList: (limit: number) => ['sessions', 'list', limit] as const,
   sessionDetail: (id: string) => ['session', id] as const,
   cost: ['cost'] as const,

--- a/src/web/components/ContextBar.tsx
+++ b/src/web/components/ContextBar.tsx
@@ -1,41 +1,12 @@
 import { useRef, useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchContext, qk } from '../api/client';
+import { fetchContext, qk, type ContextResponse } from '../api/client';
 import { useLiveStore, type ContextUpdateEvent } from '../store/liveStore';
 import { Eyebrow, Pill } from './ui';
 
-export interface ContextApiResponse {
-  readonly turnCount: number;
-  readonly growth: {
-    readonly startTokens: number;
-    readonly currentTokens: number;
-    readonly deltaTokens: number;
-  };
-  readonly currentBreakdown: {
-    readonly system: number;
-    readonly tools: number;
-    readonly user: number;
-    readonly assistant: number;
-  };
-  readonly fillPercent: number;
-  /**
-   * Per-model context window cap (tokens). Resolved from the model in the
-   * Anthropic usage metadata — claude-opus-4-7 → 1_000_000, claude-haiku-4-5 →
-   * 200_000, etc. UI formats this as "X / Y" so a 250K Opus session reads as
-   * "250K / 1M (25%)" instead of "250K (125%)".
-   */
-  readonly contextWindow: number;
-  readonly toolContributions: ReadonlyArray<{
-    readonly tool: string;
-    readonly totalBytes: number;
-    readonly estimatedTokens: number;
-    readonly percentOfToolOutput: number;
-  }>;
-}
-
 export interface ContextBarProps {
-  readonly data?: ContextApiResponse | null;
+  readonly data?: ContextResponse | null;
   readonly sessionId?: string | null;
 }
 
@@ -75,7 +46,7 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
-function toContextEvent(api: ContextApiResponse, sessionId = ''): ContextUpdateEvent {
+function toContextEvent(api: ContextResponse, sessionId = ''): ContextUpdateEvent {
   return {
     sessionId,
     turnNumber: api.turnCount,
@@ -103,9 +74,9 @@ export function ContextBar({ data, sessionId }: ContextBarProps): JSX.Element | 
   const prevFillRef = useRef(0);
   const prevTokensRef = useRef(0);
 
-  const { data: apiContext } = useQuery<ContextApiResponse>({
+  const { data: apiContext } = useQuery<ContextResponse>({
     queryKey: sessionId ? ['context', sessionId] : qk.context,
-    queryFn: () => fetchContext(sessionId ?? undefined) as Promise<ContextApiResponse>,
+    queryFn: () => fetchContext(sessionId ?? undefined),
     refetchInterval: 10_000,
     enabled: !data,
   });

--- a/src/web/views/Alerts.tsx
+++ b/src/web/views/Alerts.tsx
@@ -2,32 +2,18 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'wouter';
 
-import { fetchBudget, fetchSettings, patchSettings, postDigestSend, qk } from '../api/client';
+import {
+  fetchBudget,
+  fetchSettings,
+  patchSettings,
+  postDigestSend,
+  qk,
+  type BudgetStatus,
+  type BudgetPeriod,
+} from '../api/client';
 import type { SettingsPatch } from '../api/client';
 import { EmptyState } from '../components/EmptyState';
 import { Button, Card, Eyebrow, Pill, SectionHeader } from '../components/ui';
-
-interface BudgetPeriod {
-  readonly budgetUsd: number | null;
-  readonly spentUsd: number;
-  readonly pctUsed: number | null;
-  readonly exceeded: boolean;
-}
-
-interface BudgetAlert {
-  readonly period: string;
-  readonly thresholdPct: number;
-  readonly spentUsd: number;
-  readonly budgetUsd: number;
-  readonly timestamp: number;
-}
-
-interface BudgetStatus {
-  readonly session: BudgetPeriod;
-  readonly daily: BudgetPeriod;
-  readonly weekly: BudgetPeriod;
-  readonly alerts: readonly BudgetAlert[];
-}
 
 interface PersonalThresholds {
   readonly dailyCostUsd: number;
@@ -80,13 +66,13 @@ export function Alerts(): JSX.Element {
 
   const budgetQ = useQuery<BudgetStatus>({
     queryKey: qk.budget,
-    queryFn: () => fetchBudget() as Promise<BudgetStatus>,
+    queryFn: () => fetchBudget(),
     refetchInterval: 10_000,
   });
 
   const settingsQ = useQuery<SettingsData>({
     queryKey: qk.settings,
-    queryFn: () => fetchSettings() as Promise<SettingsData>,
+    queryFn: () => fetchSettings(),
   });
 
   const budget = budgetQ.data;
@@ -110,8 +96,7 @@ export function Alerts(): JSX.Element {
   const sendMutation = useMutation({
     mutationFn: () => postDigestSend(),
     onSuccess: (result) => {
-      const r = result as { content?: Array<{ text?: string }> };
-      const text = r.content?.[0]?.text ?? '';
+      const text = result.content[0]?.text ?? '';
       try {
         const parsed = JSON.parse(text) as { ok?: boolean; error?: string };
         setDigestStatus(parsed.ok ? 'Digest sent.' : (parsed.error ?? 'Failed to send.'));

--- a/src/web/views/Audit.test.tsx
+++ b/src/web/views/Audit.test.tsx
@@ -189,7 +189,13 @@ describe('Audit downloadJsonl', () => {
 
     try {
       downloadJsonl([
-        { ts: 1, tool: 'Read', target: '/etc/hosts', classification: 'sensitive_file' },
+        {
+          ts: 1,
+          tool: 'Read',
+          target: '/etc/hosts',
+          classification: 'sensitive_file',
+          sessionId: null,
+        },
       ]);
       // Revocation must have already happened by the time the call
       // returns — no setTimeout, no microtask deferral.
@@ -222,7 +228,13 @@ describe('Audit downloadJsonl', () => {
 
     try {
       downloadJsonl([
-        { ts: 1, tool: 'Read', target: '/etc/hosts', classification: 'sensitive_file' },
+        {
+          ts: 1,
+          tool: 'Read',
+          target: '/etc/hosts',
+          classification: 'sensitive_file',
+          sessionId: null,
+        },
       ]);
       // appendChild called with the anchor element exactly once.
       const appended = appendSpy.mock.calls.find((args) => args[0] instanceof HTMLAnchorElement);
@@ -261,7 +273,13 @@ describe('Audit downloadJsonl', () => {
     try {
       expect(() =>
         downloadJsonl([
-          { ts: 1, tool: 'Read', target: '/etc/hosts', classification: 'sensitive_file' },
+          {
+            ts: 1,
+            tool: 'Read',
+            target: '/etc/hosts',
+            classification: 'sensitive_file',
+            sessionId: null,
+          },
         ]),
       ).toThrow('user cancelled');
       expect(revoked).toEqual(created);

--- a/src/web/views/Audit.tsx
+++ b/src/web/views/Audit.tsx
@@ -1,18 +1,9 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { fetchAuditLog, qk } from '../api/client';
+import { fetchAuditLog, qk, type AuditEntry } from '../api/client';
 import { EmptyState } from '../components/EmptyState';
 import { GeoBanner } from '../components/GeoBanner';
 import { Button, Card, Pill } from '../components/ui';
-
-interface AuditEntry {
-  readonly ts: number;
-  readonly tool: string;
-  readonly target: string;
-  readonly classification: string;
-  readonly severity?: string;
-  readonly sessionId?: string;
-}
 
 const FILTERS = [
   { key: 'all', label: 'All' },
@@ -55,7 +46,7 @@ export function Audit(): JSX.Element {
   const [filter, setFilter] = useState<FilterKey>('all');
   const { data, isLoading, error } = useQuery<AuditEntry[]>({
     queryKey: qk.audit,
-    queryFn: () => fetchAuditLog() as Promise<AuditEntry[]>,
+    queryFn: () => fetchAuditLog(),
   });
 
   const rows = data ?? [];

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -20,7 +20,8 @@ import {
   qk,
   type SessionDetail,
 } from '../api/client';
-import { ContextBar, type ContextApiResponse } from '../components/ContextBar';
+import { ContextBar } from '../components/ContextBar';
+import type { ContextResponse } from '../api/client';
 import { Button, Card, Eyebrow, LiveBadge, Pill, Tabs } from '../components/ui';
 import {
   fmtDateTime,
@@ -512,7 +513,7 @@ function ToolsSection({
   const [tab, setTab] = useState<'calls' | 'context'>('calls');
 
   const contextUrl = `/api/context?sessionId=${encodeURIComponent(sessionId)}`;
-  const { data: contextData } = useQuery<ContextApiResponse>({
+  const { data: contextData } = useQuery<ContextResponse>({
     queryKey: ['context', sessionId],
     queryFn: () => fetch(contextUrl).then((r) => (r.ok ? r.json() : null)),
     refetchInterval: 10_000,

--- a/src/web/views/Settings.tsx
+++ b/src/web/views/Settings.tsx
@@ -1,7 +1,13 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { fetchSettings, patchSettings, fetchDiagnostics, qk } from '../api/client';
+import {
+  fetchSettings,
+  patchSettings,
+  fetchDiagnostics,
+  qk,
+  type DiagnosticCheck,
+} from '../api/client';
 import type { SettingsPatch } from '../api/client';
 import { EmptyState } from '../components/EmptyState';
 import { Button, Card, SectionHeader } from '../components/ui';
@@ -64,13 +70,6 @@ function NullableNumberInput({
   );
 }
 
-interface DiagnosticCheck {
-  readonly check: string;
-  readonly status: 'ok' | 'warn' | 'fail' | 'skip';
-  readonly detail: string;
-  readonly fix?: string;
-}
-
 const STATUS_ICON: Record<string, string> = {
   ok: '●',
   warn: '▲',
@@ -88,7 +87,7 @@ const STATUS_COLOR: Record<string, string> = {
 function DiagnosticsPanel(): JSX.Element {
   const { data, isLoading, isError, refetch } = useQuery<DiagnosticCheck[]>({
     queryKey: qk.diagnostics,
-    queryFn: () => fetchDiagnostics() as Promise<DiagnosticCheck[]>,
+    queryFn: () => fetchDiagnostics(),
     refetchInterval: 60_000,
     staleTime: 55_000,
   });
@@ -155,7 +154,7 @@ export function Settings(): JSX.Element {
   const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery<SettingsData>({
     queryKey: qk.settings,
-    queryFn: () => fetchSettings() as Promise<SettingsData>,
+    queryFn: () => fetchSettings(),
   });
 
   const [developer, setDeveloper] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

Part 3 of 3 for #141. Types the last 7 `Promise<unknown>` exports in `src/web/api/client.ts`, consumed by the Settings, Alerts, ContextBar, and Audit views:

- `fetchAuditLog` → `AuditEntry` (also fixes a real type-accuracy bug: `sessionId` is `string | null` at runtime, not `string | undefined` as previously declared — render-invisible, since the one render site already uses `??`)
- `fetchContext` → `ContextResponse` (includes `history` for full accuracy, even though unused today)
- `fetchSettings` → new shared `SettingsResponse` superset type (consumed by both Settings.tsx and Alerts.tsx, each keeping its own narrower local `SettingsData` via structural assignability — no cast needed)
- `fetchDiagnostics` → `DiagnosticCheck[]` (moved from a byte-identical local interface)
- `patchSettings` → `PatchSettingsResponse`
- `postDigestSend` → `DigestSendResponse`

Also deletes the confirmed-dead `fetchSessionToday` export (zero consumers anywhere in `src/web`, including tests) and its now-unused `qk.sessionToday` query key — the one other `Promise<unknown>` left in the file besides these 7.

**`grep -n "Promise<unknown>" src/web/api/client.ts` now returns nothing** — every exported function in `client.ts` has a real response interface. Fixes #141.

Every new interface is redeclared locally in `client.ts` (never imported from server source — `tsconfig.web.json` excludes it entirely), mirroring the real backend shape cited in each interface's own comment.

No behavior changes anywhere in this PR.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.web.json` — zero new errors vs. baseline
- [x] `npm run build` — clean
- [x] `npm test` — 129/130 suites, 3956/3959 tests passing
- [x] `npm run lint` — only the pre-existing gap in `scripts/*.ts` (1 error + 5 warnings), nothing new
- [x] Every new interface independently re-verified against its real backend source by a final whole-branch review, not just per-task reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)