### PR TITLE
v1.4.37: Install coverage hardening (#160, #161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.37] - 2026-07-13
+
+- Added automated test coverage for previously untested (but correct) branches across `src/install/`: `migrate.ts`'s legacy-storage-path merge/rollback logic, the `validate` CLI command, graceful process-kill escalation, several setup-wizard prompt/fallback paths, config-diagnostics edge cases, and `json-utils.ts`'s JSON parsing helpers (which previously had no dedicated test file at all). No behavior changes — this is a test-only hardening release.
+
 ## [1.4.36] - 2026-07-13
 
 - Typed the last 7 `client.ts` response contracts, consumed by the Settings, Alerts, ContextBar, and Audit views (`fetchAuditLog`, `fetchContext`, `fetchSettings`, `fetchDiagnostics`, `patchSettings`, `postDigestSend`), removing the `as Promise<T>` casts these views previously needed. Also removed the unused `fetchSessionToday` export, which had zero consumers. This closes the effort to type the rest of the dashboard's API layer (#141) — every exported function in `client.ts` now has a real response interface instead of `Promise<unknown>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.36",
+  "version": "1.4.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.36",
+      "version": "1.4.37",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.36",
+  "version": "1.4.37",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -1790,6 +1790,70 @@ describe('preflight local', () => {
     killSpy.mockRestore();
   });
 
+  it('escalates to SIGKILL when the orphaned process does not exit within the grace period', async () => {
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+      listLocalInstances: jest.fn(() => [
+        { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now(), alive: true },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+    }));
+    const readlineMod = await import('node:readline/promises');
+    (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
+      question: jest.fn(async () => 'y'),
+      close: jest.fn(),
+    });
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => true);
+
+    jest.useFakeTimers();
+    const runPromise = runInstallCli(['local', '--clean']);
+    await jest.advanceTimersByTimeAsync(2100); // past the 2s grace-period loop
+    await runPromise;
+    jest.useRealTimers();
+
+    expect(killSpy).toHaveBeenCalledWith(200, 'SIGTERM');
+    expect(killSpy).toHaveBeenCalledWith(200, 'SIGKILL');
+    killSpy.mockRestore();
+  });
+
+  it('does not escalate to SIGKILL when the process exits before the grace period ends', async () => {
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+      listLocalInstances: jest.fn(() => [
+        { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now(), alive: true },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+    }));
+    const readlineMod = await import('node:readline/promises');
+    (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
+      question: jest.fn(async () => 'y'),
+      close: jest.fn(),
+    });
+    let probeCount = 0;
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation((_pid, signal) => {
+      if (signal === 0) {
+        probeCount++;
+        if (probeCount >= 2) {
+          throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' }); // dead from the 2nd probe on
+        }
+        return true; // alive on the first probe
+      }
+      return true; // SIGTERM succeeds
+    });
+
+    jest.useFakeTimers();
+    const runPromise = runInstallCli(['local', '--clean']);
+    await jest.advanceTimersByTimeAsync(2100);
+    await runPromise;
+    jest.useRealTimers();
+
+    expect(killSpy).toHaveBeenCalledWith(200, 'SIGTERM');
+    expect(killSpy).not.toHaveBeenCalledWith(200, 'SIGKILL');
+    killSpy.mockRestore();
+  });
+
   it('--clean does not kill anything when the user declines', async () => {
     const readlineMod = await import('node:readline/promises');
     (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
@@ -1921,5 +1985,94 @@ describe('preflight doctor', () => {
     const prog = createInstallProgram();
     await prog.parseAsync(['node', 'preflight', 'doctor']);
     expect(process.exitCode).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// preflight validate
+// ---------------------------------------------------------------------------
+
+describe('preflight validate', () => {
+  let output: string[];
+  const mockedFsForValidate = fsMod as unknown as {
+    existsSync: jest.Mock;
+    readFileSync: jest.Mock;
+  };
+
+  beforeEach(() => {
+    output = [];
+    jest.spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(String(s));
+      return true;
+    });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    jest.restoreAllMocks();
+  });
+
+  it('reports no config file found when the config path does not exist', async () => {
+    mockedFsForValidate.existsSync.mockReturnValue(false);
+    const { createInstallProgram } = await import('./cli.js');
+    const prog = createInstallProgram();
+    await prog.parseAsync(['node', 'preflight', 'validate']);
+    expect(output.join('')).toContain('No config file found');
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it('reports valid with no issues for a clean config', async () => {
+    mockedFsForValidate.existsSync.mockReturnValue(true);
+    mockedFsForValidate.readFileSync.mockReturnValue(
+      JSON.stringify({ licenseKey: 'NRLIC-test', accountId: '12345' }),
+    );
+    const { createInstallProgram } = await import('./cli.js');
+    const prog = createInstallProgram();
+    await prog.parseAsync(['node', 'preflight', 'validate']);
+    expect(output.join('')).toContain('Config is valid');
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it('prints warnings and does not set an exit code for an unknown key', async () => {
+    mockedFsForValidate.existsSync.mockReturnValue(true);
+    mockedFsForValidate.readFileSync.mockReturnValue(JSON.stringify({ licenseKye: 'typo' }));
+    const { createInstallProgram } = await import('./cli.js');
+    const prog = createInstallProgram();
+    await prog.parseAsync(['node', 'preflight', 'validate']);
+    const joined = output.join('');
+    expect(joined).toContain('Warning');
+    expect(joined).toContain('1 warning');
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it('prints errors and sets exit code 1 for invalid JSON', async () => {
+    mockedFsForValidate.existsSync.mockReturnValue(true);
+    mockedFsForValidate.readFileSync.mockReturnValue('{not valid json');
+    const { createInstallProgram } = await import('./cli.js');
+    const prog = createInstallProgram();
+    await prog.parseAsync(['node', 'preflight', 'validate']);
+    const joined = output.join('');
+    expect(joined).toContain('Error');
+    expect(joined).toContain('Config is invalid');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('respects the --config flag for the file path', async () => {
+    mockedFsForValidate.existsSync.mockImplementation(
+      (p: unknown) => String(p) === '/custom/path/config.json',
+    );
+    mockedFsForValidate.readFileSync.mockReturnValue(JSON.stringify({ licenseKey: 'NRLIC-x' }));
+    const { createInstallProgram } = await import('./cli.js');
+    const prog = createInstallProgram();
+    await prog.parseAsync([
+      'node',
+      'preflight',
+      'validate',
+      '--config',
+      '/custom/path/config.json',
+    ]);
+    expect(output.join('')).toContain('/custom/path/config.json');
+    expect(output.join('')).toContain('Config is valid');
   });
 });

--- a/src/install/diagnostics.test.ts
+++ b/src/install/diagnostics.test.ts
@@ -623,6 +623,43 @@ describe('runDiagnostics', () => {
       expect(c.status).toBe('fail');
       expect(c.detail).toContain('timed out');
     });
+
+    it('skips NR check when NEW_RELIC_LICENSE_KEY env is whitespace-only (treated as absent)', async () => {
+      mockedValidateConfig.mockReturnValue({
+        fileExists: true,
+        malformed: false,
+        mode: 'cloud',
+        hasLicenseKey: false,
+        errors: [],
+        warnings: [],
+      });
+      const origEnv = process.env.NEW_RELIC_LICENSE_KEY;
+      process.env.NEW_RELIC_LICENSE_KEY = '   ';
+      const checks = await runDiagnostics(makeOpts());
+      process.env.NEW_RELIC_LICENSE_KEY = origEnv;
+      const c = checks.find((x) => x.check === 'NR reachable')!;
+      expect(c.status).toBe('skip');
+      expect(c.detail).toContain('set but empty or blank');
+    });
+
+    it('still runs the NR reachable check when Config valid has Zod errors on unrelated fields', async () => {
+      mockedValidateConfig.mockReturnValue({
+        fileExists: true,
+        malformed: false,
+        mode: 'cloud',
+        hasLicenseKey: true,
+        errors: ['accountId: Expected string, received number'],
+        warnings: [],
+      });
+      mockFetch.mockResolvedValue({ ok: true } as Response);
+
+      const checks = await runDiagnostics(makeOpts());
+
+      const configCheck = checks.find((x) => x.check === 'Config valid')!;
+      expect(configCheck.status).toBe('fail');
+      const nrCheck = checks.find((x) => x.check === 'NR reachable')!;
+      expect(nrCheck.status).toBe('ok');
+    });
   });
 
   describe('Check 7: Local instances', () => {

--- a/src/install/install-helper.test.ts
+++ b/src/install/install-helper.test.ts
@@ -560,6 +560,26 @@ describe('mergeMcpConfig', () => {
 });
 
 // ---------------------------------------------------------------------------
+// mergeSettings / mergeMcpConfig — malformed existing-file shape
+// ---------------------------------------------------------------------------
+
+describe('mergeSettings malformed input', () => {
+  it('throws a descriptive error when existing.hooks.PreToolUse is not an array', () => {
+    expect(() =>
+      mergeSettings({ hooks: { PreToolUse: 'not-an-array' } }, '/usr/local/bin/preflight'),
+    ).toThrow(/unexpected shape/);
+  });
+});
+
+describe('mergeMcpConfig malformed input', () => {
+  it('throws a descriptive error when existing.mcpServers is not an object', () => {
+    expect(() =>
+      mergeMcpConfig({ mcpServers: 'not-an-object' }, '/usr/local/bin/preflight'),
+    ).toThrow(/unexpected shape/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // removeMcpConfig
 // ---------------------------------------------------------------------------
 

--- a/src/install/json-utils.test.ts
+++ b/src/install/json-utils.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+import { readJsonFileStrict, writeJsonFile, errMsg } from './json-utils.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'nr-json-utils-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('errMsg', () => {
+  it('returns the message for an Error instance', () => {
+    expect(errMsg(new Error('boom'))).toBe('boom');
+  });
+
+  it('stringifies a non-Error value', () => {
+    expect(errMsg('plain string')).toBe('plain string');
+  });
+});
+
+describe('readJsonFileStrict', () => {
+  it('returns an empty object when the file does not exist', () => {
+    expect(readJsonFileStrict(join(tmpDir, 'missing.json'))).toEqual({});
+  });
+
+  it('parses a valid JSON object', () => {
+    const path = join(tmpDir, 'config.json');
+    writeFileSync(path, JSON.stringify({ licenseKey: 'NRLIC-x' }));
+    expect(readJsonFileStrict(path)).toEqual({ licenseKey: 'NRLIC-x' });
+  });
+
+  it('throws when the file contains a JSON array instead of an object', () => {
+    const path = join(tmpDir, 'array.json');
+    writeFileSync(path, '[1,2,3]');
+    expect(() => readJsonFileStrict(path)).toThrow(/Expected a JSON object but got array/);
+  });
+
+  it('throws when the file contains a JSON primitive instead of an object', () => {
+    const path = join(tmpDir, 'primitive.json');
+    writeFileSync(path, '"just a string"');
+    expect(() => readJsonFileStrict(path)).toThrow(/Expected a JSON object but got string/);
+  });
+
+  it('throws on malformed JSON', () => {
+    const path = join(tmpDir, 'broken.json');
+    writeFileSync(path, '{not valid');
+    expect(() => readJsonFileStrict(path)).toThrow(SyntaxError);
+  });
+});
+
+describe('writeJsonFile', () => {
+  it('writes the file inside the given directory when it is under HOME/cwd', () => {
+    const path = join(tmpDir, 'sub', 'config.json');
+    // tmpDir is not under HOME or cwd in CI — pass it as additionalAllowedBase
+    // so the symlink guard accepts the write, mirroring real callers that pass
+    // DEFAULT_STORAGE_PATH.
+    writeJsonFile(path, { hello: 'world' }, tmpDir);
+    const written = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(written).toEqual({ hello: 'world' });
+  });
+
+  it('propagates a non-ENOENT realpathSync failure on additionalAllowedBase', () => {
+    if (process.getuid?.() === 0) {
+      return; // root bypasses permission checks
+    }
+    const unreadableBase = join(tmpDir, 'unreadable');
+    mkdirSync(unreadableBase);
+    // Make the directory itself unreadable so realpathSync on a path inside it
+    // fails with EACCES rather than ENOENT (it can't even stat the segment).
+    chmodSync(unreadableBase, 0o000);
+    try {
+      expect(() =>
+        writeJsonFile(join(tmpDir, 'out.json'), { a: 1 }, join(unreadableBase, 'nested')),
+      ).toThrow(/EACCES/);
+    } finally {
+      chmodSync(unreadableBase, 0o755);
+    }
+  });
+});

--- a/src/install/migrate.test.ts
+++ b/src/install/migrate.test.ts
@@ -340,3 +340,247 @@ describe('migrateStoragePath call order', () => {
     expect(mFs.unlinkSync).toHaveBeenCalledWith(MARKER);
   });
 });
+
+// ---------------------------------------------------------------------------
+// migrateStoragePath — rename-only happy path
+// ---------------------------------------------------------------------------
+
+describe('migrateStoragePath rename-only path', () => {
+  let mFs: MockedFs & { cpSync: jest.Mock; rmSync: jest.Mock };
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mFs = fsMod as unknown as MockedFs & { cpSync: jest.Mock; rmSync: jest.Mock };
+    (fsMod as unknown as { realpathSync: jest.Mock }).realpathSync.mockImplementation(
+      (p: unknown) => p,
+    );
+    mFs.renameSync.mockImplementation(() => {});
+    mFs.unlinkSync.mockImplementation(() => {});
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    // Only OLD_PATH exists — no marker, no NEW_PATH.
+    mFs.existsSync.mockImplementation((p: unknown) => String(p) === OLD_PATH);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it('renames oldPath to newPath and prints a success notice', () => {
+    migrateStoragePath();
+
+    expect(mFs.renameSync).toHaveBeenCalledWith(OLD_PATH, STORAGE);
+    const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Migrated storage directory');
+  });
+
+  it('returns silently when rename fails with ENOENT and newPath already exists (concurrent migration)', () => {
+    mFs.existsSync.mockImplementation(
+      (p: unknown) => String(p) === OLD_PATH || String(p) === STORAGE,
+    );
+    mFs.renameSync.mockImplementation(() => {
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+
+    expect(() => migrateStoragePath()).not.toThrow();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('prints a warning when rename fails with ENOTEMPTY (newPath created concurrently)', () => {
+    mFs.renameSync.mockImplementation(() => {
+      const err = Object.assign(new Error('ENOTEMPTY'), { code: 'ENOTEMPTY' });
+      throw err;
+    });
+
+    migrateStoragePath();
+
+    const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('could not migrate storage directory');
+  });
+
+  it('prints a warning with the error message on an unexpected rename error', () => {
+    mFs.renameSync.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    migrateStoragePath();
+
+    const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('could not migrate storage directory');
+    expect(output).toContain('EACCES: permission denied');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// migrateStoragePath — both paths exist
+// ---------------------------------------------------------------------------
+
+describe('migrateStoragePath both-paths-exist branch', () => {
+  let mFs: MockedFs & {
+    cpSync: jest.Mock;
+    rmSync: jest.Mock;
+    readSync: jest.Mock;
+    openSync: jest.Mock;
+    closeSync: jest.Mock;
+  };
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  const savedIsTTY = process.stdin.isTTY;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mFs = fsMod as unknown as typeof mFs;
+    (fsMod as unknown as { realpathSync: jest.Mock }).realpathSync.mockImplementation(
+      (p: unknown) => p,
+    );
+    mFs.readFileSync.mockImplementation(() => '{}');
+    mFs.writeFileSync.mockImplementation(() => {});
+    mFs.unlinkSync.mockImplementation(() => {});
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    // Both OLD_PATH and NEW_PATH (STORAGE) exist, and OLD_PATH has real content
+    // (config.json) so the branch doesn't short-circuit on hasOldContent=false.
+    const oldConfigPath = resolve(OLD_PATH, 'config.json');
+    mFs.existsSync.mockImplementation(
+      (p: unknown) =>
+        String(p) === OLD_PATH ||
+        String(p) === STORAGE ||
+        String(p) === CONFIG ||
+        String(p) === oldConfigPath,
+    );
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    Object.defineProperty(process.stdin, 'isTTY', { value: savedIsTTY, configurable: true });
+  });
+
+  it('prints a non-interactive notice and does not prompt when interactive=false', () => {
+    migrateStoragePath(false);
+
+    expect(mFs.openSync).not.toHaveBeenCalled();
+    const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('already exists');
+  });
+
+  it('prints a non-interactive notice and does not prompt when stdin is not a TTY, even if interactive=true', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+    migrateStoragePath(true);
+
+    expect(mFs.openSync).not.toHaveBeenCalled();
+    const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('already exists');
+  });
+
+  it('skips the prompt and returns when declined (interactive, TTY, answer "n")', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    mFs.openSync.mockImplementation(() => 42);
+    mFs.closeSync.mockImplementation(() => {});
+    mFs.readSync.mockImplementation(
+      (
+        _fd: unknown,
+        buf: unknown,
+        offset: unknown,
+        _length: unknown,
+        _position: unknown,
+      ): number => {
+        const b = buf as Buffer;
+        const written = b.write('n\n', offset as number);
+        return written;
+      },
+    );
+
+    migrateStoragePath(true);
+
+    expect(mFs.cpSync).not.toHaveBeenCalled();
+    const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Migration skipped');
+  });
+
+  it('merges via cpSync and removes the old directory via rmSync when accepted', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    mFs.openSync.mockImplementation(() => 42);
+    mFs.closeSync.mockImplementation(() => {});
+    mFs.readSync.mockImplementation(
+      (
+        _fd: unknown,
+        buf: unknown,
+        offset: unknown,
+        _length: unknown,
+        _position: unknown,
+      ): number => {
+        const b = buf as Buffer;
+        return b.write('y\n', offset as number);
+      },
+    );
+    mFs.cpSync.mockImplementation(() => {});
+    mFs.rmSync.mockImplementation(() => {});
+
+    migrateStoragePath(true);
+
+    expect(mFs.cpSync).toHaveBeenCalledWith(OLD_PATH, STORAGE, {
+      recursive: true,
+      force: false,
+      errorOnExist: false,
+    });
+    expect(mFs.rmSync).toHaveBeenCalledWith(OLD_PATH, { recursive: true, force: true });
+    const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Merged storage directory');
+  });
+
+  it('reports the cpSync error and leaves old data intact when the merge copy fails', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    mFs.openSync.mockImplementation(() => 42);
+    mFs.closeSync.mockImplementation(() => {});
+    mFs.readSync.mockImplementation(
+      (
+        _fd: unknown,
+        buf: unknown,
+        offset: unknown,
+        _length: unknown,
+        _position: unknown,
+      ): number => {
+        const b = buf as Buffer;
+        return b.write('y\n', offset as number);
+      },
+    );
+    mFs.cpSync.mockImplementation(() => {
+      throw new Error('ENOSPC: no space left on device');
+    });
+
+    migrateStoragePath(true);
+
+    expect(mFs.rmSync).not.toHaveBeenCalled();
+    const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Could not merge storage directories');
+    expect(output).toContain('ENOSPC');
+  });
+
+  it('reports the cleanup failure but does not throw when rmSync fails after a successful cpSync', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    mFs.openSync.mockImplementation(() => 42);
+    mFs.closeSync.mockImplementation(() => {});
+    mFs.readSync.mockImplementation(
+      (
+        _fd: unknown,
+        buf: unknown,
+        offset: unknown,
+        _length: unknown,
+        _position: unknown,
+      ): number => {
+        const b = buf as Buffer;
+        return b.write('y\n', offset as number);
+      },
+    );
+    mFs.cpSync.mockImplementation(() => {});
+    mFs.rmSync.mockImplementation(() => {
+      throw new Error('EBUSY: resource busy or locked');
+    });
+
+    expect(() => migrateStoragePath(true)).not.toThrow();
+
+    const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('but old directory could not be removed');
+    expect(output).toContain('EBUSY');
+  });
+});

--- a/src/install/schedule.test.ts
+++ b/src/install/schedule.test.ts
@@ -140,6 +140,24 @@ describe('removeSchedule', () => {
     expect(calls.some((args) => args[0] === 'unload')).toBe(true);
     expect(existsSync(PLIST_PATH)).toBe(false);
   });
+
+  it('logs a warning but still returns true when unlinkSync fails after unload succeeds', () => {
+    if (process.getuid?.() === 0) {
+      return; // root bypasses directory permission checks — not meaningful as root
+    }
+    installSchedule('/usr/local/bin/preflight', 8, 0);
+    mockedExecFileSync.mockClear();
+    const launchAgentsDir = dirname(PLIST_PATH);
+    chmodSync(launchAgentsDir, 0o500); // read+execute, no write — unlinkSync fails EACCES
+    try {
+      const result = removeSchedule();
+      expect(result).toBe(true);
+      expect(existsSync(PLIST_PATH)).toBe(true); // file still there — delete failed
+    } finally {
+      chmodSync(launchAgentsDir, 0o755);
+      rmSync(PLIST_PATH, { force: true });
+    }
+  });
 });
 
 const FIXTURE_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
@@ -344,6 +362,24 @@ describe('removeDashboardDaemon', () => {
     expect(calls.some((args) => args[0] === 'unload')).toBe(true);
     expect(existsSync(DASHBOARD_PLIST_PATH)).toBe(false);
   });
+
+  it('logs a warning but still returns true when unlinkSync fails after unload succeeds', () => {
+    if (process.getuid?.() === 0) {
+      return; // root bypasses directory permission checks — not meaningful as root
+    }
+    installDashboardDaemon('/usr/local/bin/preflight');
+    mockedExecFileSync.mockClear();
+    const launchAgentsDir = dirname(DASHBOARD_PLIST_PATH);
+    chmodSync(launchAgentsDir, 0o500);
+    try {
+      const result = removeDashboardDaemon();
+      expect(result).toBe(true);
+      expect(existsSync(DASHBOARD_PLIST_PATH)).toBe(true);
+    } finally {
+      chmodSync(launchAgentsDir, 0o755);
+      rmSync(DASHBOARD_PLIST_PATH, { force: true });
+    }
+  });
 });
 
 describe('getDashboardDaemonStatus', () => {
@@ -426,6 +462,19 @@ describe('findExecutableNodeDir', () => {
     try {
       const result = findExecutableNodeDir([tmpDir]);
       expect(result.dir).toBeNull();
+      expect(result.hasNonExecutable).toBe(false);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('finds an executable binary named "nodejs" (Debian/Ubuntu package naming)', () => {
+    const tmpDir = mkdtempSync(join(nodeOs.tmpdir(), 'nr-findnode-test-'));
+    try {
+      const nodejsPath = join(tmpDir, 'nodejs');
+      writeFileSync(nodejsPath, '#!/bin/sh\necho node', { mode: 0o755 });
+      const result = findExecutableNodeDir([tmpDir]);
+      expect(result.dir).toBe(tmpDir);
       expect(result.hasNonExecutable).toBe(false);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });

--- a/src/install/setup-wizard.test.ts
+++ b/src/install/setup-wizard.test.ts
@@ -1,5 +1,6 @@
 import * as fsMod from 'node:fs';
 import * as rlMod from 'node:readline/promises';
+import { join } from 'node:path';
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 
 import { buildConfig, runSetupWizard, copyStarterAlertRules } from './setup-wizard.js';
@@ -67,6 +68,7 @@ const mockedFs = fsMod as unknown as {
   existsSync: jest.Mock;
   copyFileSync: jest.Mock;
   chmodSync: jest.Mock;
+  realpathSync: jest.Mock;
 };
 const mockedRl = rlMod as unknown as { createInterface: jest.Mock };
 const mockedSchedule = scheduleMod as unknown as {
@@ -82,9 +84,11 @@ const mockedDashboardHealth = {
     typeof dashboardHealthMod.waitForHealthyDashboard
   >,
 };
-const mockedCli = cliMod as unknown as {
-  runInstallCli: jest.Mock;
-  verifyBinaryOnPath: jest.Mock;
+const mockedCli = {
+  runInstallCli: cliMod.runInstallCli as jest.MockedFunction<typeof cliMod.runInstallCli>,
+  verifyBinaryOnPath: cliMod.verifyBinaryOnPath as jest.MockedFunction<
+    typeof cliMod.verifyBinaryOnPath
+  >,
 };
 const mockedPlatform = platformMod as unknown as {
   isWsl: jest.Mock;
@@ -205,6 +209,61 @@ describe('copyStarterAlertRules', () => {
     });
 
     expect(result.copied).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultStarterRulesSource — repo-root-fallback branch
+// findRepoRoot() is mocked to return null for every test in this file (see
+// the module-level jest.mock('./cli.js', ...) above), so every wizard run
+// already exercises this fallback — this test is the first to assert on the
+// exact resolved sourcePath it produces.
+// ---------------------------------------------------------------------------
+
+describe('defaultStarterRulesSource fallback (via runSetupWizard)', () => {
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let mockRl: { question: jest.Mock; close: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    mockRl = { question: jest.fn(), close: jest.fn() };
+    mockedRl.createInterface.mockReturnValue(mockRl);
+    mockedFs.mkdirSync.mockReturnValue(undefined);
+    mockedFs.writeFileSync.mockReturnValue(undefined);
+    mockedFs.readFileSync.mockReturnValue('{}');
+    mockedFs.existsSync.mockReturnValue(false); // starter rules "source missing" — simplest path
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it('resolves the starter-rules source two directories up from the entry point when findRepoRoot returns null', async () => {
+    const originalArgv1 = process.argv[1];
+    process.argv[1] = '/opt/preflight/dist/index.js';
+    mockedFs.realpathSync.mockImplementation((p: unknown) => p);
+
+    // Order for local mode: mode, developer, teamId, projectId, sessionBudget,
+    // dashboardPort, copyStarterRules (blank = default yes, so
+    // copyStarterAlertRules actually runs), installHooks='n' (skip hooks).
+    let i = 0;
+    const values = ['local', 'tester', '', '', '', '', '', 'n'];
+    mockRl.question.mockImplementation(async () => values[i++] ?? '');
+
+    await runSetupWizard();
+
+    process.argv[1] = originalArgv1;
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    // copyStarterAlertRules reports "source-missing" (existsSync returns false above);
+    // the wizard prints this outcome without the resolved path, so instead assert
+    // indirectly: existsSync was asked about a path ending in the expected fallback
+    // location, proving defaultStarterRulesSource computed it correctly.
+    const checkedPaths = mockedFs.existsSync.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(
+      checkedPaths.some((p) => p.endsWith(join('opt', 'examples', 'local-alert-rules.json'))),
+    ).toBe(true);
+    void output;
   });
 });
 
@@ -888,6 +947,28 @@ describe('setupWizard auto-update step', () => {
 
     expect(mockedSchedule.installSchedule).not.toHaveBeenCalled();
   });
+
+  it('falls back to 08:00 with a warning when the entered time is malformed', async () => {
+    mockedSchedule.resolveBinaryPath.mockReturnValue('/usr/local/bin/preflight');
+    cloudAnswers('cloud', '12345', 'NRLIC-test', '', '', 'dev', '', '', '', 'n', 'y', 'not-a-time');
+
+    await runSetupWizard();
+
+    expect(mockedSchedule.installSchedule).toHaveBeenCalledWith('/usr/local/bin/preflight', 8, 0);
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Invalid time "not-a-time"');
+  });
+
+  it('falls back to 08:00 with a warning when the entered hour is out of range', async () => {
+    mockedSchedule.resolveBinaryPath.mockReturnValue('/usr/local/bin/preflight');
+    cloudAnswers('cloud', '12345', 'NRLIC-test', '', '', 'dev', '', '', '', 'n', 'y', '25:00');
+
+    await runSetupWizard();
+
+    expect(mockedSchedule.installSchedule).toHaveBeenCalledWith('/usr/local/bin/preflight', 8, 0);
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('Invalid time "25:00"');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1379,6 +1460,7 @@ describe('setupWizard WSL CC-mode selection', () => {
     Object.defineProperty(process, 'platform', { value: savedPlatform, configurable: true });
     mockedPlatform.isWsl.mockReturnValue(false);
     mockedPlatform.resolveWindowsHome.mockReturnValue(null);
+    process.exitCode = undefined;
   });
 
   // Answer order for cloud mode + WSL + installHooks='y':
@@ -1435,5 +1517,34 @@ describe('setupWizard WSL CC-mode selection', () => {
     expect(mockedCli.runInstallCli).toHaveBeenCalledWith(['install', '--linux-cc']);
     const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(output).toContain('No valid choice entered after 3 attempts');
+  });
+
+  it('does not print "Hooks installed." when runInstallCli rejects', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false);
+    mockedCli.runInstallCli.mockRejectedValueOnce(new Error('hook install failed'));
+    mockedCli.verifyBinaryOnPath.mockReturnValue(true);
+    // Non-WSL cloud sequence through the hooks-install step:
+    // mode, accountId, licenseKey, environment, nrApiKey, developer, teamId, projectId,
+    // sessionBudget, installHooks='y'
+    answers('cloud', '12345', 'NRLIC-test', '', '', 'tester', '', '', '', 'y');
+
+    await runSetupWizard();
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).not.toContain('Hooks installed.');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('prints the PATH warning at the hooks-install step when verifyBinaryOnPath returns false', async () => {
+    mockedPlatform.isWsl.mockReturnValue(false);
+    mockedCli.runInstallCli.mockResolvedValueOnce(undefined);
+    mockedCli.verifyBinaryOnPath.mockReturnValue(false);
+    answers('cloud', '12345', 'NRLIC-test', '', '', 'tester', '', '', '', 'y');
+
+    await runSetupWizard();
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('is not on your PATH');
+    expect(output).toContain('npm install -g @newrelic/preflight');
   });
 });


### PR DESCRIPTION
## Summary

Adds automated test coverage for previously-untested-but-correct branches across `src/install/`. Test-only release — no production code changes.

- `migrate.ts`'s legacy-storage-path merge/rollback branch: rename-only happy path, both-paths-exist notice/interactive-prompt/merge, and all 3 documented failure sub-cases (rename ENOENT/ENOTEMPTY race, `cpSync` throw, `rmSync`-after-successful-copy).
- `cli.ts`'s `validate` command (previously zero coverage) and `killProcessGracefully()`'s SIGKILL-escalation path.
- 4 untested `setup-wizard.ts` branches: `defaultStarterRulesSource()`'s repo-root fallback, the "Hooks installed." negative case, the hooks-install-step PATH warning, and the auto-update malformed-time-input fallback.
- 3 untested `diagnostics.ts`/`install-helper.ts` branches: whitespace-only license-key handling, Zod-errors-but-NR-check-still-runs, and `mergeSettings`/`mergeMcpConfig`'s malformed-shape throw paths.
- 3 untested `schedule.ts` branches (`unlinkSync`-failure "report success anyway" sub-case, `findExecutableNodeDir`'s Debian `nodejs`-binary-name case) plus a brand-new `json-utils.test.ts` (that module previously had zero test coverage at all).
- Version bump to 1.4.37 + CHANGELOG entry.

Two items named in the original issue #161 text were found already covered by tests added in prior releases and were correctly excluded from this release's scope.

Fixes #160. Fixes #161.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [x] `npm run lint` clean

🤖 Generated with subagent-driven-development