### PR TITLE
Fix: undici missing as a direct dependency, breaking fresh installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.38] - 2026-07-14
+
+### Fixed
+
+- `undici` is now a direct runtime dependency. `src/proxy/otlp-receiver.ts` imports it directly, but it was declared only as a version `overrides` pin (added for security hardening), never as an actual dependency — so a clean `npm install`/`npm install -g` (no devDependencies) never installed it, and the proxy crashed with `ERR_MODULE_NOT_FOUND: undici` on startup. It previously worked in this repo's own dev/CI environment only because `jsdom` (a devDependency) pulls in `undici` transitively.
+
 ## [1.4.37] - 2026-07-13
 
 - Added automated test coverage for previously untested (but correct) branches across `src/install/`: `migrate.ts`'s legacy-storage-path merge/rollback logic, the `validate` CLI command, graceful process-kill escalation, several setup-wizard prompt/fallback paths, config-diagnostics edge cases, and `json-utils.ts`'s JSON parsing helpers (which previously had no dedicated test file at all). No behavior changes — this is a test-only hardening release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.37",
+  "version": "1.4.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.37",
+      "version": "1.4.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -20,6 +20,7 @@
         "@opentelemetry/sdk-trace-node": "2.8.0",
         "commander": "15.0.0",
         "dotenv": "17.4.2",
+        "undici": "^7.28.0",
         "zod": "4.4.3"
       },
       "bin": {
@@ -11275,7 +11276,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.37",
+  "version": "1.4.38",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,
@@ -79,6 +79,7 @@
     "@opentelemetry/sdk-trace-node": "2.8.0",
     "commander": "15.0.0",
     "dotenv": "17.4.2",
+    "undici": "^7.28.0",
     "zod": "4.4.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- `src/proxy/otlp-receiver.ts` imports `undici` directly, but it was only declared as a version `overrides` pin (added for security hardening), never as an actual dependency.
- A clean `npm install`/`npm install -g` skips devDependencies, so `undici` was never installed and the proxy crashed with `ERR_MODULE_NOT_FOUND: undici` on startup. It only "worked" in CI because `jsdom` (a devDependency) pulls `undici` in transitively.
- Adds `undici` to `dependencies`, bumps to 1.4.38, updates CHANGELOG.

Fixes #189

## Test plan
- [x] `npm run build`
- [x] `npm test` (passing)
- [x] `npm run lint` (pre-existing unrelated issues only)
- [x] Confirmed against the live `registry.npmjs.org` packument and the actual published 1.4.34/1.4.37 tarballs that `undici` is absent from `dependencies` in both