### PR TITLE
v1.4.39: Proxy defensive-coding fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.39] - 2026-07-14
+
+### Fixed
+
+- Proxy stdio upstream: expanded the dangerous env-var denylist to cover non-Node interpreters (`PYTHONPATH`, `RUBYOPT`, `PERL5LIB`, and others) that an operator-configured stdio upstream command could be pointed at.
+- Proxy stdio upstream: a dispatch timeout now aborts the underlying MCP client call instead of only racing past it, so a wedged child process no longer accumulates abandoned in-flight requests.
+- Proxy OTLP receiver: resource-attribute enrichment no longer duplicates a key the instrumented application already set on the payload.
+
 ## [1.4.38] - 2026-07-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.38",
+  "version": "1.4.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.38",
+      "version": "1.4.39",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.38",
+  "version": "1.4.39",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/proxy/otlp-receiver.test.ts
+++ b/src/proxy/otlp-receiver.test.ts
@@ -130,6 +130,28 @@ describe('enrichPayload', () => {
     const result = receiver.enrichPayload(binary);
     expect(result).toBe(binary);
   });
+
+  it('does not duplicate an enrichment key already present in the payload', () => {
+    const receiver = makeReceiver({ enrichmentAttributes: { 'ai.session.id': 'new-value' } });
+    const input = {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [{ key: 'ai.session.id', value: { stringValue: 'existing-value' } }],
+          },
+        },
+      ],
+    };
+    const result = JSON.parse(
+      receiver.enrichPayload(Buffer.from(JSON.stringify(input))).toString('utf-8'),
+    ) as typeof input;
+
+    const sessionIdEntries = result.resourceSpans[0].resource.attributes.filter(
+      (a) => a.key === 'ai.session.id',
+    );
+    expect(sessionIdEntries).toHaveLength(1);
+    expect(sessionIdEntries[0]?.value.stringValue).toBe('existing-value');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/proxy/otlp-receiver.ts
+++ b/src/proxy/otlp-receiver.ts
@@ -366,8 +366,15 @@ export class OtlpReceiver {
       for (const resource of resources) {
         if (!resource.resource) resource.resource = {};
         if (!Array.isArray(resource.resource.attributes)) resource.resource.attributes = [];
+        const attributes = resource.resource.attributes as Array<{
+          key: string;
+          value?: unknown;
+        }>;
+        const existingKeys = new Set(attributes.map((a) => a.key));
         for (const [k, v] of Object.entries(attrs)) {
-          resource.resource.attributes.push({ key: k, value: { stringValue: v } });
+          // Never clobber a value the instrumented app deliberately set itself.
+          if (existingKeys.has(k)) continue;
+          attributes.push({ key: k, value: { stringValue: v } });
         }
       }
     }

--- a/src/proxy/upstream-stdio.test.ts
+++ b/src/proxy/upstream-stdio.test.ts
@@ -316,6 +316,37 @@ describe('StdioUpstream.forward() with mock client', () => {
     expect(result.responseSizeBytes).toBeGreaterThan(0);
     expect(typeof result.responseSizeBytes).toBe('number');
   });
+
+  it('aborts the underlying client call when dispatch times out', async () => {
+    jest.useFakeTimers();
+
+    const mockCallTool = jest
+      .fn<(...args: unknown[]) => Promise<never>>()
+      .mockReturnValue(new Promise(() => {})); // never resolves — simulates a hung child
+    const upstream = makeUpstreamWithMockClient({ callTool: mockCallTool });
+
+    const { res, getStatus } = makeFakeResponse();
+    const body = Buffer.from(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'tools/call',
+        params: { name: 'test_tool', arguments: {} },
+      }),
+    );
+
+    const forwardPromise = upstream.forward(makeFakeRequest(), res, body);
+
+    // Advance past the 30-second dispatch timeout
+    await jest.runAllTimersAsync();
+    await forwardPromise;
+
+    expect(getStatus()).toBe(500);
+    const options = mockCallTool.mock.calls[0]?.[2] as { signal: AbortSignal } | undefined;
+    expect(options?.signal.aborted).toBe(true);
+
+    jest.useRealTimers();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/proxy/upstream-stdio.ts
+++ b/src/proxy/upstream-stdio.ts
@@ -31,6 +31,15 @@ export const DANGEROUS_ENV_KEYS = new Set([
   'DYLD_INSERT_LIBRARIES',
   'DYLD_LIBRARY_PATH',
   'NODE_OPTIONS',
+  'PYTHONPATH',
+  'PYTHONSTARTUP',
+  'RUBYOPT',
+  'PERL5LIB',
+  'LD_AUDIT',
+  'GCONV_PATH',
+  'BASH_ENV',
+  'ENV',
+  'ELECTRON_RUN_AS_NODE',
 ]);
 
 export function sanitizeEnv(
@@ -288,35 +297,50 @@ export class StdioUpstream implements ProxyUpstream {
   private async dispatchToClient(rpc: JsonRpcRequest): Promise<unknown> {
     const client = this.client!;
     const params = rpc.params ?? {};
+    const controller = new AbortController();
+    const options = { signal: controller.signal };
 
     // Wrap the dispatch in a timeout so a hung child process doesn't hold
-    // the HTTP connection open indefinitely.
+    // the HTTP connection open indefinitely. Aborting the underlying SDK
+    // call (not just racing past it) stops the abandoned request from
+    // continuing to run against the child process with nothing awaiting it.
     const timeoutPromise = new Promise<never>((_, reject) => {
-      const t = setTimeout(
-        () => reject(new Error(`Stdio dispatch timeout after ${DISPATCH_TIMEOUT_MS}ms`)),
-        DISPATCH_TIMEOUT_MS,
-      );
+      const t = setTimeout(() => {
+        controller.abort();
+        reject(new Error(`Stdio dispatch timeout after ${DISPATCH_TIMEOUT_MS}ms`));
+      }, DISPATCH_TIMEOUT_MS);
       t.unref();
     });
 
     let dispatchPromise: Promise<unknown>;
     switch (rpc.method) {
       case 'tools/call':
-        dispatchPromise = client.callTool(params as Parameters<typeof client.callTool>[0]);
+        dispatchPromise = client.callTool(
+          params as Parameters<typeof client.callTool>[0],
+          undefined,
+          options,
+        );
         break;
       case 'tools/list':
-        dispatchPromise = client.listTools(params as Parameters<typeof client.listTools>[0]);
+        dispatchPromise = client.listTools(
+          params as Parameters<typeof client.listTools>[0],
+          options,
+        );
         break;
       case 'resources/list':
         dispatchPromise = client.listResources(
           params as Parameters<typeof client.listResources>[0],
+          options,
         );
         break;
       case 'resources/read':
-        dispatchPromise = client.readResource(params as Parameters<typeof client.readResource>[0]);
+        dispatchPromise = client.readResource(
+          params as Parameters<typeof client.readResource>[0],
+          options,
+        );
         break;
       case 'ping':
-        dispatchPromise = client.ping();
+        dispatchPromise = client.ping(options);
         break;
       case 'initialize':
         // The Client has already initialized; return current server info synchronously.
@@ -329,6 +353,7 @@ export class StdioUpstream implements ProxyUpstream {
         dispatchPromise = client.request(
           { method: rpc.method, params } as Parameters<typeof client.request>[0],
           z.any(),
+          options,
         );
     }
 


### PR DESCRIPTION
## Summary

Three independent defensive-coding fixes in `src/proxy/`:

- **Env-var denylist**: `DANGEROUS_ENV_KEYS` in `src/proxy/upstream-stdio.ts` now covers non-Node interpreter injection vectors (`PYTHONPATH`, `PYTHONSTARTUP`, `RUBYOPT`, `PERL5LIB`, `LD_AUDIT`, `GCONV_PATH`, `BASH_ENV`, `ENV`, `ELECTRON_RUN_AS_NODE`) in addition to the existing Node/dynamic-linker keys, since `UpstreamConfig.command` accepts any absolute-path executable.
- **Dispatch timeout cancellation**: `dispatchToClient()` now creates an `AbortController` and passes `{signal}` to every MCP SDK call it dispatches, aborting it in the existing timeout callback — a timed-out request now actually stops instead of continuing to run against the child process with nothing awaiting it.
- **OTLP enrichment de-duplication**: `injectResourceAttributes()` in `src/proxy/otlp-receiver.ts` now skips injecting an enrichment key the payload already carries, so Preflight's enrichment never clobbers a value the instrumented app deliberately set itself.

Fixes #148

## Test plan

- [x] `npm run build && npm test && npm run lint` — 4005/4008 tests passing
- [x] New regression test for the dispatch-timeout abort (asserts the underlying SDK call's `options.signal.aborted`)
- [x] New regression test for the OTLP dedup guard (asserts exactly one surviving entry with the original value)
- [x] Existing parametrized test auto-covers all 14 denylist keys

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>