### PR TITLE
v1.4.40: Web dashboard UX/defensive-coding fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.40] - 2026-07-14
+
+### Fixed
+
+- Today.tsx's empty-state gate omitted concurrency/activity-heatmap/live-session pending state, letting the empty state show briefly even as a live session registered.
+- History.tsx and Alerts.tsx now surface query load errors instead of silently rendering as "no data yet."
+- Git Efficiency's branch-divergence and repo-context now derive the real default branch instead of assuming `main`.
+- `formatDuration` now guards against non-finite/negative input, matching `formatNumber`'s existing guard.
+- Alerts.tsx's Slack Digest card now shows a loading indicator while settings load, matching the cards above it.
+- Audit.tsx's classification Pill now shows the friendly label instead of the raw internal key.
+- Removed `Kpi`'s redundant `tone="accent"`, which rendered identically to `tone="good"`.
+- Corrected a stale comment in `liveStore.ts` overstating cross-path dedup guarantees for live tool-call events.
+
 ## [1.4.39] - 2026-07-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.39",
+  "version": "1.4.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.39",
+      "version": "1.4.40",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.39",
+  "version": "1.4.40",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,10 @@ import { ApiFailureTracker } from './metrics/api-failure-tracker.js';
 import { LiveSessionRegistry } from './metrics/live-session-registry.js';
 import { TurnCostAttributor } from './metrics/turn-cost-attributor.js';
 import { TurnTracker } from './metrics/turn-tracker.js';
-import { GitEfficiencyTracker } from './metrics/git-efficiency-tracker.js';
+import {
+  GitEfficiencyTracker,
+  parseDefaultBranchFromSymbolicRef,
+} from './metrics/git-efficiency-tracker.js';
 import { NrIngestManager } from './transport/nr-ingest.js';
 import { AuditTrailManager } from './security/audit-trail.js';
 import { LiveEventBus } from './dashboard/index.js';
@@ -885,6 +888,8 @@ async function main(): Promise<void> {
     // Repo context for the dashboard header
     const remoteResult = spawnSync('git', ['remote', 'get-url', 'origin'], GIT_OPTS);
     const branchResult = spawnSync('git', ['branch', '--show-current'], GIT_OPTS);
+    const remoteName = 'origin';
+    let defaultBranch = 'main';
     if (remoteResult.status === 0 && branchResult.status === 0) {
       const remoteUrl = remoteResult.stdout.trim();
       const branch = branchResult.stdout.trim();
@@ -892,17 +897,36 @@ async function main(): Promise<void> {
       const repoMatch = remoteUrl.match(/[/:]([^/]+\/[^/]+?)(?:\.git)?$/);
       const repoName = repoMatch ? repoMatch[1] : null;
       currentRepoName = repoName;
+
+      const symbolicRefResult = spawnSync(
+        'git',
+        ['symbolic-ref', '--short', `refs/remotes/${remoteName}/HEAD`],
+        GIT_OPTS,
+      );
+      if (symbolicRefResult.status === 0) {
+        defaultBranch = parseDefaultBranchFromSymbolicRef(symbolicRefResult.stdout, remoteName);
+      }
+
       gitEfficiencyTracker.hydrateRepoContext({
         repoName,
         branch: branch || null,
-        remoteName: 'origin',
-        defaultBranch: 'main',
+        remoteName,
+        defaultBranch,
       });
     }
 
-    // Branch divergence from main — how far ahead/behind are we?
-    const aheadResult = spawnSync('git', ['rev-list', '--count', 'origin/main..HEAD'], GIT_OPTS);
-    const behindResult = spawnSync('git', ['rev-list', '--count', 'HEAD..origin/main'], GIT_OPTS);
+    // Branch divergence from the real default branch — how far ahead/behind are we?
+    const remoteDefaultBranch = `${remoteName}/${defaultBranch}`;
+    const aheadResult = spawnSync(
+      'git',
+      ['rev-list', '--count', `${remoteDefaultBranch}..HEAD`],
+      GIT_OPTS,
+    );
+    const behindResult = spawnSync(
+      'git',
+      ['rev-list', '--count', `HEAD..${remoteDefaultBranch}`],
+      GIT_OPTS,
+    );
     if (aheadResult.status === 0 && behindResult.status === 0) {
       const ahead = parseInt(aheadResult.stdout.trim(), 10);
       const behind = parseInt(behindResult.stdout.trim(), 10);

--- a/src/metrics/git-efficiency-tracker.test.ts
+++ b/src/metrics/git-efficiency-tracker.test.ts
@@ -1,4 +1,7 @@
-import { GitEfficiencyTracker } from './git-efficiency-tracker.js';
+import {
+  GitEfficiencyTracker,
+  parseDefaultBranchFromSymbolicRef,
+} from './git-efficiency-tracker.js';
 import type { ToolCallRecord, ReplayTimelineEntry } from '../storage/types.js';
 
 const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
@@ -16,6 +19,30 @@ function makeRecord(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
     ...overrides,
   };
 }
+
+describe('parseDefaultBranchFromSymbolicRef()', () => {
+  it('strips the remote prefix from a well-formed symbolic-ref short output', () => {
+    expect(parseDefaultBranchFromSymbolicRef('origin/main\n', 'origin')).toBe('main');
+  });
+
+  it('handles a non-main default branch name', () => {
+    expect(parseDefaultBranchFromSymbolicRef('origin/master\n', 'origin')).toBe('master');
+  });
+
+  it('handles branch names containing slashes', () => {
+    expect(parseDefaultBranchFromSymbolicRef('origin/release/stable\n', 'origin')).toBe(
+      'release/stable',
+    );
+  });
+
+  it('falls back to "main" on empty output', () => {
+    expect(parseDefaultBranchFromSymbolicRef('', 'origin')).toBe('main');
+  });
+
+  it('falls back to "main" when output does not start with the remote prefix', () => {
+    expect(parseDefaultBranchFromSymbolicRef('unexpected-output', 'origin')).toBe('main');
+  });
+});
 
 describe('GitEfficiencyTracker', () => {
   let tracker: GitEfficiencyTracker;

--- a/src/metrics/git-efficiency-tracker.ts
+++ b/src/metrics/git-efficiency-tracker.ts
@@ -1,5 +1,21 @@
 import type { ToolCallRecord, ReplayTimelineEntry } from '../storage/types.js';
 
+/**
+ * Parse `git symbolic-ref --short refs/remotes/<remoteName>/HEAD`'s stdout
+ * (e.g. "origin/main") into just the branch name. Falls back to 'main' if
+ * the ref is missing (empty output — e.g. an unusual shallow checkout that
+ * never fetched a remote HEAD) or malformed (doesn't start with the
+ * expected remote prefix).
+ */
+export function parseDefaultBranchFromSymbolicRef(output: string, remoteName: string): string {
+  const trimmed = output.trim();
+  const prefix = `${remoteName}/`;
+  if (trimmed.startsWith(prefix) && trimmed.length > prefix.length) {
+    return trimmed.slice(prefix.length);
+  }
+  return 'main';
+}
+
 // ---------------------------------------------------------------------------
 // Git command classification patterns
 // ---------------------------------------------------------------------------

--- a/src/web/components/Kpi.test.tsx
+++ b/src/web/components/Kpi.test.tsx
@@ -24,4 +24,10 @@ describe('Kpi', () => {
     render(<Kpi label="spend" value="$3.42" sub="+34% vs avg" />);
     expect(screen.getByText('+34% vs avg')).toBeInTheDocument();
   });
+
+  it('does not accept tone="accent" (removed — use "good")', () => {
+    render(<Kpi label="spend" value="$3.42" tone="good" />);
+    const v = screen.getByText('$3.42');
+    expect(v.className).toMatch(/text-accent-green/);
+  });
 });

--- a/src/web/components/Kpi.tsx
+++ b/src/web/components/Kpi.tsx
@@ -1,13 +1,12 @@
 import { useAnimatedValue } from '../hooks/useAnimatedValue';
 
-export type KpiTone = 'neutral' | 'good' | 'warn' | 'bad' | 'accent';
+export type KpiTone = 'neutral' | 'good' | 'warn' | 'bad';
 
 const TONE: Record<KpiTone, string> = {
   neutral: 'text-ink-base',
   good: 'text-accent-green',
   warn: 'text-accent-amber',
   bad: 'text-accent-red',
-  accent: 'text-accent-green',
 };
 
 export interface KpiProps {

--- a/src/web/lib/format.test.tsx
+++ b/src/web/lib/format.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration } from './format';
+
+describe('formatDuration()', () => {
+  it('formats seconds', () => {
+    expect(formatDuration(45_000)).toBe('45s');
+  });
+
+  it('formats minutes and seconds', () => {
+    expect(formatDuration(198_000)).toBe('3m 18s');
+  });
+
+  it('formats whole minutes with no trailing seconds', () => {
+    expect(formatDuration(120_000)).toBe('2m');
+  });
+
+  it('formats hours and minutes', () => {
+    expect(formatDuration(5_400_000)).toBe('1h 30m');
+  });
+
+  it('formats days and hours', () => {
+    expect(formatDuration(187_200_000)).toBe('2d 4h');
+  });
+
+  it('returns the em-dash placeholder for NaN', () => {
+    expect(formatDuration(NaN)).toBe('—');
+  });
+
+  it('returns the em-dash placeholder for negative input', () => {
+    expect(formatDuration(-500)).toBe('—');
+  });
+
+  it('returns the em-dash placeholder for Infinity', () => {
+    expect(formatDuration(Infinity)).toBe('—');
+  });
+});

--- a/src/web/lib/format.ts
+++ b/src/web/lib/format.ts
@@ -68,6 +68,7 @@ export function fmtElapsed(ms: number): string {
  * rounding loss would be noticeable: "45s", "3m 18s", "1h 30m", "2d 4h".
  */
 export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '—';
   const totalSec = Math.floor(ms / 1000);
   if (totalSec < 60) return `${totalSec}s`;
   const totalMin = Math.floor(totalSec / 60);

--- a/src/web/store/liveStore.ts
+++ b/src/web/store/liveStore.ts
@@ -133,7 +133,12 @@ export const useLiveStore = create<LiveState>((set) => ({
 
   pushToolCall: (e) =>
     set((s) => {
-      // Deduplicate by id so SSE and hydrateFromApi() don't push the same event twice.
+      // Deduplicate by id — but only within a single path. hydrateFromApi()
+      // builds id as `${timestamp}-${toolName}` (no server id available on
+      // that response shape), while the SSE path forwards the server's real
+      // randomUUID()-based id, so a hydrate-then-SSE double-emit of the same
+      // underlying tool call is NOT caught here — only same-path repeats
+      // (e.g. an SSE reconnect replaying an already-seen event) are.
       if (s.recentToolCalls.some((t) => t.id === e.id)) return {};
       const next = [...s.recentToolCalls, e];
       return {

--- a/src/web/views/Alerts.test.tsx
+++ b/src/web/views/Alerts.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it } from 'vitest';
 import { Alerts } from './Alerts';
@@ -76,5 +76,57 @@ describe('Alerts view', () => {
 
     await waitFor(() => expect(screen.getByText('Not configured')).toBeInTheDocument());
     expect(input).toHaveValue('');
+  });
+});
+
+describe('Alerts view — error and loading states', () => {
+  it('shows an error message when the budget query fails', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = (async (url: string) => {
+      if (url === '/api/budget') return new Response('Internal Server Error', { status: 503 });
+      if (url === '/api/settings') return jsonResponse(BASE_SETTINGS);
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <Alerts />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/Error loading budget status/)).toBeInTheDocument(),
+    );
+  });
+
+  it('shows a loading spinner on the Slack Digest card while settings are pending', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    const settingsBox: { current: (() => void) | null } = { current: null };
+    globalThis.fetch = (async (url: string) => {
+      if (url === '/api/budget') return jsonResponse(DEFAULT_BUDGET);
+      if (url === '/api/settings') {
+        return new Promise<Response>((resolve) => {
+          settingsBox.current = () => resolve(jsonResponse(BASE_SETTINGS));
+        });
+      }
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <Alerts />
+      </QueryClientProvider>,
+    );
+
+    const heading = await screen.findByText('Slack Digest');
+    const card = heading.closest('.glass-card');
+    expect(card).not.toBeNull();
+    // Scoped to the Slack Digest card specifically — the Alert Thresholds card
+    // above it also renders a "Loading..." node while its own query is pending,
+    // so an unscoped screen-wide query can't distinguish "this card's spinner
+    // exists" from "some other card's pre-existing spinner rendered."
+    expect(within(card as HTMLElement).getByText('Loading...')).toBeInTheDocument();
+
+    settingsBox.current?.();
   });
 });

--- a/src/web/views/Alerts.tsx
+++ b/src/web/views/Alerts.tsx
@@ -166,6 +166,9 @@ export function Alerts(): JSX.Element {
       <Card padding="md" className="mb-4">
         <SectionHeader title="Budget Status" />
         {budgetQ.isLoading && <EmptyState icon="clock" variant="loading" title="Loading..." />}
+        {budgetQ.isError && (
+          <div className="text-accent-red text-xs">Error loading budget status.</div>
+        )}
         {budget && (
           <>
             <PeriodRow label="session" p={budget.session} />
@@ -264,6 +267,7 @@ export function Alerts(): JSX.Element {
           subtitle="Weekly digest sent to a Slack incoming webhook. URL changes take effect immediately."
         />
 
+        {settingsQ.isLoading && <EmptyState icon="clock" variant="loading" title="Loading..." />}
         {settings && (
           <>
             <div className="flex items-center gap-2 mb-3">

--- a/src/web/views/Audit.test.tsx
+++ b/src/web/views/Audit.test.tsx
@@ -73,10 +73,31 @@ describe('Audit view', () => {
       },
     ];
     renderAudit(withSeverity);
-    await waitFor(() => expect(screen.getByText('destructive_command')).toBeInTheDocument());
-    expect(screen.getByText('destructive_command').className).toMatch(/bg-accent-red/);
-    expect(screen.getByText('sensitive_file').className).toMatch(/bg-accent-amber/);
-    expect(screen.getByText('other').className).toMatch(/bg-surface-5/);
+    await waitFor(() => expect(screen.getByText('/etc/hosts')).toBeInTheDocument());
+    const table = screen.getByRole('table');
+    const destructivePills = Array.from(table.querySelectorAll('td'))
+      .find((td) => td.textContent?.includes('Destructive'))
+      ?.querySelector('span');
+    const sensitivePills = Array.from(table.querySelectorAll('td'))
+      .find((td) => td.textContent?.includes('Sensitive files'))
+      ?.querySelector('span');
+    const otherPills = Array.from(table.querySelectorAll('td'))
+      .find((td) => td.textContent?.includes('other'))
+      ?.querySelector('span');
+    expect(destructivePills?.className).toMatch(/bg-accent-red/);
+    expect(sensitivePills?.className).toMatch(/bg-accent-amber/);
+    expect(otherPills?.className).toMatch(/bg-surface-5/);
+  });
+
+  it('renders friendly classification labels, not raw keys', async () => {
+    renderAudit(SAMPLE);
+    await waitFor(() => expect(screen.getByText('/etc/hosts')).toBeInTheDocument());
+    expect(screen.getAllByText('Sensitive files').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Destructive').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('External network').length).toBeGreaterThan(0);
+    expect(screen.queryByText('sensitive_file')).toBeNull();
+    expect(screen.queryByText('destructive_command')).toBeNull();
+    expect(screen.queryByText('external_network')).toBeNull();
   });
 
   it('filters by classification when a chip is clicked', async () => {

--- a/src/web/views/Audit.tsx
+++ b/src/web/views/Audit.tsx
@@ -126,7 +126,7 @@ export function Audit(): JSX.Element {
                       tone={r.severity ? (SEVERITY_TONE[r.severity] ?? 'neutral') : 'neutral'}
                       size="sm"
                     >
-                      {r.classification}
+                      {FILTERS.find((f) => f.key === r.classification)?.label ?? r.classification}
                     </Pill>
                   </td>
                   <td className="p-2 text-ink-subtle">{r.sessionId ?? '—'}</td>

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -345,6 +345,87 @@ describe('History view', () => {
   });
 });
 
+describe('History — error handling', () => {
+  it('shows an error banner when a query fails', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = ((url: string) => {
+      if (url.startsWith('/api/weekly')) {
+        return Promise.resolve(new Response('Internal Server Error', { status: 503 }));
+      }
+      if (url.startsWith('/api/cost-per-outcome')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_OUTCOME), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/personal-coach')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_COACH_OK), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/sessions')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_SESSIONS), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/activity-heatmap')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ days: [], maxCount: 0 }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/concurrency')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ dailyPeaks: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('Not Found', { status: 404 }));
+    }) as typeof globalThis.fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <History />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(
+      () => expect(screen.getByText(/Error loading some history data/)).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+  });
+
+  it('shows no error banner when every query succeeds', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <History />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText('History')).toBeInTheDocument());
+    expect(screen.queryByText(/Error loading some history data/)).toBeNull();
+  });
+});
+
 describe('History data helpers', () => {
   describe('aggregateDailyCost', () => {
     it('groups sessions by day, sums cost, and trims to N most recent days', () => {

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -117,6 +117,9 @@ export function History(): JSX.Element {
     queryFn: () => fetchConcurrencyHistory(30),
   });
 
+  const hasLoadError =
+    weekly.isError || sessions.isError || costPerOutcome.isError || concurrencyHistory.isError;
+
   // API returns newest-first; reverse for chronological left-to-right chart rendering
   const weeklyChronological = [...(weekly.data ?? [])].reverse();
   const weeklyData = weeklyChronological.map((w) => {
@@ -136,6 +139,12 @@ export function History(): JSX.Element {
     <section>
       <GeoBanner theme="history" />
       <h1 className="text-xl font-semibold gradient-text mb-4">History</h1>
+
+      {hasLoadError && (
+        <div className="text-accent-red text-xs mb-3">
+          Error loading some history data. Charts below may be incomplete.
+        </div>
+      )}
 
       <div className="grid grid-cols-2 gap-3">
         <Panel title="Weekly Efficiency · Last 12">

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -136,6 +136,51 @@ describe('Today view', () => {
     expect(screen.queryByText(/\?× on/)).toBeNull();
   });
 
+  it('does not show the empty state while concurrency/heatmap/liveSessions are still pending', async () => {
+    // Zero out the cost/antiPatterns/tool-call state that resetStore() (in
+    // the outer beforeEach) set to non-zero values, so calls === 0,
+    // todayTotal === 0, and flagsCount === 0 all hold here — i.e.
+    // `noActivityToday` WOULD evaluate true in this test if the
+    // concurrency/heatmap/liveSessions pending gate weren't wired in.
+    useLiveStore.setState({
+      recentToolCalls: [],
+      cost: null,
+      antiPatterns: [],
+      firingAlerts: new Map(),
+      dismissedAlerts: new Set(),
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    // /api/concurrency never resolves for the duration of this test — this
+    // simulates the race window where every other query has already settled
+    // but concurrency (backing `concurrencyPending`) has not. No resolver is
+    // needed: the test only asserts the empty state stays suppressed while
+    // this query is pending, not that it eventually stops being pending.
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (url === '/api/concurrency') {
+        return new Promise<Response>(() => {
+          // Intentionally never settles.
+        });
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday(qc);
+
+    // Wait until every other query (cost, aggregate, sessions, anti-patterns)
+    // has settled — the "spend today" KPI moves off its loading ellipsis to
+    // a real dollar value. This is the exact moment `noActivityToday` would
+    // flip to true if `concurrencyPending` weren't part of the gate.
+    await waitFor(() => expect(screen.getByText('$0.00')).toBeInTheDocument());
+
+    // The empty state must still be suppressed, because /api/concurrency is
+    // still pending.
+    expect(screen.queryByText(/No activity yet today/)).toBeNull();
+  });
+
   it('renders the forecast-EOD card with the projected end-of-day spend', () => {
     renderToday();
     expect(screen.getByText(/forecast/i)).toBeInTheDocument();

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -160,19 +160,20 @@ export function Today(): JSX.Element {
     queryKey: qk.antiPatterns,
     queryFn: fetchAntiPatterns,
   });
-  const { data: concurrency } = useQuery<ConcurrencyData>({
+  const { data: concurrency, isPending: concurrencyPending } = useQuery<ConcurrencyData>({
     queryKey: qk.concurrency,
     queryFn: fetchConcurrency,
     refetchInterval: 10_000,
   });
-  const { data: todayHeatmap } = useQuery<ActivityHeatmapTodayResponse>({
-    queryKey: qk.activityHeatmap('today'),
-    queryFn: () => fetchActivityHeatmap('today'),
-    refetchInterval: 30_000,
-  });
+  const { data: todayHeatmap, isPending: todayHeatmapPending } =
+    useQuery<ActivityHeatmapTodayResponse>({
+      queryKey: qk.activityHeatmap('today'),
+      queryFn: () => fetchActivityHeatmap('today'),
+      refetchInterval: 30_000,
+    });
   // Task #17 (D3): live-session list — drives the selector default and the
   // "Session ended" badge logic when the selected session goes stale.
-  const { data: liveSessions } = useQuery<LiveSessionEntry[]>({
+  const { data: liveSessions, isPending: liveSessionsPending } = useQuery<LiveSessionEntry[]>({
     queryKey: qk.sessionsLive,
     queryFn: fetchLiveSessions,
     refetchInterval: 10_000,
@@ -249,6 +250,9 @@ export function Today(): JSX.Element {
     !aggregatePending &&
     !sessionsPending &&
     !antiPatternsPending &&
+    !concurrencyPending &&
+    !todayHeatmapPending &&
+    !liveSessionsPending &&
     calls === 0 &&
     todayTotal === 0 &&
     flagsCount === 0;
@@ -291,7 +295,7 @@ export function Today(): JSX.Element {
                 />
                 <Kpi
                   label="spend today"
-                  tone="accent"
+                  tone="good"
                   value={spendLoading ? '…' : `$${todayTotal.toFixed(2)}`}
                   {...(!spendLoading
                     ? { animate: true, numericValue: todayTotal, prefix: '$', decimals: 2 }


### PR DESCRIPTION
## Summary

Fixes #138 — 8 small UX/defensive-coding gaps in the web dashboard:

- Today.tsx's empty-state gate omitted `concurrency`/`todayHeatmap`/`liveSessions` pending state, letting the empty state show briefly even as a live session registered.
- History.tsx and Alerts.tsx now surface query load errors instead of silently rendering as "no data yet."
- Git Efficiency's branch-divergence and repo-context now derive the real default branch instead of assuming `main`.
- `formatDuration` now guards against non-finite/negative input, matching `formatNumber`'s existing guard.
- Alerts.tsx's Slack Digest card now shows a loading indicator while settings load, matching the cards above it.
- Audit.tsx's classification Pill now shows the friendly label instead of the raw internal key.
- Removed `Kpi`'s redundant `tone="accent"`, which rendered identically to `tone="good"`.
- Corrected a stale comment in `liveStore.ts` overstating cross-path dedup guarantees for live tool-call events.

## Test plan

- [x] `npm install && npm run build` — clean
- [x] `npm test` (Jest) — 4010 passed, 0 failed
- [x] `npm run test:web` (Vitest) — 278 passed, 1 pre-existing failure (`AlertBanner.test.tsx`, confirmed unrelated to this change and present on `main` before this PR)
- [x] `npm run lint` — 0 errors, 0 warnings

🤖 Generated with subagent-driven-development

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>