### PR TITLE
v1.4.43: Fix Windows path handling (WSL transcript + native PATH delimiter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.43] - 2026-07-14
+
+### Fixed
+
+- Fixed the WSL-hosted collector failing to read Windows-style transcript paths sent by desktop Claude Code, which silently dropped all token/model/cost collection for `wsl-windows-cc` installs.
+- Fixed `resolveBinaryPath()` splitting `PATH` on `:` instead of the platform delimiter and never probing npm's `.cmd`/`.ps1` shim extensions, which always returned null on native Windows — causing a false "not on PATH" warning, loss of absolute hook-path resolution, and a stalled hook upgrade when switching from WSL to native Windows installs.
+
 ## [1.4.42] - 2026-07-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.42",
+  "version": "1.4.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.42",
+      "version": "1.4.43",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.42",
+  "version": "1.4.43",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -13,6 +13,7 @@ import {
   collectTranscriptTokens,
   readLastAssistantUsage,
   getTranscriptPath,
+  translateWslPath,
   getBufferPath,
   writePpidBreadcrumb,
   getLinuxAncestorPids,
@@ -1088,6 +1089,38 @@ describe('collector-script', () => {
 
     it('getTranscriptPath returns null when sessionId is missing', () => {
       expect(getTranscriptPath('/some/path', undefined)).toBeNull();
+    });
+
+    describe('WSL Windows path translation', () => {
+      const originalPlatform = process.platform;
+
+      afterEach(() => {
+        Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+      });
+
+      it('translateWslPath converts a Windows drive path to its WSL mount on Linux', () => {
+        Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+        expect(translateWslPath('C:\\Users\\test\\.claude\\projects\\proj\\abc.jsonl')).toBe(
+          '/mnt/c/Users/test/.claude/projects/proj/abc.jsonl',
+        );
+      });
+
+      it('translateWslPath leaves POSIX paths unchanged on Linux', () => {
+        Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+        expect(translateWslPath('/home/test/.claude/projects/proj/abc.jsonl')).toBe(
+          '/home/test/.claude/projects/proj/abc.jsonl',
+        );
+      });
+
+      it('translateWslPath leaves Windows drive paths unchanged outside Linux', () => {
+        Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+        expect(translateWslPath('C:\\Users\\test\\abc.jsonl')).toBe('C:\\Users\\test\\abc.jsonl');
+      });
+
+      it('getTranscriptPath sanitizes a backslash-separated (Windows) cwd into the project dir name', () => {
+        const path = getTranscriptPath('C:\\Users\\test\\myproject', 'abc-123');
+        expect(path).toContain('.claude/projects/C:-Users-test-myproject/abc-123.jsonl');
+      });
     });
 
     it('readLastAssistantUsage extracts usage from transcript', () => {

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -174,9 +174,21 @@ function getClaudeHome(): string {
 
 function getTranscriptPath(cwd: string | undefined, sessionId: string | undefined): string | null {
   if (!sessionId) return null;
-  const projectDir = cwd ? cwd.replace(/\//g, '-') : process.env.PWD?.replace(/\//g, '-');
+  const projectDir = cwd ? cwd.replace(/[\\/]/g, '-') : process.env.PWD?.replace(/[\\/]/g, '-');
   if (!projectDir) return null;
   return resolve(getClaudeHome(), 'projects', projectDir, `${sessionId}.jsonl`);
+}
+
+const WINDOWS_DRIVE_PATH_RE = /^([A-Za-z]):[\\/](.*)$/;
+
+// Windows Claude Code sends Windows-style paths (C:\Users\...) even when this
+// collector runs inside WSL; translate to the WSL mount so statSync can read it.
+function translateWslPath(path: string): string {
+  if (process.platform !== 'linux') return path;
+  const match = WINDOWS_DRIVE_PATH_RE.exec(path);
+  if (!match) return path;
+  const [, drive, rest] = match;
+  return `/mnt/${drive.toLowerCase()}/${rest.replace(/\\/g, '/')}`;
 }
 
 function readLastAssistantUsage(transcriptPath: string): TranscriptUsage | null {
@@ -267,10 +279,11 @@ function collectTranscriptTokens(data: {
   // Prefer Claude Code's own transcript_path field — it's authoritative and
   // works under git worktrees, where deriving the path from cwd produces a
   // dashed directory that doesn't match the parent project's transcript dir.
-  const transcriptPath =
+  const rawTranscriptPath =
     typeof data.transcript_path === 'string' && data.transcript_path.length > 0
       ? data.transcript_path
       : getTranscriptPath(data.cwd, sessionId);
+  const transcriptPath = rawTranscriptPath ? translateWslPath(rawTranscriptPath) : null;
   if (!transcriptPath || !sessionId) return;
 
   let currentSize: number;
@@ -985,6 +998,7 @@ export {
   collectTranscriptTokens,
   readLastAssistantUsage,
   getTranscriptPath,
+  translateWslPath,
   getBufferPath,
   writePpidBreadcrumb,
   readStdinSync,

--- a/src/install/schedule.test.ts
+++ b/src/install/schedule.test.ts
@@ -227,9 +227,11 @@ describe('getScheduleStatus', () => {
 
 describe('resolveBinaryPath', () => {
   const originalPath = process.env.PATH;
+  const originalPlatform = process.platform;
 
   afterEach(() => {
     process.env.PATH = originalPath;
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
   });
 
   it('returns null when no PATH directories contain the binary', () => {
@@ -251,6 +253,32 @@ describe('resolveBinaryPath', () => {
       writeFileSync(binaryPath, '#!/usr/bin/env node\n', { mode: 0o644 });
       process.env.PATH = tmpDir;
       expect(resolveBinaryPath()).toBeNull();
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('splits PATH on ";" on win32, where entries contain drive-letter colons', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const tmpDir = mkdtempSync(join(nodeOs.tmpdir(), 'schedule-test-win-'));
+    try {
+      const binaryPath = join(tmpDir, 'preflight');
+      writeFileSync(binaryPath, '#!/usr/bin/env node\n', { mode: 0o755 });
+      process.env.PATH = `C:\\nonexistent;${tmpDir}`;
+      expect(resolveBinaryPath()).toBe(binaryPath);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('probes Windows binary extensions (e.g. .cmd) on win32', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const tmpDir = mkdtempSync(join(nodeOs.tmpdir(), 'schedule-test-win-ext-'));
+    try {
+      const binaryPath = join(tmpDir, 'preflight.cmd');
+      writeFileSync(binaryPath, '@echo off\r\n', { mode: 0o755 });
+      process.env.PATH = tmpDir;
+      expect(resolveBinaryPath()).toBe(binaryPath);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/src/install/schedule.ts
+++ b/src/install/schedule.ts
@@ -330,19 +330,27 @@ export function getDashboardDaemonStatus(): DashboardDaemonStatus {
   }
 }
 
+const WINDOWS_BINARY_SUFFIXES = ['.cmd', '.ps1', ''];
+
 export function resolveBinaryPath(): string | null {
   // Walk PATH directly — avoids hardcoding the `which` location and is safe
   // for Nix/Homebrew installs where binaries live outside /usr/bin.
-  const pathDirs = (process.env.PATH ?? '').split(':').filter(Boolean);
+  // PATH is ':'-delimited on POSIX and ';'-delimited on Windows (whose
+  // entries themselves contain drive-letter colons, e.g. "C:\foo").
+  const delimiter = process.platform === 'win32' ? ';' : ':';
+  const pathDirs = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  const suffixes = process.platform === 'win32' ? WINDOWS_BINARY_SUFFIXES : [''];
   for (const dir of pathDirs) {
-    const candidate = join(dir, 'preflight');
-    try {
-      if (statSync(candidate).isFile()) {
-        accessSync(candidate, constants.X_OK);
-        return candidate;
+    for (const suffix of suffixes) {
+      const candidate = join(dir, `preflight${suffix}`);
+      try {
+        if (statSync(candidate).isFile()) {
+          accessSync(candidate, constants.X_OK);
+          return candidate;
+        }
+      } catch {
+        continue;
       }
-    } catch {
-      continue;
     }
   }
   return null;


### PR DESCRIPTION
## Summary

- Fixed the `wsl-windows-cc` collector failing to read Windows-style transcript paths sent by desktop Claude Code, which silently dropped all token/model/cost collection for every WSL-hosted install.
- Fixed `resolveBinaryPath()` splitting `PATH` on `:` instead of the platform delimiter and never probing npm's `.cmd`/`.ps1` shim extensions, which always returned null on native Windows — causing a false "not on PATH" warning, loss of absolute hook-path resolution, and a stalled hook upgrade when switching from WSL to native Windows installs.

Fixes https://github.com/newrelic-experimental/preflight/issues/193
Fixes https://github.com/newrelic-experimental/preflight/issues/205

## Test plan

- [x] New regression tests for the WSL path translation and PATH-delimiter fixes
- [x] Full suite passing, lint clean
- [x] `package-lock.json` version synced to 1.4.43