### PR TITLE
v1.4.44: Content-based instruction drift hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.44] - 2026-07-15
+
+### Fixed
+
+- Fixed instruction/prompt drift tracking correlating on the arguments of a `Read` tool call (file path, offset, limit) instead of the target file's actual content, which produced false drift signals when re-reading an unchanged file at a different offset or limit, and missed real content changes read at an identical offset/limit.
+
 ## [1.4.43] - 2026-07-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.43",
+  "version": "1.4.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.43",
+      "version": "1.4.44",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.43",
+  "version": "1.4.44",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/metrics/instruction-drift-tracker.test.ts
+++ b/src/metrics/instruction-drift-tracker.test.ts
@@ -1,7 +1,38 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ToolCallRecord } from '../storage/types.js';
 import { InstructionDriftTracker, hashPrompt } from './instruction-drift-tracker.js';
 
 const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 afterEach(() => stderrSpy.mockClear());
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = join(
+    tmpdir(),
+    `nr-instruction-drift-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeReadRecord(overrides?: Partial<ToolCallRecord>): ToolCallRecord {
+  return {
+    id: `tc-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    sessionId: 'sess-1',
+    toolName: 'Read',
+    toolUseId: `tu-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    timestamp: Date.now(),
+    durationMs: 100,
+    success: true,
+    ...overrides,
+  } as ToolCallRecord;
+}
 
 describe('hashPrompt', () => {
   it('returns a 16-char hex string', () => {
@@ -255,5 +286,72 @@ describe('InstructionDriftTracker', () => {
 
     tracker.setPromptHash('def456');
     expect(tracker.promptHash).toBe('def456');
+  });
+});
+
+describe('InstructionDriftTracker.recordToolCall (content-based hashing)', () => {
+  it('detects a real content change even when inputHash is unchanged', () => {
+    const claudeMdPath = join(tmpDir, 'CLAUDE.md');
+    writeFileSync(claudeMdPath, 'v1 content');
+
+    const tracker = new InstructionDriftTracker();
+    tracker.recordToolCall(makeReadRecord({ filePath: claudeMdPath, inputHash: 'same-arg-hash' }));
+    const hashAfterV1 = tracker.promptHash;
+    expect(hashAfterV1).not.toBeNull();
+
+    writeFileSync(claudeMdPath, 'v2 content, materially different');
+    tracker.recordToolCall(makeReadRecord({ filePath: claudeMdPath, inputHash: 'same-arg-hash' }));
+    const hashAfterV2 = tracker.promptHash;
+
+    expect(hashAfterV2).not.toBe(hashAfterV1);
+  });
+
+  it('does not report a change when content is unchanged, even if inputHash differs', () => {
+    const claudeMdPath = join(tmpDir, 'CLAUDE.md');
+    writeFileSync(claudeMdPath, 'stable content');
+
+    const tracker = new InstructionDriftTracker();
+    tracker.recordToolCall(makeReadRecord({ filePath: claudeMdPath, inputHash: 'hash-offset-0' }));
+    const firstHash = tracker.promptHash;
+
+    // Simulates re-reading the same unchanged file at a different offset/limit —
+    // inputHash would differ under the old (buggy) args-based hashing.
+    tracker.recordToolCall(makeReadRecord({ filePath: claudeMdPath, inputHash: 'hash-offset-50' }));
+    const secondHash = tracker.promptHash;
+
+    expect(secondHash).toBe(firstHash);
+  });
+
+  it('does not throw and leaves promptHash unchanged when the file is unreadable', () => {
+    const tracker = new InstructionDriftTracker();
+    const missingPath = join(tmpDir, 'CLAUDE.md'); // never created — does not exist on disk
+
+    expect(() => tracker.recordToolCall(makeReadRecord({ filePath: missingPath }))).not.toThrow();
+    expect(tracker.promptHash).toBeNull();
+  });
+
+  it('preserves a previously-set promptHash when a later read fails', () => {
+    const claudeMdPath = join(tmpDir, 'CLAUDE.md');
+    writeFileSync(claudeMdPath, 'known-good content');
+
+    const tracker = new InstructionDriftTracker();
+    tracker.recordToolCall(makeReadRecord({ filePath: claudeMdPath }));
+    const establishedHash = tracker.promptHash;
+    expect(establishedHash).not.toBeNull();
+
+    const missingPath = join(tmpDir, 'now-deleted-CLAUDE.md'); // never created
+
+    expect(() => tracker.recordToolCall(makeReadRecord({ filePath: missingPath }))).not.toThrow();
+    expect(tracker.promptHash).toBe(establishedHash);
+  });
+
+  it('ignores Read calls on files outside CLAUDE.md/.claude/', () => {
+    const otherPath = join(tmpDir, 'some-source-file.ts');
+    writeFileSync(otherPath, 'export const x = 1;');
+
+    const tracker = new InstructionDriftTracker();
+    tracker.recordToolCall(makeReadRecord({ filePath: otherPath }));
+
+    expect(tracker.promptHash).toBeNull();
   });
 });

--- a/src/metrics/instruction-drift-tracker.ts
+++ b/src/metrics/instruction-drift-tracker.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { createLogger } from '../shared/index.js';
+import { ClaudeMdTracker } from './claudemd-tracker.js';
 import type { ToolCallRecord } from '../storage/types.js';
 
 const logger = createLogger('instruction-drift');
@@ -90,8 +91,17 @@ export class InstructionDriftTracker {
     // Only track reads of instruction files
     if (!filePath.includes('CLAUDE.md') && !filePath.includes('.claude/')) return;
 
-    const hash = record.inputHash as string | undefined;
-    if (!hash) return;
+    let hash: string;
+    try {
+      hash = ClaudeMdTracker.computeFileHash(filePath);
+    } catch (err) {
+      // File gone/unreadable by the time we process this event — no signal,
+      // but log at debug level since this can also mean permission-denied
+      // or an EISDIR (unlike the pre-fix code, which never touched the
+      // filesystem here at all).
+      logger.debug('Could not hash instruction file', { filePath, error: String(err) });
+      return;
+    }
 
     this.setPromptHash(hash);
   }


### PR DESCRIPTION
## Summary
- `nr_observe_get_instruction_drift` correlated CLAUDE.md/instruction-file drift on the arguments of a `Read` tool call (file path, offset, limit) instead of the file's actual content, producing false drift signals on re-reads at a different offset/limit and missing real content changes read at an identical offset/limit.
- Fixed by reusing the existing `ClaudeMdTracker.computeFileHash()` helper to hash the file's real on-disk content instead, wrapped in a try/catch for the unreadable-file case.
- Version bumped to 1.4.44 with a CHANGELOG entry.

Fixes #123

## Test plan
- [x] New tests using real temp files prove both the false-positive (same content, different `inputHash`) and false-negative (different content, same `inputHash`) bugs are fixed
- [x] New test covers a previously-set `promptHash` surviving a subsequent failed/unreadable read
- [x] Full suite passes in this clone (4123 passed, 3 skips, 0 failures)
- [x] Lint clean
- [x] Vitest shows only the pre-existing, unrelated `AlertBanner.test.tsx` failure (tracked as #183)