### PR TITLE
Decision-tree real reasoning extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.45] - 2026-07-15
+
+### Fixed
+
+- Fixed `nr_observe_get_decision_tree`'s `reasoning` field always being one of 3 hardcoded template strings instead of the model's actual reasoning. When content recording is enabled and the underlying model exposes plaintext thinking or visible text for that turn, the field now reflects the model's real reasoning (passed through the existing redaction filter), falling back to the prior rule-based label when the model exposes no plaintext reasoning.
+
 ## [1.4.44] - 2026-07-15
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.44",
+  "version": "1.4.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.44",
+      "version": "1.4.45",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.44",
+  "version": "1.4.45",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -135,6 +135,13 @@ describe('collector-script', () => {
       expect(event.toolUseId).toBe('toolu_abc123');
     });
 
+    it('captures transcript_path as transcriptPath', () => {
+      processHook(makePreToolUse({ transcript_path: '/tmp/fake-session.jsonl' }));
+
+      const event = readBufferEvents()[0]!;
+      expect(event.transcriptPath).toBe('/tmp/fake-session.jsonl');
+    });
+
     it('does not include content fields by default', () => {
       processHook(makePreToolUse());
 

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -948,6 +948,7 @@ function processHook(raw: string): void {
 
   // Attach session metadata
   if (data.cwd) event.cwd = data.cwd;
+  if (data.transcript_path) event.transcriptPath = data.transcript_path;
   if (data.permission_mode) event.permissionMode = data.permission_mode;
   if (sessionId) event.sessionId = sessionId;
   if (data.tool_use_id) event.toolUseId = data.tool_use_id;

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -116,6 +116,18 @@ describe('HookEventProcessor', () => {
       expect(record.outputSizeBytes).toBe(2048);
       expect(record.inputHash).toBe('hash1234hash1234');
     });
+
+    it('includes transcriptPath when the pre event carries one', () => {
+      const processor = new HookEventProcessor({ store, onRecord });
+
+      processor.processEvents([
+        makePreEvent({ transcriptPath: '/tmp/fake-transcript.jsonl' }),
+        makePostEvent(),
+      ]);
+
+      const record = records[0]!;
+      expect(record.transcriptPath).toBe('/tmp/fake-transcript.jsonl');
+    });
   });
 
   describe('processEvents() — interleaved ordering', () => {

--- a/src/hooks/event-processor.ts
+++ b/src/hooks/event-processor.ts
@@ -297,6 +297,9 @@ export class HookEventProcessor {
         ...(event.outputSize !== undefined && { outputSizeBytes: event.outputSize }),
         ...(preEvent.inputHash !== undefined && { inputHash: preEvent.inputHash }),
         ...(preEvent.cwd !== undefined && { cwd: preEvent.cwd as string }),
+        ...(preEvent.transcriptPath !== undefined && {
+          transcriptPath: preEvent.transcriptPath as string,
+        }),
         ...(preEvent.permissionMode !== undefined && {
           permissionMode: preEvent.permissionMode as string,
         }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -802,7 +802,7 @@ async function main(): Promise<void> {
     // coarse tool-execution-vs-everything-else split isn't currently derivable.
     // Kept dormant; would need new hook wiring or an LLM-facing proxy to fix for real.
     const latencyDecompositionTracker: LatencyDecompositionTracker | undefined = undefined;
-    const decisionTracker = new DecisionTracker();
+    const decisionTracker = new DecisionTracker({ recordContent: config.recordContent });
     const instructionDriftTracker = new InstructionDriftTracker();
     const toolSelectionScorer = new ToolSelectionScorer();
     const qualityProxyTracker = new QualityProxyTracker();

--- a/src/metrics/decision-tracker.test.ts
+++ b/src/metrics/decision-tracker.test.ts
@@ -1,4 +1,8 @@
 import { DecisionTracker } from './decision-tracker.js';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import type { ToolCallRecord } from '../storage/types.js';
 
 const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 afterEach(() => stderrSpy.mockClear());
@@ -22,7 +26,7 @@ describe('DecisionTracker', () => {
     const tracker = new DecisionTracker();
     const metrics = tracker.getMetrics();
     expect(metrics.note).toBe(
-      "reasoning fields above are rule-based labels (e.g. 'recovery after X failure', 'retrying Y on Z'), not extracted model chain-of-thought -- recordToolCall() has no access to actual reasoning text. Branches are only recorded on 3 narrow triggers (failure recovery, AskUserQuestion, 3rd+ same-tool-same-file retry), not on every turn, so totalBranches undercounts ordinary turns.",
+      "reasoning fields are the model's own thinking/text output for that turn when NEW_RELIC_AI_MCP_RECORD_CONTENT is enabled and the underlying model exposes plaintext reasoning -- some models/transports return only an encrypted thinking signature with no plaintext, in which case this falls back to a rule-based label (e.g. 'recovery after X failure'). Branches are only recorded on 3 narrow triggers (failure recovery, AskUserQuestion, 3rd+ same-tool-same-file retry), not on every turn, so totalBranches undercounts ordinary turns.",
     );
 
     // Recording a real decision must not change the note -- the limitation
@@ -185,5 +189,94 @@ describe('DecisionTracker', () => {
     tracker.reset('new-session');
     expect(tracker.getMetrics().totalBranches).toBe(0);
     expect(tracker.getBranches()).toHaveLength(0);
+  });
+});
+
+describe('DecisionTracker transcript reasoning extraction (recordContent)', () => {
+  let tmpDir: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(resolve(tmpdir(), 'nr-decision-tracker-test-'));
+    transcriptPath = resolve(tmpDir, 'transcript.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function assistantLine(
+    messageId: string,
+    block: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return { type: 'assistant', message: { id: messageId, content: [block] } };
+  }
+
+  function writeTranscript(lines: Record<string, unknown>[]): void {
+    writeFileSync(transcriptPath, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+  }
+
+  function makeRecord(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
+    return {
+      id: 'id-1',
+      sessionId: 'session-1',
+      toolName: 'Read',
+      toolUseId: 'tool_1',
+      timestamp: Date.now(),
+      durationMs: 10,
+      success: true,
+      ...overrides,
+    };
+  }
+
+  it('uses the extracted transcript reasoning for the recovery branch when recordContent is enabled', () => {
+    writeTranscript([
+      assistantLine('msg_1', {
+        type: 'thinking',
+        thinking: 'Retrying with Read since Bash failed.',
+      }),
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_2', name: 'Read', input: {} }),
+    ]);
+
+    const tracker = new DecisionTracker({ recordContent: true });
+    tracker.recordToolCall(makeRecord({ toolName: 'Bash', success: false, toolUseId: 'tool_1' }));
+    tracker.recordToolCall(
+      makeRecord({ toolName: 'Read', success: true, toolUseId: 'tool_2', transcriptPath }),
+    );
+
+    const branches = tracker.getBranches();
+    expect(branches[0]?.reasoning).toBe('Retrying with Read since Bash failed.');
+  });
+
+  it('falls back to the template reasoning when recordContent is enabled but extraction finds no match', () => {
+    writeTranscript([
+      assistantLine('msg_1', { type: 'thinking', thinking: 'Unrelated reasoning.' }),
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_other', name: 'Read', input: {} }),
+    ]);
+
+    const tracker = new DecisionTracker({ recordContent: true });
+    tracker.recordToolCall(makeRecord({ toolName: 'Bash', success: false, toolUseId: 'tool_1' }));
+    tracker.recordToolCall(
+      makeRecord({ toolName: 'Read', success: true, toolUseId: 'tool_2', transcriptPath }),
+    );
+
+    const branches = tracker.getBranches();
+    expect(branches[0]?.reasoning).toBe('recovery after Bash failure');
+  });
+
+  it('never attempts transcript extraction when recordContent is disabled (default)', () => {
+    writeTranscript([
+      assistantLine('msg_1', { type: 'thinking', thinking: 'This should never be read.' }),
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_2', name: 'Read', input: {} }),
+    ]);
+
+    const tracker = new DecisionTracker();
+    tracker.recordToolCall(makeRecord({ toolName: 'Bash', success: false, toolUseId: 'tool_1' }));
+    tracker.recordToolCall(
+      makeRecord({ toolName: 'Read', success: true, toolUseId: 'tool_2', transcriptPath }),
+    );
+
+    const branches = tracker.getBranches();
+    expect(branches[0]?.reasoning).toBe('recovery after Bash failure');
   });
 });

--- a/src/metrics/decision-tracker.ts
+++ b/src/metrics/decision-tracker.ts
@@ -1,4 +1,5 @@
 import type { ToolCallRecord } from '../storage/types.js';
+import { extractReasoningForToolUse } from './transcript-reasoning.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -29,6 +30,7 @@ export interface DecisionTreeMetrics {
 export interface DecisionTrackerOptions {
   readonly maxBranches?: number;
   readonly reasoningMaxLength?: number;
+  readonly recordContent?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -39,7 +41,7 @@ const DEFAULT_MAX_BRANCHES = 500;
 const DEFAULT_REASONING_MAX_LENGTH = 500;
 
 export const DECISION_TREE_REASONING_NOTE =
-  "reasoning fields above are rule-based labels (e.g. 'recovery after X failure', 'retrying Y on Z'), not extracted model chain-of-thought -- recordToolCall() has no access to actual reasoning text. Branches are only recorded on 3 narrow triggers (failure recovery, AskUserQuestion, 3rd+ same-tool-same-file retry), not on every turn, so totalBranches undercounts ordinary turns.";
+  "reasoning fields are the model's own thinking/text output for that turn when NEW_RELIC_AI_MCP_RECORD_CONTENT is enabled and the underlying model exposes plaintext reasoning -- some models/transports return only an encrypted thinking signature with no plaintext, in which case this falls back to a rule-based label (e.g. 'recovery after X failure'). Branches are only recorded on 3 narrow triggers (failure recovery, AskUserQuestion, 3rd+ same-tool-same-file retry), not on every turn, so totalBranches undercounts ordinary turns.";
 
 // ---------------------------------------------------------------------------
 // DecisionTracker
@@ -48,6 +50,7 @@ export const DECISION_TREE_REASONING_NOTE =
 export class DecisionTracker {
   private readonly maxBranches: number;
   private readonly reasoningMaxLength: number;
+  private readonly recordContent: boolean;
   private readonly branches: DecisionBranch[] = [];
 
   private turnCounter = 0;
@@ -58,17 +61,21 @@ export class DecisionTracker {
   constructor(options?: DecisionTrackerOptions) {
     this.maxBranches = options?.maxBranches ?? DEFAULT_MAX_BRANCHES;
     this.reasoningMaxLength = options?.reasoningMaxLength ?? DEFAULT_REASONING_MAX_LENGTH;
+    this.recordContent = options?.recordContent ?? false;
   }
 
   recordToolCall(record: ToolCallRecord): void {
     this.turnCounter++;
     const turn = this.turnCounter;
+    const transcriptPath = record.transcriptPath as string | undefined;
 
     if (this.lastRecordFailed) {
       // Previous tool failed — this tool call represents a recovery decision
       this.recordDecision({
         turnNumber: turn,
-        reasoning: `recovery after ${this.lastToolName ?? 'unknown'} failure`,
+        reasoning:
+          this.extractReasoning(transcriptPath, record.toolUseId) ??
+          `recovery after ${this.lastToolName ?? 'unknown'} failure`,
         chosenAction: record.toolName,
         toolName: record.toolName,
       });
@@ -77,7 +84,7 @@ export class DecisionTracker {
     if (record.toolName === 'AskUserQuestion') {
       this.recordDecision({
         turnNumber: turn,
-        reasoning: 'delegating to user',
+        reasoning: this.extractReasoning(transcriptPath, record.toolUseId) ?? 'delegating to user',
         chosenAction: 'ask_user',
         toolName: record.toolName,
       });
@@ -92,7 +99,9 @@ export class DecisionTracker {
       if (count >= 3) {
         this.recordDecision({
           turnNumber: turn,
-          reasoning: `retrying ${record.toolName} on ${filePath} (${count} attempts)`,
+          reasoning:
+            this.extractReasoning(transcriptPath, record.toolUseId) ??
+            `retrying ${record.toolName} on ${filePath} (${count} attempts)`,
           chosenAction: 'retry',
           toolName: record.toolName,
         });
@@ -106,6 +115,11 @@ export class DecisionTracker {
 
     this.lastRecordFailed = !record.success;
     this.lastToolName = record.toolName;
+  }
+
+  private extractReasoning(transcriptPath: string | undefined, toolUseId: string): string | null {
+    if (!this.recordContent || !transcriptPath) return null;
+    return extractReasoningForToolUse(transcriptPath, toolUseId);
   }
 
   recordDecision(input: {

--- a/src/metrics/transcript-reasoning.test.ts
+++ b/src/metrics/transcript-reasoning.test.ts
@@ -1,0 +1,125 @@
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { extractReasoningForToolUse } from './transcript-reasoning.js';
+
+let tmpDir: string;
+let transcriptPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(resolve(tmpdir(), 'nr-transcript-reasoning-test-'));
+  transcriptPath = resolve(tmpDir, 'transcript.jsonl');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function assistantLine(messageId: string, block: Record<string, unknown>): Record<string, unknown> {
+  return { type: 'assistant', message: { id: messageId, content: [block] } };
+}
+
+function writeTranscript(lines: Record<string, unknown>[]): void {
+  writeFileSync(transcriptPath, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+}
+
+describe('extractReasoningForToolUse', () => {
+  it('prefers thinking text when present', () => {
+    writeTranscript([
+      assistantLine('msg_1', { type: 'thinking', thinking: 'I should check the file first.' }),
+      assistantLine('msg_1', { type: 'text', text: 'Let me look.' }),
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_abc', name: 'Read', input: {} }),
+    ]);
+
+    expect(extractReasoningForToolUse(transcriptPath, 'tool_abc')).toBe(
+      'I should check the file first.',
+    );
+  });
+
+  it('falls back to the text block when thinking is empty', () => {
+    writeTranscript([
+      assistantLine('msg_1', { type: 'text', text: 'Checking the config now.' }),
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_abc', name: 'Read', input: {} }),
+    ]);
+
+    expect(extractReasoningForToolUse(transcriptPath, 'tool_abc')).toBe('Checking the config now.');
+  });
+
+  it('returns null when neither thinking nor text is present', () => {
+    writeTranscript([
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_abc', name: 'Read', input: {} }),
+    ]);
+
+    expect(extractReasoningForToolUse(transcriptPath, 'tool_abc')).toBeNull();
+  });
+
+  it('shares the group reasoning across multiple parallel tool_use blocks', () => {
+    writeTranscript([
+      assistantLine('msg_1', { type: 'thinking', thinking: 'Two independent lookups needed.' }),
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_a', name: 'Read', input: {} }),
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_b', name: 'Read', input: {} }),
+    ]);
+
+    expect(extractReasoningForToolUse(transcriptPath, 'tool_a')).toBe(
+      'Two independent lookups needed.',
+    );
+    expect(extractReasoningForToolUse(transcriptPath, 'tool_b')).toBe(
+      'Two independent lookups needed.',
+    );
+  });
+
+  it('returns null when the toolUseId is not found in the tail window', () => {
+    writeTranscript([
+      assistantLine('msg_1', { type: 'thinking', thinking: 'Some reasoning.' }),
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_a', name: 'Read', input: {} }),
+    ]);
+
+    expect(extractReasoningForToolUse(transcriptPath, 'tool_nonexistent')).toBeNull();
+  });
+
+  it('returns null when the transcript file does not exist', () => {
+    expect(extractReasoningForToolUse(resolve(tmpDir, 'missing.jsonl'), 'tool_a')).toBeNull();
+  });
+
+  it('skips malformed or partial JSON lines silently', () => {
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify(
+          assistantLine('msg_1', { type: 'thinking', thinking: 'Reasoning before the glitch.' }),
+        ),
+        '{"type":"assistant","message":{"id":"msg_1","content":[{"type":"text","text":"cut off mid-w',
+        JSON.stringify(
+          assistantLine('msg_1', { type: 'tool_use', id: 'tool_a', name: 'Read', input: {} }),
+        ),
+      ].join('\n') + '\n',
+    );
+
+    expect(extractReasoningForToolUse(transcriptPath, 'tool_a')).toBe(
+      'Reasoning before the glitch.',
+    );
+  });
+
+  it('does not leak reasoning from a previous turn with a different message id', () => {
+    writeTranscript([
+      assistantLine('msg_0', { type: 'thinking', thinking: 'Previous turn reasoning.' }),
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_a', name: 'Read', input: {} }),
+    ]);
+
+    expect(extractReasoningForToolUse(transcriptPath, 'tool_a')).toBeNull();
+  });
+
+  it('redacts sensitive content in the extracted reasoning', () => {
+    writeTranscript([
+      assistantLine('msg_1', {
+        type: 'thinking',
+        thinking: 'API_KEY=sk-abc123def456 needs rotating',
+      }),
+      assistantLine('msg_1', { type: 'tool_use', id: 'tool_a', name: 'Read', input: {} }),
+    ]);
+
+    const result = extractReasoningForToolUse(transcriptPath, 'tool_a');
+    expect(result).toContain('[REDACTED]');
+    expect(result).not.toContain('sk-abc123def456');
+  });
+});

--- a/src/metrics/transcript-reasoning.ts
+++ b/src/metrics/transcript-reasoning.ts
@@ -1,0 +1,136 @@
+import { closeSync, openSync, readSync, statSync, constants as fsConstants } from 'node:fs';
+
+import { redactSensitive } from '../config.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// Duplicated from src/hooks/collector-script.ts's TRANSCRIPT_TAIL_BYTES --
+// intentional, matching that file's own precedent of duplicating small
+// platform-specific constants rather than importing across the
+// collector-script/server boundary.
+const TRANSCRIPT_TAIL_BYTES = 16_384;
+
+// Safety cap on how far back a single logical turn's content blocks can
+// span, guarding against malformed data producing an unbounded walk.
+const MAX_GROUP_WALK_BACK_LINES = 20;
+
+const WINDOWS_DRIVE_PATH_RE = /^([A-Za-z]):[\\/](.*)$/;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TranscriptContentBlock {
+  readonly type?: string;
+  readonly id?: string;
+  readonly text?: string;
+  readonly thinking?: string;
+}
+
+interface TranscriptLine {
+  readonly type?: string;
+  readonly message?: {
+    readonly id?: string;
+    readonly content?: readonly TranscriptContentBlock[];
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Duplicated from src/hooks/collector-script.ts's translateWslPath -- same
+// WSL-path-fixup precedent, needed because this module tail-reads the same
+// transcript file independently of the collector.
+function translateWslPath(path: string): string {
+  if (process.platform !== 'linux') return path;
+  const match = WINDOWS_DRIVE_PATH_RE.exec(path);
+  if (!match) return path;
+  const [, drive, rest] = match;
+  return `/mnt/${drive.toLowerCase()}/${rest.replace(/\\/g, '/')}`;
+}
+
+function parseTranscriptLine(line: string): TranscriptLine | null {
+  try {
+    return JSON.parse(line) as TranscriptLine;
+  } catch {
+    return null;
+  }
+}
+
+function readTranscriptTail(transcriptPath: string): string[] {
+  try {
+    const stat = statSync(transcriptPath);
+    if (stat.size === 0) return [];
+
+    const fd = openSync(transcriptPath, fsConstants.O_RDONLY);
+    try {
+      const readSize = Math.min(stat.size, TRANSCRIPT_TAIL_BYTES);
+      const buffer = Buffer.alloc(readSize);
+      const bytesRead = readSync(fd, buffer, 0, readSize, stat.size - readSize);
+      return buffer.toString('utf-8', 0, bytesRead).split('\n').filter(Boolean);
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds the model's own reasoning (thinking text, falling back to visible
+ * text) for the turn that produced a given tool_use block. Returns null on
+ * any miss -- id not found in the tail window, file gone, malformed JSON --
+ * never throws. Callers must gate on `recordContent` themselves; this
+ * function always attempts the read.
+ */
+export function extractReasoningForToolUse(
+  transcriptPath: string,
+  toolUseId: string,
+): string | null {
+  const lines = readTranscriptTail(translateWslPath(transcriptPath));
+  if (lines.length === 0) return null;
+
+  let targetLine = -1;
+  let groupId: string | undefined;
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const entry = parseTranscriptLine(lines[i]!);
+    if (!entry || entry.type !== 'assistant' || !entry.message?.content) continue;
+    const matched = entry.message.content.some(
+      (block) => block.type === 'tool_use' && block.id === toolUseId,
+    );
+    if (matched) {
+      targetLine = i;
+      groupId = entry.message.id;
+      break;
+    }
+  }
+
+  if (targetLine === -1 || !groupId) return null;
+
+  const thinkingParts: string[] = [];
+  const textParts: string[] = [];
+
+  for (let i = targetLine, steps = 0; i >= 0 && steps < MAX_GROUP_WALK_BACK_LINES; i--, steps++) {
+    const entry = parseTranscriptLine(lines[i]!);
+    if (!entry) continue; // skip malformed/partial lines silently
+    if (entry.type !== 'assistant' || entry.message?.id !== groupId) break;
+    for (const block of entry.message?.content ?? []) {
+      if (block.type === 'thinking' && block.thinking) {
+        thinkingParts.unshift(block.thinking);
+      } else if (block.type === 'text' && block.text) {
+        textParts.unshift(block.text);
+      }
+    }
+  }
+
+  const reasoning = thinkingParts.join('\n').trim() || textParts.join('\n').trim();
+  return reasoning.length > 0 ? redactSensitive(reasoning) : null;
+}

--- a/src/tools/extended-analytics-tools.test.ts
+++ b/src/tools/extended-analytics-tools.test.ts
@@ -62,7 +62,7 @@ describe('extended-analytics-tools handlers', () => {
     expect(metrics.totalBranches).toBe(1);
     expect(metrics.longestFailureStreak).toBe(1);
     expect(metrics.note).toBe(
-      "reasoning fields above are rule-based labels (e.g. 'recovery after X failure', 'retrying Y on Z'), not extracted model chain-of-thought -- recordToolCall() has no access to actual reasoning text. Branches are only recorded on 3 narrow triggers (failure recovery, AskUserQuestion, 3rd+ same-tool-same-file retry), not on every turn, so totalBranches undercounts ordinary turns.",
+      "reasoning fields are the model's own thinking/text output for that turn when NEW_RELIC_AI_MCP_RECORD_CONTENT is enabled and the underlying model exposes plaintext reasoning -- some models/transports return only an encrypted thinking signature with no plaintext, in which case this falls back to a rule-based label (e.g. 'recovery after X failure'). Branches are only recorded on 3 narrow triggers (failure recovery, AskUserQuestion, 3rd+ same-tool-same-file retry), not on every turn, so totalBranches undercounts ordinary turns.",
     );
 
     const pmResult = handleGetDecisionTree(tracker, true);

--- a/src/tools/extended-analytics-tools.ts
+++ b/src/tools/extended-analytics-tools.ts
@@ -54,7 +54,7 @@ export const LATENCY_DECOMPOSITION_TOOL = {
 export const DECISION_TREE_TOOL = {
   name: 'nr_observe_get_decision_tree',
   description:
-    'Get decision branch analysis: rule-based decision labeling and action tagging for triggered branches (recovery, retry, delegation), with outcome tagging. Includes post-mortem of failure chains and longest failure streak. LIMITATION: the reasoning field is a fixed rule-based label, not extracted model chain-of-thought, and branches are only recorded on 3 narrow triggers rather than every turn (see the note field in the response).',
+    "Get decision branch analysis: reasoning and action extraction per turn for triggered branches (recovery, retry, delegation), with outcome tagging. Includes post-mortem of failure chains and longest failure streak. LIMITATION: the reasoning field is the model's own thinking/text output only when NEW_RELIC_AI_MCP_RECORD_CONTENT is enabled and the model exposes plaintext reasoning; otherwise it falls back to a fixed rule-based label. Branches are only recorded on 3 narrow triggers rather than every turn (see the note field in the response).",
   inputSchema: {
     type: 'object' as const,
     properties: {


### PR DESCRIPTION
## Summary

- `nr_observe_get_decision_tree`'s `reasoning` field was always one of 3 hardcoded template strings, never the model's actual reasoning, despite the tool's description promising real extraction.
- Passes `transcript_path` through the hook pipeline unconditionally (mirrors the existing `cwd` field): `src/hooks/collector-script.ts`, `src/hooks/event-processor.ts`.
- New isolated module `src/metrics/transcript-reasoning.ts` tail-reads a transcript JSONL, groups content blocks by turn, and extracts the model's real `thinking` text (falling back to visible `text`) for a given `tool_use` id — returns `null` on any miss, redacts via the existing `redactSensitive()` before returning.
- `DecisionTracker` now calls this extraction at its 3 existing narrow trigger sites (recovery-after-failure, `AskUserQuestion` delegation, 3rd+ same-file retry), gated behind a new `recordContent` option (default off), falling back to the prior template strings when disabled or on a miss.
- Wires the real config's `recordContent` (already `highSecurity`-gated) into `DecisionTracker`'s construction, and rewords the tool's disclosure text to describe the new behavior accurately.
- Version bump to 1.4.45 + CHANGELOG entry.

Fixes #124

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 131/132 suites passed (1 pre-existing skip), 4137/4140 tests passed (3 pre-existing skips)
- [x] `npm run lint` — clean, 0 errors/0 warnings