### PR TITLE
Close OTLP forward-agent leak, fix fetch test cleanup, correct AlertBanner regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.46] - 2026-07-15
+
+### Fixed
+
+- The OTLP receiver now closes its outbound connection pool when stopped, and no longer hangs if closing that pool fails, instead of leaving the pool open for the life of the process.
+- Corrected a test assertion in the alert banner suite that no longer matched the component's real number formatting.
+
 ## [1.4.45] - 2026-07-15
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.45",
+  "version": "1.4.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.45",
+      "version": "1.4.46",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.45",
+  "version": "1.4.46",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/proxy/otlp-receiver.test.ts
+++ b/src/proxy/otlp-receiver.test.ts
@@ -19,6 +19,11 @@ import { gzipSync, deflateSync, brotliCompressSync } from 'node:zlib';
 import { OtlpReceiver } from './otlp-receiver.js';
 import type { OtlpReceiverOptions } from './otlp-receiver.js';
 
+// Captured once at module load, before any test mocks globalThis.fetch, so any
+// describe block can restore the real implementation instead of leaving it
+// undefined for whichever block runs next.
+const realFetch = globalThis.fetch;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -213,7 +218,7 @@ describe('forward', () => {
   });
 
   afterEach(() => {
-    (globalThis as { fetch?: unknown }).fetch = undefined;
+    globalThis.fetch = realFetch;
   });
 
   it('calls fetch with the forward URL and api-key header', async () => {
@@ -287,17 +292,10 @@ describe('forward', () => {
 });
 
 describe('forward — DNS rebinding protection', () => {
-  // This describe block is a sibling of describe('forward', ...), not nested inside it,
-  // so that block's own beforeEach (which sets globalThis.fetch = mockFetch) never runs
-  // here. However, describe('forward', ...)'s afterEach (and the unrelated 'error
-  // message sanitization' describe block, further below) resets globalThis.fetch to
-  // `undefined` rather than restoring the original native implementation — so by the
-  // time this block's test runs, globalThis.fetch is left undefined by that earlier
-  // block's cleanup, regardless of nesting. Save the real fetch once at module load
-  // (before any test has run) and restore it around this block's own test so the
-  // Agent's connect.lookup gets a genuine, unmocked fetch to actually run through.
-  const realFetch = globalThis.fetch;
-
+  // This describe block is a sibling of describe('forward', ...), not nested inside
+  // it, so that block's own beforeEach (which mocks globalThis.fetch) never runs here.
+  // Explicitly restore the real fetch anyway so this test's Agent/connect.lookup path
+  // always runs through a genuine, unmocked fetch, independent of file-level ordering.
   beforeEach(() => {
     globalThis.fetch = realFetch;
   });
@@ -360,6 +358,51 @@ describe('start / stop lifecycle', () => {
   it('stop() resolves immediately when not yet started', async () => {
     const receiver = makeReceiver();
     await expect(receiver.stop()).resolves.toBeUndefined();
+  });
+
+  it('stop() closes the forwardDispatcher Agent when forwarding is configured', async () => {
+    const { Agent } = await import('undici');
+    const closeSpy = jest.spyOn(Agent.prototype, 'close').mockResolvedValue(undefined);
+    try {
+      const receiver = makeReceiver({ forwardEndpoint: 'https://otlp.nr-data.net' });
+      await receiver.start();
+      await receiver.stop();
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
+  it('stop() does not throw when forwarding is not configured (no dispatcher to close)', async () => {
+    const receiver = makeReceiver();
+    await receiver.start();
+    await expect(receiver.stop()).resolves.toBeUndefined();
+  });
+
+  it('stop() closes the forwardDispatcher even if the receiver was never started', async () => {
+    const { Agent } = await import('undici');
+    const closeSpy = jest.spyOn(Agent.prototype, 'close').mockResolvedValue(undefined);
+    try {
+      const receiver = makeReceiver({ forwardEndpoint: 'https://otlp.nr-data.net' });
+      await receiver.stop();
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
+  it('stop() still resolves even if the forwardDispatcher rejects on close()', async () => {
+    const { Agent } = await import('undici');
+    const closeSpy = jest
+      .spyOn(Agent.prototype, 'close')
+      .mockRejectedValue(new Error('already destroyed'));
+    try {
+      const receiver = makeReceiver({ forwardEndpoint: 'https://otlp.nr-data.net' });
+      await receiver.start();
+      await expect(receiver.stop()).resolves.toBeUndefined();
+    } finally {
+      closeSpy.mockRestore();
+    }
   });
 });
 
@@ -773,7 +816,7 @@ describe('incomplete body', () => {
 
 describe('error message sanitization', () => {
   afterEach(() => {
-    (globalThis as { fetch?: unknown }).fetch = undefined;
+    globalThis.fetch = realFetch;
   });
 
   it('logs only err.message without stack frames on forward error', async () => {

--- a/src/proxy/otlp-receiver.ts
+++ b/src/proxy/otlp-receiver.ts
@@ -77,12 +77,20 @@ export class OtlpReceiver {
   }
 
   stop(): Promise<void> {
+    const closeDispatcher = (): Promise<void> =>
+      this.forwardDispatcher
+        ? this.forwardDispatcher.close().catch((err: unknown) => {
+            logger.error('Error closing OTLP forward dispatcher', { error: String(err) });
+          })
+        : Promise.resolve();
     return new Promise((resolve) => {
       if (!this.server) {
-        resolve();
+        void closeDispatcher().then(() => resolve());
         return;
       }
-      this.server.close(() => resolve());
+      this.server.close(() => {
+        void closeDispatcher().then(() => resolve());
+      });
     });
   }
 

--- a/src/web/components/AlertBanner.test.tsx
+++ b/src/web/components/AlertBanner.test.tsx
@@ -22,7 +22,7 @@ describe('AlertBanner', () => {
     render(<AlertBanner alert={makeAlert()} onDismiss={() => {}} />);
     expect(screen.getByText('Session cost spike')).toBeInTheDocument();
     expect(screen.getByText(/Spent 12\.34/)).toBeInTheDocument();
-    expect(screen.getByText(/12\.34 \/ 10/)).toBeInTheDocument();
+    expect(screen.getByText(/12\.3 \/ 10\.0/)).toBeInTheDocument();
   });
 
   it('shows the severity label', () => {


### PR DESCRIPTION
## Summary
- `OtlpReceiver.stop()` now closes its outbound `undici.Agent` dispatcher (previously left open, leaking the connection pool for the life of the process), and never hangs even if closing that dispatcher rejects.
- Fixed a test-cleanup bug in `otlp-receiver.test.ts` where two `afterEach` blocks set `globalThis.fetch = undefined` instead of restoring the real implementation, creating file-order test pollution that a third describe block had to work around.
- Corrected a stale regex in `AlertBanner.test.tsx` that no longer matched the component's real number formatting (a 1-decimal rounding tier for values ≥10).
- Version bump to 1.4.46.

Fixes #173. Fixes #183.

## Test plan
- [x] `npm test` — 131/132 suites passed (1 pre-existing skip), 4141/4144 tests passed (3 pre-existing skips), no failures
- [x] `npm run test:web` — 23/23 files, 279/279 tests passed
- [x] `npm run build` — clean
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)