### PR TITLE
Fix anti-pattern REST hydration mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.47] - 2026-07-15
+
+### Fixed
+
+- The live dashboard's pre-connection anti-pattern hydration now maps the server's anti-pattern fields (file/command, iteration/read/repeat/edit/agent counts) onto the display shape correctly, instead of leaving the target file and count blank until the first live event arrives.
+
 ## [1.4.46] - 2026-07-15
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.46",
+  "version": "1.4.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.4.46",
+      "version": "1.4.47",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.4.46",
+  "version": "1.4.47",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/web/hooks/useLiveEvents.test.tsx
+++ b/src/web/hooks/useLiveEvents.test.tsx
@@ -117,6 +117,45 @@ describe('useLiveEvents', () => {
     expect(useLiveStore.getState().antiPatterns).toHaveLength(1);
   });
 
+  describe('REST hydration of anti-patterns', () => {
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('maps the real AntiPattern shape into the store, not the SSE shape', async () => {
+      globalThis.fetch = vi.fn((url: string, _init?: RequestInit) => {
+        if (url === '/api/anti-patterns') {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve([
+                { type: 're_reading', file: 'auth.ts', readCount: 4, suggestion: 'x' },
+              ]),
+          } as Response);
+        }
+        return Promise.resolve({ ok: false } as Response);
+      }) as typeof globalThis.fetch;
+
+      renderHook(() => useLiveEvents());
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const patterns = useLiveStore.getState().antiPatterns;
+      expect(patterns).toHaveLength(1);
+      expect(patterns[0].type).toBe('re_reading');
+      expect(patterns[0].target).toBe('auth.ts');
+      expect(patterns[0].count).toBe(4);
+    });
+  });
+
   describe('staleness watchdog', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/src/web/hooks/useLiveEvents.ts
+++ b/src/web/hooks/useLiveEvents.ts
@@ -49,7 +49,12 @@ function hydrateFromApi(signal: AbortSignal): void {
       if (!Array.isArray(data)) return;
       for (const ap of data) {
         if (ap && typeof ap === 'object' && 'type' in ap) {
-          store.pushAntiPattern(ap as unknown as { type: string; target: string; count: number });
+          store.pushAntiPattern({
+            type: ap.type,
+            target: ap.file ?? ap.command ?? 'unknown',
+            count:
+              ap.iterations ?? ap.readCount ?? ap.repeatCount ?? ap.editCount ?? ap.agentCount ?? 0,
+          });
         }
       }
     })


### PR DESCRIPTION
## Summary
- `useLiveEvents.ts`'s `hydrateFromApi()` REST-hydration path force-cast the fetched anti-pattern objects into a shape they don't have (`{ type, target, count }`), so `target`/`count` were always `undefined` in the dashboard until the first live SSE event arrived.
- Replaced the cast with an explicit field mapping (`file`/`command` → `target`, `iterations`/`readCount`/`repeatCount`/`editCount`/`agentCount` → `count`), identical to the mapping `Today.tsx` already uses for the same data shape.
- Added a regression test exercising the real hook against a mocked `/api/anti-patterns` response.
- Version bump to 1.4.47 + CHANGELOG entry.

Fixes #186

## Test plan
- [x] New test: `src/web/hooks/useLiveEvents.test.tsx` — REST hydration maps real `AntiPattern` fields onto the store correctly
- [x] `npm test` — 4141/4144 passed (3 pre-existing skips), 0 failures
- [x] `npm run test:web` — 280/280 passed
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit -p tsconfig.web.json` — no new errors vs. baseline