### PR TITLE
Chore: v1.5.1 — watcher hardening, GanttTimeline perf/a11y, Sessions test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-07-16
+
+### Fixed
+
+- The subagent transcript watcher now emits a health event instead of silently skipping a transcript file whose filename doesn't match the expected agent-id shape, so a future change to that format would be observable instead of silently reintroducing lost subagent cost tracking.
+- The workflow watcher no longer accumulates unbounded internal bookkeeping for the life of the process; stale tracking entries are evicted on each poll instead of persisting indefinitely.
+- Both the subagent and workflow watchers now go straight to the active session's own directory when tracking a single session, instead of listing every session on disk on every poll.
+- The session trace's Gantt timeline no longer re-sorts and rebuilds its highlight state on every mouse movement, and its bars now expose an accessible name to assistive technology.
+- Fixed a missing file extension on an internal module import.
+
+### Added
+
+- Added test coverage for the Sessions view's workflow-consolidation logic: KPI aggregation across workflow runs, run-source and status filtering, the session/run/agent expansion tree, and the in-place workflow-run detail view.
+
 ## [1.5.0] - 2026-07-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/alerts/alert-snapshot-collector.ts
+++ b/src/alerts/alert-snapshot-collector.ts
@@ -4,7 +4,7 @@ const logger = createLogger('alert-snapshot-collector');
 
 // ---------------------------------------------------------------------------
 // Snapshot type — owns the shape that LocalAlertEngine.evaluate() consumes.
-// (Re-exported from local-alert-engine.ts to keep Phase 1 imports stable.)
+// (Re-exported from local-alert-engine.ts to keep imports stable.)
 // ---------------------------------------------------------------------------
 
 /**

--- a/src/alerts/local-alert-engine.test.ts
+++ b/src/alerts/local-alert-engine.test.ts
@@ -411,7 +411,7 @@ describe('LocalAlertEngine — clock + state housekeeping', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Phase 2 — non-budget rule types
+// Non-budget rule types
 // ---------------------------------------------------------------------------
 
 describe('LocalAlertEngine — cost.window rule', () => {
@@ -909,7 +909,7 @@ describe('LocalAlertEngine — getRequiredWindows', () => {
 });
 
 // ---------------------------------------------------------------------------
-// OS notification wiring (Phase 4 — task 22)
+// OS notification wiring
 // ---------------------------------------------------------------------------
 
 describe('LocalAlertEngine — OS notifications', () => {

--- a/src/alerts/local-alert-engine.ts
+++ b/src/alerts/local-alert-engine.ts
@@ -23,7 +23,7 @@ const logger = createLogger('local-alert-engine');
 // ---------------------------------------------------------------------------
 
 // AlertSnapshot lives in alert-snapshot-collector.ts. Re-exported here to
-// keep Phase 1 imports stable.
+// keep imports stable.
 export type { AlertSnapshot } from './alert-snapshot-collector.js';
 import type { AlertSnapshot } from './alert-snapshot-collector.js';
 
@@ -504,7 +504,7 @@ export class LocalAlertEngine {
     return `${isoYear}-W${weekNum}`;
   }
 
-  // For tests + Phase 2 hand-off: read-only view of currently firing rules.
+  // For tests: read-only view of currently firing rules.
   getFiringRuleIds(): readonly string[] {
     const ids: string[] = [];
     for (const [id, st] of this.state.entries()) {
@@ -543,7 +543,7 @@ export class LocalAlertEngine {
     return out;
   }
 
-  /** Exposed for Phase 2 wiring; returns the current monotonic clock reading. */
+  /** Exposed for tests; returns the current monotonic clock reading. */
   now(): number {
     return this.clock();
   }

--- a/src/alerts/local-alerts-acceptance.test.ts
+++ b/src/alerts/local-alerts-acceptance.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
   stderrSpy.mockRestore();
 });
 
-describe('Local alerts — Phase 1 acceptance', () => {
+describe('Local alerts — simple acceptance', () => {
   it('drives a budget threshold through tracker → engine → bus end-to-end', () => {
     const bus = new LiveEventBus();
     const engine = new LocalAlertEngine();
@@ -85,7 +85,7 @@ describe('Local alerts — Phase 1 acceptance', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Phase 2 acceptance — drive the full starter rule set through evaluate()
+// Acceptance — drive the full starter rule set through evaluate()
 // ---------------------------------------------------------------------------
 
 const STARTER_RULES: LocalAlertRule[] = [
@@ -209,7 +209,7 @@ function emptySnapshot(timestamp: number, overrides: Partial<AlertSnapshot> = {}
   };
 }
 
-describe('Local alerts — Phase 2 acceptance (full starter rule set)', () => {
+describe('Local alerts — acceptance (full starter rule set)', () => {
   it('drives a sequence of synthetic snapshots and emits expected fire/clear events', () => {
     const bus = new LiveEventBus();
     const engine = new LocalAlertEngine();

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1417,7 +1417,7 @@ describe('dashboard config', () => {
   });
 });
 
-describe('alerts config (Phase 4 task 25)', () => {
+describe('alerts config', () => {
   beforeEach(() => {
     delete process.env.NR_AI_ALERTS_ENABLED;
     delete process.env.NR_AI_ALERTS_INTERVAL_SECONDS;

--- a/src/dashboard/dashboard-server.ts
+++ b/src/dashboard/dashboard-server.ts
@@ -46,8 +46,8 @@ export interface DashboardServerOptions {
   readonly bus: LiveEventBus;
   readonly staticDir?: string;
   readonly api?: ApiHandlerDeps;
-  // Phase 1 wiring: passed in when the server is constructed in local/both
-  // mode. Phase 3 will surface them via the API + SPA. They live on the
+  // Wiring: passed in when the server is constructed in local/both
+  // mode. Surfaced via the API + SPA. They live on the
   // server for now so other modules (e.g. budget threshold callback in
   // index.ts) can route events through the engine.
   readonly alertEngine?: LocalAlertEngine;
@@ -127,12 +127,12 @@ export class DashboardServer {
     });
   }
 
-  /** Phase 1 hook for tests + Phase 3 API route wiring. */
+  /** Hook for tests + API route wiring. */
   getAlertEngine(): LocalAlertEngine | undefined {
     return this.opts.alertEngine;
   }
 
-  /** Phase 1 hook for tests + Phase 3 API route wiring. */
+  /** Hook for tests + API route wiring. */
   getAlertLog(): AlertLog | undefined {
     return this.opts.alertLog;
   }

--- a/src/dashboard/live-event-bus.test.ts
+++ b/src/dashboard/live-event-bus.test.ts
@@ -111,7 +111,7 @@ describe('LiveEventBus', () => {
     expect((replay[0]!.payload as { id: string }).id).toBe('first');
   });
 
-  // Task #17 (D3): the live event schema requires sessionId on the events
+  // The live event schema requires sessionId on the events
   // that have a single owning session. The compile-time test below would
   // fail to type-check if the sessionId field were ever removed; the runtime
   // test confirms the bus carries the field through to subscribers.
@@ -157,7 +157,7 @@ describe('LiveEventBus', () => {
     ]);
   });
 
-  // Task #17 (D3): AlertEvent.sessionId is optional — system-level alerts
+  // AlertEvent.sessionId is optional — system-level alerts
   // (e.g. dashboard-server health) have no owning session.
   it('AlertEvent.sessionId is optional', () => {
     const bus = new LiveEventBus();

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1223,7 +1223,7 @@ describe('api-handler GET /api/personal-coach', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Task #17 (D3): cross-session aggregate + live session list
+// Cross-session aggregate + live session list
 // ---------------------------------------------------------------------------
 
 describe('api-handler GET /api/sessions/live', () => {

--- a/src/dashboard/routes/sse-handler.test.ts
+++ b/src/dashboard/routes/sse-handler.test.ts
@@ -387,7 +387,7 @@ describe('sse-handler', () => {
     expect(offSpy).toHaveBeenCalledTimes(5);
   });
 
-  // Task #17 (D3): server-side sessionId filtering for the per-session
+  // Server-side sessionId filtering for the per-session
   // live tail. When `?sessionId=` is present, frames with a sessionId that
   // doesn't match are dropped before being written; events with no sessionId
   // (e.g. system-level alerts) and the heartbeat keepalive always pass.

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -1377,10 +1377,10 @@ describe('collector-script', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Fix 3: per-session buffer paths + PPID breadcrumb
+  // Per-session buffer paths + PPID breadcrumb
   // ---------------------------------------------------------------------------
 
-  describe('getBufferPath() (Fix 3)', () => {
+  describe('getBufferPath()', () => {
     it('honours NEW_RELIC_AI_MCP_BUFFER_PATH verbatim and ignores sessionId', () => {
       const explicit = resolve(tmpDir, 'explicit.jsonl');
       process.env.NEW_RELIC_AI_MCP_BUFFER_PATH = explicit;
@@ -1406,7 +1406,7 @@ describe('collector-script', () => {
     });
   });
 
-  describe('processHook() per-session buffer scoping (Fix 3)', () => {
+  describe('processHook() per-session buffer scoping', () => {
     it('writes events to buffer-<sessionId>.jsonl when no explicit BUFFER_PATH is set', () => {
       delete process.env.NEW_RELIC_AI_MCP_BUFFER_PATH;
       process.env.NEW_RELIC_AI_MCP_STORAGE_PATH = tmpDir;

--- a/src/hooks/subagent-watcher.test.ts
+++ b/src/hooks/subagent-watcher.test.ts
@@ -445,6 +445,70 @@ describe('SubagentWatcher', () => {
     expect(healthEvents).toHaveLength(1);
   });
 
+  it('emits a discovery_skipped health event when an agent filename does not match AGENT_ID_RE', () => {
+    // Malformed agent id: right prefix/suffix shape, wrong length/charset.
+    const badFile = join(sessionDir, 'subagents', 'agent-not-a-valid-id.jsonl');
+    writeFileSync(badFile, '');
+    const watcher = new SubagentWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+    watcher.poll();
+    const bufPath = join(storagePath, `buffer-${PARENT_SESSION}.jsonl`);
+    const exists = existsSync(bufPath);
+    const healthEvents = exists
+      ? readFileSync(bufPath, 'utf-8')
+          .split('\n')
+          .filter(Boolean)
+          .map((l) => JSON.parse(l))
+          .filter((l) => l.mode === 'observability_health' && l.event === 'discovery_skipped')
+      : [];
+    expect(healthEvents).toHaveLength(1);
+  });
+
+  it('does not re-emit the discovery_skipped event for the same malformed agent id on a second poll', () => {
+    const badFile = join(sessionDir, 'subagents', 'agent-not-a-valid-id.jsonl');
+    writeFileSync(badFile, '');
+    const watcher = new SubagentWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+    watcher.poll();
+    watcher.poll();
+    const bufPath = join(storagePath, `buffer-${PARENT_SESSION}.jsonl`);
+    const healthEvents = readFileSync(bufPath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
+      .filter((l) => l.mode === 'observability_health' && l.event === 'discovery_skipped');
+    expect(healthEvents).toHaveLength(1);
+  });
+
+  it('emits a discovery_skipped health event for a malformed agent id under a workflow run dir', () => {
+    const wfDir = join(sessionDir, 'subagents', 'workflows', 'wf_abc12345-6dd');
+    mkdirSync(wfDir, { recursive: true });
+    const badFile = join(wfDir, 'agent-not-a-valid-id.jsonl');
+    writeFileSync(badFile, '');
+    const watcher = new SubagentWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+    watcher.poll();
+    const bufPath = join(storagePath, `buffer-${PARENT_SESSION}.jsonl`);
+    const exists = existsSync(bufPath);
+    const healthEvents = exists
+      ? readFileSync(bufPath, 'utf-8')
+          .split('\n')
+          .filter(Boolean)
+          .map((l) => JSON.parse(l))
+          .filter((l) => l.mode === 'observability_health' && l.event === 'discovery_skipped')
+      : [];
+    expect(healthEvents).toHaveLength(1);
+  });
+
   // -------------------------------------------------------------------------
   // Memory-bound regression tests (OOM fix)
   //

--- a/src/hooks/subagent-watcher.ts
+++ b/src/hooks/subagent-watcher.ts
@@ -241,6 +241,9 @@ export class SubagentWatcher {
   // Files that already emitted `discovery_skipped` so we don't re-emit on
   // every poll for the same too-old file.
   private readonly discoverySkippedAnnounced = new Set<string>();
+  // Files shaped like `agent-*.jsonl` whose id doesn't match AGENT_ID_RE that
+  // already emitted `discovery_skipped`, so we don't re-emit on every poll.
+  private readonly agentIdMismatchAnnounced = new Set<string>();
   private lastCostSelfCheckMs = 0;
 
   constructor(options: SubagentWatcherOptions = {}) {
@@ -359,12 +362,16 @@ export class SubagentWatcher {
 
       // Each project dir contains <sessionId> subdirs whose name matches
       // SESSION_ID_RE (UUID v4 lower-hex with hyphens).
-      let sessionEntries: string[];
-      try {
-        sessionEntries = readdirSync(projectPath);
-      } catch {
-        continue;
-      }
+      // See workflow-watcher.ts's identical short-circuit for the rationale.
+      const sessionEntries: string[] = this.parentSessionFilter
+        ? [this.parentSessionFilter]
+        : (() => {
+            try {
+              return readdirSync(projectPath);
+            } catch {
+              return [];
+            }
+          })();
       for (const sessionId of sessionEntries) {
         if (!SESSION_ID_RE.test(sessionId)) continue;
         if (this.parentSessionFilter && sessionId !== this.parentSessionFilter) continue;
@@ -377,7 +384,10 @@ export class SubagentWatcher {
           for (const name of readdirSync(subDir)) {
             if (!name.startsWith('agent-') || !name.endsWith('.jsonl')) continue;
             const agentId = name.slice('agent-'.length, -'.jsonl'.length);
-            if (!AGENT_ID_RE.test(agentId)) continue;
+            if (!AGENT_ID_RE.test(agentId)) {
+              this.announceAgentIdMismatch(join(subDir, name));
+              continue;
+            }
             const path = join(subDir, name);
             const stat = this.filterByMtime(path, cutoffMs);
             if (stat) {
@@ -407,7 +417,10 @@ export class SubagentWatcher {
               for (const name of readdirSync(wfRunDir)) {
                 if (!name.startsWith('agent-') || !name.endsWith('.jsonl')) continue;
                 const agentId = name.slice('agent-'.length, -'.jsonl'.length);
-                if (!AGENT_ID_RE.test(agentId)) continue;
+                if (!AGENT_ID_RE.test(agentId)) {
+                  this.announceAgentIdMismatch(join(wfRunDir, name));
+                  continue;
+                }
                 const path = join(wfRunDir, name);
                 const stat = this.filterByMtime(path, cutoffMs);
                 if (stat) {
@@ -459,6 +472,27 @@ export class SubagentWatcher {
     } catch {
       return null;
     }
+  }
+
+  /** Emits a discovery_skipped health event, once per path, when a file
+   * shaped like `agent-*.jsonl` doesn't match AGENT_ID_RE — makes an id-format
+   * drift observable instead of a silent stop in subagent token capture. */
+  private announceAgentIdMismatch(path: string): void {
+    if (this.agentIdMismatchAnnounced.has(path)) return;
+    this.agentIdMismatchAnnounced.add(path);
+    this.appendHealth({
+      mode: 'observability_health',
+      tool: 'observability_health',
+      timestamp: Date.now(),
+      watcher: 'subagent',
+      filesWatched: 0,
+      linesRead: 0,
+      bytesRead: 0,
+      parseErrors: 0,
+      schemaDrifts: 0,
+      lastError: null,
+      event: 'discovery_skipped',
+    });
   }
 
   // -------------------------------------------------------------------------

--- a/src/hooks/workflow-watcher.test.ts
+++ b/src/hooks/workflow-watcher.test.ts
@@ -244,6 +244,13 @@ describe('WorkflowWatcher', () => {
     expect(runs).toHaveLength(0);
     // A discovery_skipped health event should be emitted exactly once.
     expect(health.filter((h) => h.event === 'discovery_skipped')).toHaveLength(1);
+
+    // Regression guard: a second poll must NOT re-emit discovery_skipped.
+    // The cold-skipped file's seenMtime guard entry is never part of the
+    // eviction-tracked `out` set, so a naive evictStale() would delete it
+    // every poll and cause this event to fire indefinitely instead of once.
+    watcher.poll();
+    expect(health.filter((h) => h.event === 'discovery_skipped')).toHaveLength(1);
   });
 
   it('resolves the sibling scripts/ dir and parses topology on POSIX-style paths', () => {
@@ -352,5 +359,54 @@ describe('WorkflowWatcher', () => {
     // no run and the parse error path must not throw.
     expect(() => watcher.poll()).not.toThrow();
     expect(runs).toHaveLength(0);
+  });
+
+  it('evicts seenMtime/emittedRuns entries once a run file disappears from the discovered set', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wf-evict-'));
+    const sessionId = '11111111-1111-1111-1111-111111111111';
+    const wfDir = join(root, 'proj', sessionId, 'workflows');
+    mkdirSync(wfDir, { recursive: true });
+    const runPath = join(wfDir, 'wf_evicttest.json');
+    writeFileSync(
+      runPath,
+      JSON.stringify({ runId: 'wf_evicttest', status: 'completed', startTime: Date.now() }),
+    );
+
+    const watcher = new WorkflowWatcher({ projectsDir: root, parentSessionId: sessionId });
+    watcher.poll();
+    // @ts-expect-error -- reaching into private state for the eviction assertion
+    expect(watcher.seenMtime.size).toBe(1);
+    // @ts-expect-error -- reaching into private state for the eviction assertion
+    expect(watcher.emittedRuns.size).toBe(1);
+
+    rmSync(runPath);
+    watcher.poll();
+    // @ts-expect-error -- reaching into private state for the eviction assertion
+    expect(watcher.seenMtime.size).toBe(0);
+    // @ts-expect-error -- reaching into private state for the eviction assertion
+    expect(watcher.emittedRuns.size).toBe(0);
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('discovers the same run whether or not parentSessionId is set, with or without unrelated sibling sessions', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wf-shortcircuit-'));
+    const target = '22222222-2222-2222-2222-222222222222';
+    const other = '33333333-3333-3333-3333-333333333333';
+    for (const sid of [target, other]) {
+      mkdirSync(join(root, 'proj', sid, 'workflows'), { recursive: true });
+    }
+    writeFileSync(
+      join(root, 'proj', target, 'workflows', 'wf_short.json'),
+      JSON.stringify({ runId: 'wf_short', status: 'completed', startTime: Date.now() }),
+    );
+
+    const seen: string[] = [];
+    const watcher = new WorkflowWatcher({ projectsDir: root, parentSessionId: target });
+    watcher.setOnRun((run) => seen.push(run.workflow_run_id));
+    watcher.poll();
+
+    expect(seen).toEqual(['wf_short']);
+    rmSync(root, { recursive: true, force: true });
   });
 });

--- a/src/hooks/workflow-watcher.ts
+++ b/src/hooks/workflow-watcher.ts
@@ -93,6 +93,11 @@ export class WorkflowWatcher {
   private readonly seenMtime = new Map<string, number>();
   private readonly emittedRuns = new Set<string>();
   private readonly topologyCache = new Map<string, DeclaredTopology | null>();
+  // Paths whose seenMtime entry exists only to guard a one-time
+  // discovery_skipped health event (see the cold-scan-skip branch in
+  // discoverFiles()) — these never enter the processed `out` set, so
+  // evictStale() must never delete them based on currentPaths membership.
+  private readonly coldSkipGuards = new Set<string>();
 
   // Health counters
   private filesWatched = 0;
@@ -152,7 +157,11 @@ export class WorkflowWatcher {
     try {
       const files = this.discoverFiles();
       this.filesWatched = files.length;
+      const currentPaths = new Set<string>();
+      const currentRunIds = new Set<string>();
       for (const file of files) {
+        currentPaths.add(file.path);
+        currentRunIds.add(file.runId);
         let st;
         try {
           st = statSync(file.path);
@@ -164,8 +173,37 @@ export class WorkflowWatcher {
         this.seenMtime.set(file.path, st.mtimeMs);
         this.processFile(file, st.mtimeMs);
       }
+      this.evictStale(currentPaths, currentRunIds);
     } catch (err) {
       this.recordError(err);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Eviction
+  // -------------------------------------------------------------------------
+
+  // Drops bookkeeping for paths/runs no longer present in the current
+  // discovered set, mirroring SubagentWatcher.evictStalePartials() — without
+  // this, seenMtime/emittedRuns/topologyCache grow for the process lifetime in
+  // a long-lived --local dashboard, scaling with total historical run count
+  // rather than active run count. topologyCache is keyed by the
+  // content-derived runId, which can (rarely) differ from file.runId — an
+  // over-eager evict there just forces a cache-miss recompute next access,
+  // never a correctness issue. seenMtime entries in coldSkipGuards are
+  // exempt from currentPaths-based eviction — they belong to files that
+  // never enter the processed `out` set (see discoverFiles()), so they'd
+  // otherwise be deleted and re-added every poll, re-emitting the
+  // discovery_skipped health event indefinitely instead of just once.
+  private evictStale(currentPaths: ReadonlySet<string>, currentRunIds: ReadonlySet<string>): void {
+    for (const path of this.seenMtime.keys()) {
+      if (!currentPaths.has(path) && !this.coldSkipGuards.has(path)) this.seenMtime.delete(path);
+    }
+    for (const runId of this.emittedRuns) {
+      if (!currentRunIds.has(runId)) this.emittedRuns.delete(runId);
+    }
+    for (const runId of this.topologyCache.keys()) {
+      if (!currentRunIds.has(runId)) this.topologyCache.delete(runId);
     }
   }
 
@@ -194,12 +232,20 @@ export class WorkflowWatcher {
       }
       if (!st.isDirectory()) continue;
 
-      let sessionEntries: string[];
-      try {
-        sessionEntries = readdirSync(projectPath);
-      } catch {
-        continue;
-      }
+      // When a parent session filter is set (the common case for a
+      // per-session --stdio server instance), skip listing every sibling
+      // session in this project — go straight to the one directory we care
+      // about. Falls back to the full listing only when no filter is set
+      // (e.g. --local, which watches every session).
+      const sessionEntries: string[] = this.parentSessionFilter
+        ? [this.parentSessionFilter]
+        : (() => {
+            try {
+              return readdirSync(projectPath);
+            } catch {
+              return [];
+            }
+          })();
       for (const sessionId of sessionEntries) {
         if (!SESSION_ID_RE.test(sessionId)) continue;
         if (this.parentSessionFilter && sessionId !== this.parentSessionFilter) continue;
@@ -224,9 +270,13 @@ export class WorkflowWatcher {
             // Skip cold-scan of files older than the discovery budget. The
             // first time we encounter such a file we emit a discovery_skipped
             // health event so the operator can tell why a known run is absent
-            // from the dashboard.
+            // from the dashboard. This path is never pushed to `out`, so it
+            // never counts toward filesWatched/currentPaths — coldSkipGuards
+            // records it separately so evictStale() knows to spare its
+            // seenMtime entry (see the comment there).
             if (!this.seenMtime.has(path)) {
               this.seenMtime.set(path, fst.mtimeMs);
+              this.coldSkipGuards.add(path);
               this.emitHealth({ event: 'discovery_skipped' });
             }
             continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -782,7 +782,7 @@ async function main(): Promise<void> {
     if (options.stdio && !isProvisional) localStore.writeHeartbeat();
     localStoreForShutdown = localStore;
 
-    // Migrate any pre-Fix-3 events from the legacy shared `buffer.jsonl` into
+    // Migrate any pre-existing events from the legacy shared `buffer.jsonl` into
     // per-session files. Idempotent and a no-op on fresh installs.
     try {
       localStore.migrateLegacyBuffer();

--- a/src/metrics/anti-patterns.test.ts
+++ b/src/metrics/anti-patterns.test.ts
@@ -138,7 +138,7 @@ describe('Re-reading detection', () => {
     expect(reReading[0].readCount).toBe(4);
   });
 
-  it('detects when file read exactly at threshold (3 times) (B-04)', () => {
+  it('detects when file read exactly at threshold (3 times)', () => {
     const detector = new AntiPatternDetector();
 
     const calls: ToolCallRecord[] = [
@@ -307,7 +307,7 @@ describe('Blind editing detection', () => {
     expect(blind[0].editCount).toBe(4);
   });
 
-  it('detects exactly at threshold (3 edits) without verification (B-04)', () => {
+  it('detects exactly at threshold (3 edits) without verification', () => {
     const detector = new AntiPatternDetector();
 
     const calls: ToolCallRecord[] = [

--- a/src/metrics/cost-tracker.test.ts
+++ b/src/metrics/cost-tracker.test.ts
@@ -816,7 +816,7 @@ describe('CostTracker', () => {
       const pct = tracker.getSubagentMetrics().subagentSharePct;
       expect(pct).toBeGreaterThan(0);
       expect(pct).toBeLessThan(100);
-      // reconciliationDeltaPct is null (Phase 3 placeholder)
+      // reconciliationDeltaPct is null (not yet computed)
       expect(tracker.getSubagentMetrics().reconciliationDeltaPct).toBeNull();
     });
 

--- a/src/metrics/cost-tracker.ts
+++ b/src/metrics/cost-tracker.ts
@@ -54,7 +54,7 @@ const LATE_ARRIVAL_REJECTION_MS = 48 * 60 * 60 * 1000;
 
 export interface CostMetrics {
   readonly sessionTotalCostUsd: number | null;
-  readonly costByTask: null; // stub — task boundary detection is Phase 2.3
+  readonly costByTask: null; // stub — task boundary detection is not yet implemented
   readonly costByModel: Record<string, number>;
   readonly costPerLineOfCode: number | null;
   readonly costPerFileModified: number | null;
@@ -85,7 +85,7 @@ export interface SubagentMetrics {
   readonly parentUsd: number;
   readonly subagentSharePct: number;
   /**
-   * Placeholder for Phase 3 reconciliation: the delta between total tokens
+   * Placeholder for future reconciliation: the delta between total tokens
    * reported by a WorkflowRunEvent and the sum of per-subagent cost. null
    * until at least one workflow run has both totals available.
    */
@@ -330,7 +330,7 @@ export class CostTracker {
   /**
    * Subagent / parent cost split for the current session.
    *
-   * `reconciliationDeltaPct` is a Phase 3 placeholder: it will compare the
+   * `reconciliationDeltaPct` is a placeholder: it will compare the
    * total tokens reported by WorkflowRunEvent against the sum of per-subagent
    * cost to detect attribution gaps. Returns null until that data is available.
    */

--- a/src/metrics/recommendation-engine.ts
+++ b/src/metrics/recommendation-engine.ts
@@ -1,5 +1,5 @@
 /**
- * Unified Recommendation Engine — synthesizes all Phase 4 analyzers into
+ * Unified Recommendation Engine — synthesizes all analyzers into
  * a single prioritized, deduplicated recommendation list.
  *
  * Categories:

--- a/src/multi-instance.integration.test.ts
+++ b/src/multi-instance.integration.test.ts
@@ -27,7 +27,7 @@ import type { AddressInfo } from 'node:net';
 //        per-session-correct data, not polluted across sessions.
 //   #6 — Only one of the three MCPs binds the dashboard port; the other two
 //        log the "Dashboard already owned by..." graceful-handoff line
-//        introduced by Fix 1.
+//        introduced by that change.
 //
 // Sequencing notes:
 //   - We pre-write 50 hook events (25 pre + 25 post) to each session's
@@ -63,7 +63,7 @@ interface ChildHandle {
 }
 
 beforeAll(() => {
-  // Rebuild when the binary is missing OR when it predates the Fix 1 / Fix 3
+  // Rebuild when the binary is missing OR when it predates the
   // landmarks the test depends on. The latter guards against a stale dist
   // left over from a pre-merge checkout — without this the test would fail
   // with "session_id randomly generated" / "Dashboard port ... in use"
@@ -223,7 +223,7 @@ describe('multi-instance integration (proposal #11)', () => {
   }, 30_000);
 
   // -----------------------------------------------------------------------
-  // Task #13: dashboard ownership re-poll. After Fix 1 the second MCP runs
+  // Dashboard ownership re-poll. After this fix the second MCP runs
   // headless. This test verifies it takes over the dashboard if the owner
   // exits — without this the dashboard goes dead even though a live MCP
   // could serve it.
@@ -389,7 +389,7 @@ function spawnChild(
       // collisions when multiple children share the same parent test process.
       CLAUDE_JOB_DIR: jobDir,
       // All three children compete for the same dashboard port to exercise
-      // Fix 1's EADDRINUSE handoff.
+      // The EADDRINUSE handoff.
       NR_AI_DASHBOARD_PORT: String(port),
       NEW_RELIC_LICENSE_KEY: '',
       NEW_RELIC_ACCOUNT_ID: '',

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -355,10 +355,10 @@ describe('LocalStore', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Fix 3: per-session buffer files
+  // Per-session buffer files
   // ---------------------------------------------------------------------------
 
-  describe('per-session buffer scoping (Fix 3)', () => {
+  describe('per-session buffer scoping', () => {
     it('uses buffer-<sessionId>.jsonl when a sessionId is passed', () => {
       const store = new LocalStore(tmpDir, 'sess-abc-123');
       mkdirSync(tmpDir, { recursive: true });
@@ -700,7 +700,7 @@ describe('LocalStore', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Task #18: orphan buffer + breadcrumb GC
+  // Orphan buffer + breadcrumb GC
   // ---------------------------------------------------------------------------
 
   describe('writeHeartbeat / removeHeartbeat', () => {

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -174,7 +174,7 @@ export class LocalStore {
     }
     for (const name of entries) {
       // Per-session: buffer-<id>.jsonl. Also pick up the legacy shared
-      // buffer.jsonl so a freshly-upgraded user's pre-Fix-3 events still flow.
+      // buffer.jsonl so a freshly-upgraded user's pre-existing events still flow.
       if (!name.endsWith('.jsonl')) continue;
       if (name !== 'buffer.jsonl' && !name.startsWith('buffer-')) continue;
       const drained = this.drainPath(resolve(this.storagePath, name));
@@ -712,7 +712,7 @@ export class LocalStore {
   }
 
   /**
-   * Migrate any pre-Fix-3 events left in the legacy shared `buffer.jsonl` into
+   * Migrate any pre-existing events left in the legacy shared `buffer.jsonl` into
    * per-session `buffer-<sessionId>.jsonl` files, then delete the legacy file.
    * Idempotent: returns 0 when the legacy file is absent or already empty.
    *

--- a/src/tools/cost-tools.test.ts
+++ b/src/tools/cost-tools.test.ts
@@ -102,7 +102,7 @@ describe('handleReportTokens()', () => {
     expect(metrics.totalCacheCreationTokens).toBe(500);
   });
 
-  it('totalTokens excludes cache tokens to match Anthropic dashboard convention (B-03)', () => {
+  it('totalTokens excludes cache tokens to match Anthropic dashboard convention', () => {
     const tracker = new CostTracker();
     const args: TokenReport = {
       input_tokens: 1_000,

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -551,7 +551,7 @@ describe('Cross-session tool handlers', () => {
   });
 
   // -------------------------------------------------------------------------
-  // 11. get_platform_comparison — error_rate weighted formula (B-02)
+  // 11. get_platform_comparison — error_rate weighted formula
   // -------------------------------------------------------------------------
 
   it('handleGetPlatformComparison error_rate uses weighted formula across sessions', () => {

--- a/src/tools/extended-analytics-tools.ts
+++ b/src/tools/extended-analytics-tools.ts
@@ -1,5 +1,5 @@
 /**
- * MCP tool handlers for extended metric trackers (Phase 2).
+ * MCP tool handlers for extended metric trackers.
  *
  * Defines and handles:
  *   - nr_observe_get_retry_alerts — thrashing/retry detection alerts

--- a/src/tools/session-stats.test.ts
+++ b/src/tools/session-stats.test.ts
@@ -804,7 +804,7 @@ describe('Cross-session tool registration', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Fix 3: pre-resolution gating via registerPendingTools()
+// Pre-resolution gating via registerPendingTools()
 // ---------------------------------------------------------------------------
 
 describe('registerPendingTools()', () => {

--- a/src/tools/workflow-tools.test.ts
+++ b/src/tools/workflow-tools.test.ts
@@ -437,7 +437,7 @@ describe('handleGetEfficiencyScore()', () => {
     expect(scorer.getScores()).toHaveLength(1);
   });
 
-  it('latest reflects the active task after updateScore, not a later-inserted completed task (B-05)', () => {
+  it('latest reflects the active task after updateScore, not a later-inserted completed task', () => {
     const scorer = new EfficiencyScorer();
 
     // Score active task first (inserted at index 0), endTime = 1000
@@ -671,10 +671,10 @@ describe('FeedbackCollector.emitMetrics()', () => {
 });
 
 // ---------------------------------------------------------------------------
-// MCP protocol integration — all Phase 2 tools
+// MCP protocol integration — all workflow tools
 // ---------------------------------------------------------------------------
 
-describe('MCP protocol integration — Phase 2 tools', () => {
+describe('MCP protocol integration — workflow tools', () => {
   let server: NrMcpServer;
   let client: Client;
   let costTracker: CostTracker;
@@ -713,7 +713,7 @@ describe('MCP protocol integration — Phase 2 tools', () => {
     await server.close();
   });
 
-  it('tools/list includes all Phase 2 tools with correct schemas', async () => {
+  it('tools/list includes all workflow tools with correct schemas', async () => {
     const result = await client.listTools();
     const names = result.tools.map((t) => t.name);
 

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -919,11 +919,11 @@ describe('codingTaskToNrEvent()', () => {
     expect(event.end_time).toBe(1_700_000_060_000);
   });
 
-  it('sets session_id from the resolved sessionTraceId, not the tool call record (Fix 3)', () => {
+  it('sets session_id from the resolved sessionTraceId, not the tool call record', () => {
     const task = makeTask({
       toolCalls: [makeRecord({ sessionId: 'sess-from-record' })],
     });
-    // No sessionTraceId provided — Fix 3 removes the fallback to firstRecord.sessionId
+    // No sessionTraceId provided — there is no fallback to firstRecord.sessionId
     // because the MCP no longer fabricates its own ID; the resolved Claude Code
     // session_id is shared across all events of a session.
     const event = codingTaskToNrEvent(task, { developer: 'd', appName: 'a' });
@@ -1231,12 +1231,12 @@ describe('session trace ID propagation', () => {
     expect(event.session_id).toBe(TRACE_ID);
   });
 
-  it('codingTaskToNrEvent: omits session_id when sessionTraceId is absent (Fix 3 removes record fallback)', () => {
+  it('codingTaskToNrEvent: omits session_id when sessionTraceId is absent', () => {
     const task = makeTask({
       toolCalls: [makeRecord({ sessionId: 'record-session-id' })],
     });
     const event = codingTaskToNrEvent(task, { developer: 'dev', appName: 'app' });
-    // Fix 3: no longer falls back to firstRecord.sessionId. The resolved
+    // No longer falls back to firstRecord.sessionId. The resolved
     // sessionTraceId is the single source of truth for session_id on events.
     expect(event).not.toHaveProperty('session_id');
   });

--- a/src/transport/nr-ingest.ts
+++ b/src/transport/nr-ingest.ts
@@ -356,7 +356,7 @@ export function codingTaskToNrEvent(
   if (attrs.projectId) event.project_id = attrs.projectId;
   if (attrs.orgId) event.org_id = attrs.orgId;
 
-  // Fix 3: sessionTraceId is the resolved Claude Code session_id; the
+  // sessionTraceId is the resolved Claude Code session_id; the
   // firstRecord?.sessionId fallback was only meaningful when the MCP fabricated
   // its own UUID and lost cross-reference with the tool-call records.
   if (attrs.sessionTraceId != null) event.session_id = attrs.sessionTraceId;
@@ -662,7 +662,7 @@ export function workflowRunToNrEvent(
   if (attrs.orgId) event.org_id = attrs.orgId;
 
   // Prefer the resolved Claude Code session ID when threaded through the
-  // manager (matches Fix 3 on codingTaskToNrEvent); otherwise fall back to
+  // manager (matches codingTaskToNrEvent); otherwise fall back to
   // the session ID baked into the tracker output.
   const resolvedSessionId = attrs.sessionTraceId ?? metrics.session_id;
   if (resolvedSessionId) event.session_id = resolvedSessionId;

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -815,8 +815,15 @@ export const postDigestSend = (): Promise<DigestSendResponse> =>
     return (await r.json()) as DigestSendResponse;
   });
 
-export const fetchObservabilityHealth = (): Promise<unknown> =>
-  getJson<unknown>('/api/observability-health');
+export interface ObservabilityHealthResponse {
+  readonly watcherActive?: boolean;
+  readonly watcherDisabledByLock?: boolean;
+  readonly filesWatched?: number;
+  readonly parseErrors?: number;
+}
+
+export const fetchObservabilityHealth = (): Promise<ObservabilityHealthResponse> =>
+  getJson<ObservabilityHealthResponse>('/api/observability-health');
 type WorkflowRunStatus = 'running' | 'completed' | 'failed' | 'cancelled' | 'unknown';
 
 // Mirrors WorkflowRunDto serialized by both GET /api/workflows (list, one

--- a/src/web/components/AgentSwimlanes.tsx
+++ b/src/web/components/AgentSwimlanes.tsx
@@ -1,6 +1,14 @@
 import { useMemo, useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { formatNumber, formatDuration, formatUsdOrDash, shortToolName } from '../lib/format';
+import { formatNumber, formatDuration, formatUsdOrDash, shortToolName } from '../lib/format.js';
+import {
+  groupAgents,
+  GROUP_BAR_COLORS,
+  PARENT_GROUP_ID,
+  ADHOC_GROUP_ID,
+  subagentGroupId,
+  fmtTickLabel,
+} from '../lib/agent-groups.js';
 
 // The canonical AgentSpan type now lives in api/client.ts (it mirrors a wire
 // response, not a component-local shape) — re-exported here so none of this
@@ -24,22 +32,6 @@ export interface AgentSwimlanesProps {
   readonly onSelectRun?: (runId: string) => void;
 }
 
-// Cycle the dedicated categorical "series" ramp, one hue per workflow group.
-// These are purpose-built grouping tokens: lower-saturation and visually
-// distinct from the saturated status/tool accents, so a group bar reads as a
-// CATEGORY rather than a status. They carry no semantic meaning (unlike green
-// =success, amber=warning, teal="Agent", red=danger). Index is the group's
-// position once sorted by earliest startMs, so colors are stable for a given
-// session render.
-const GROUP_BAR_COLORS = [
-  'bg-series-1',
-  'bg-series-2',
-  'bg-series-3',
-  'bg-series-4',
-  'bg-series-5',
-  'bg-series-6',
-] as const;
-
 // Tool → accent color for the parent activity lane. Replicated from
 // GanttTimeline.getBarColor (intentionally NOT imported — we don't depend on
 // that component). These accents legitimately encode TOOL TYPE here, the same
@@ -50,61 +42,6 @@ function getParentBarColor(toolName: string): string {
   if (toolName === 'Bash') return 'bg-accent-purple';
   if (toolName === 'Agent') return 'bg-accent-teal';
   return 'bg-ink-subtle';
-}
-
-// mm:ss relative to the window start — same axis style as GanttTimeline.
-function fmtTickLabel(ms: number): string {
-  const totalSec = Math.floor(ms / 1000);
-  const min = Math.floor(totalSec / 60);
-  const sec = totalSec % 60;
-  return `${min}:${String(sec).padStart(2, '0')}`;
-}
-
-interface AgentGroup {
-  readonly runId: string | null;
-  readonly name: string;
-  readonly earliestStartMs: number;
-  readonly agents: AgentSpan[];
-}
-
-// Group agents by workflowRunId. Null runId agents collapse into a single
-// "Ad-hoc subagents" group. Groups are sorted by their earliest agent start.
-function groupAgents(agents: AgentSpan[]): AgentGroup[] {
-  const byRun = new Map<string | null, AgentSpan[]>();
-  for (const agent of agents) {
-    const key = agent.workflowRunId;
-    const bucket = byRun.get(key);
-    if (bucket) {
-      bucket.push(agent);
-    } else {
-      byRun.set(key, [agent]);
-    }
-  }
-
-  const groups: AgentGroup[] = [];
-  for (const [runId, members] of byRun) {
-    const sortedMembers = [...members].sort((a, b) => a.startMs - b.startMs);
-    const earliestStartMs = sortedMembers.reduce(
-      (m, a) => Math.min(m, a.startMs),
-      Number.POSITIVE_INFINITY,
-    );
-    const name = runId === null ? 'Ad-hoc subagents' : (members[0]?.workflowName ?? 'Workflow run');
-    groups.push({ runId, name, earliestStartMs, agents: sortedMembers });
-  }
-
-  groups.sort((a, b) => a.earliestStartMs - b.earliestStartMs);
-  return groups;
-}
-
-// Stable group id used to key collapse state. The parent lane gets a reserved
-// id; subagent groups key off their runId (with a fixed token for the ad-hoc
-// null-runId group). Stable across re-renders so a user's expand/collapse
-// choice sticks even as data refreshes.
-const PARENT_GROUP_ID = '__parent__';
-const ADHOC_GROUP_ID = '__adhoc__';
-
-function subagentGroupId(runId: string | null): string {
-  return runId === null ? ADHOC_GROUP_ID : `run:${runId}`;
 }
 
 // Groups with more than this many lanes start collapsed so the chart doesn't

--- a/src/web/components/AlertBanner.test.tsx
+++ b/src/web/components/AlertBanner.test.tsx
@@ -31,7 +31,7 @@ describe('AlertBanner', () => {
   });
 
   // role="alert" implies aria-live="assertive"; role="status" implies "polite".
-  // The explicit aria-live attribute was removed in F-048 because both roles
+  // The explicit aria-live attribute was removed because both roles
   // carry the live-region semantic by default per the ARIA spec.
   it('uses role="alert" for critical severity (assertive)', () => {
     const { container } = render(

--- a/src/web/components/AlertBannerStack.test.tsx
+++ b/src/web/components/AlertBannerStack.test.tsx
@@ -116,13 +116,13 @@ describe('AlertBannerStack', () => {
     expect(screen.getAllByRole('button', { name: 'Dismiss alert' }).length).toBe(1);
   });
 
-  // F-015: once the user expands a 5+ stack and the count drops below the
+  // Once the user expands a 5+ stack and the count drops below the
   // threshold (e.g., dismisses 2 down to 4), the expanded path renders
   // without a collapse button — there's no way to recollapse without
   // reloading the page. The fix resets `expanded` when count falls back
   // below the threshold so the next time it crosses, the stack starts
   // collapsed again.
-  it('resets expanded state when count drops below the collapse threshold (F-015)', () => {
+  it('resets expanded state when count drops below the collapse threshold', () => {
     for (let i = 0; i < 6; i++) {
       fireOne({ id: `r-${i}`, title: `Rule ${i}` });
     }

--- a/src/web/components/AlertBannerStack.tsx
+++ b/src/web/components/AlertBannerStack.tsx
@@ -29,7 +29,7 @@ export function AlertBannerStack(): JSX.Element | null {
   const { alerts, maxSeverity, count, dismiss } = useLiveAlerts();
   const [expanded, setExpanded] = useState(false);
 
-  // F-015: when count drops back below the collapse threshold the expanded
+  // When count drops back below the collapse threshold the expanded
   // path renders without a collapse button (because count < threshold), so
   // a stuck-expanded user could never recollapse without reloading. Reset
   // expanded so the next time the threshold is crossed it starts collapsed.

--- a/src/web/components/ErrorBoundary.tsx
+++ b/src/web/components/ErrorBoundary.tsx
@@ -15,7 +15,7 @@ interface ErrorBoundaryState {
 /**
  * Catches render-time errors anywhere in the subtree and renders a recoverable
  * fallback UI instead of letting React unmount the entire root and white-screen
- * the dashboard. See finding F-004.
+ * the dashboard.
  */
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null };

--- a/src/web/components/GanttTimeline.test.tsx
+++ b/src/web/components/GanttTimeline.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { GanttTimeline } from './GanttTimeline';
+
+const ENTRIES = [
+  { timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true },
+  { timestamp: 2_000, toolName: 'Edit', durationMs: 240, success: true },
+  { timestamp: 500, toolName: 'Bash', durationMs: 80, success: false },
+];
+
+describe('GanttTimeline', () => {
+  it('renders one row per entry, sorted by timestamp ascending', () => {
+    render(<GanttTimeline entries={ENTRIES} segments={[]} />);
+    const rowLabels = screen.getAllByTitle(/^(Read|Edit|Bash)$/);
+    expect(rowLabels.map((el) => el.textContent)).toEqual(['Bash', 'Read', 'Edit']);
+  });
+
+  it('shows the empty state when entries is empty', () => {
+    render(<GanttTimeline entries={[]} segments={[]} />);
+    expect(screen.getByText('No tool calls recorded.')).toBeInTheDocument();
+  });
+
+  it('highlights a row whose original index falls inside a segment', () => {
+    // Segment covers original indices [0, 1] = Read, Edit (pre-sort order).
+    render(
+      <GanttTimeline
+        entries={ENTRIES}
+        segments={[{ type: 'thrashing', startIndex: 0, endIndex: 1, severity: 'critical' }]}
+      />,
+    );
+    // Sanity: component still renders all 3 rows with a segment applied.
+    expect(screen.getAllByTitle(/^(Read|Edit|Bash)$/)).toHaveLength(3);
+  });
+
+  it('gives each bar an accessible name with tool, duration, and outcome', () => {
+    render(<GanttTimeline entries={ENTRIES} segments={[]} />);
+    expect(screen.getByRole('img', { name: 'Read · 120ms · success' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Edit · 240ms · success' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Bash · 80ms · failed' })).toBeInTheDocument();
+  });
+});

--- a/src/web/components/GanttTimeline.tsx
+++ b/src/web/components/GanttTimeline.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { shortToolName } from '../lib/format.js';
 
 interface GanttTimelineEntry {
@@ -73,17 +73,52 @@ export function GanttTimeline({
 }: GanttTimelineProps): JSX.Element {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
-  if (entries.length === 0) {
-    return <div className="text-ink-muted text-xs">No tool calls recorded.</div>;
-  }
-
   // Sort by timestamp so out-of-order entries (clock skew, live injection) don't
   // produce negative offsets or clip bars behind the label column. Carry the
   // original index so segment indices (which refer to the unsorted `entries`)
-  // still map to the right rows after sorting.
-  const sorted = entries
-    .map((entry, originalIdx) => ({ entry, originalIdx }))
-    .sort((a, b) => a.entry.timestamp - b.entry.timestamp);
+  // still map to the right rows after sorting. Memoized: this component is now
+  // embedded repeatedly in SessionTrace (parent lane + every expanded agent's
+  // call list, sometimes thousands of rows), and hovering any bar triggers a
+  // setHoveredIndex re-render — without memoization every mouse move across
+  // bars re-sorts and rebuilds the segment map from scratch.
+  const sorted = useMemo(
+    () =>
+      entries
+        .map((entry, originalIdx) => ({ entry, originalIdx }))
+        .sort((a, b) => a.entry.timestamp - b.entry.timestamp),
+    [entries],
+  );
+
+  // Build per-row segment lookup. Segment indices reference the original
+  // `entries` order; map them through the sort so highlights land on the
+  // right row when entries arrive out of timestamp order. Also memoized —
+  // see rationale above.
+  const segmentAt = useMemo(() => {
+    const originalToSorted = new Map<number, number>();
+    for (let i = 0; i < sorted.length; i++) {
+      originalToSorted.set(sorted[i]!.originalIdx, i);
+    }
+    const segmentAt: (GanttSegment | null)[] = new Array(sorted.length).fill(null);
+    for (const seg of segments) {
+      const start = Math.max(0, seg.startIndex);
+      const end = Math.min(seg.endIndex, entries.length - 1);
+      for (let i = start; i <= end; i++) {
+        const sIdx = originalToSorted.get(i);
+        if (sIdx === undefined) continue;
+        if (
+          segmentAt[sIdx] === null ||
+          (seg.severity === 'critical' && segmentAt[sIdx]!.severity !== 'critical')
+        ) {
+          segmentAt[sIdx] = seg;
+        }
+      }
+    }
+    return segmentAt;
+  }, [sorted, segments, entries.length]);
+
+  if (entries.length === 0) {
+    return <div className="text-ink-muted text-xs">No tool calls recorded.</div>;
+  }
 
   // A shared window is supplied only when BOTH bounds are present. In that mode
   // the reference frame (firstTs + totalDuration) comes from the caller so this
@@ -118,29 +153,6 @@ export function GanttTimeline({
   const ticks: number[] = [];
   for (let t = tickIntervalMs; t < totalDuration; t += tickIntervalMs) {
     ticks.push(t);
-  }
-
-  // Build per-row segment lookup. Segment indices reference the original
-  // `entries` order; map them through the sort so highlights land on the
-  // right row when entries arrive out of timestamp order.
-  const segmentAt: (GanttSegment | null)[] = new Array(sorted.length).fill(null);
-  const originalToSorted = new Map<number, number>();
-  for (let i = 0; i < sorted.length; i++) {
-    originalToSorted.set(sorted[i]!.originalIdx, i);
-  }
-  for (const seg of segments) {
-    const start = Math.max(0, seg.startIndex);
-    const end = Math.min(seg.endIndex, entries.length - 1);
-    for (let i = start; i <= end; i++) {
-      const sIdx = originalToSorted.get(i);
-      if (sIdx === undefined) continue;
-      if (
-        segmentAt[sIdx] === null ||
-        (seg.severity === 'critical' && segmentAt[sIdx]!.severity !== 'critical')
-      ) {
-        segmentAt[sIdx] = seg;
-      }
-    }
   }
 
   const maxStaggerMs = 800;
@@ -199,6 +211,8 @@ export function GanttTimeline({
               </div>
               <div className="relative flex-1 h-full flex items-center">
                 <div
+                  role="img"
+                  aria-label={`${entry.toolName} · ${entry.durationMs != null ? `${entry.durationMs}ms` : 'unknown'} · ${entry.success ? 'success' : 'failed'}`}
                   className={`gantt-bar absolute h-5 rounded-sm opacity-80 ${getBarColor(shortToolName(entry.toolName))} ${!entry.success ? 'ring-1 ring-accent-red/60' : ''}`}
                   style={{
                     left: `${leftPct}%`,

--- a/src/web/components/SessionTrace.tsx
+++ b/src/web/components/SessionTrace.tsx
@@ -14,6 +14,15 @@ import {
   fmtElapsed,
   shortToolName,
 } from '../lib/format.js';
+import {
+  groupAgents,
+  GROUP_BAR_COLORS,
+  PARENT_GROUP_ID,
+  ADHOC_GROUP_ID,
+  subagentGroupId,
+  fmtTickLabel as fmtSpanLabel,
+  type AgentGroup,
+} from '../lib/agent-groups.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -58,64 +67,6 @@ export interface SessionTraceProps {
   readonly parentSegments?: ReadonlyArray<ParentSegment>;
 }
 
-// ---------------------------------------------------------------------------
-// Grouping (mirrors AgentSwimlanes.groupAgents so the two charts agree on how
-// subagents bucket by workflow run — this is the chart that replaces it).
-// ---------------------------------------------------------------------------
-
-interface AgentGroup {
-  readonly runId: string | null;
-  readonly name: string;
-  readonly earliestStartMs: number;
-  readonly agents: ReadonlyArray<AgentSpan>;
-}
-
-function groupAgents(agents: ReadonlyArray<AgentSpan>): AgentGroup[] {
-  const byRun = new Map<string | null, AgentSpan[]>();
-  for (const agent of agents) {
-    const bucket = byRun.get(agent.workflowRunId);
-    if (bucket) {
-      bucket.push(agent);
-    } else {
-      byRun.set(agent.workflowRunId, [agent]);
-    }
-  }
-
-  const groups: AgentGroup[] = [];
-  for (const [runId, members] of byRun) {
-    const sortedMembers = [...members].sort((a, b) => a.startMs - b.startMs);
-    const earliestStartMs = sortedMembers.reduce(
-      (m, a) => Math.min(m, a.startMs),
-      Number.POSITIVE_INFINITY,
-    );
-    const name = runId === null ? 'Ad-hoc subagents' : (members[0]?.workflowName ?? 'Workflow run');
-    groups.push({ runId, name, earliestStartMs, agents: sortedMembers });
-  }
-
-  groups.sort((a, b) => a.earliestStartMs - b.earliestStartMs);
-  return groups;
-}
-
-// Cycle the dedicated categorical "series" ramp, one hue per workflow group —
-// matches AgentSwimlanes so a given session renders the same group colors here.
-// These tokens carry no semantic meaning (unlike green=success / red=danger);
-// the swatch reads as a CATEGORY. Index is the group's sorted position.
-const GROUP_BAR_COLORS = [
-  'bg-series-1',
-  'bg-series-2',
-  'bg-series-3',
-  'bg-series-4',
-  'bg-series-5',
-  'bg-series-6',
-] as const;
-
-const PARENT_GROUP_ID = '__parent__';
-const ADHOC_GROUP_ID = '__adhoc__';
-
-function subagentGroupId(runId: string | null): string {
-  return runId === null ? ADHOC_GROUP_ID : `run:${runId}`;
-}
-
 // Groups with more than this many agents start collapsed so the trace doesn't
 // open at an unreasonable height. Users can still expand them. Drives the
 // INITIAL collapse state only — the segmented control overrides it wholesale.
@@ -127,14 +78,6 @@ const AUTO_COLLAPSE_AGENT_THRESHOLD = 15;
 // all bars column-aligned under the one axis. Wider than the standalone w-24
 // default so longer agent labels (e.g. "investigate:…") don't truncate badly.
 const TRACE_GUTTER = 'w-44';
-
-// mm:ss span label, same style as AgentSwimlanes' group summary.
-function fmtSpanLabel(ms: number): string {
-  const totalSec = Math.floor(ms / 1000);
-  const min = Math.floor(totalSec / 60);
-  const sec = totalSec % 60;
-  return `${min}:${String(sec).padStart(2, '0')}`;
-}
 
 // Three-level expand/collapse preset for the segmented control.
 type TraceLevel = 'collapsed' | 'agents' | 'expanded';

--- a/src/web/index.css
+++ b/src/web/index.css
@@ -258,7 +258,7 @@ html.light .mesh-bg::after {
   }
 }
 
-/* Phase 2: Motion */
+/* Motion */
 @keyframes sparkline-draw {
   from {
     stroke-dashoffset: 1;
@@ -314,7 +314,7 @@ html.light .mesh-bg::after {
   }
 }
 
-/* Phase 3: Gantt timeline */
+/* Gantt timeline */
 @keyframes gantt-bar-enter {
   from {
     transform: scaleX(0);
@@ -467,7 +467,7 @@ html.light .mesh-bg::after {
   }
 }
 
-/* Phase 3: Empty state radar */
+/* Empty state radar */
 @keyframes radar-sweep {
   from {
     transform: rotate(0deg);
@@ -488,7 +488,7 @@ html.light .mesh-bg::after {
   }
 }
 
-/* Phase 3: Shortcut overlay */
+/* Shortcut overlay */
 @keyframes overlay-enter {
   from {
     opacity: 0;

--- a/src/web/lib/agent-groups.test.ts
+++ b/src/web/lib/agent-groups.test.ts
@@ -1,0 +1,55 @@
+import { groupAgents, GROUP_BAR_COLORS, subagentGroupId, fmtTickLabel } from './agent-groups.js';
+import type { AgentSpan } from '../api/client.js';
+
+function makeAgent(overrides: Partial<AgentSpan> = {}): AgentSpan {
+  return {
+    agentId: 'a1',
+    workflowRunId: null,
+    workflowName: null,
+    label: 'agent 1',
+    model: 'claude-sonnet-5',
+    startMs: 1_000,
+    endMs: 2_000,
+    durationMs: 1_000,
+    turnCount: 1,
+    totalTokens: 100,
+    usd: null,
+    ...overrides,
+  };
+}
+
+describe('groupAgents', () => {
+  it('buckets agents by workflowRunId and sorts groups by earliest start', () => {
+    const agents = [
+      makeAgent({ agentId: 'a1', workflowRunId: 'run-2', startMs: 5_000 }),
+      makeAgent({ agentId: 'a2', workflowRunId: 'run-1', startMs: 1_000 }),
+      makeAgent({ agentId: 'a3', workflowRunId: null, startMs: 3_000 }),
+    ];
+    const groups = groupAgents(agents);
+    expect(groups.map((g) => g.runId)).toEqual(['run-1', null, 'run-2']);
+  });
+
+  it('names the null-runId group "Ad-hoc subagents"', () => {
+    const groups = groupAgents([makeAgent({ workflowRunId: null })]);
+    expect(groups[0]!.name).toBe('Ad-hoc subagents');
+  });
+});
+
+describe('subagentGroupId', () => {
+  it('returns a stable ad-hoc token for null and a run-prefixed id otherwise', () => {
+    expect(subagentGroupId(null)).toBe('__adhoc__');
+    expect(subagentGroupId('run-1')).toBe('run:run-1');
+  });
+});
+
+describe('fmtTickLabel', () => {
+  it('formats milliseconds as mm:ss', () => {
+    expect(fmtTickLabel(65_000)).toBe('1:05');
+  });
+});
+
+describe('GROUP_BAR_COLORS', () => {
+  it('has 6 stable color tokens', () => {
+    expect(GROUP_BAR_COLORS).toHaveLength(6);
+  });
+});

--- a/src/web/lib/agent-groups.ts
+++ b/src/web/lib/agent-groups.ts
@@ -1,0 +1,70 @@
+import type { AgentSpan } from '../api/client.js';
+
+export interface AgentGroup {
+  readonly runId: string | null;
+  readonly name: string;
+  readonly earliestStartMs: number;
+  readonly agents: AgentSpan[];
+}
+
+// Group agents by workflowRunId. Null runId agents collapse into a single
+// "Ad-hoc subagents" group. Groups are sorted by their earliest agent start.
+// Shared by AgentSwimlanes.tsx and SessionTrace.tsx so both charts agree on
+// how subagents bucket by workflow run.
+export function groupAgents(agents: ReadonlyArray<AgentSpan>): AgentGroup[] {
+  const byRun = new Map<string | null, AgentSpan[]>();
+  for (const agent of agents) {
+    const key = agent.workflowRunId;
+    const bucket = byRun.get(key);
+    if (bucket) {
+      bucket.push(agent);
+    } else {
+      byRun.set(key, [agent]);
+    }
+  }
+
+  const groups: AgentGroup[] = [];
+  for (const [runId, members] of byRun) {
+    const sortedMembers = [...members].sort((a, b) => a.startMs - b.startMs);
+    const earliestStartMs = sortedMembers.reduce(
+      (m, a) => Math.min(m, a.startMs),
+      Number.POSITIVE_INFINITY,
+    );
+    const name = runId === null ? 'Ad-hoc subagents' : (members[0]?.workflowName ?? 'Workflow run');
+    groups.push({ runId, name, earliestStartMs, agents: sortedMembers });
+  }
+
+  groups.sort((a, b) => a.earliestStartMs - b.earliestStartMs);
+  return groups;
+}
+
+// Cycle the dedicated categorical "series" ramp, one hue per workflow group.
+// These tokens carry no semantic meaning (unlike green=success / red=danger);
+// the swatch reads as a CATEGORY. Index is the group's sorted position.
+export const GROUP_BAR_COLORS = [
+  'bg-series-1',
+  'bg-series-2',
+  'bg-series-3',
+  'bg-series-4',
+  'bg-series-5',
+  'bg-series-6',
+] as const;
+
+// Stable group id used to key collapse state. The parent lane gets a reserved
+// id; subagent groups key off their runId (with a fixed token for the ad-hoc
+// null-runId group). Stable across re-renders so a user's expand/collapse
+// choice sticks even as data refreshes.
+export const PARENT_GROUP_ID = '__parent__';
+export const ADHOC_GROUP_ID = '__adhoc__';
+
+export function subagentGroupId(runId: string | null): string {
+  return runId === null ? ADHOC_GROUP_ID : `run:${runId}`;
+}
+
+// mm:ss relative to the window start — shared axis style for both charts.
+export function fmtTickLabel(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}:${String(sec).padStart(2, '0')}`;
+}

--- a/src/web/store/liveStore.test.ts
+++ b/src/web/store/liveStore.test.ts
@@ -201,7 +201,7 @@ describe('liveStore alert slice', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Task #17 (D3): activeSessionId + setActiveSession
+// activeSessionId + setActiveSession
 // ---------------------------------------------------------------------------
 
 describe('liveStore — setActiveSession', () => {

--- a/src/web/views/Audit.test.tsx
+++ b/src/web/views/Audit.test.tsx
@@ -229,10 +229,10 @@ describe('Audit downloadJsonl', () => {
     }
   });
 
-  // F-018: Firefox silently no-ops .click() on an anchor that's not in
+  // Firefox silently no-ops .click() on an anchor that's not in
   // the DOM. Audit export must append the anchor to document.body before
   // clicking and remove it after, even when click() throws.
-  it('appends the anchor to document.body before clicking and removes after (F-018)', () => {
+  it('appends the anchor to document.body before clicking and removes after', () => {
     const origCreate = URL.createObjectURL;
     const origRevoke = URL.revokeObjectURL;
     URL.createObjectURL = vi.fn(() => 'blob:test/0') as typeof URL.createObjectURL;

--- a/src/web/views/Audit.tsx
+++ b/src/web/views/Audit.tsx
@@ -28,7 +28,7 @@ export function downloadJsonl(rows: AuditEntry[]): void {
   a.href = url;
   a.download = `audit-${new Date().toISOString().slice(0, 10)}.jsonl`;
   a.rel = 'noopener';
-  // F-018: Firefox silently no-ops .click() on an anchor that's not in
+  // Firefox silently no-ops .click() on an anchor that's not in
   // the DOM. Append before clicking, then remove. Chromium/Safari work
   // either way; the append is harmless there.
   document.body.appendChild(a);
@@ -51,7 +51,7 @@ export function Audit(): JSX.Element {
 
   const rows = data ?? [];
   const visible = filter === 'all' ? rows : rows.filter((r) => r.classification === filter);
-  // F-029: Cap rendered rows so the Audit view stays responsive on large
+  // Cap rendered rows so the Audit view stays responsive on large
   // logs. Server-side pagination is the proper fix; this guard prevents
   // the table from freezing the page in the meantime.
   const VISIBLE_LIMIT = 200;

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -431,7 +431,7 @@ describe('History data helpers', () => {
     it('groups sessions by day, sums cost, and trims to N most recent days', () => {
       // Locally-constructed instants so the test is timezone-portable;
       // UTC ISO strings would shift days under negative-offset runners
-      // after the F-026 fix moved bucketing to local-time getters.
+      // after bucketing moved to local-time getters.
       const out = aggregateDailyCost(
         [
           {
@@ -649,7 +649,7 @@ describe('History data helpers', () => {
           antiPatternCounts: { stuck_loop: 4 },
         },
       ]);
-      // F-040: keep the full ISO date in chart data so cross-year ticks
+      // Keep the full ISO date in chart data so cross-year ticks
       // remain unique; the XAxis tickFormatter shortens to MM-DD on render.
       expect(out).toEqual([
         { week: '2026-04-21', count: 3 },
@@ -755,7 +755,7 @@ describe('History helpers with real API data shapes', () => {
           antiPatternCounts: { stuck_loop: 3 },
         },
       ]);
-      // F-040: keep the full week identifier in chart data; the XAxis
+      // Keep the full week identifier in chart data; the XAxis
       // tickFormatter shortens to MM-DD on render (or leaves unchanged
       // for non-ISO labels like '2026-W22').
       expect(out).toEqual([
@@ -776,7 +776,7 @@ describe('History helpers with real API data shapes', () => {
       ]);
       expect(out).toHaveLength(1);
       expect(out[0].count).toBe(5);
-      // F-040: full label preserved in chart data; XAxis tickFormatter
+      // Full label preserved in chart data; XAxis tickFormatter
       // handles display-time shortening.
       expect(out[0].week).toBe('2026-W22');
     });

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -93,7 +93,7 @@ describe('Sessions view', () => {
   });
 
   it('shows a cap notice when the list returns the full page', async () => {
-    // F-051: 50 rows is the page-size sentinel — the API caps at this and
+    // 50 rows is the page-size sentinel — the API caps at this and
     // the SPA uses the same constant. Asserting the notice appears at the
     // boundary protects the contract without having to inspect the literal.
     const fullPage = Array.from({ length: 50 }, (_, i) => ({
@@ -387,5 +387,186 @@ describe('Sessions view — real API shapes', () => {
     expect(screen.getByText('Tool Selection')).toBeInTheDocument();
     expect(screen.getByText('80%')).toBeInTheDocument();
     expect(screen.getByText('0.75')).toBeInTheDocument();
+  });
+});
+
+describe('Sessions view — workflow consolidation', () => {
+  interface WorkflowDetailMap {
+    readonly [runId: string]: unknown;
+  }
+
+  function renderSessionsFull(
+    sessionList: unknown,
+    workflowRuns: unknown,
+    workflowDetails: WorkflowDetailMap = {},
+  ) {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = ((url: string) => {
+      if (url.startsWith('/api/workflows/')) {
+        const runId = decodeURIComponent(url.split('/').pop() ?? '');
+        const detail = workflowDetails[runId] ?? { run: null, agents: [], topology: null };
+        return Promise.resolve(
+          new Response(JSON.stringify(detail), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url === '/api/workflows') {
+        return Promise.resolve(
+          new Response(JSON.stringify(workflowRuns), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/sessions/')) {
+        const id = decodeURIComponent(url.split('/').pop() ?? '');
+        return Promise.resolve(
+          new Response(JSON.stringify({ sessionId: id, timeline: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(sessionList), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as typeof globalThis.fetch;
+    return render(
+      <QueryClientProvider client={qc}>
+        <Sessions />
+      </QueryClientProvider>,
+    );
+  }
+
+  const SESSIONS = [
+    {
+      sessionId: 'sess-a',
+      startTime: '2026-05-28T09:00:00Z',
+      toolCallCount: 10,
+      estimatedCostUsd: 1,
+    },
+    {
+      sessionId: 'sess-b',
+      startTime: '2026-05-27T09:00:00Z',
+      toolCallCount: 5,
+      estimatedCostUsd: 0.5,
+    },
+  ];
+
+  const RUNS = [
+    {
+      runId: 'run-1',
+      parentSessionId: 'sess-a',
+      taskId: null,
+      workflowName: 'review',
+      status: 'completed',
+      defaultModel: 'claude-sonnet-5',
+      startedAt: Date.parse('2026-05-28T09:05:00Z'),
+      durationMs: 60_000,
+      agentCount: 3,
+      totalUsd: 2,
+      runSource: 'script',
+    },
+    {
+      runId: 'run-2',
+      parentSessionId: 'sess-b',
+      taskId: null,
+      workflowName: 'migrate',
+      status: 'failed',
+      defaultModel: 'claude-sonnet-5',
+      startedAt: Date.parse('2026-05-27T09:05:00Z'),
+      durationMs: 30_000,
+      agentCount: 1,
+      totalUsd: 1,
+      runSource: 'agent_tool',
+    },
+  ];
+
+  it('computes real KPI aggregation from workflow run data, not session-shaped stand-ins', async () => {
+    const { container } = renderSessionsFull(SESSIONS, RUNS);
+    await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());
+    // avgDurationMs = (60000 + 30000) / 2 = 45000ms — same formatDuration()
+    // convention as the existing "5s" assertion for durationMs: 5000 above.
+    expect(container.textContent).toContain('45s');
+    // totalSpend = 2 + 1 = 3 — regex tolerates whatever decimal padding
+    // formatUsdOrDash uses.
+    expect(container.textContent).toMatch(/\$3(\.0+)?/);
+  });
+
+  it('scopes the visible session list to the run-source filter', async () => {
+    renderSessionsFull(SESSIONS, RUNS);
+    await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'Script' }));
+    await waitFor(() => expect(screen.queryByText(/sess-b/)).not.toBeInTheDocument());
+    expect(screen.getByText(/sess-a/)).toBeInTheDocument();
+  });
+
+  it('scopes the visible session list to the status filter', async () => {
+    renderSessionsFull(SESSIONS, RUNS);
+    await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'Failed' }));
+    await waitFor(() => expect(screen.queryByText(/sess-a/)).not.toBeInTheDocument());
+    expect(screen.getByText(/sess-b/)).toBeInTheDocument();
+  });
+
+  it('expands a session to reveal its workflow runs, then expands a run to reveal its agents', async () => {
+    renderSessionsFull(SESSIONS, RUNS, {
+      'run-1': {
+        run: RUNS[0],
+        agents: [
+          {
+            agentId: 'a1',
+            label: 'agent 1',
+            model: 'claude-sonnet-5',
+            startedAt: 1000,
+            durationMs: 500,
+            toolCalls: 3,
+            tokens: 100,
+          },
+        ],
+        topology: null,
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());
+    fireEvent.click(screen.getAllByRole('button', { name: 'Expand workflows' })[0]!);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /View workflow run review/ })).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Expand agents' }));
+    await waitFor(() => expect(screen.getByText('agent 1')).toBeInTheDocument());
+  });
+
+  it('opens the in-place workflow-run drawer when a run row is clicked', async () => {
+    renderSessionsFull(SESSIONS, RUNS, {
+      'run-1': { run: RUNS[0], agents: [], topology: null },
+    });
+    await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());
+    fireEvent.click(screen.getAllByRole('button', { name: 'Expand workflows' })[0]!);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /View workflow run review/ })).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /View workflow run review/ }));
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    // The dialog shell mounts immediately on open, before its own
+    // WorkflowRunDetail query resolves — wait for the heading separately so
+    // this doesn't race the fetch.
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'review' })).toBeInTheDocument(),
+    );
+  });
+
+  it('selects the session named in the ?session= query param on mount', async () => {
+    const original = window.location;
+    // @ts-expect-error -- test-only reassignment of a read-only global
+    delete window.location;
+    window.location = { ...original, search: '?session=sess-b' } as Location;
+    renderSessionsFull(SESSIONS, RUNS);
+    await waitFor(() => expect(screen.getByText(/sess-b/)).toBeInTheDocument());
+    window.location = original;
   });
 });

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -38,7 +38,7 @@ import {
 } from '../lib/format';
 import { bucketTimeline, autoBucketSize } from '../lib/bucket';
 
-// F-051: keep the query limit and the "showing N most recent" notice in
+// Keep the query limit and the "showing N most recent" notice in
 // lock-step. If you bump this, also update the api-handler clamp upper
 // bound if you intend to allow more than the current 500 ceiling.
 const SESSIONS_PAGE_SIZE = 50;
@@ -502,7 +502,7 @@ export function Sessions(): JSX.Element {
                 onOpenRun={openRun}
               />
             ))}
-            {/* F-051: when the API returns the full page, surface that older
+            {/* When the API returns the full page, surface that older
               sessions exist beyond what's rendered. The cap is enforced
               server-side (api-handler `limit` clamp) and matches the
               `qk.sessionsList(50)` query above; bump both together if the

--- a/src/web/views/Settings.tsx
+++ b/src/web/views/Settings.tsx
@@ -8,6 +8,7 @@ import {
   fetchObservabilityHealth,
   qk,
   type DiagnosticCheck,
+  type ObservabilityHealthResponse,
 } from '../api/client';
 import type { SettingsPatch } from '../api/client';
 import { EmptyState } from '../components/EmptyState';
@@ -26,12 +27,6 @@ interface SettingsData {
   readonly dailyBudgetUsd: number | null;
   readonly weeklyBudgetUsd: number | null;
   readonly retainSessionsDays: number | null;
-}
-
-interface ObservabilityHealthApiResponse {
-  readonly watcherActive?: boolean;
-  readonly filesWatched?: number;
-  readonly parseErrors?: number;
 }
 
 function ReadOnlyField({ label, value }: { label: string; value: string | null | undefined }) {
@@ -164,9 +159,9 @@ export function Settings(): JSX.Element {
     queryFn: () => fetchSettings(),
   });
 
-  const { data: healthApi } = useQuery<ObservabilityHealthApiResponse>({
+  const { data: healthApi } = useQuery<ObservabilityHealthResponse>({
     queryKey: ['observability-health'],
-    queryFn: () => fetchObservabilityHealth() as Promise<ObservabilityHealthApiResponse>,
+    queryFn: fetchObservabilityHealth,
     refetchInterval: 30_000,
   });
 

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -197,7 +197,7 @@ describe('Today view', () => {
   // un-spend money), so a raw forecast below current spend renders the
   // clamped value with an "on pace" annotation (delta ≤ 0 branch in
   // ForecastEodCard) — never a negative delta.
-  it('clamps forecast to todayTotal when raw forecast is lower (F-017)', () => {
+  it('clamps forecast to todayTotal when raw forecast is lower', () => {
     useLiveStore.setState({
       cost: { sessionTotalUsd: 3.42, todayTotalUsd: 10, forecastEodUsd: 8 },
     });
@@ -211,7 +211,7 @@ describe('Today view', () => {
     expect(screen.queryByText(/\$8\.00/)).toBeNull();
   });
 
-  it('still renders a positive delta with "+$" (F-017 regression guard)', () => {
+  it('still renders a positive delta with "+$"', () => {
     useLiveStore.setState({
       cost: { sessionTotalUsd: 3.42, todayTotalUsd: 10, forecastEodUsd: 12 },
     });
@@ -360,7 +360,7 @@ describe('Today header timestamp', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Task #17 (D3): cross-session aggregate KPIs and Today view UX
+// Cross-session aggregate KPIs and Today view UX
 // ---------------------------------------------------------------------------
 
 describe('Today view — aggregate endpoint', () => {
@@ -786,7 +786,7 @@ describe('Today view — Recent alerts panel', () => {
     expect(await screen.findByText(/Error loading recent alerts/i)).toBeInTheDocument();
   });
 
-  // Regression for F-007: in cloud mode the alert engine isn't constructed
+  // Regression test: in cloud mode the alert engine isn't constructed
   // and /api/alerts/recent returns 404. The panel must render nothing —
   // not a permanent red error banner. Without this fix users running the
   // dashboard in cloud mode see "Error loading recent alerts" indefinitely.
@@ -824,11 +824,11 @@ describe('Today view — Recent alerts panel', () => {
     expect(alertsCalls).toHaveLength(1);
   });
 
-  // Regression for F-016: AlertLog.readRecent returns the file's last N
+  // Regression test: AlertLog.readRecent returns the file's last N
   // lines in append (chronological) order — oldest-first within the slice.
   // The panel must sort descending by firedAt so the most-recent firing
   // sits at the top.
-  it('orders rows by firedAt descending (most recent first — F-016)', async () => {
+  it('orders rows by firedAt descending (most recent first)', async () => {
     const oldAlert = {
       id: 'rule-old',
       state: 'firing' as const,

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -43,6 +43,7 @@ import {
   LiveSessionEntry,
   NotFoundError,
   CacheHealthResponse,
+  ObservabilityHealthResponse,
   qk,
   type SessionSubagentsResponse,
 } from '../api/client';
@@ -78,7 +79,7 @@ interface CostApiResponse {
   readonly sessionTodayUsd?: number | null;
 }
 
-// Minimal view of the /api/session/current payload. F-050 added efficiencyScore.
+// Minimal view of the /api/session/current payload.
 interface SessionCurrentApiResponse {
   readonly efficiencyScore?: number | null;
   readonly toolSuccessRate?: number | null;
@@ -137,13 +138,6 @@ interface ToolSelectionMetrics {
   readonly worstOffenders: readonly ToolSelectionOffender[];
 }
 
-interface ObservabilityHealthApiResponse {
-  readonly watcherActive?: boolean;
-  readonly watcherDisabledByLock?: boolean;
-  readonly filesWatched?: number;
-  readonly parseErrors?: number;
-}
-
 const QUALITY_REFETCH_MS = 10_000;
 
 export function Today(): JSX.Element {
@@ -151,9 +145,9 @@ export function Today(): JSX.Element {
   const antiPatterns = useLiveStore((s) => s.antiPatterns);
   const subagentStats = useSubagentStats();
   const observabilityHealth = useObservabilityHealth();
-  const { data: healthApi } = useQuery<ObservabilityHealthApiResponse>({
+  const { data: healthApi } = useQuery<ObservabilityHealthResponse>({
     queryKey: ['observability-health'],
-    queryFn: () => fetchObservabilityHealth() as Promise<ObservabilityHealthApiResponse>,
+    queryFn: fetchObservabilityHealth,
     refetchInterval: 30_000,
   });
 
@@ -161,7 +155,7 @@ export function Today(): JSX.Element {
     queryKey: qk.cost,
     queryFn: fetchCost,
   });
-  // Task #17 (D3): the dashboard owner's session_current is arbitrary across
+  // The dashboard owner's session_current is arbitrary across
   // N concurrent sessions, so we keep the call only for the efficiencyScore
   // KPI (which is local to whichever MCP holds the dashboard). All other
   // KPIs now derive from the aggregate endpoint, which fans out across every
@@ -196,7 +190,7 @@ export function Today(): JSX.Element {
       queryFn: () => fetchActivityHeatmap('today'),
       refetchInterval: 30_000,
     });
-  // Task #17 (D3): live-session list — drives the selector default and the
+  // Live-session list — drives the selector default and the
   // "Session ended" badge logic when the selected session goes stale.
   const { data: liveSessions, isPending: liveSessionsPending } = useQuery<LiveSessionEntry[]>({
     queryKey: qk.sessionsLive,
@@ -218,7 +212,7 @@ export function Today(): JSX.Element {
   );
   const hourlySpend = useMemo(() => buildHourlySpend(todaySessions ?? []), [todaySessions]);
 
-  // Task #17 (D3): prefer the cross-session aggregate when present; fall
+  // Prefer the cross-session aggregate when present; fall
   // back to the legacy persisted-sessions math during the loading window so
   // the KPIs don't blink to zero on first paint. Use Math.max (not `??`)
   // because the aggregate endpoint can legitimately return 0 when its
@@ -413,7 +407,7 @@ export function Today(): JSX.Element {
                       <span className="text-ink-muted">— </span>
                       <span>{antiPatterns[0].count}× on </span>
                       <code className="bg-surface-5 px-1 rounded">{antiPatterns[0].target}</code>
-                      {/* Task #17 (D3): per-session pill so users can identify
+                      {/* Per-session pill so users can identify
                           which of N concurrent sessions triggered the alert. */}
                       {antiPatterns[0].sessionId && (
                         <Pill tone="neutral" size="sm" className="ml-2">
@@ -840,7 +834,7 @@ function LiveSessionPane({
   const [, navigate] = useLocation();
   const setActiveSession = useLiveStore((s) => s.setActiveSession);
 
-  // Task #17 (D3): live-session ids from /api/sessions/live (already sorted
+  // Live-session ids from /api/sessions/live (already sorted
   // most-recently-active first by the server). Falls back to /api/session/
   // current's `liveSessions` array during the loading window so the pane
   // populates immediately on first paint instead of waiting an interval.
@@ -872,14 +866,14 @@ function LiveSessionPane({
     mostRecentlyActiveId ?? (liveSessionIds.size > 0 ? [...liveSessionIds][0]! : null);
   const activeId = selectedId ?? firstLiveId;
   const isLive = activeId !== null && liveSessionIds.has(activeId);
-  // Task #17 (D3): "Session ended" badge — true when the user explicitly
+  // "Session ended" badge — true when the user explicitly
   // selected a session that was previously live but is no longer in the live
   // set (e.g. the owning Claude Code window closed). We deliberately don't
   // auto-switch to a different session: that's jarring, and the user might be
   // mid-investigation. Instead we pin the selection and surface a badge.
   const sessionEnded = selectedId !== null && !liveSessionIds.has(selectedId);
 
-  // Task #17 (D3): keep the global liveStore in sync with the local selector
+  // Keep the global liveStore in sync with the local selector
   // so the rest of the dashboard (and any per-session caches) re-key when
   // the user switches. Empty deps + activeId in array — fires only on change.
   useEffect(() => {
@@ -1090,7 +1084,7 @@ function LiveSessionPane({
             <div className="flex items-center justify-between px-2 py-1 border-b border-border-subtle shrink-0">
               <Eyebrow>Trace</Eyebrow>
               <div className="flex items-center gap-2">
-                {/* Task #17 (D3): "Session ended" badge — pinned to the selected
+                {/* "Session ended" badge — pinned to the selected
                   session even after it leaves the live set, so the user can
                   finish reviewing without an auto-switch. */}
                 {sessionEnded && (
@@ -1158,7 +1152,7 @@ function LiveSessionPane({
   );
 }
 
-// Task #17 (D3): label resolver for the per-session pill on anti-pattern
+// Label resolver for the per-session pill on anti-pattern
 // alerts. Falls back to the truncated session id when no friendly name is
 // known yet — sessionName is only set after the live registry has seen a
 // `cwd` from the first hook event.
@@ -1192,7 +1186,7 @@ function RecentAlertsPanel(): JSX.Element | null {
   if (data === null) return null;
 
   const entries: readonly AlertEvent[] = data ?? [];
-  // F-016: defensive sort — `AlertLog.readRecent` already reverses the
+  // Defensive sort — `AlertLog.readRecent` already reverses the
   // last-N-lines slice before returning, so the API is newest-first today.
   // Sorting again is idempotent and pins the UI ordering against any future
   // refactor of `readRecent` that drops or reorders the .reverse() call.


### PR DESCRIPTION
## Summary

Closes #212.

- The subagent transcript watcher now emits a health event instead of silently skipping a transcript file whose filename doesn't match the expected agent-id shape, so a future change to that format would be observable instead of silently reintroducing lost subagent cost tracking.
- The workflow watcher no longer accumulates unbounded internal bookkeeping for the life of the process; stale tracking entries are evicted on each poll instead of persisting indefinitely.
- Both the subagent and workflow watchers now go straight to the active session's own directory when tracking a single session, instead of listing every session on disk on every poll.
- The session trace's Gantt timeline no longer re-sorts and rebuilds its highlight state on every mouse movement, and its bars now expose an accessible name to assistive technology.
- Added test coverage for the Sessions view's workflow-consolidation logic: KPI aggregation across workflow runs, run-source and status filtering, the session/run/agent expansion tree, and the in-place workflow-run detail view.
- Fixed a missing file extension on an internal module import.
- Deduped agent-grouping logic that was previously copy-pasted between two components, and consolidated an untyped API response into a shared, exported type.

## Test plan

- [x] `npm run build && npm test` — all suites pass
- [x] `npm run lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)