### PR TITLE
Fix 3 deferred unknown-type audit items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3] - 2026-07-16
+
+### Fixed
+
+- The dashboard's live-session view now aggregates anti-pattern occurrences by type before returning them, instead of returning a mismatched shape the frontend couldn't render correctly.
+- Replaced an unsafe type cast used to attach turn attribution to tool-call records with a properly-typed record construction; no change to the attribution data itself.
+- The hook event buffer's internal type now reflects that each buffered line has a different shape depending on its mode, removing an unchecked type cast from the event-processing pipeline.
+
 ## [1.5.2] - 2026-07-16
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -442,6 +442,45 @@ describe('api-handler GET /api/sessions/:id', () => {
     expect(parsed.toolSelectionScore?.redundantReadCount).toBe(1);
   });
 
+  it('aggregates live-session anti-patterns by type into {type, count} pairs', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({
+          sessionId: 'live-anti',
+          sessionName: null,
+          sessionStartTime: 1000,
+          sessionDurationMs: 500,
+          toolCallCount: 3,
+          toolCallCountByTool: { Read: 3 },
+          uniqueFilesRead: 1,
+          uniqueFilesWritten: 0,
+          toolCallTimeline: [],
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+      antiPatternDetector: {
+        getCurrentPatterns: () => [
+          { type: 're_reading', file: '/a.ts', readCount: 4, suggestion: 'Consider breaking task' },
+          { type: 're_reading', file: '/b.ts', readCount: 5, suggestion: 'Consider breaking task' },
+          { type: 'thrashing', file: '/c.ts', iterations: 3, suggestion: 'Try different approach' },
+        ],
+      } as unknown as Parameters<typeof createApiHandler>[0]['antiPatternDetector'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/live-anti' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { antiPatterns?: Array<{ type: string; count: number }> };
+    expect(parsed.antiPatterns).toEqual([
+      { type: 're_reading', count: 2 },
+      { type: 'thrashing', count: 1 },
+    ]);
+  });
+
   it('attaches toolSelectionScore (but not qualityProxy) to the registry-synthesized branch', async () => {
     const handler = createApiHandler({
       sessionStore: {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1999,18 +1999,16 @@ export function createApiHandler(
             const costMetrics = deps.costTracker?.getMetrics();
             const costUsd = costMetrics?.sessionTotalCostUsd ?? null;
             const model = costMetrics?.model ?? null;
-            // BUG (pre-existing, not introduced here): getCurrentPatterns() returns
-            // per-occurrence AntiPattern objects (type/file/iterations/...), not the
-            // {type,count}[] aggregate the frontend expects here (see
-            // FullSessionSummary.antiPatterns and src/web/views/Sessions.tsx:866-870).
-            // This cast preserves that existing behavior; fixing it requires grouping
-            // by type (see src/storage/session-store.ts:335-343) — a separate change.
-            const antiPatterns = deps.antiPatternDetector
-              ? (deps.antiPatternDetector.getCurrentPatterns() as unknown as Array<{
-                  type: string;
-                  count: number;
-                }>)
-              : [];
+            const antiPatterns: Array<{ type: string; count: number }> = [];
+            if (deps.antiPatternDetector) {
+              const grouped = new Map<string, number>();
+              for (const p of deps.antiPatternDetector.getCurrentPatterns()) {
+                grouped.set(p.type, (grouped.get(p.type) ?? 0) + 1);
+              }
+              for (const [type, count] of grouped) {
+                antiPatterns.push({ type, count });
+              }
+            }
             const ownSessionRecords = (deps.toolCallBuffer?.getRecords() ?? []).filter(
               (r) => r.sessionId === sessionId,
             );

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { LocalStore } from '../storage/local-store.js';
 import { HookEventProcessor } from './event-processor.js';
-import type { HookEvent, ToolCallRecord } from '../storage/types.js';
+import type { HookEvent, PreHookEvent, PostHookEvent, ToolCallRecord } from '../storage/types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -35,7 +35,7 @@ afterEach(() => {
 // Test helpers
 // ---------------------------------------------------------------------------
 
-function makePreEvent(overrides?: Partial<HookEvent>): HookEvent {
+function makePreEvent(overrides?: Partial<Omit<PreHookEvent, 'mode'>>): PreHookEvent {
   return {
     mode: 'pre',
     tool: 'Read',
@@ -48,7 +48,7 @@ function makePreEvent(overrides?: Partial<HookEvent>): HookEvent {
   };
 }
 
-function makePostEvent(overrides?: Partial<HookEvent>): HookEvent {
+function makePostEvent(overrides?: Partial<Omit<PostHookEvent, 'mode'>>): PostHookEvent {
   return {
     mode: 'post',
     tool: 'Read',
@@ -61,7 +61,7 @@ function makePostEvent(overrides?: Partial<HookEvent>): HookEvent {
   };
 }
 
-function makeFailureEvent(overrides?: Partial<HookEvent>): HookEvent {
+function makeFailureEvent(overrides?: Partial<Omit<PostHookEvent, 'mode'>>): PostHookEvent {
   return {
     mode: 'post',
     tool: 'Bash',

--- a/src/hooks/event-processor.ts
+++ b/src/hooks/event-processor.ts
@@ -17,6 +17,11 @@ import type { PlatformAdapter } from '../platforms/types.js';
 import type { LocalStore } from '../storage/local-store.js';
 import type {
   HookEvent,
+  PreHookEvent,
+  PostHookEvent,
+  TokenHookEvent,
+  SubagentTokenHookEvent,
+  ObservabilityHealthHookEvent,
   ToolCallRecord,
   TokenEvent,
   SubagentTokenEvent,
@@ -162,7 +167,7 @@ export class HookEventProcessor {
   private readonly workflowRunDedup = new Set<string>();
   private readonly workflowRunDedupOrder: string[] = [];
 
-  private readonly pending: Map<string, HookEvent> = new Map();
+  private readonly pending: Map<string, PreHookEvent> = new Map();
   private readonly maxPendingEvents: number;
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private running = false;
@@ -290,7 +295,7 @@ export class HookEventProcessor {
         } else if (event.mode === 'observability_health') {
           this.handleObservabilityHealthEvent(event);
         } else if (event.mode === 'workflow_run') {
-          this.handleWorkflowRunEvent(event as unknown as WorkflowRunEvent);
+          this.handleWorkflowRunEvent(event);
         }
       } catch (err) {
         logger.warn('Error processing hook event', {
@@ -328,7 +333,7 @@ export class HookEventProcessor {
     return this.drainAllSessions ? this.store.drainAllBuffers() : this.store.drainBuffer();
   }
 
-  private handlePreEvent(event: HookEvent): void {
+  private handlePreEvent(event: PreHookEvent): void {
     if (this.pending.size >= this.maxPendingEvents) {
       // Prefer evicting events that are already past the orphan timeout
       const now = Date.now();
@@ -351,9 +356,9 @@ export class HookEventProcessor {
         const toolFields = parseToolSpecificFields(evicted.tool, evicted.toolInput, undefined);
         this.emitRecord({
           id: randomUUID(),
-          sessionId: (evicted.sessionId as string) ?? null,
+          sessionId: evicted.sessionId ?? null,
           toolName: evicted.tool,
-          toolUseId: (evicted.toolUseId as string) ?? evictedKey,
+          toolUseId: evicted.toolUseId ?? evictedKey,
           timestamp: evicted.timestamp,
           durationMs: null,
           success: false,
@@ -367,8 +372,8 @@ export class HookEventProcessor {
     this.pending.set(this.pairingKey(event), event);
   }
 
-  private handlePostEvent(event: HookEvent): void {
-    const toolUseId = event.toolUseId as string | undefined;
+  private handlePostEvent(event: PostHookEvent): void {
+    const toolUseId = event.toolUseId;
     // When toolUseId is present use it directly; otherwise find the oldest pending
     // pre-event with the same tool name (FIFO) so parallel same-tool calls don't
     // collide — the counter in pairingKey() gives each pre-event a unique key.
@@ -388,22 +393,22 @@ export class HookEventProcessor {
       );
       const record: ToolCallRecord = {
         id: randomUUID(),
-        sessionId: (preEvent.sessionId as string) ?? (event.sessionId as string) ?? null,
+        sessionId: preEvent.sessionId ?? event.sessionId ?? null,
         toolName: preEvent.tool,
-        toolUseId: (preEvent.toolUseId as string) ?? key,
+        toolUseId: preEvent.toolUseId ?? key,
         timestamp: preEvent.timestamp,
         durationMs: Math.max(0, event.timestamp - preEvent.timestamp),
         success: event.success ?? true,
-        ...(event.error !== undefined && { error: event.error as string }),
+        ...(event.error !== undefined && { error: event.error }),
         ...(preEvent.inputSize !== undefined && { inputSizeBytes: preEvent.inputSize }),
         ...(event.outputSize !== undefined && { outputSizeBytes: event.outputSize }),
         ...(preEvent.inputHash !== undefined && { inputHash: preEvent.inputHash }),
-        ...(preEvent.cwd !== undefined && { cwd: preEvent.cwd as string }),
+        ...(preEvent.cwd !== undefined && { cwd: preEvent.cwd }),
         ...(preEvent.transcriptPath !== undefined && {
-          transcriptPath: preEvent.transcriptPath as string,
+          transcriptPath: preEvent.transcriptPath,
         }),
         ...(preEvent.permissionMode !== undefined && {
-          permissionMode: preEvent.permissionMode as string,
+          permissionMode: preEvent.permissionMode,
         }),
         ...toolFields,
       };
@@ -414,13 +419,13 @@ export class HookEventProcessor {
       const toolFields = parseToolSpecificFields(event.tool, event.toolInput, event.toolOutput);
       const record: ToolCallRecord = {
         id: randomUUID(),
-        sessionId: (event.sessionId as string) ?? null,
+        sessionId: event.sessionId ?? null,
         toolName: event.tool,
-        toolUseId: (event.toolUseId as string) ?? key,
+        toolUseId: event.toolUseId ?? key,
         timestamp: event.timestamp,
         durationMs: null,
         success: event.success ?? true,
-        ...(event.error !== undefined && { error: event.error as string }),
+        ...(event.error !== undefined && { error: event.error }),
         ...(event.outputSize !== undefined && { outputSizeBytes: event.outputSize }),
         ...toolFields,
       };
@@ -428,7 +433,7 @@ export class HookEventProcessor {
     }
   }
 
-  private handleTokenEvent(event: HookEvent): void {
+  private handleTokenEvent(event: TokenHookEvent): void {
     if (!this.onTokenEvent) return;
     const tokenEvent: TokenEvent = {
       mode: 'token',
@@ -447,8 +452,8 @@ export class HookEventProcessor {
         typeof event.cacheCreationTokens === 'number' && !isNaN(event.cacheCreationTokens)
           ? event.cacheCreationTokens
           : 0,
-      model: (event.model as string) ?? 'unknown',
-      sessionId: event.sessionId as string | undefined,
+      model: event.model ?? 'unknown',
+      sessionId: event.sessionId,
     };
     try {
       this.onTokenEvent(tokenEvent);
@@ -476,9 +481,9 @@ export class HookEventProcessor {
       const toolFields = parseToolSpecificFields(event.tool, event.toolInput, undefined);
       const record: ToolCallRecord = {
         id: randomUUID(),
-        sessionId: (event.sessionId as string) ?? null,
+        sessionId: event.sessionId ?? null,
         toolName: event.tool,
-        toolUseId: (event.toolUseId as string) ?? key,
+        toolUseId: event.toolUseId ?? key,
         timestamp: event.timestamp,
         durationMs: null,
         success: false,
@@ -496,9 +501,9 @@ export class HookEventProcessor {
       const toolFields = parseToolSpecificFields(event.tool, event.toolInput, undefined);
       const record: ToolCallRecord = {
         id: randomUUID(),
-        sessionId: (event.sessionId as string) ?? null,
+        sessionId: event.sessionId ?? null,
         toolName: event.tool,
-        toolUseId: (event.toolUseId as string) ?? key,
+        toolUseId: event.toolUseId ?? key,
         timestamp: event.timestamp,
         durationMs: null,
         success: false,
@@ -512,8 +517,8 @@ export class HookEventProcessor {
     this.pending.clear();
   }
 
-  private pairingKey(event: HookEvent): string {
-    const toolUseId = event.toolUseId as string | undefined;
+  private pairingKey(event: PreHookEvent): string {
+    const toolUseId = event.toolUseId;
     if (toolUseId) return toolUseId;
     // Append UUID so parallel pre-events for the same tool at the same timestamp
     // each get a unique slot in this.pending instead of overwriting each other.
@@ -540,10 +545,10 @@ export class HookEventProcessor {
     return oldestKey;
   }
 
-  private handleSubagentTokenEvent(event: HookEvent): void {
+  private handleSubagentTokenEvent(event: SubagentTokenHookEvent): void {
     if (!this.onSubagentTurn && !this.onSubagentToken) return;
-    const agentId = (event.agentId as string | undefined) ?? '';
-    const messageId = (event.messageId as string | undefined) ?? '';
+    const agentId = event.agentId ?? '';
+    const messageId = event.messageId ?? '';
     if (!agentId || !messageId) return;
     const dedupKey = `${agentId}|${messageId}`;
     if (this.subagentDedup.has(dedupKey)) return;
@@ -559,19 +564,19 @@ export class HookEventProcessor {
         typeof event.timestamp === 'number' && Number.isFinite(event.timestamp)
           ? event.timestamp
           : Date.now(),
-      parentSessionId: (event.sessionId as string | undefined) ?? '',
+      parentSessionId: event.sessionId ?? '',
       agentId,
-      workflowRunId: (event.workflowRunId as string | null | undefined) ?? null,
+      workflowRunId: event.workflowRunId ?? null,
       messageId,
-      turnUuid: (event.turnUuid as string | undefined) ?? '',
-      model: (event.model as string | undefined) ?? 'unknown',
+      turnUuid: event.turnUuid ?? '',
+      model: event.model ?? 'unknown',
       inputTokens: numAttr(event.inputTokens),
       outputTokens: numAttr(event.outputTokens),
       cacheReadTokens: numAttr(event.cacheReadTokens),
       cacheCreationTokens: numAttr(event.cacheCreationTokens),
       reasoningTokens: numAttr(event.reasoningTokens),
-      stopReason: (event.stopReason as string | null | undefined) ?? null,
-      schemaFingerprint: (event.schemaFingerprint as string | undefined) ?? '',
+      stopReason: event.stopReason ?? null,
+      schemaFingerprint: event.schemaFingerprint ?? '',
     };
     if (this.onSubagentTurn) {
       try {
@@ -628,23 +633,20 @@ export class HookEventProcessor {
     }
   }
 
-  private handleObservabilityHealthEvent(event: HookEvent): void {
+  private handleObservabilityHealthEvent(event: ObservabilityHealthHookEvent): void {
     if (!this.onObservabilityHealth) return;
     const frame: ObservabilityHealthFrame = {
       timestamp:
         typeof event.timestamp === 'number' && Number.isFinite(event.timestamp)
           ? event.timestamp
           : Date.now(),
-      watcher: (event.watcher as 'workflow' | 'subagent' | undefined) ?? 'subagent',
+      watcher: event.watcher ?? 'subagent',
       filesWatched: numAttr(event.filesWatched),
       linesRead: numAttr(event.linesRead),
       bytesRead: numAttr(event.bytesRead),
       parseErrors: numAttr(event.parseErrors),
       schemaDrifts: numAttr(event.schemaDrifts),
-      lastError:
-        event.lastError && typeof event.lastError === 'object'
-          ? (event.lastError as { code: string; class: string })
-          : null,
+      lastError: event.lastError && typeof event.lastError === 'object' ? event.lastError : null,
       ...(typeof event.event === 'string' ? { event: event.event } : {}),
       ...(typeof event.dimension === 'string' ? { dimension: event.dimension } : {}),
       ...(typeof event.fingerprint === 'string' ? { fingerprint: event.fingerprint } : {}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import type { McpServerConfig } from './config.js';
 import { ProxyManager } from './proxy/index.js';
 import type { ProxyToolCallRecord, ProxyRequestRecord } from './proxy/index.js';
 import { LocalStore } from './storage/index.js';
+import type { ToolCallRecord } from './storage/types.js';
 import {
   SessionStore,
   buildSessionSummary,
@@ -1197,7 +1198,9 @@ async function main(): Promise<void> {
           // so the dashboard tree stays decoupled from storage internals.
           localStore: {
             peekAllBuffers: () =>
-              localStore.peekAllBuffers() as ReadonlyArray<{ readonly [key: string]: unknown }>,
+              localStore.peekAllBuffers() as unknown as ReadonlyArray<{
+                readonly [key: string]: unknown;
+              }>,
           },
           // Workflow store reads on-disk wf_*.json rollups so
           // the /api/workflows endpoints work even when the watcher is
@@ -1387,7 +1390,7 @@ async function main(): Promise<void> {
       // live sessions' events. After real session ID resolution the processor
       // is hot-swapped to the scoped store via replaceStore().
       drainAllSessions: !options.stdio || isProvisional,
-      onRecord: (record) => {
+      onRecord: (rawRecord) => {
         if (!config || !sessionTracker || !taskDetector) {
           logger.warn('onRecord called before full initialization; skipping');
           return;
@@ -1397,10 +1400,10 @@ async function main(): Promise<void> {
         const taskIdBeforeRecord =
           config.transport !== 'nr-events-api' ? taskDetector.getActiveTaskId() : null;
 
-        sessionTracker.recordToolCall(record);
-        taskDetector.recordToolCall(record);
-        if (record.sessionId) {
-          liveSessionRegistry!.touch(record.sessionId, record.cwd as string | undefined);
+        sessionTracker.recordToolCall(rawRecord);
+        taskDetector.recordToolCall(rawRecord);
+        if (rawRecord.sessionId) {
+          liveSessionRegistry!.touch(rawRecord.sessionId, rawRecord.cwd as string | undefined);
         }
 
         if (config.transport !== 'nr-events-api' && taskSpanTracker && sessionSpan) {
@@ -1409,28 +1412,27 @@ async function main(): Promise<void> {
           const parentCtx = taskIdBeforeRecord
             ? taskSpanTracker.getContext(taskIdBeforeRecord, sessionSpan.getContext())
             : sessionSpan.getContext();
-          emitToolCallSpan(record, parentCtx, activeTaskId ?? undefined);
+          emitToolCallSpan(rawRecord, parentCtx, activeTaskId ?? undefined);
 
           // Open a task span if a new task was started by this record
           if (activeTaskId !== null && activeTaskId !== taskIdBeforeRecord) {
-            taskSpanTracker.openTask(activeTaskId, record.toolName, sessionSpan.getContext());
+            taskSpanTracker.openTask(activeTaskId, rawRecord.toolName, sessionSpan.getContext());
           }
         }
 
-        contextWindowTracker.recordToolCall(record);
-        contextTracker.recordToolCall(record);
-        latencyTracker.recordToolCall(record);
-        retryDetector.recordToolCall(record);
-        qualityProxyTracker.recordToolCall(record);
-        const turnId = turnTracker.recordToolCall(record);
+        contextWindowTracker.recordToolCall(rawRecord);
+        contextTracker.recordToolCall(rawRecord);
+        latencyTracker.recordToolCall(rawRecord);
+        retryDetector.recordToolCall(rawRecord);
+        qualityProxyTracker.recordToolCall(rawRecord);
+        const turnId = turnTracker.recordToolCall(rawRecord);
         const turnNumber = turnTracker.getCurrentTurnNumber();
-        turnCostAttributor.recordToolCall(record, turnId);
-        decisionTracker.recordToolCall(record);
-        instructionDriftTracker.recordToolCall(record);
-        gitEfficiencyTracker.recordToolCall(record);
+        turnCostAttributor.recordToolCall(rawRecord, turnId);
+        decisionTracker.recordToolCall(rawRecord);
+        instructionDriftTracker.recordToolCall(rawRecord);
+        gitEfficiencyTracker.recordToolCall(rawRecord);
 
-        (record as Record<string, unknown>).turn_id = turnId;
-        (record as Record<string, unknown>).turn_number = turnNumber;
+        const record: ToolCallRecord = { ...rawRecord, turn_id: turnId, turn_number: turnNumber };
 
         toolCallBuffer.push(record);
 

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -13,7 +13,7 @@ import {
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { LocalStore } from './local-store.js';
-import type { HookEvent, AuditEntry } from './types.js';
+import type { HookEvent, PostHookEvent, AuditEntry } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -33,12 +33,11 @@ afterEach(() => {
   }
 });
 
-function makeEvent(overrides?: Partial<HookEvent>): HookEvent {
+function makeEvent(overrides?: Partial<Omit<PostHookEvent, 'mode'>>): PostHookEvent {
   return {
     mode: 'post',
     tool: 'Read',
     timestamp: Date.now(),
-    inputSize: 42,
     outputSize: 100,
     success: true,
     ...overrides,
@@ -312,7 +311,7 @@ describe('LocalStore', () => {
       mkdirSync(tmpDir, { recursive: true });
 
       const bufferPath = resolve(tmpDir, 'buffer.jsonl');
-      const eventCount = 12_000;
+      const eventCount = 13_000;
       const lines: string[] = [];
       for (let i = 0; i < eventCount; i++) {
         lines.push(JSON.stringify(makeEvent({ tool: `tool-${i}`, timestamp: i })));

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,20 +1,98 @@
-export interface HookEvent {
-  /**
-   * Buffer line discriminator. `pre` / `post` / `token` are the original
-   * collector modes. `subagent_token`, `workflow_run`, and
-   * `observability_health` are emitted by the SubagentWatcher /
-   * WorkflowWatcher.
-   */
-  readonly mode:
-    'pre' | 'post' | 'token' | 'subagent_token' | 'workflow_run' | 'observability_health';
+interface HookEventBase {
   readonly tool: string;
   readonly timestamp: number;
-  readonly inputHash?: string;
+}
+
+/**
+ * Emitted before a tool call executes. Buffered by the collector, paired
+ * with a matching `PostHookEvent` by `HookEventProcessor`.
+ */
+export interface PreHookEvent extends HookEventBase {
+  readonly mode: 'pre';
+  readonly toolUseId?: string;
+  readonly sessionId?: string;
+  readonly toolInput?: unknown;
   readonly inputSize?: number;
+  readonly inputHash?: string;
+  readonly cwd?: string;
+  readonly transcriptPath?: string;
+  readonly permissionMode?: string;
+}
+
+/**
+ * Emitted after a tool call completes. Paired with its `PreHookEvent` by
+ * toolUseId (or FIFO tool-name fallback) to produce a `ToolCallRecord`.
+ */
+export interface PostHookEvent extends HookEventBase {
+  readonly mode: 'post';
+  readonly toolUseId?: string;
+  readonly sessionId?: string;
+  readonly toolInput?: unknown;
+  readonly toolOutput?: unknown;
   readonly outputSize?: number;
   readonly success?: boolean;
-  readonly [key: string]: unknown;
+  readonly error?: string;
+  readonly isInterrupt?: boolean;
 }
+
+/** Emitted per LLM API turn with token usage; feeds CostTracker. */
+export interface TokenHookEvent extends HookEventBase {
+  readonly mode: 'token';
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheCreationTokens?: number;
+  readonly model?: string;
+  readonly sessionId?: string;
+}
+
+/** Emitted by the SubagentWatcher for each subagent assistant turn. */
+export interface SubagentTokenHookEvent extends HookEventBase {
+  readonly mode: 'subagent_token';
+  readonly agentId?: string;
+  readonly messageId?: string;
+  readonly sessionId?: string;
+  readonly workflowRunId?: string | null;
+  readonly turnUuid?: string;
+  readonly model?: string;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheCreationTokens?: number;
+  readonly reasoningTokens?: number;
+  readonly stopReason?: string | null;
+  readonly schemaFingerprint?: string;
+}
+
+/** Emitted by the WorkflowWatcher / SubagentWatcher with pipeline health counters. */
+export interface ObservabilityHealthHookEvent extends HookEventBase {
+  readonly mode: 'observability_health';
+  readonly watcher?: 'workflow' | 'subagent';
+  readonly filesWatched?: number;
+  readonly linesRead?: number;
+  readonly bytesRead?: number;
+  readonly parseErrors?: number;
+  readonly schemaDrifts?: number;
+  readonly lastError?: { code: string; class: string } | null;
+  readonly event?: string;
+  readonly dimension?: string;
+  readonly fingerprint?: string;
+  readonly workflowRunId?: string;
+  readonly costSelfCheckDeltaPct?: number;
+}
+
+/**
+ * Buffer line discriminated union. `pre`/`post`/`token` are the original
+ * collector modes. `subagent_token`, `workflow_run`, and
+ * `observability_health` are emitted by the SubagentWatcher / WorkflowWatcher.
+ */
+export type HookEvent =
+  | PreHookEvent
+  | PostHookEvent
+  | TokenHookEvent
+  | SubagentTokenHookEvent
+  | WorkflowRunEvent
+  | ObservabilityHealthHookEvent;
 
 export interface TokenEvent {
   readonly mode: 'token';
@@ -91,9 +169,8 @@ export interface SubagentTokenEvent {
   readonly parentSessionId: string;
 }
 
-export interface WorkflowRunEvent {
+export interface WorkflowRunEvent extends HookEventBase {
   readonly mode: 'workflow_run';
-  readonly timestamp: number;
   readonly workflowRunId: string;
   readonly status: string;
   readonly durationMs: number | null;

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -246,6 +246,22 @@ describe('toolCallToNrEvent()', () => {
     expect(event.bashNetwork).toBe(false);
   });
 
+  it('includes turn_id and turn_number when present on the record', () => {
+    // Locks in the mechanism the index.ts onRecord restructuring depends on:
+    // turn_id/turn_number are attached to a plain ToolCallRecord object (not
+    // mutated onto a readonly-typed one) and must still flow through here via
+    // the generic index-signature spread loop.
+    const record = makeRecord({
+      turn_id: 'turn-abc-123',
+      turn_number: 4,
+    } as Partial<ToolCallRecord>);
+
+    const event = toolCallToNrEvent(record, { developer: 'd', appName: 'a' });
+
+    expect(event.turn_id).toBe('turn-abc-123');
+    expect(event.turn_number).toBe(4);
+  });
+
   it('includes platform attribute defaulting to claude-code', () => {
     const record = makeRecord();
     const event = toolCallToNrEvent(record, { developer: 'd', appName: 'a' });


### PR DESCRIPTION
## Summary
- Fix the anti-pattern detector shape mismatch in the live-session dashboard route (aggregate by type instead of an unsafe cast).
- Replace a readonly-field mutation used to attach turn attribution to tool-call records with a properly-typed record construction.
- Turn the internal hook event buffer's type into a real discriminated union (shared base + 6 per-mode variants), removing an unchecked cast from the event-processing pipeline.

Fixes #217

## Test plan
- [x] `npm run build && npm test && npm run lint` all clean
- [x] New test proving anti-pattern aggregation
- [x] New test proving turn attribution still propagates correctly
- [x] Existing hook event processor and local store tests pass with an unchanged pass count after the type retype