### PR TITLE
Feat: track cost per 1M tokens (session-blended + per-model)

### DIFF
--- a/docs/COMMANDS_TABLE.md
+++ b/docs/COMMANDS_TABLE.md
@@ -241,6 +241,7 @@ Session cost breakdown by task, model, and efficiency.
   "by_task": [{ "task_id": "task-001", "cost_usd": 0.25, "tokens_used": 15000 }],
   "cost_per_line_of_code": 0.003,
   "cost_per_file_modified": 0.065,
+  "cost_per_million_tokens": 7.43,
   "tokens": { "input": 50000, "output": 20000, "thinking": 10000 }
 }
 ```
@@ -254,6 +255,7 @@ Session cost breakdown by task, model, and efficiency.
 - `by_task` — maps `TaskDetector.getCompletedTasks()` to their `estimatedCostUsd` and `tokensUsed`
 - `cost_per_line_of_code` — `totalCost / totalLinesChanged` (null if no lines changed)
 - `cost_per_file_modified` — `totalCost / uniqueFilesWritten` (null if no files modified)
+- `cost_per_million_tokens` — blended session rate: `(totalCost / totalTokens) * 1_000_000`, summed across input, output, thinking, cache-read, and cache-creation tokens (null if no tokens reported). Also emitted as the `ai.cost.per_million_tokens` NR metric, faceted by `model`.
 - `tokens` — running totals by token type from all reports
 
 **Requires:** `CostTracker`; `TaskDetector` for per-task breakdown

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -2987,6 +2987,7 @@ describe('api-handler GET /api/model-usage', () => {
           totalOutputTokens: 500,
           totalCostUsd: 3.2,
           costPerOutputToken: 0.0064,
+          costPerMillionTokens: 2133.33,
           avgOutputTokensPerRequest: 12.5,
         },
       },

--- a/src/metrics/cost-tracker.test.ts
+++ b/src/metrics/cost-tracker.test.ts
@@ -337,6 +337,25 @@ describe('CostTracker', () => {
     });
   });
 
+  describe('costPerMillionTokens', () => {
+    it('computes the blended session rate across input/output tokens', () => {
+      const tracker = new CostTracker();
+
+      // claude-sonnet-4: 500k*3/1M + 500k*15/1M = 1.5 + 7.5 = 9.0 for 1M tokens
+      tracker.recordTokenUsage(
+        makeUsage({ inputTokens: 500_000, outputTokens: 500_000, totalTokens: 1_000_000 }),
+        'claude-sonnet-4',
+      );
+
+      expect(tracker.getMetrics().costPerMillionTokens).toBeCloseTo(9.0, 2);
+    });
+
+    it('returns null when no tokens have been reported', () => {
+      const tracker = new CostTracker();
+      expect(tracker.getMetrics().costPerMillionTokens).toBeNull();
+    });
+  });
+
   describe('null fields when no data', () => {
     it('returns null for cost fields when no tokens reported', () => {
       const tracker = new CostTracker();
@@ -345,6 +364,7 @@ describe('CostTracker', () => {
       expect(metrics.sessionTotalCostUsd).toBeNull();
       expect(metrics.costPerLineOfCode).toBeNull();
       expect(metrics.costPerFileModified).toBeNull();
+      expect(metrics.costPerMillionTokens).toBeNull();
       expect(metrics.costByTask).toBeNull();
       expect(metrics.model).toBeNull();
       expect(metrics.latestCostBreakdown).toBeNull();
@@ -499,6 +519,17 @@ describe('CostTracker', () => {
       expect(names).toContain('ai.cost.cost_per_line_of_code');
       expect(names).toContain('ai.cost.report_count');
       expect(names).toContain('ai.cost.estimation_count');
+      expect(names).toContain('ai.cost.per_million_tokens');
+    });
+
+    it('omits per_million_tokens when no tokens have been reported', () => {
+      const tracker = new CostTracker();
+
+      const aggregator = new MetricAggregator();
+      tracker.emitMetrics(aggregator);
+
+      const names = aggregator.harvest(60_000).map((m) => m.name);
+      expect(names).not.toContain('ai.cost.per_million_tokens');
     });
 
     it('emits cost_per_file_modified when session tracker has file data', () => {

--- a/src/metrics/cost-tracker.ts
+++ b/src/metrics/cost-tracker.ts
@@ -58,6 +58,8 @@ export interface CostMetrics {
   readonly costByModel: Record<string, number>;
   readonly costPerLineOfCode: number | null;
   readonly costPerFileModified: number | null;
+  /** Blended session cost rate: totalCostUsd / totalTokens (all types) * 1M. */
+  readonly costPerMillionTokens: number | null;
   readonly model: string | null;
   readonly totalInputTokens: number;
   readonly totalOutputTokens: number;
@@ -365,6 +367,13 @@ export class CostTracker {
       costByWorkflowRunId[runId] = Object.fromEntries(dayMap);
     }
 
+    const totalTokensAllTypes =
+      this.totalInputTokens +
+      this.totalOutputTokens +
+      this.totalThinkingTokens +
+      this.totalCacheReadTokens +
+      this.totalCacheCreationTokens;
+
     return {
       sessionTotalCostUsd: hasData ? this.totalCostUsd : null,
       costByTask: null,
@@ -373,6 +382,10 @@ export class CostTracker {
         hasData && this.totalLinesChanged > 0 ? this.totalCostUsd / this.totalLinesChanged : null,
       costPerFileModified:
         hasData && uniqueFilesWritten > 0 ? this.totalCostUsd / uniqueFilesWritten : null,
+      costPerMillionTokens:
+        hasData && totalTokensAllTypes > 0
+          ? (this.totalCostUsd / totalTokensAllTypes) * 1_000_000
+          : null,
       model: this.currentModel,
       totalInputTokens: this.totalInputTokens,
       totalOutputTokens: this.totalOutputTokens,
@@ -394,6 +407,20 @@ export class CostTracker {
     const attrs: Record<string, string | number> = {};
     if (this.currentModel) {
       attrs.model = this.currentModel;
+    }
+
+    const totalTokensAllTypes =
+      this.totalInputTokens +
+      this.totalOutputTokens +
+      this.totalThinkingTokens +
+      this.totalCacheReadTokens +
+      this.totalCacheCreationTokens;
+    if (totalTokensAllTypes > 0) {
+      aggregator.record(
+        'ai.cost.per_million_tokens',
+        (this.totalCostUsd / totalTokensAllTypes) * 1_000_000,
+        attrs,
+      );
     }
 
     aggregator.record('ai.cost.session_total_usd', this.totalCostUsd, attrs);

--- a/src/metrics/model-usage-tracker.test.ts
+++ b/src/metrics/model-usage-tracker.test.ts
@@ -57,6 +57,19 @@ describe('ModelUsageTracker', () => {
     expect(t.getMetrics().byModel['model-a']?.costPerOutputToken).toBeNull();
   });
 
+  it('computes costPerMillionTokens correctly', () => {
+    const t = new ModelUsageTracker();
+    t.recordUsage('model-a', 500_000, 500_000, 1.0);
+    const stats = t.getMetrics().byModel['model-a'];
+    expect(stats?.costPerMillionTokens).toBeCloseTo(1.0);
+  });
+
+  it('costPerMillionTokens is null when no tokens are recorded', () => {
+    const t = new ModelUsageTracker();
+    t.recordUsage('model-a', 0, 0, 0);
+    expect(t.getMetrics().byModel['model-a']?.costPerMillionTokens).toBeNull();
+  });
+
   it('avgOutputTokensPerRequest is correct', () => {
     const t = new ModelUsageTracker();
     t.recordUsage('model-a', 0, 200, 0);

--- a/src/metrics/model-usage-tracker.ts
+++ b/src/metrics/model-usage-tracker.ts
@@ -4,6 +4,7 @@ export interface ModelStats {
   readonly totalOutputTokens: number;
   readonly totalCostUsd: number;
   readonly costPerOutputToken: number | null;
+  readonly costPerMillionTokens: number | null;
   readonly avgOutputTokensPerRequest: number | null;
 }
 
@@ -46,6 +47,9 @@ export class ModelUsageTracker {
     for (const [model, stats] of this.byModel) {
       const costPerOutputToken =
         stats.totalOutputTokens > 0 ? stats.totalCostUsd / stats.totalOutputTokens : null;
+      const totalTokens = stats.totalInputTokens + stats.totalOutputTokens;
+      const costPerMillionTokens =
+        totalTokens > 0 ? (stats.totalCostUsd / totalTokens) * 1_000_000 : null;
       const avgOutputTokensPerRequest =
         stats.requestCount > 0 ? stats.totalOutputTokens / stats.requestCount : null;
 
@@ -55,6 +59,7 @@ export class ModelUsageTracker {
         totalOutputTokens: stats.totalOutputTokens,
         totalCostUsd: stats.totalCostUsd,
         costPerOutputToken,
+        costPerMillionTokens,
         avgOutputTokensPerRequest,
       };
 

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -784,6 +784,7 @@ describe('buildSessionSummary', () => {
       costByModel: {},
       costPerLineOfCode: null,
       costPerFileModified: null,
+      costPerMillionTokens: null,
       model: 'claude-sonnet-4-6',
       totalInputTokens: 3_000,
       totalOutputTokens: 1_000,

--- a/src/tools/cost-tools.test.ts
+++ b/src/tools/cost-tools.test.ts
@@ -3,6 +3,7 @@ import {
   handleReportTokens,
   REPORT_TOKENS_TOOL,
   handleGetPromptCacheHealth,
+  handleGetCostBreakdown,
 } from './cost-tools.js';
 import { CostTracker } from '../metrics/cost-tracker.js';
 import type { TokenReport } from './cost-tools.js';
@@ -194,6 +195,34 @@ describe('handleReportTokens()', () => {
 });
 
 // ---------------------------------------------------------------------------
+// handleGetCostBreakdown
+// ---------------------------------------------------------------------------
+
+describe('handleGetCostBreakdown()', () => {
+  it('includes cost_per_million_tokens in the response', () => {
+    const tracker = new CostTracker();
+    handleReportTokens(tracker, {
+      input_tokens: 500_000,
+      output_tokens: 500_000,
+      model: 'claude-sonnet-4',
+    });
+
+    const result = handleGetCostBreakdown(tracker);
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.cost_per_million_tokens).toBeCloseTo(9.0, 2);
+  });
+
+  it('returns null cost_per_million_tokens when no tokens reported', () => {
+    const tracker = new CostTracker();
+    const result = handleGetCostBreakdown(tracker);
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.cost_per_million_tokens).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // handleGetPromptCacheHealth
 // ---------------------------------------------------------------------------
 
@@ -208,6 +237,7 @@ describe('handleGetPromptCacheHealth()', () => {
       costByModel: {},
       costPerLineOfCode: null,
       costPerFileModified: null,
+      costPerMillionTokens: null,
       model: null,
       totalInputTokens: 0,
       totalOutputTokens: 0,

--- a/src/tools/cost-tools.ts
+++ b/src/tools/cost-tools.ts
@@ -159,6 +159,7 @@ export function handleGetCostBreakdown(costTracker: CostTracker, taskDetector?: 
     by_task: byTask,
     cost_per_line_of_code: metrics.costPerLineOfCode,
     cost_per_file_modified: metrics.costPerFileModified,
+    cost_per_million_tokens: metrics.costPerMillionTokens,
     tokens: {
       input: metrics.totalInputTokens,
       output: metrics.totalOutputTokens,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -186,6 +186,7 @@ export interface CostMetrics {
   readonly costByModel: Record<string, number>;
   readonly costPerLineOfCode: number | null;
   readonly costPerFileModified: number | null;
+  readonly costPerMillionTokens: number | null;
   readonly model: string | null;
   readonly totalInputTokens: number;
   readonly totalOutputTokens: number;
@@ -590,6 +591,7 @@ export interface ModelStats {
   readonly totalOutputTokens: number;
   readonly totalCostUsd: number;
   readonly costPerOutputToken: number | null;
+  readonly costPerMillionTokens: number | null;
   readonly avgOutputTokensPerRequest: number | null;
 }
 


### PR DESCRIPTION
## Summary
- Adds a normalized cost-rate metric — `costPerMillionTokens` (`totalCostUsd / totalTokens * 1_000_000`) — computed from data already tracked, so spend can be compared across sessions/models independent of raw token volume.
- `CostTracker`: session-blended rate across all token types (input/output/thinking/cache-read/cache-creation), exposed via `nr_observe_get_cost_breakdown` (`cost_per_million_tokens` field) and emitted as the `ai.cost.per_million_tokens` NR dimensional metric, faceted by `model`.
- `ModelUsageTracker`: per-model rate on `ModelStats`, exposed via `nr_observe_get_model_usage` with zero handler changes (it passes `getMetrics()` through unchanged).
- Updated the client-side type mirrors in `src/web/api/client.ts` for consistency.
- Updated `docs/COMMANDS_TABLE.md` for the `nr_observe_get_cost_breakdown` field list.

## Test plan
- [x] `npm run build && npm test` — full suite passes (4357 tests)
- [x] `npm run lint` — 0 errors/warnings
- [x] New/updated unit tests: `cost-tracker.test.ts`, `model-usage-tracker.test.ts`, `cost-tools.test.ts`, plus mock-fixture fixes in `session-store.test.ts` and `api-handler.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)