### PR TITLE
Test: close 77 coverage gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.4] - 2026-07-17
+
+### Added
+
+- Added test coverage across the MCP server's session and hook handling, metric trackers, platform adapters, proxy and transport layer, storage, alerting, and MCP tool handlers, plus the web dashboard's components, views, and API client — covering error paths, malformed-input handling, and edge-case behavior that previously worked but was unverified.
+
+### Fixed
+
+- Corrected an ambiguous assertion in the Today view's test suite that could match either of two KPI tiles rendering the same value, instead of the one it was meant to check.
+
 ## [1.5.3] - 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/alerts/alert-snapshot-collector.test.ts
+++ b/src/alerts/alert-snapshot-collector.test.ts
@@ -291,4 +291,28 @@ describe('AlertSnapshotCollector — tracker reads', () => {
     const collector = new AlertSnapshotCollector(deps);
     expect(collector.snapshot(NOW, []).cost.sessionUsd).toBe(0);
   });
+
+  it('reads todayUsd/weekUsd from budgetTracker.getStatus()', () => {
+    const deps: AlertSnapshotCollectorDeps = {
+      budgetTracker: {
+        getStatus: () => ({ daily: { spentUsd: 12 }, weekly: { spentUsd: 40 } }),
+      },
+    };
+    const collector = new AlertSnapshotCollector(deps);
+    const snap = collector.snapshot(NOW, []);
+    expect(snap.cost.todayUsd).toBe(12);
+    expect(snap.cost.weekUsd).toBe(40);
+  });
+
+  it('swallows errors from budgetTracker.getStatus() and falls back to zeros', () => {
+    const deps: AlertSnapshotCollectorDeps = {
+      budgetTracker: {
+        getStatus: () => {
+          throw new Error('boom');
+        },
+      },
+    };
+    const collector = new AlertSnapshotCollector(deps);
+    expect(collector.snapshot(NOW, []).cost).toEqual({ sessionUsd: 0, todayUsd: 0, weekUsd: 0 });
+  });
 });

--- a/src/alerts/local-alert-engine.test.ts
+++ b/src/alerts/local-alert-engine.test.ts
@@ -389,6 +389,56 @@ describe('LocalAlertEngine — budget rules', () => {
   });
 });
 
+describe('LocalAlertEngine — budget.daily / budget.weekly periodKey rollover', () => {
+  it('clears a firing budget.daily rule when the calendar day rolls over', () => {
+    const engine = new LocalAlertEngine();
+    engine.loadRules([makeBudgetRule({ id: 'daily-budget', type: 'budget.daily' })]);
+
+    const day1 = new Date(2026, 5, 15, 10, 0, 0).getTime();
+    const day2 = new Date(2026, 5, 16, 10, 0, 0).getTime();
+
+    let events = engine.evaluate(
+      makeSnapshot({
+        budgetThresholds: [{ period: 'daily', thresholdPct: 80, spentUsd: 4, budgetUsd: 5 }],
+      }),
+      day1,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]!.state).toBe('firing');
+
+    // Day rolls over with no matching threshold — must clear, proving periodKey()'s
+    // 'daily' branch rolled over rather than treating the rule as still in-period.
+    events = engine.evaluate(makeSnapshot(), day2);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.state).toBe('cleared');
+    expect(engine.getFiringRuleIds()).toEqual([]);
+  });
+
+  it('clears a firing budget.weekly rule across an ISO week boundary (Sun -> Mon)', () => {
+    const engine = new LocalAlertEngine();
+    engine.loadRules([makeBudgetRule({ id: 'weekly-budget', type: 'budget.weekly' })]);
+
+    const sunday = new Date(2026, 5, 7, 10, 0, 0).getTime();
+    const monday = new Date(2026, 5, 8, 10, 0, 0).getTime();
+
+    let events = engine.evaluate(
+      makeSnapshot({
+        budgetThresholds: [{ period: 'weekly', thresholdPct: 80, spentUsd: 40, budgetUsd: 50 }],
+      }),
+      sunday,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]!.state).toBe('firing');
+
+    // Monday starts a new ISO week — must clear, proving periodKey()'s 'weekly'
+    // branch computed a different ISO week number.
+    events = engine.evaluate(makeSnapshot(), monday);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.state).toBe('cleared');
+    expect(engine.getFiringRuleIds()).toEqual([]);
+  });
+});
+
 describe('LocalAlertEngine — clock + state housekeeping', () => {
   it('uses the injected clock for now()', () => {
     const engine = new LocalAlertEngine({ clock: () => 42 });

--- a/src/dashboard/dashboard-server.test.ts
+++ b/src/dashboard/dashboard-server.test.ts
@@ -6,6 +6,7 @@ import { DashboardServer } from './dashboard-server.js';
 import { LiveEventBus } from './live-event-bus.js';
 import { LocalAlertEngine } from '../alerts/local-alert-engine.js';
 import { AlertLog } from '../alerts/alert-log.js';
+import { VERSION } from '../version.js';
 
 describe('DashboardServer', () => {
   let server: DashboardServer;
@@ -110,6 +111,74 @@ describe('DashboardServer', () => {
     const res = await fetch(`http://127.0.0.1:${addr.port}/api/health`);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.updateAvailable).toBe(false);
+  });
+
+  it('health updateAvailable is true for a same-major, newer-minor candidate', async () => {
+    const [major, minor] = VERSION.split('.').map(Number);
+    const candidate = `${major}.${(minor ?? 0) + 1}.0`;
+    server = new DashboardServer({
+      port: 0,
+      host: '127.0.0.1',
+      bus: new LiveEventBus(),
+      npmFetcher: () => Promise.resolve(candidate),
+    });
+    const addr = await server.start();
+    await Promise.resolve();
+    const res = await fetch(`http://127.0.0.1:${addr.port}/api/health`);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.updateAvailable).toBe(true);
+  });
+
+  it('health updateAvailable is true for a same-major-minor, newer-patch candidate', async () => {
+    const [major, minor, patch] = VERSION.split('.').map(Number);
+    const candidate = `${major}.${minor}.${(patch ?? 0) + 1}`;
+    server = new DashboardServer({
+      port: 0,
+      host: '127.0.0.1',
+      bus: new LiveEventBus(),
+      npmFetcher: () => Promise.resolve(candidate),
+    });
+    const addr = await server.start();
+    await Promise.resolve();
+    const res = await fetch(`http://127.0.0.1:${addr.port}/api/health`);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.updateAvailable).toBe(true);
+  });
+
+  // Without stripping the `-beta` suffix before parsing, the patch segment
+  // ("<n>-beta") parses to NaN and the newer-patch comparison silently
+  // resolves to false instead of true — this pins the strip-before-parse
+  // regex, not just the numeric comparison.
+  it('health updateAvailable strips a -beta prerelease suffix before comparing the patch number', async () => {
+    const [major, minor, patch] = VERSION.split('.').map(Number);
+    const candidate = `${major}.${minor}.${(patch ?? 0) + 1}-beta`;
+    server = new DashboardServer({
+      port: 0,
+      host: '127.0.0.1',
+      bus: new LiveEventBus(),
+      npmFetcher: () => Promise.resolve(candidate),
+    });
+    const addr = await server.start();
+    await Promise.resolve();
+    const res = await fetch(`http://127.0.0.1:${addr.port}/api/health`);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.updateAvailable).toBe(true);
+  });
+
+  it('health updateAvailable strips a -rc.1 prerelease suffix before comparing the patch number', async () => {
+    const [major, minor, patch] = VERSION.split('.').map(Number);
+    const candidate = `${major}.${minor}.${(patch ?? 0) + 1}-rc.1`;
+    server = new DashboardServer({
+      port: 0,
+      host: '127.0.0.1',
+      bus: new LiveEventBus(),
+      npmFetcher: () => Promise.resolve(candidate),
+    });
+    const addr = await server.start();
+    await Promise.resolve();
+    const res = await fetch(`http://127.0.0.1:${addr.port}/api/health`);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.updateAvailable).toBe(true);
   });
 
   it('stop() closes the server cleanly', async () => {
@@ -463,5 +532,88 @@ describe('DashboardServer security headers', () => {
     const addr = await server.start();
     const res = await fetch(`http://127.0.0.1:${addr.port}/api/health`);
     expect(res.headers.get('referrer-policy')).toBe('no-referrer');
+  });
+});
+
+describe('DashboardServer handle() defensive error handling', () => {
+  let server: DashboardServer;
+  afterEach(async () => {
+    await server?.stop();
+  });
+
+  // Regression guard for the registered-route try/catch in handle(): the
+  // /sse route handler has no internal error handling of its own, so a
+  // throw from bus.replayFrom() (invoked synchronously when a client
+  // reconnects with Last-Event-ID) must be caught and logged by handle()
+  // rather than crashing the request.
+  it('logs and swallows a synchronous throw from a registered route handler (/sse replay)', async () => {
+    const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const bus = new LiveEventBus();
+    jest.spyOn(bus, 'replayFrom').mockImplementation(() => {
+      throw new Error('replay boom');
+    });
+    try {
+      server = new DashboardServer({ port: 0, host: '127.0.0.1', bus });
+      const addr = await server.start();
+      await new Promise<void>((resolve) => {
+        const req = http.request(
+          {
+            hostname: '127.0.0.1',
+            port: addr.port,
+            path: '/sse',
+            method: 'GET',
+            headers: { 'last-event-id': '0' },
+          },
+          (res) => {
+            res.on('data', () => {});
+            req.destroy();
+            resolve();
+          },
+        );
+        req.on('error', () => resolve());
+        req.end();
+      });
+      await new Promise((r) => setImmediate(r));
+      const captured = stderrSpy.mock.calls.map((args) => String(args[0])).join('');
+      expect(captured).toContain('Route handler error');
+      expect(captured).toContain('replay boom');
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  // Regression guard for the /api/... branch's try/catch in handle(): the
+  // api handler (routes/api-handler.ts) already catches dependency-level
+  // throws internally and returns its own 500 response, so that path never
+  // reaches handle()'s own fallback. This reaches into the private
+  // apiHandler field to simulate a throw that escapes the inner handler
+  // entirely, proving handle()'s defense-in-depth fallback (500
+  // {error:'internal'}) still logs and responds correctly.
+  it('logs and falls back to 500 {error:"internal"} when the api handler itself throws', async () => {
+    const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      server = new DashboardServer({
+        port: 0,
+        host: '127.0.0.1',
+        bus: new LiveEventBus(),
+        api: {},
+      });
+      const addr = await server.start();
+      (
+        server as unknown as {
+          apiHandler: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>;
+        }
+      ).apiHandler = () => {
+        throw new Error('api handler boom');
+      };
+      const res = await fetch(`http://127.0.0.1:${addr.port}/api/whatever`);
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: 'internal' });
+      const captured = stderrSpy.mock.calls.map((args) => String(args[0])).join('');
+      expect(captured).toContain('API handler error');
+      expect(captured).toContain('api handler boom');
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1595,6 +1595,182 @@ describe('api-handler GET /api/sessions/today/aggregate', () => {
   });
 });
 
+describe('api-handler GET /api/workflows', () => {
+  it('returns 503 unavailable when workflowStore dep is absent', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/workflows' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+    expect(JSON.parse(body())).toEqual({ error: 'unavailable', what: 'workflowStore' });
+  });
+
+  it('passes since/run_source/status query params through to listRuns() unchanged, and returns a bare array', async () => {
+    const fakeRow = {
+      workflow_run_id: 'wf_abc12345-6dd',
+      parent_session_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      task_id: null,
+      workflow_name: 'sample',
+      status: 'completed',
+      incomplete: false,
+      error_reason: null,
+      default_model: 'claude-opus-4-7',
+      started_at: 1_781_652_144_959,
+      duration_ms: 745_892,
+      agent_count: 2,
+      total_tokens: 826_463,
+      total_usd: null,
+      declared_phases: null,
+      observed_phases: 1,
+      declared_parallel_widths: [],
+      token_reconciliation_delta: null,
+      run_source: 'script',
+      script_path: null,
+      workflow_json_path: '/tmp/wf_abc12345-6dd.json',
+    };
+    const listRunsSpy = jest.fn(() => [fakeRow]);
+    const handler = createApiHandler({
+      workflowStore: {
+        listRuns: listRunsSpy,
+        getRun: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['workflowStore'],
+    });
+    const req = {
+      method: 'GET',
+      url: '/api/workflows?since=1000&run_source=agent_tool&status=incomplete',
+    } as IncomingMessage;
+    const { res, status, body, headers } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(headers()['content-type']).toMatch(/application\/json/);
+    expect(listRunsSpy).toHaveBeenCalledWith({
+      since: 1000,
+      runSource: 'agent_tool',
+      status: 'incomplete',
+    });
+    const parsed = JSON.parse(body());
+    // Bare array, not { runs: [...] } — the SPA feeds this straight into
+    // Array.isArray().
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].runId).toBe('wf_abc12345-6dd');
+  });
+});
+
+describe('api-handler GET /api/observability-health', () => {
+  it('returns 503 unavailable when observabilityHealth dep is absent', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/observability-health' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+    expect(JSON.parse(body())).toEqual({ error: 'unavailable', what: 'observabilityHealth' });
+  });
+
+  it('passes through observabilityHealth.getSnapshot()', async () => {
+    const snapshot = {
+      watcherActive: true,
+      filesWatched: 3,
+      parseErrors: 0,
+      watcherDisabledByLock: false,
+      costSelfCheckDeltaPct: null,
+    };
+    const handler = createApiHandler({
+      observabilityHealth: { getSnapshot: () => snapshot },
+    });
+    const req = { method: 'GET', url: '/api/observability-health' } as IncomingMessage;
+    const { res, status, body, headers } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(headers()['content-type']).toMatch(/application\/json/);
+    expect(JSON.parse(body())).toEqual(snapshot);
+  });
+});
+
+describe('api-handler GET /api/workflows/:runId', () => {
+  it('returns 503 unavailable when workflowStore dep is absent', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/workflows/wf_abc12345-6dd' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+    expect(JSON.parse(body())).toEqual({ error: 'unavailable', what: 'workflowStore' });
+  });
+
+  it('returns 404 {error:"not_found"} when getRun() returns null', async () => {
+    const handler = createApiHandler({
+      workflowStore: { listRuns: () => [], getRun: () => null },
+    });
+    const req = { method: 'GET', url: '/api/workflows/wf_nonexistent' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(404);
+    expect(JSON.parse(body())).toEqual({ error: 'not_found' });
+  });
+
+  it('maps the run + agents + topology fields to their DTO shape when found', async () => {
+    const runRow = {
+      workflow_run_id: 'wf_abc12345-6dd',
+      parent_session_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      task_id: 'task-1',
+      workflow_name: 'sample',
+      status: 'completed',
+      incomplete: false,
+      error_reason: null,
+      default_model: 'claude-opus-4-7',
+      started_at: 1_781_652_144_959,
+      duration_ms: 745_892,
+      agent_count: 1,
+      total_tokens: 137_810,
+      total_usd: 4.56,
+      declared_phases: 2,
+      observed_phases: 1,
+      declared_parallel_widths: [1, 'dynamic'],
+      token_reconciliation_delta: null,
+      run_source: 'script',
+      script_path: null,
+      workflow_json_path: '/tmp/wf_abc12345-6dd.json',
+      agents: [
+        {
+          agent_id: 'a45d96d201bf2f1ef',
+          label: 'investigate:hooks-coverage',
+          phase_index: 1,
+          phase_title: 'Investigate',
+          model: 'claude-opus-4-7',
+          state: 'done',
+          attempt: 1,
+          duration_ms: 222_186,
+          tokens: 137_810,
+          tool_calls: 35,
+          started_at: 1,
+        },
+      ],
+      topology: {
+        workflowName: 'sample',
+        declaredPhases: 2,
+        declaredParallelWidths: [1, 'dynamic'],
+      },
+    };
+    const handler = createApiHandler({
+      workflowStore: {
+        listRuns: () => [],
+        getRun: (runId: string) => (runId === 'wf_abc12345-6dd' ? runRow : null),
+      } as unknown as Parameters<typeof createApiHandler>[0]['workflowStore'],
+    });
+    const req = { method: 'GET', url: '/api/workflows/wf_abc12345-6dd' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body());
+    expect(parsed.run.runId).toBe('wf_abc12345-6dd');
+    expect(parsed.run.taskId).toBe('task-1');
+    expect(parsed.run.totalUsd).toBeCloseTo(4.56, 2);
+    expect(parsed.agents).toHaveLength(1);
+    expect(parsed.agents[0].agentId).toBe('a45d96d201bf2f1ef');
+    expect(parsed.topology).toEqual(runRow.topology);
+  });
+});
+
 describe('api-handler GET /api/concurrency (96-bucket grid)', () => {
   function midnightToday(): number {
     const d = new Date();

--- a/src/dashboard/workflow-store.test.ts
+++ b/src/dashboard/workflow-store.test.ts
@@ -246,6 +246,30 @@ describe('WorkflowStore', () => {
     expect(row!.error_reason!.length).toBe(200);
   });
 
+  // WorkflowStore's readRow() currently hardcodes run_source: 'script' for
+  // every wf_*.json it reads (there is no on-disk producer of 'agent_tool'
+  // rows yet), so this pins the query-filtering branch itself (lines
+  // ~161-167) in both directions rather than asserting on an unfiltered row:
+  // filtering FOR the value every row actually has must include it,
+  // filtering for the OTHER value must exclude it, and 'all'/omitted must
+  // never filter.
+  it('listRuns() filters by runSource, excluding non-matching values', () => {
+    writeFileSync(join(wfDir, 'wf_abc12345-6dd.json'), makeWfJson());
+    const store = new WorkflowStore({ projectsDir });
+    const scriptOnly = store.listRuns({ runSource: 'script' });
+    expect(scriptOnly).toHaveLength(1);
+    expect(scriptOnly[0].run_source).toBe('script');
+
+    const agentToolOnly = store.listRuns({ runSource: 'agent_tool' });
+    expect(agentToolOnly).toHaveLength(0);
+
+    const all = store.listRuns({ runSource: 'all' });
+    expect(all).toHaveLength(1);
+
+    const omitted = store.listRuns();
+    expect(omitted).toHaveLength(1);
+  });
+
   it('caps listRuns() at MAX_RUNS, keeping the most recent runs', () => {
     const TOTAL = 520; // exceeds the planned MAX_RUNS = 500 cap
     for (let i = 0; i < TOTAL; i++) {

--- a/src/deploy/data-paths.test.ts
+++ b/src/deploy/data-paths.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { resolveDataDir } from './data-paths.js';
+
+describe('resolveDataDir', () => {
+  let root: string;
+  let originalArgv1: string;
+  let cwdSpy: ReturnType<typeof jest.spyOn> | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'data-paths-test-'));
+    originalArgv1 = process.argv[1]!;
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    process.argv[1] = originalArgv1;
+    cwdSpy?.mockRestore();
+    cwdSpy = undefined;
+  });
+
+  // scriptDir sits two levels below root, and cwd is a sibling of root, so the
+  // six candidate paths (below) never overlap with one another.
+  function setScriptAndCwd(scriptDir: string, cwd: string): void {
+    process.argv[1] = join(scriptDir, 'index.js');
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(cwd);
+  }
+
+  it('finds the bundledFromIndex candidate (<scriptDir>/data/<name>)', () => {
+    const scriptDir = join(root, 'x', 'y');
+    const cwd = join(root, 'cwd');
+    const expected = join(scriptDir, 'data', 'alerts');
+    mkdirSync(expected, { recursive: true });
+    setScriptAndCwd(scriptDir, cwd);
+    expect(resolveDataDir('alerts')).toBe(expected);
+  });
+
+  it('finds the sourceTreeFromIndex candidate (<scriptDir>/../<name>)', () => {
+    const scriptDir = join(root, 'x', 'y');
+    const cwd = join(root, 'cwd');
+    const expected = join(root, 'x', 'alerts');
+    mkdirSync(expected, { recursive: true });
+    setScriptAndCwd(scriptDir, cwd);
+    expect(resolveDataDir('alerts')).toBe(expected);
+  });
+
+  it('finds the bundledFromDeploy candidate (<scriptDir>/../data/<name>)', () => {
+    const scriptDir = join(root, 'x', 'y');
+    const cwd = join(root, 'cwd');
+    const expected = join(root, 'x', 'data', 'alerts');
+    mkdirSync(expected, { recursive: true });
+    setScriptAndCwd(scriptDir, cwd);
+    expect(resolveDataDir('alerts')).toBe(expected);
+  });
+
+  it('finds the sourceTreeFromDeploy candidate (<scriptDir>/../../<name>)', () => {
+    const scriptDir = join(root, 'x', 'y');
+    const cwd = join(root, 'cwd');
+    const expected = join(root, 'alerts');
+    mkdirSync(expected, { recursive: true });
+    setScriptAndCwd(scriptDir, cwd);
+    expect(resolveDataDir('alerts')).toBe(expected);
+  });
+
+  it('finds the fromCwd candidate (<cwd>/<name>)', () => {
+    const scriptDir = join(root, 'x', 'y');
+    const cwd = join(root, 'cwd');
+    const expected = join(cwd, 'alerts');
+    mkdirSync(expected, { recursive: true });
+    setScriptAndCwd(scriptDir, cwd);
+    expect(resolveDataDir('alerts')).toBe(expected);
+  });
+
+  it('finds the bundledFromCwd candidate (<cwd>/dist/data/<name>)', () => {
+    const scriptDir = join(root, 'x', 'y');
+    const cwd = join(root, 'cwd');
+    const expected = join(cwd, 'dist', 'data', 'alerts');
+    mkdirSync(expected, { recursive: true });
+    setScriptAndCwd(scriptDir, cwd);
+    expect(resolveDataDir('alerts')).toBe(expected);
+  });
+
+  it('throws an Error listing all six tried paths when none of the candidates exist', () => {
+    const scriptDir = join(root, 'x', 'y');
+    const cwd = join(root, 'cwd');
+    setScriptAndCwd(scriptDir, cwd);
+
+    let caught: Error | undefined;
+    try {
+      resolveDataDir('alerts');
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const message = caught!.message;
+    expect(message).toContain('Could not locate alerts/ data directory');
+    expect(message).toContain(join(scriptDir, 'data', 'alerts'));
+    expect(message).toContain(join(root, 'x', 'alerts'));
+    expect(message).toContain(join(root, 'x', 'data', 'alerts'));
+    expect(message).toContain(join(root, 'alerts'));
+    expect(message).toContain(join(cwd, 'alerts'));
+    expect(message).toContain(join(cwd, 'dist', 'data', 'alerts'));
+  });
+});

--- a/src/deploy/deploy-alerts.test.ts
+++ b/src/deploy/deploy-alerts.test.ts
@@ -1,12 +1,25 @@
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { jest } from '@jest/globals';
+
+// Point homedir() at a throw-away temp tree so loadPersonalThresholds() (which
+// reads ~/.newrelic-preflight/config.json with no injection seam) never
+// touches the real user home directory.
+const TEST_HOME = `/tmp/nr-deploy-alerts-test-${process.pid}`;
+jest.mock('node:os', () => {
+  const real = jest.requireActual<typeof import('node:os')>('node:os');
+  return { ...real, homedir: () => TEST_HOME };
+});
+
 import {
   runDeployAlerts,
   loadDefinitions,
   loadPersonalDefinitions,
   buildConditionInput,
+  loadPersonalThresholds,
 } from './deploy-alerts.js';
+import { DEFAULT_PERSONAL_THRESHOLDS } from '../alerts/types.js';
 import type { PersonalAlertThresholds } from '../alerts/types.js';
 
 interface MockResponse {
@@ -572,5 +585,33 @@ describe('runDeployAlerts', () => {
       stdout: out,
     });
     expect(calls[0].url).toBe('https://api.eu.newrelic.com/graphql');
+  });
+});
+
+describe('loadPersonalThresholds', () => {
+  const configDir = join(TEST_HOME, '.newrelic-preflight');
+
+  beforeEach(() => {
+    mkdirSync(configDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('mixes a partial alerts.personal config with DEFAULT_PERSONAL_THRESHOLDS for the rest', () => {
+    writeFileSync(
+      join(configDir, 'config.json'),
+      JSON.stringify({ alerts: { personal: { dailyCostUsd: 9.5 } } }),
+    );
+    expect(loadPersonalThresholds()).toEqual({
+      ...DEFAULT_PERSONAL_THRESHOLDS,
+      dailyCostUsd: 9.5,
+    });
+  });
+
+  it('falls back to DEFAULT_PERSONAL_THRESHOLDS entirely on malformed JSON', () => {
+    writeFileSync(join(configDir, 'config.json'), '{ not valid json');
+    expect(loadPersonalThresholds()).toEqual(DEFAULT_PERSONAL_THRESHOLDS);
   });
 });

--- a/src/deploy/deploy-dashboards.test.ts
+++ b/src/deploy/deploy-dashboards.test.ts
@@ -281,6 +281,86 @@ describe('runDeployDashboards', () => {
     expect(calls).toHaveLength(2);
   });
 
+  it('--update finds the existing dashboard and updates it', async () => {
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    process.env.NEW_RELIC_API_KEY = 'NRAK-test';
+    const { fetch: fetchImpl, calls } = makeFetchMock([
+      // findDashboardGuid
+      {
+        data: {
+          actor: {
+            entitySearch: {
+              results: { entities: [{ guid: 'GUID-EXISTING', name: 'Test Dashboard' }] },
+            },
+          },
+        },
+      },
+      // dashboardUpdate
+      {
+        data: {
+          dashboardUpdate: {
+            entityResult: { guid: 'GUID-EXISTING', name: 'Test Dashboard' },
+            errors: null,
+          },
+        },
+      },
+    ]);
+    const out = new CapturedStdout();
+    const code = await runDeployDashboards({
+      all: false,
+      update: true,
+      teardown: false,
+      print: false,
+      eu: false,
+      developer: null,
+      file: 'sample.json',
+      dataDir,
+      fetchImpl,
+      stdout: out,
+    });
+    expect(code).toBe(0);
+    expect(calls).toHaveLength(2);
+    expect(calls[1].body.query).toContain('dashboardUpdate');
+    expect(out.text()).toContain('Updating...');
+    expect(out.text()).toContain('GUID: GUID-EXISTING');
+  });
+
+  it('--teardown finds the existing dashboard and deletes it', async () => {
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    process.env.NEW_RELIC_API_KEY = 'NRAK-test';
+    const { fetch: fetchImpl, calls } = makeFetchMock([
+      // findDashboardGuid
+      {
+        data: {
+          actor: {
+            entitySearch: {
+              results: { entities: [{ guid: 'GUID-EXISTING', name: 'Test Dashboard' }] },
+            },
+          },
+        },
+      },
+      // dashboardDelete
+      { data: { dashboardDelete: { status: 'SUCCESS', errors: null } } },
+    ]);
+    const out = new CapturedStdout();
+    const code = await runDeployDashboards({
+      all: false,
+      update: false,
+      teardown: true,
+      print: false,
+      eu: false,
+      developer: null,
+      file: 'sample.json',
+      dataDir,
+      fetchImpl,
+      stdout: out,
+    });
+    expect(code).toBe(0);
+    expect(calls).toHaveLength(2);
+    expect(calls[1].body.query).toContain('dashboardDelete');
+    expect(out.text()).toContain('✓ Deleted "Test Dashboard" (SUCCESS)');
+  });
+
   it('--teardown skips when no matching dashboard is found', async () => {
     process.env.NEW_RELIC_ACCOUNT_ID = '12345';
     process.env.NEW_RELIC_API_KEY = 'NRAK-test';

--- a/src/digest/digest-formatter.test.ts
+++ b/src/digest/digest-formatter.test.ts
@@ -53,4 +53,18 @@ describe('formatSlackDigest', () => {
     );
     expect(JSON.stringify(payload)).toContain('thrashing');
   });
+
+  it('falls back to "none" for the top anti-pattern when antiPatternCounts is empty', () => {
+    const payload = formatSlackDigest(makeWeeklySummary({ antiPatternCounts: {} }));
+    expect(JSON.stringify(payload)).toContain('`none`');
+  });
+
+  it('sanitizes backticks and newlines in the top anti-pattern label before embedding it in a Slack code span', () => {
+    const payload = formatSlackDigest(
+      makeWeeklySummary({ antiPatternCounts: { 'evil`pattern\ninjected': 5 } }),
+    );
+    const text = JSON.stringify(payload);
+    expect(text).not.toContain('evil`pattern');
+    expect(text).toContain('evil_pattern_injected');
+  });
 });

--- a/src/digest/digest-sender.test.ts
+++ b/src/digest/digest-sender.test.ts
@@ -68,5 +68,30 @@ describe('digest-sender', () => {
         global.fetch = originalFetch;
       }
     });
+
+    it('rejects a malformed URL with no parseable scheme', async () => {
+      await expect(sendSlackDigest('not-a-url-at-all', { text: 'test' })).rejects.toThrow(
+        'Invalid webhook URL: must be a valid https://hooks.slack.com/ URL',
+      );
+    });
+
+    it('rejects when Slack responds with a non-2xx status', async () => {
+      const validUrl = 'https://hooks.slack.com/services/T00/B00/X';
+
+      const originalFetch = global.fetch;
+      global.fetch = async () =>
+        ({
+          ok: false,
+          status: 500,
+        }) as Response;
+
+      try {
+        await expect(sendSlackDigest(validUrl, { text: 'test' })).rejects.toThrow(
+          'Slack webhook returned 500',
+        );
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
   });
 });

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -417,6 +417,12 @@ describe('collector-script', () => {
 
       expect(readBufferEvents()).toHaveLength(0);
     });
+
+    it('silently ignores malformed (non-JSON) stdin payloads', () => {
+      expect(() => processHook('not valid json{{{')).not.toThrow();
+
+      expect(readBufferEvents()).toHaveLength(0);
+    });
   });
 
   function makeKiroPreToolUse(overrides?: Record<string, unknown>): string {

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -999,6 +999,53 @@ describe('HookEventProcessor', () => {
     });
   });
 
+  describe('mode: workflow_run', () => {
+    function makeWorkflowRunEvent(overrides?: Partial<Omit<HookEvent, 'mode'>>): HookEvent {
+      return {
+        mode: 'workflow_run',
+        tool: 'workflow_run',
+        timestamp: 1700000000000,
+        workflowRunId: 'wf_abc12345-6dd',
+        status: 'completed',
+        durationMs: 5000,
+        totalTokens: 1234,
+        agentCount: 3,
+        workflowName: 'my-workflow',
+        phases: ['phase-1', 'phase-2'],
+        workflowProgress: [],
+        parentSessionId: 'sess-1',
+        ...overrides,
+      } as HookEvent;
+    }
+
+    it('dedups by (workflowRunId, timestamp) — fires onWorkflowRun exactly once', () => {
+      const runs: import('../storage/types.js').WorkflowRunEvent[] = [];
+      const processor = new HookEventProcessor({
+        store,
+        onRecord: () => undefined,
+        onWorkflowRun: (event) => runs.push(event),
+      });
+      const event = makeWorkflowRunEvent();
+
+      processor.processEvents([event, event]);
+
+      expect(runs).toHaveLength(1);
+      expect(runs[0].workflowRunId).toBe('wf_abc12345-6dd');
+    });
+
+    it('swallows errors from a throwing onWorkflowRun callback', () => {
+      const processor = new HookEventProcessor({
+        store,
+        onRecord: () => undefined,
+        onWorkflowRun: () => {
+          throw new Error('boom');
+        },
+      });
+
+      expect(() => processor.processEvents([makeWorkflowRunEvent()])).not.toThrow();
+    });
+  });
+
   describe('platform tool-name mapping', () => {
     it('maps a non-canonical tool name using the injected platform adapter', () => {
       const fakeAdapter = {

--- a/src/hooks/subagent-watcher.test.ts
+++ b/src/hooks/subagent-watcher.test.ts
@@ -621,4 +621,109 @@ describe('SubagentWatcher', () => {
     // duplicated, the JSON would be malformed and never parse to msg_b.
     expect(tokens[1]!.messageId).toBe('msg_b');
   });
+
+  // -------------------------------------------------------------------------
+  // Schema-drift + cost self-check observability health events
+  // -------------------------------------------------------------------------
+
+  function makeAssistantLineWithUsage(
+    messageId: string,
+    uuid: string,
+    usage: Record<string, unknown>,
+  ): string {
+    return JSON.stringify({
+      type: 'assistant',
+      agentId: AGENT_ID,
+      uuid,
+      timestamp: '2026-06-15T12:00:00.000Z',
+      sessionId: PARENT_SESSION,
+      message: {
+        id: messageId,
+        role: 'assistant',
+        model: 'claude-opus-4-7',
+        stop_reason: 'end_turn',
+        content: [{ type: 'text' }],
+        usage,
+      },
+    });
+  }
+
+  function readHealthEvents(): {
+    event?: string;
+    dimension?: string;
+    costSelfCheckDeltaPct?: number;
+  }[] {
+    const bufPath = join(storagePath, `buffer-${PARENT_SESSION}.jsonl`);
+    if (!existsSync(bufPath)) return [];
+    return readFileSync(bufPath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
+      .filter((l) => l.mode === 'observability_health');
+  }
+
+  it('emits schema_drift once for a new usage-key shape, then suppresses a repeat within the reemission window', () => {
+    const fullUsage = {
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_input_tokens: 1000,
+      cache_creation_input_tokens: 200,
+    };
+    const missingCacheCreation = {
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_input_tokens: 1000,
+    };
+    const driftEvents = () =>
+      readHealthEvents().filter((e) => e.event === 'schema_drift' && e.dimension === 'usage_keys');
+
+    writeFileSync(agentJsonl, makeAssistantLineWithUsage('msg_1', 'u1', fullUsage) + '\n');
+    const watcher = new SubagentWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+    watcher.poll();
+    // Baseline fingerprint — first time seen, so it fires.
+    expect(driftEvents()).toHaveLength(1);
+
+    writeFileSync(
+      agentJsonl,
+      makeAssistantLineWithUsage('msg_1', 'u1', fullUsage) +
+        '\n' +
+        makeAssistantLineWithUsage('msg_2', 'u2', missingCacheCreation) +
+        '\n',
+    );
+    watcher.poll();
+    // A distinct usage-key shape produces its own new schema_drift event.
+    expect(driftEvents()).toHaveLength(2);
+
+    writeFileSync(
+      agentJsonl,
+      makeAssistantLineWithUsage('msg_1', 'u1', fullUsage) +
+        '\n' +
+        makeAssistantLineWithUsage('msg_2', 'u2', missingCacheCreation) +
+        '\n' +
+        makeAssistantLineWithUsage('msg_3', 'u3', missingCacheCreation) +
+        '\n',
+    );
+    watcher.poll();
+    // The same shape recurring within the 1h reemission window does not re-fire.
+    expect(driftEvents()).toHaveLength(2);
+  });
+
+  it('emits cost_self_check with the ground-truth-vs-tracked delta percentage', () => {
+    const watcher = new SubagentWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+      costSelfCheck: () => ({ trackedUsd: 8, groundTruthUsd: 10 }),
+    });
+    watcher.poll();
+
+    const costEvents = readHealthEvents().filter((e) => e.event === 'cost_self_check');
+    expect(costEvents).toHaveLength(1);
+    // (groundTruthUsd - trackedUsd) / groundTruthUsd * 100 = (10 - 8) / 10 * 100 = 20
+    expect(costEvents[0]!.costSelfCheckDeltaPct).toBeCloseTo(20, 5);
+  });
 });

--- a/src/hooks/workflow-script-parser.test.ts
+++ b/src/hooks/workflow-script-parser.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from '@jest/globals';
-import { parseWorkflowScriptSource } from './workflow-script-parser.js';
+import { describe, expect, it, afterEach } from '@jest/globals';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseWorkflowScript, parseWorkflowScriptSource } from './workflow-script-parser.js';
 
 describe('parseWorkflowScriptSource', () => {
   it('extracts a simple meta block with phases', () => {
@@ -175,5 +178,41 @@ describe('parseWorkflowScriptSource', () => {
     // The parser counts all agent() call sites regardless of nesting:
     // 1 (Seed) + 1 (Fetch inside map lambda) + 3 (Verify) + 1 (Synthesize) = 6
     expect(result.topology?.declaredAgents).toBe(6);
+  });
+});
+
+describe('parseWorkflowScript', () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('returns parser_skip with reason file_not_found for a missing path', () => {
+    const result = parseWorkflowScript('/does/not/exist.js');
+    expect(result).toEqual({ status: 'parser_skip', reason: 'file_not_found', topology: null });
+  });
+
+  it('reads a real file and returns the same topology parseWorkflowScriptSource would produce', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'workflow-script-parser-test-'));
+    const src = `
+      export const meta = {
+        name: 'sample',
+        phases: [{ title: 'Investigate', detail: 'go' }],
+      }
+      phase('Investigate')
+      const a = await agent('do thing')
+    `;
+    const path = join(tmpDir, 'workflow.js');
+    writeFileSync(path, src);
+
+    const fileResult = parseWorkflowScript(path);
+    const sourceResult = parseWorkflowScriptSource(src);
+
+    expect(fileResult.status).toBe('ok');
+    expect(fileResult).toEqual(sourceResult);
   });
 });

--- a/src/hooks/workflow-watcher.test.ts
+++ b/src/hooks/workflow-watcher.test.ts
@@ -332,6 +332,50 @@ describe('WorkflowWatcher', () => {
     }
   });
 
+  it('emits parser_skip for a contained (non-traversal) script that parseWorkflowScript itself rejects', () => {
+    const projectsDir = mkdtempSync(join(tmpdir(), 'wfw-malformed-script-'));
+    try {
+      const sessionId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+      const wfDir = join(projectsDir, 'proj', sessionId, 'workflows');
+      mkdirSync(wfDir, { recursive: true });
+      const runId = 'wf_deadbeefcafebabe';
+      // Contained under projectsDir — no path-traversal — but has no
+      // `export const meta = {...}` block, so parseWorkflowScript itself
+      // returns { status: 'parser_skip', reason: 'no_meta' }.
+      const malformedScript = join(wfDir, 'malformed.js');
+      writeFileSync(malformedScript, "const x = 1;\nagent('a')\n");
+      writeFileSync(
+        join(wfDir, `${runId}.json`),
+        JSON.stringify({
+          runId,
+          workflowName: 'malformed-meta',
+          status: 'completed',
+          startTime: Date.now(),
+          durationMs: 1000,
+          agentCount: 1,
+          totalTokens: 10,
+          scriptPath: malformedScript,
+        }),
+      );
+
+      const runs: ScriptWorkflowRunMetrics[] = [];
+      const health: ObservabilityHealthMetrics[] = [];
+      const watcher = new WorkflowWatcher({ projectsDir });
+      watcher.setOnRun((r) => runs.push(r));
+      watcher.setOnHealth((h) => health.push(h));
+      watcher.poll();
+
+      expect(runs).toHaveLength(1);
+      // The run still emits — topology falls back to null, distinct from
+      // (and independent of) the containment-escape branch tested above.
+      expect(runs[0]!.declared_phases).toBeNull();
+      expect(runs[0]!.workflow_name).toBe('malformed-meta');
+      expect(health.some((h) => h.event === 'parser_skip')).toBe(true);
+    } finally {
+      rmSync(projectsDir, { recursive: true, force: true });
+    }
+  });
+
   it('counts parse errors when bad JSON has a stable mtime', () => {
     // The partial-write protection discards errors only when mtime changes
     // between read and re-stat. With stable mtime the error is counted.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve, join } from 'node:path';
 import {
@@ -723,6 +723,70 @@ describe('stdio integration', () => {
       await client.close();
     } finally {
       rmSync(tmpJobDir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('serves the pending tool set immediately when session_id cannot resolve synchronously, then swaps to the full set once the breadcrumb resolves', async () => {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+    const binPath = resolve(__dirname, '..', 'dist', 'index.js');
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-provisional-storage-'));
+
+    // Deliberately omit CLAUDE_JOB_DIR and pre-write no breadcrumb, so neither
+    // resolveFromJobDir() nor resolveFromBreadcrumb() can resolve synchronously
+    // at startup — main() falls back to the provisional `pending-<ts>` session
+    // id and registers the pending tool set (registerPendingTools) immediately.
+    const env = { ...process.env };
+    delete env.CLAUDE_JOB_DIR;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [binPath, '--stdio'],
+      env: {
+        ...env,
+        NR_AI_DASHBOARD_PORT: '0',
+        NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
+      },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+
+      const pendingTools = await client.listTools();
+      const pendingNames = pendingTools.tools.map((t) => t.name);
+      expect(pendingNames).toContain('nr_observe_health');
+      expect(pendingNames).toContain('nr_observe_install_hooks');
+      expect(pendingNames).not.toContain('nr_observe_get_session_stats');
+
+      // Supply the breadcrumb asynchronously. The spawned child sees this
+      // test process as its ppid (direct child_process.spawn), so
+      // resolveFromBreadcrumb() looks for <storagePath>/session-by-ppid/<our
+      // own process.pid>.txt — matching resolveSessionId()'s default
+      // `options.ppid ?? process.ppid` inside the child.
+      const breadcrumbDir = resolve(tmpStoragePath, 'session-by-ppid');
+      mkdirSync(breadcrumbDir, { recursive: true });
+      writeFileSync(resolve(breadcrumbDir, `${process.pid}.txt`), 'resolved-real-session-id');
+
+      // Poll listTools() until the full tool set (registerTools) replaces the
+      // pending one — resolution happens on resolveSessionId()'s backoff
+      // schedule (100/200/500/1000/2000ms, then steady 2s).
+      let sawFullSet = false;
+      for (let i = 0; i < 20; i++) {
+        const result = await client.listTools();
+        if (result.tools.map((t) => t.name).includes('nr_observe_get_session_stats')) {
+          sawFullSet = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      expect(sawFullSet).toBe(true);
+
+      await client.close();
+    } finally {
+      rmSync(tmpStoragePath, { recursive: true, force: true });
     }
   }, 30000);
 });

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -66,6 +66,9 @@ jest.mock('../config.js', () => ({
   ...(jest.requireActual('../config.js') as object),
   loadMcpConfig: jest.fn(),
 }));
+jest.mock('./setup-wizard.js', () => ({
+  runSetupWizard: jest.fn(),
+}));
 
 import { LocalStore } from '../storage/index.js';
 import * as scheduleMod from './schedule.js';
@@ -73,6 +76,7 @@ import * as platformMod from './platform.js';
 import { runInstallCli } from './cli.js';
 import * as installHelperMod from './install-helper.js';
 import * as configMod from '../config.js';
+import * as setupWizardMod from './setup-wizard.js';
 
 const mockedRunDiagnostics = diagnostics.runDiagnostics as jest.MockedFunction<
   typeof diagnostics.runDiagnostics
@@ -97,6 +101,11 @@ const mockedHelper = installHelperMod as unknown as {
   detectMcpConfigPath: jest.Mock;
 };
 const mockedConfig = configMod as unknown as { loadMcpConfig: jest.Mock };
+const mockedSetupWizard = {
+  runSetupWizard: setupWizardMod.runSetupWizard as jest.MockedFunction<
+    typeof setupWizardMod.runSetupWizard
+  >,
+};
 
 describe('schedule subcommand', () => {
   let stdoutSpy: ReturnType<typeof jest.spyOn>;
@@ -1459,6 +1468,33 @@ describe('preflight update', () => {
     expect(output).not.toContain('could not be verified');
   });
 
+  it('reports unhealthy when the daemon restarts but responds with a stale/mismatched version', async () => {
+    mockSuccessfulBuild();
+    mockedSchedule.getDashboardDaemonStatus.mockReturnValue({
+      installed: true,
+      readable: true,
+      binaryPath: '/usr/local/bin/preflight',
+    });
+    mFs.readFileSync.mockReturnValue('{"version":"1.4.0"}');
+    mockedConfig.loadMcpConfig.mockReturnValue({
+      dashboard: { host: '127.0.0.1', port: 7777 },
+    });
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, version: '0.9.0' }),
+    } as unknown as Response);
+
+    jest.useFakeTimers();
+    const updatePromise = runInstallCli(['update']);
+    await jest.advanceTimersByTimeAsync(6_000);
+    await updatePromise;
+    jest.useRealTimers();
+
+    const output = getOutput();
+    expect(output).toContain('could not be verified as healthy');
+    expect(output).not.toContain('✓ Restarted the dashboard daemon');
+  });
+
   it('skips verification silently and keeps the success message when config cannot be loaded', async () => {
     mockSuccessfulBuild();
     mockedSchedule.getDashboardDaemonStatus.mockReturnValue({
@@ -2074,5 +2110,41 @@ describe('preflight validate', () => {
     ]);
     expect(output.join('')).toContain('/custom/path/config.json');
     expect(output.join('')).toContain('Config is valid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// preflight setup
+// ---------------------------------------------------------------------------
+
+describe('preflight setup', () => {
+  let output: string[];
+
+  beforeEach(() => {
+    output = [];
+    jest.spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(String(s));
+      return true;
+    });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    jest.restoreAllMocks();
+  });
+
+  it('prints "Setup failed" and sets exitCode 1 when the wizard rejects', async () => {
+    mockedSetupWizard.runSetupWizard.mockRejectedValue(new Error('boom'));
+    await runInstallCli(['setup']);
+    expect(output.join('')).toContain('Setup failed: boom');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('prints nothing and leaves exitCode unset when the wizard resolves', async () => {
+    mockedSetupWizard.runSetupWizard.mockResolvedValue(undefined);
+    await runInstallCli(['setup']);
+    expect(output.join('')).not.toContain('Setup failed');
+    expect(process.exitCode).toBeFalsy();
   });
 });

--- a/src/install/setup-wizard.test.ts
+++ b/src/install/setup-wizard.test.ts
@@ -1363,6 +1363,35 @@ describe('setupWizard environment and nrApiKey steps', () => {
     expect(output).toContain('⚠ License key: could not reach NR ingest API');
   });
 
+  it('prints ⚠ "unexpected response" when license key check returns a server error', async () => {
+    mockedKeyValidator.validateLicenseKey.mockResolvedValue({
+      valid: false,
+      reason: 'server-error',
+      detail: 'HTTP 500',
+    });
+    answers('cloud', '12345', 'NRLIC-test', '', '', 'tester', '', '', '', 'n');
+
+    await runSetupWizard();
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('⚠ License key: unexpected response (HTTP 500) — proceeding anyway');
+  });
+
+  it('prints ⚠ "unexpected response" when API key check returns a server error', async () => {
+    mockedKeyValidator.validateLicenseKey.mockResolvedValue({ valid: true });
+    mockedKeyValidator.validateApiKey.mockResolvedValue({
+      valid: false,
+      reason: 'server-error',
+      detail: 'HTTP 500',
+    });
+    answers('cloud', '12345', 'NRLIC-test', '', 'NRAK-bad', 'tester', '', '', '', 'n');
+
+    await runSetupWizard();
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('⚠ API key: unexpected response (HTTP 500) — proceeding anyway');
+  });
+
   it('skips API key validation when no API key is set', async () => {
     answers('cloud', '12345', 'NRLIC-test', '', '', 'tester', '', '', '', 'n');
 

--- a/src/metrics/context-tracker.test.ts
+++ b/src/metrics/context-tracker.test.ts
@@ -1,4 +1,4 @@
-import { ContextTracker } from './context-tracker.js';
+import { ContextTracker, ContextTrackerRegistry } from './context-tracker.js';
 import type { TokenEvent, ToolCallRecord } from '../storage/types.js';
 
 function makeTokenEvent(overrides: Partial<TokenEvent> = {}): TokenEvent {
@@ -306,5 +306,75 @@ describe('ContextTracker', () => {
       expect(fresh.getMetrics().fillPercent).toBe(60.5);
       expect(snapshot.fillPercent).toBe(60.5);
     });
+  });
+});
+
+describe('ContextTrackerRegistry', () => {
+  it('evicts the oldest session once maxSessions is exceeded (LRU)', () => {
+    const registry = new ContextTrackerRegistry({ maxSessions: 2 });
+
+    registry.recordTurn(
+      makeTokenEvent({
+        sessionId: 'sess-a',
+        inputTokens: 10_000,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      }),
+    );
+    registry.recordTurn(
+      makeTokenEvent({
+        sessionId: 'sess-b',
+        inputTokens: 20_000,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      }),
+    );
+    registry.recordTurn(
+      makeTokenEvent({
+        sessionId: 'sess-c',
+        inputTokens: 30_000,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      }),
+    );
+
+    expect(registry.getTracker('sess-a')).toBeUndefined();
+    expect(registry.getMetrics('sess-b').growth.currentTokens).toBe(20_000);
+    expect(registry.getMetrics('sess-c').growth.currentTokens).toBe(30_000);
+  });
+
+  it('getMetrics() with no sessionId returns the most-recently-active tracker', () => {
+    const registry = new ContextTrackerRegistry({ maxSessions: 5 });
+
+    registry.recordTurn(
+      makeTokenEvent({
+        sessionId: 'sess-a',
+        inputTokens: 10_000,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      }),
+    );
+    registry.recordTurn(
+      makeTokenEvent({
+        sessionId: 'sess-b',
+        inputTokens: 90_000,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      }),
+    );
+
+    // sess-a was created first, but sess-b was touched most recently —
+    // getMetrics() with no sessionId must return sess-b's metrics, not sess-a's.
+    expect(registry.getMetrics().growth.currentTokens).toBe(90_000);
+  });
+
+  it('ignores recordToolCall and recordTurn when sessionId is empty', () => {
+    const registry = new ContextTrackerRegistry();
+
+    registry.recordToolCall(makeRecord({ sessionId: '' }));
+    const snapshot = registry.recordTurn(makeTokenEvent({ sessionId: '' }));
+
+    expect(snapshot).toBeNull();
+    expect(registry.getSessionIds()).toHaveLength(0);
   });
 });

--- a/src/metrics/decision-tracker.test.ts
+++ b/src/metrics/decision-tracker.test.ts
@@ -192,6 +192,49 @@ describe('DecisionTracker', () => {
   });
 });
 
+describe('DecisionTracker.recordToolCall triggers', () => {
+  function makeRecord(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
+    return {
+      id: 'id-1',
+      sessionId: 'session-1',
+      toolName: 'Read',
+      toolUseId: 'tool_1',
+      timestamp: Date.now(),
+      durationMs: 10,
+      success: true,
+      ...overrides,
+    };
+  }
+
+  it('records an ask_user branch when AskUserQuestion is called', () => {
+    const tracker = new DecisionTracker();
+    tracker.recordToolCall(makeRecord({ toolName: 'AskUserQuestion', toolUseId: 'tool_1' }));
+
+    const branches = tracker.getBranches();
+    expect(branches).toHaveLength(1);
+    expect(branches[0].chosenAction).toBe('ask_user');
+    expect(branches[0].reasoning).toBe('delegating to user');
+  });
+
+  it('records a retry branch on the 3rd same-tool-same-file call, with the count in the reasoning', () => {
+    const tracker = new DecisionTracker();
+    tracker.recordToolCall(
+      makeRecord({ toolName: 'Read', filePath: 'src/a.ts', toolUseId: 'tool_1' }),
+    );
+    tracker.recordToolCall(
+      makeRecord({ toolName: 'Read', filePath: 'src/a.ts', toolUseId: 'tool_2' }),
+    );
+    tracker.recordToolCall(
+      makeRecord({ toolName: 'Read', filePath: 'src/a.ts', toolUseId: 'tool_3' }),
+    );
+
+    const branches = tracker.getBranches();
+    const retryBranch = branches.find((b) => b.chosenAction === 'retry');
+    expect(retryBranch).toBeDefined();
+    expect(retryBranch?.reasoning).toBe('retrying Read on src/a.ts (3 attempts)');
+  });
+});
+
 describe('DecisionTracker transcript reasoning extraction (recordContent)', () => {
   let tmpDir: string;
   let transcriptPath: string;

--- a/src/metrics/git-efficiency-tracker.test.ts
+++ b/src/metrics/git-efficiency-tracker.test.ts
@@ -640,4 +640,168 @@ describe('GitEfficiencyTracker', () => {
       expect(metrics.forcePushes).toBe(1);
     });
   });
+
+  describe('GitHub CLI PR tracking', () => {
+    it('tracks PR create/checks/merge events and captures the PR number', () => {
+      tracker.recordToolCall(makeRecord({ command: 'gh pr create --title "Add feature"' }));
+      tracker.recordToolCall(makeRecord({ command: 'gh pr checks 42' }));
+      tracker.recordToolCall(makeRecord({ command: 'gh pr merge 42' }));
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.prMetrics.created).toBe(1);
+      expect(metrics.prMetrics.checksViewed).toBe(1);
+      expect(metrics.prMetrics.merged).toBe(1);
+
+      const checksEvent = metrics.prMetrics.prActivity.find((e) => e.action === 'checks');
+      const mergeEvent = metrics.prMetrics.prActivity.find((e) => e.action === 'merge');
+      expect(checksEvent?.prNumber).toBe('42');
+      expect(mergeEvent?.prNumber).toBe('42');
+    });
+
+    it('tracks gh pr edit/ready as prsUpdated', () => {
+      tracker.recordToolCall(makeRecord({ command: 'gh pr edit 7 --add-label ready' }));
+      tracker.recordToolCall(makeRecord({ command: 'gh pr ready 7' }));
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.prMetrics.prsUpdated).toBe(2);
+    });
+
+    it('does not treat "gh" text inside a git commit message as a gh command', () => {
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "gh pr create note"' }));
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.prMetrics.created).toBe(0);
+    });
+  });
+
+  describe('hydration entry points', () => {
+    it('hydrateGitLog adds historical commits without double-counting duplicates', () => {
+      const t = Date.now() - 3600_000;
+      tracker.hydrateGitLog([
+        { timestamp: t, hash: 'abc123' },
+        { timestamp: t + 1000, hash: 'def456' },
+      ]);
+
+      let metrics = tracker.getMetrics();
+      expect(metrics.commitCount).toBe(2);
+      expect(metrics.totalGitCommands).toBe(2);
+      // Historical commits must not count toward real-time sync drift.
+      expect(metrics.riskIndicators.commitsSinceLastSync).toBe(0);
+
+      // Re-hydrating an already-seen hash must not create a duplicate event.
+      tracker.hydrateGitLog([{ timestamp: t, hash: 'abc123' }]);
+      metrics = tracker.getMetrics();
+      expect(metrics.commitCount).toBe(2);
+    });
+
+    it('hydrateBranchDivergence sets ahead/behind counts on risk indicators', () => {
+      tracker.hydrateBranchDivergence(3, 7);
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.riskIndicators.commitsAheadOfMain).toBe(3);
+      expect(metrics.riskIndicators.commitsBehindMain).toBe(7);
+    });
+
+    it('hydrateRepoContext sets the repo context returned in metrics', () => {
+      tracker.hydrateRepoContext({
+        repoName: 'nr-ai-observatory',
+        branch: 'main',
+        remoteName: 'origin',
+        defaultBranch: 'main',
+      });
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.repoContext).toEqual({
+        repoName: 'nr-ai-observatory',
+        branch: 'main',
+        remoteName: 'origin',
+        defaultBranch: 'main',
+      });
+    });
+  });
+
+  describe('conflict resolution strategy', () => {
+    it('tracks ours/theirs/cherry-pick conflict resolution counters', () => {
+      tracker.recordToolCall(makeRecord({ command: 'git checkout --ours file.ts' }));
+      tracker.recordToolCall(makeRecord({ command: 'git checkout --theirs other.ts' }));
+      tracker.recordToolCall(makeRecord({ command: 'git cherry-pick abc123' }));
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.conflictResolutionStrategy.oursCount).toBe(1);
+      expect(metrics.conflictResolutionStrategy.theirsCount).toBe(1);
+      expect(metrics.conflictResolutionStrategy.cherryPickCount).toBe(1);
+    });
+  });
+
+  describe('velocity metrics', () => {
+    it('computes avg/longest gap and detects a 3-commit burst', () => {
+      const t = Date.now();
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "a"', timestamp: t }));
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "b"', timestamp: t + 10_000 }));
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "c"', timestamp: t + 20_000 }));
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.velocityMetrics.avgTimeBetweenCommitsMs).toBe(10_000);
+      expect(metrics.velocityMetrics.longestGapMs).toBe(10_000);
+      expect(metrics.velocityMetrics.commitBurstCount).toBe(1);
+    });
+
+    it('does not flag a burst when commits are spread far apart', () => {
+      const t = Date.now();
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "a"', timestamp: t }));
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "b"', timestamp: t + 10_000 }));
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "c"', timestamp: t + 500_000 }));
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.velocityMetrics.longestGapMs).toBe(490_000);
+      expect(metrics.velocityMetrics.commitBurstCount).toBe(0);
+    });
+  });
+
+  describe('conflict resolution edge cases', () => {
+    it('clears the pending conflict without recording a resolution on --amend', () => {
+      const t = Date.now();
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git merge main',
+          timestamp: t,
+          success: false,
+          error: 'CONFLICT (content): Merge conflict in src/file.ts',
+        }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git commit --amend -m "fix"', timestamp: t + 5000 }),
+      );
+      let metrics = tracker.getMetrics();
+      expect(metrics.conflictHistory).toHaveLength(0);
+
+      // A later, unrelated commit must not retroactively resolve the old conflict.
+      tracker.recordToolCall(
+        makeRecord({ command: 'git commit -m "later change"', timestamp: t + 10_000 }),
+      );
+      metrics = tracker.getMetrics();
+      expect(metrics.conflictHistory).toHaveLength(0);
+    });
+
+    it('flags quick conflict resolutions when a multi-file conflict resolves in under 30s', () => {
+      const t = Date.now();
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git merge main',
+          timestamp: t,
+          success: false,
+          error:
+            'CONFLICT (content): Merge conflict in src/a.ts\n' +
+            'CONFLICT (content): Merge conflict in src/b.ts\n' +
+            'Automatic merge failed',
+        }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git commit -m "resolve"', timestamp: t + 15_000 }),
+      );
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.riskIndicators.quickConflictResolutions).toBe(1);
+    });
+  });
 });

--- a/src/metrics/model-usage-tracker.test.ts
+++ b/src/metrics/model-usage-tracker.test.ts
@@ -79,6 +79,13 @@ describe('ModelUsageTracker', () => {
     expect(t.getMetrics().mostEfficientModel).toBe('cheap-model');
   });
 
+  it('mostEfficientModel breaks a costPerOutputToken tie alphabetically', () => {
+    const t = new ModelUsageTracker();
+    t.recordUsage('model-b', 0, 100, 0.1);
+    t.recordUsage('model-a', 0, 100, 0.1);
+    expect(t.getMetrics().mostEfficientModel).toBe('model-a');
+  });
+
   it('totalModelsUsed counts distinct models', () => {
     const t = new ModelUsageTracker();
     t.recordUsage('model-a', 100, 50, 0.01);

--- a/src/metrics/personal-coach.test.ts
+++ b/src/metrics/personal-coach.test.ts
@@ -241,6 +241,27 @@ describe('PersonalCoach', () => {
     }
   });
 
+  it('flags anti-pattern regression against baseline and prioritizes it in topRecommendation', () => {
+    // baseline rate (thrashing:3/200=0.015 across 3 weeks) vs this week (stuck_loop:10/200=0.05)
+    // is a >25% spike, and thisWeek.antiPatternRate > baseline.antiPatternRate * 1.25.
+    const summaries = [
+      makeWeeklySummary('2026-W04', developer, { antiPatternCounts: { stuck_loop: 10 } }),
+      makeWeeklySummary('2026-W03', developer, { antiPatternCounts: { thrashing: 3 } }),
+      makeWeeklySummary('2026-W02', developer, { antiPatternCounts: { thrashing: 3 } }),
+      makeWeeklySummary('2026-W01', developer, { antiPatternCounts: { thrashing: 3 } }),
+    ];
+    const gen = makeSummaryGenerator(summaries);
+    const coach = new PersonalCoach(gen, developer);
+    const result = coach.generate();
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(
+        result.regressions.some((r) => r.includes('Anti-pattern rate') && r.includes('stuck loop')),
+      ).toBe(true);
+      expect(result.topRecommendation).toContain('Focus on reducing "stuck loop"');
+    }
+  });
+
   it('baseline metrics do not contain NaN', () => {
     const summaries = [
       makeWeeklySummary('2026-W02', developer),

--- a/src/metrics/recommendation-engine.test.ts
+++ b/src/metrics/recommendation-engine.test.ts
@@ -286,6 +286,79 @@ describe('RecommendationEngine', () => {
   });
 
   // -------------------------------------------------------------------------
+  // 7. generateTeamRecommendations
+  // -------------------------------------------------------------------------
+
+  it('generateTeamRecommendations flags high team correction rate and low autonomy', () => {
+    const { engine } = createEngine();
+
+    for (const developer of ['alice', 'bob']) {
+      store.saveSession(
+        makeSummary({
+          sessionId: `team-${developer}`,
+          developer,
+          userMessages: 10,
+          userCorrections: 8, // correctionRate = 1 - 8/10 = 0.2 -> team correction pct = 80%
+          toolCallCount: 5,
+          assistantMessages: 10, // autonomy = (5/10)/5 = 0.1
+        }),
+      );
+    }
+
+    const recs = engine.generateTeamRecommendations();
+
+    expect(
+      recs.some(
+        (r) =>
+          r.category === 'efficiency' &&
+          r.priority === 'high' &&
+          r.title === 'High team correction rate',
+      ),
+    ).toBe(true);
+    expect(
+      recs.some(
+        (r) =>
+          r.category === 'prompt_engineering' &&
+          r.priority === 'medium' &&
+          r.title === 'Low team autonomy',
+      ),
+    ).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. getModelRecommendations via generateAllRecommendations
+  // -------------------------------------------------------------------------
+
+  it('flags cost-inefficient model usage when cost ratio exceeds 2x with <15% efficiency difference', () => {
+    const { engine } = createEngine();
+
+    for (let i = 0; i < 2; i++) {
+      store.saveSession(
+        makeSummary({
+          sessionId: `expensive-${i}`,
+          model: 'model-alpha',
+          estimatedCostUsd: 1.0,
+          efficiencyScore: 0.8,
+        }),
+      );
+      store.saveSession(
+        makeSummary({
+          sessionId: `cheap-${i}`,
+          model: 'model-beta',
+          estimatedCostUsd: 0.4,
+          efficiencyScore: 0.8,
+        }),
+      );
+    }
+
+    const recs = engine.generateAllRecommendations('alice');
+
+    const modelRec = recs.find((r) => r.category === 'model_selection');
+    expect(modelRec).toBeDefined();
+    expect(modelRec?.detail).toContain('model-beta');
+  });
+
+  // -------------------------------------------------------------------------
   // 6. emitMetrics
   // -------------------------------------------------------------------------
 

--- a/src/metrics/task-detector.test.ts
+++ b/src/metrics/task-detector.test.ts
@@ -103,6 +103,30 @@ describe('Idle-based task detection', () => {
 
     detector.dispose();
   });
+
+  it('caps durationMs at 4 hours when the measured span exceeds it (laptop sleep/container pause)', () => {
+    const detector = new TaskDetector();
+    const start = Date.now();
+
+    detector.recordToolCall(makeRecord({ toolName: 'Read', timestamp: start }));
+
+    // Jump the clock forward without running pending timers, simulating a
+    // process suspension rather than a normal idle gap.
+    const fourHoursMs = 4 * 60 * 60 * 1000;
+    const resumedAt = start + fourHoursMs + 60_000;
+    jest.setSystemTime(resumedAt);
+
+    // Explicit boundary signal closes the task at the jumped timestamp.
+    detector.recordToolCall(
+      makeRecord({ toolName: 'AskUserQuestion', questionCount: 1, timestamp: resumedAt }),
+    );
+
+    const tasks = detector.getCompletedTasks();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].durationMs).toBe(fourHoursMs);
+
+    detector.dispose();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/metrics/transcript-reasoning.test.ts
+++ b/src/metrics/transcript-reasoning.test.ts
@@ -1,7 +1,25 @@
+import { jest } from '@jest/globals';
 import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
+
+// statSync/openSync are wrapped in jest.fn() (defaulting to the real
+// implementation) so the WSL-translation test below can redirect calls for a
+// specific translated path onto the real transcript file, while every other
+// test in this file continues to hit the real filesystem unmodified.
+jest.mock('node:fs', () => {
+  const real = jest.requireActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...real,
+    statSync: jest.fn(real.statSync),
+    openSync: jest.fn(real.openSync),
+  };
+});
+
+import * as nodeFs from 'node:fs';
 import { extractReasoningForToolUse } from './transcript-reasoning.js';
+
+const realFs = jest.requireActual<typeof import('node:fs')>('node:fs');
 
 let tmpDir: string;
 let transcriptPath: string;
@@ -13,6 +31,12 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
+  (nodeFs.statSync as jest.Mock).mockImplementation(
+    realFs.statSync as (...args: unknown[]) => unknown,
+  );
+  (nodeFs.openSync as jest.Mock).mockImplementation(
+    realFs.openSync as (...args: unknown[]) => unknown,
+  );
 });
 
 function assistantLine(messageId: string, block: Record<string, unknown>): Record<string, unknown> {
@@ -121,5 +145,56 @@ describe('extractReasoningForToolUse', () => {
     const result = extractReasoningForToolUse(transcriptPath, 'tool_a');
     expect(result).toContain('[REDACTED]');
     expect(result).not.toContain('sk-abc123def456');
+  });
+
+  describe('translateWslPath (via the exported extractReasoningForToolUse)', () => {
+    let originalPlatform: string;
+
+    beforeEach(() => {
+      originalPlatform = process.platform;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    });
+
+    it('translates a Windows drive path to its WSL mount and reads the file when platform is linux', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+      writeTranscript([
+        assistantLine('msg_1', { type: 'thinking', thinking: 'Reasoning from the WSL mount.' }),
+        assistantLine('msg_1', { type: 'tool_use', id: 'tool_a', name: 'Read', input: {} }),
+      ]);
+
+      const windowsPath = 'C:\\Users\\dev\\project\\transcript.jsonl';
+      const translatedPath = '/mnt/c/Users/dev/project/transcript.jsonl';
+
+      // Redirect only the translated path onto the real temp transcript file;
+      // any other path (e.g. the untranslated windowsPath, proving a bug)
+      // falls through to the real filesystem call and fails to resolve.
+      (nodeFs.statSync as jest.Mock).mockImplementation((p: unknown) =>
+        realFs.statSync(p === translatedPath ? transcriptPath : (p as string)),
+      );
+      (nodeFs.openSync as jest.Mock).mockImplementation((p: unknown, flags: unknown) =>
+        realFs.openSync(p === translatedPath ? transcriptPath : (p as string), flags as number),
+      );
+
+      expect(extractReasoningForToolUse(windowsPath, 'tool_a')).toBe(
+        'Reasoning from the WSL mount.',
+      );
+    });
+
+    it('leaves a Windows drive path untranslated on a non-linux platform, so it fails to resolve', () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+
+      writeTranscript([
+        assistantLine('msg_1', { type: 'thinking', thinking: 'Reasoning from the WSL mount.' }),
+        assistantLine('msg_1', { type: 'tool_use', id: 'tool_a', name: 'Read', input: {} }),
+      ]);
+
+      const windowsPath = 'C:\\Users\\dev\\project\\transcript.jsonl';
+
+      expect(extractReasoningForToolUse(windowsPath, 'tool_a')).toBeNull();
+    });
   });
 });

--- a/src/metrics/workflow-run-tracker.test.ts
+++ b/src/metrics/workflow-run-tracker.test.ts
@@ -227,6 +227,36 @@ describe('WorkflowRunTracker', () => {
     expect(drained.map((r) => r.workflow_run_id)).toEqual(['b', 'c']);
   });
 
+  it('enforceOpenRunsCap evicts the oldest open run once maxOpenRuns is exceeded', () => {
+    const tracker = new WorkflowRunTracker({ maxOpenRuns: 2 });
+
+    // Three non-overlapping run windows: a=[1000,1100], b=[2000,2100], c=[3000,3100].
+    tracker.recordToolCall(makeAgentRecord({ toolUseId: 'a', timestamp: 1_100, durationMs: 100 }));
+    tracker.recordToolCall(makeAgentRecord({ toolUseId: 'b', timestamp: 2_100, durationMs: 100 }));
+    tracker.recordToolCall(makeAgentRecord({ toolUseId: 'c', timestamp: 3_100, durationMs: 100 }));
+
+    // Drain so `completed` no longer holds these runs -- only openRuns (now
+    // capped to the 2 most-recently-opened) can serve attribution below.
+    tracker.drainCompleted();
+
+    // A child call inside the evicted run 'a's window finds no enclosing run.
+    tracker.recordToolCall(
+      makeRecord({ toolName: 'Read', timestamp: 1_050, toolUseId: 'child_a' }),
+    );
+    // Child calls inside the two retained runs' windows still attribute correctly.
+    tracker.recordToolCall(
+      makeRecord({ toolName: 'Read', timestamp: 2_050, toolUseId: 'child_b' }),
+    );
+    tracker.recordToolCall(
+      makeRecord({ toolName: 'Bash', timestamp: 3_050, toolUseId: 'child_c' }),
+    );
+
+    const byId = new Map(tracker.getMetrics().map((r) => [r.workflow_run_id, r]));
+    expect(byId.has('a')).toBe(false);
+    expect(byId.get('b')?.tool_call_count).toBe(1);
+    expect(byId.get('c')?.tool_call_count).toBe(1);
+  });
+
   it('getMetrics returns a snapshot without clearing', () => {
     const tracker = new WorkflowRunTracker();
     tracker.recordToolCall(makeAgentRecord());

--- a/src/platforms/amazon-q-adapter.test.ts
+++ b/src/platforms/amazon-q-adapter.test.ts
@@ -166,6 +166,12 @@ describe('AmazonQAdapter', () => {
       });
       expect(normalized.sessionId).toBe('q-sess-001');
     });
+
+    it('does not validate field types — a wrong-typed "tool" leaks through unchanged', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 42, timestamp: 'not-a-number' });
+      expect(normalized.platformToolName).toBe(42);
+      expect(normalized.timestamp).toBe('not-a-number');
+    });
   });
 
   describe('getSessionMetadata', () => {

--- a/src/platforms/continue-adapter.test.ts
+++ b/src/platforms/continue-adapter.test.ts
@@ -238,6 +238,12 @@ describe('ContinueAdapter', () => {
       });
       expect(normalized.sessionId).toBe('cont-sess-001');
     });
+
+    it('does not validate field types — wrong-typed "tool" and "filepath" leak through unchanged', () => {
+      const normalized = adapter.normalizeToolCall({ tool: ['read_file'], filepath: 99 });
+      expect(normalized.platformToolName).toEqual(['read_file']);
+      expect(normalized.filePath).toBe(99);
+    });
   });
 
   describe('getSessionMetadata', () => {

--- a/src/platforms/cursor-adapter.test.ts
+++ b/src/platforms/cursor-adapter.test.ts
@@ -149,6 +149,12 @@ describe('CursorAdapter', () => {
       expect(normalized.success).toBe(true);
       expect(normalized.durationMs).toBeNull();
     });
+
+    it('does not validate field types — an object-typed "tool" leaks through unchanged', () => {
+      const normalized = adapter.normalizeToolCall({ tool: { nested: true }, timestamp: 2000 });
+      expect(normalized.platformToolName).toEqual({ nested: true });
+      expect(normalized.toolName).toBe('Unknown');
+    });
   });
 
   describe('getSessionMetadata', () => {

--- a/src/platforms/kiro-adapter.test.ts
+++ b/src/platforms/kiro-adapter.test.ts
@@ -210,6 +210,11 @@ describe('KiroAdapter', () => {
       });
       expect(normalized.sessionId).toBe('kiro-sess-001');
     });
+
+    it('does not validate field types — a numeric "path" leaks through unchanged as filePath', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'fsRead', path: 12345 });
+      expect(normalized.filePath).toBe(12345);
+    });
   });
 
   describe('getSessionMetadata', () => {

--- a/src/platforms/windsurf-adapter.test.ts
+++ b/src/platforms/windsurf-adapter.test.ts
@@ -168,6 +168,11 @@ describe('WindsurfAdapter', () => {
       expect(normalized.success).toBe(true);
       expect(normalized.durationMs).toBeNull();
     });
+
+    it('does not validate field types — a string-typed "durationMs" leaks through unchanged', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'Read File', durationMs: '150' });
+      expect(normalized.durationMs).toBe('150');
+    });
   });
 
   describe('getSessionMetadata', () => {

--- a/src/platforms/zed-adapter.test.ts
+++ b/src/platforms/zed-adapter.test.ts
@@ -192,6 +192,11 @@ describe('ZedAdapter', () => {
       expect(normalized.success).toBe(true);
       expect(normalized.durationMs).toBeNull();
     });
+
+    it('does not validate field types — a numeric "sessionId" leaks through unchanged', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file', sessionId: 42 });
+      expect(normalized.sessionId).toBe(42);
+    });
   });
 
   describe('getSessionMetadata', () => {

--- a/src/proxy/types.test.ts
+++ b/src/proxy/types.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from '@jest/globals';
+import { shouldForwardHeader } from './types.js';
+
+describe('shouldForwardHeader', () => {
+  describe('spoofable client-trust headers', () => {
+    it.each(['x-forwarded-for', 'x-forwarded-host', 'x-real-ip'])('blocks %s', (header) => {
+      expect(shouldForwardHeader(header)).toBe(false);
+    });
+
+    it.each(['X-Forwarded-For', 'X-Forwarded-Host', 'X-Real-Ip', 'X-REAL-IP'])(
+      'blocks mixed-case variant %s',
+      (header) => {
+        expect(shouldForwardHeader(header)).toBe(false);
+      },
+    );
+  });
+
+  describe('explicitly allowed headers', () => {
+    it.each(['content-type', 'accept', 'authorization', 'mcp-session-id'])(
+      'forwards %s',
+      (header) => {
+        expect(shouldForwardHeader(header)).toBe(true);
+      },
+    );
+
+    it.each(['Content-Type', 'Authorization', 'MCP-Session-Id'])(
+      'forwards mixed-case variant %s',
+      (header) => {
+        expect(shouldForwardHeader(header)).toBe(true);
+      },
+    );
+  });
+
+  describe('other x-* headers', () => {
+    it.each(['x-custom', 'x-request-id', 'X-Custom-Header'])('forwards %s', (header) => {
+      expect(shouldForwardHeader(header)).toBe(true);
+    });
+  });
+
+  describe('headers not on any allowlist', () => {
+    it.each(['host', 'cookie', 'user-agent', 'connection'])('blocks %s', (header) => {
+      expect(shouldForwardHeader(header)).toBe(false);
+    });
+  });
+});

--- a/src/proxy/upstream-http.test.ts
+++ b/src/proxy/upstream-http.test.ts
@@ -714,6 +714,71 @@ describe('HttpUpstream.forward()', () => {
     expect(result.responseSizeBytes).toBeGreaterThan(0);
   });
 
+  it('resolves, destroys the client socket, and destroys the upstream response when the ByteCountTransform errors mid-SSE', async () => {
+    const transformSpy = jest
+      .spyOn(ByteCountTransform.prototype, '_transform')
+      .mockImplementationOnce((_chunk, _encoding, callback) => {
+        callback(new Error('boom'));
+      });
+
+    let upstreamSocketClosed = false;
+    ({ server: mockServer, port } = await createMockServer((_req, res) => {
+      _req.socket.on('close', () => {
+        upstreamSocketClosed = true;
+      });
+      _req.on('data', () => {});
+      _req.on('end', () => {
+        res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+        res.write('data: {"event":"one"}\n\n');
+        // Intentionally never end — the transform error should resolve forward() early.
+      });
+    }));
+
+    const upstream = new HttpUpstream(makeConfig(port));
+
+    const outcome = await new Promise<{
+      fwdResult: import('./types.js').ForwardResult;
+      clientSocketDestroyed: boolean;
+    }>((resolve) => {
+      const proxyServer = createServer(async (proxyReq, proxyRes) => {
+        let clientSocketDestroyed = false;
+        const socket = proxyRes.socket;
+        if (socket) {
+          const originalDestroy = socket.destroy.bind(socket);
+          socket.destroy = ((...args: Parameters<typeof originalDestroy>) => {
+            clientSocketDestroyed = true;
+            return originalDestroy(...args);
+          }) as typeof socket.destroy;
+        }
+        const fwdResult = await upstream.forward(proxyReq, proxyRes, Buffer.from('{}'));
+        proxyServer.close(() => resolve({ fwdResult, clientSocketDestroyed }));
+      });
+      proxyServer.listen(0, '127.0.0.1', () => {
+        const addr = proxyServer.address();
+        const proxyPort = typeof addr === 'object' && addr ? addr.port : 0;
+        const req = nodeRequest({
+          hostname: '127.0.0.1',
+          port: proxyPort,
+          method: 'POST',
+          path: '/',
+        });
+        req.on('error', () => {
+          // Expected once the server-side socket is destroyed mid-response.
+        });
+        req.end();
+      });
+    });
+
+    // Give the destroyed upstream socket a tick to emit its 'close' event.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(outcome.fwdResult.isStreaming).toBe(true);
+    expect(outcome.clientSocketDestroyed).toBe(true);
+    expect(upstreamSocketClosed).toBe(true);
+
+    transformSpy.mockRestore();
+  });
+
   it('strips hop-by-hop headers from upstream response', async () => {
     ({ server: mockServer, port } = await createMockServer((_req, res) => {
       _req.on('data', () => {});

--- a/src/proxy/upstream-stdio.test.ts
+++ b/src/proxy/upstream-stdio.test.ts
@@ -1,5 +1,6 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import {
   StdioUpstream,
   sanitizeEnv,
@@ -526,5 +527,50 @@ describe('StdioUpstream.connect() command validation', () => {
       transportType: 'stdio',
     });
     await expect(upstream.connect()).rejects.toThrow('must be an absolute path');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// connect() — transport.onclose wiring
+// ---------------------------------------------------------------------------
+
+describe('StdioUpstream connect() onclose wiring', () => {
+  it('marks the upstream disconnected when the transport reports an unexpected process exit', async () => {
+    // Client.connect() calls transport.start(), which spawns a real child
+    // process — mock it out so this test never spawns anything, while the
+    // rest of connect() (constructing a real StdioClientTransport and wiring
+    // its onclose callback) runs unmodified.
+    const connectSpy = jest.spyOn(Client.prototype, 'connect').mockResolvedValue(undefined);
+
+    const upstream = new StdioUpstream({
+      name: 'test',
+      command: '/usr/bin/node',
+      transportType: 'stdio',
+    });
+
+    await upstream.connect();
+
+    const transport = (upstream as unknown as Record<string, unknown>).transport as {
+      onclose?: () => void;
+    };
+    expect(typeof transport.onclose).toBe('function');
+
+    // Simulate the child process exiting unexpectedly.
+    transport.onclose!();
+
+    const { res, getStatus, getBody } = makeFakeResponse();
+    const result = await upstream.forward(
+      makeFakeRequest(),
+      res,
+      Buffer.from(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' })),
+    );
+
+    expect(result.statusCode).toBe(500);
+    expect(getStatus()).toBe(500);
+    const body = JSON.parse(getBody());
+    expect(body.error.code).toBe(-32603);
+    expect(body.error.message).toBe('Upstream not connected');
+
+    connectSpy.mockRestore();
   });
 });

--- a/src/security/ssrf.test.ts
+++ b/src/security/ssrf.test.ts
@@ -3,7 +3,7 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 jest.mock('node:dns', () => ({ lookup: jest.fn() }));
 
 import * as dns from 'node:dns';
-import { createSsrfSafeLookup } from './ssrf.js';
+import { createSsrfSafeLookup, validateSsrfUrl } from './ssrf.js';
 
 // `dns.lookup` is a 5-overload union with no single callable type, so it can't
 // flow into `jest.Mock`'s generic directly. Naming the one overload shape this
@@ -106,5 +106,69 @@ describe('createSsrfSafeLookup', () => {
     const result = await callLookup(lookup, 'nonexistent.example', true);
 
     expect(result.err).toBe(dnsError);
+  });
+});
+
+describe('validateSsrfUrl', () => {
+  it('allows a safe public https URL', () => {
+    expect(() => validateSsrfUrl('test', new URL('https://example.com/path'))).not.toThrow();
+  });
+
+  it('rejects a decimal-integer-encoded loopback host (e.g. http://2130706433/)', () => {
+    expect(() => validateSsrfUrl('test', new URL('http://2130706433/'))).toThrow(
+      /private or loopback/,
+    );
+  });
+
+  it('rejects an octal-leading-zero-encoded loopback host (e.g. http://0177.0.0.1/)', () => {
+    expect(() => validateSsrfUrl('test', new URL('http://0177.0.0.1/'))).toThrow(
+      /private or loopback/,
+    );
+  });
+
+  it('rejects a hex-encoded loopback host (e.g. http://0x7f.0.0.1/)', () => {
+    expect(() => validateSsrfUrl('test', new URL('http://0x7f.0.0.1/'))).toThrow(
+      /private or loopback/,
+    );
+  });
+
+  it('rejects the metadata.google.internal cloud-metadata FQDN', () => {
+    expect(() => validateSsrfUrl('test', new URL('http://metadata.google.internal/'))).toThrow(
+      /cloud metadata service endpoint/,
+    );
+  });
+
+  it('rejects the 169.254.169.254 metadata IP (caught by the link-local block)', () => {
+    expect(() => validateSsrfUrl('test', new URL('http://169.254.169.254/'))).toThrow(
+      /private or loopback/,
+    );
+  });
+
+  it('rejects the 100.100.100.200 metadata IP (explicit metadata-IP blocklist)', () => {
+    expect(() => validateSsrfUrl('test', new URL('http://100.100.100.200/'))).toThrow(
+      /cloud metadata service endpoint/,
+    );
+  });
+
+  it('rejects an IPv4-mapped-IPv6 loopback host (::ffff:127.0.0.1)', () => {
+    expect(() => validateSsrfUrl('test', new URL('http://[::ffff:127.0.0.1]/'))).toThrow(
+      /private or loopback/,
+    );
+  });
+
+  it('rejects an IPv4-mapped-IPv6 multicast host not covered by the hardcoded hex-prefix regex (::ffff:224.0.0.1)', () => {
+    // Node normalizes this to the hex form ::ffff:e000:1. Its "e0" prefix isn't one of the
+    // loopback/RFC-1918/link-local prefixes BLOCKED_HOST_RE's mapped-IPv6 branch hardcodes, so
+    // this specifically exercises extractIPv4FromMappedIPv6's decode-then-recheck fallback,
+    // rather than the plain regex match that the other mapped-IPv6 case above hits directly.
+    expect(() => validateSsrfUrl('test', new URL('http://[::ffff:224.0.0.1]/'))).toThrow(
+      /private or loopback/,
+    );
+  });
+
+  it('rejects a disallowed scheme (ftp:)', () => {
+    expect(() => validateSsrfUrl('test', new URL('ftp://127.0.0.1/'))).toThrow(
+      /scheme "ftp:" is not allowed/,
+    );
   });
 });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,6 +1,7 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { createServer, NrMcpServer } from './server.js';
 import { AuditTrailManager } from './security/audit-trail.js';
 
@@ -96,5 +97,27 @@ describe('MCP protocol via InMemoryTransport', () => {
     const text = 'text' in content ? content.text : '';
     const parsed = JSON.parse(text) as unknown[];
     expect(Array.isArray(parsed)).toBe(true);
+  });
+
+  it('resources/read rejects an unknown resource URI with McpError InvalidRequest', async () => {
+    await expect(client.readResource({ uri: 'nr-observe://nonexistent' })).rejects.toMatchObject({
+      code: ErrorCode.InvalidRequest,
+    });
+  });
+
+  it('resources/read logs and re-throws when the handler throws a non-McpError', async () => {
+    server.auditTrailManager = new AuditTrailManager({ developer: 'test', sessionId: null });
+    jest.spyOn(server.auditTrailManager, 'getAuditLog').mockImplementation(() => {
+      throw new Error('audit log unavailable');
+    });
+
+    await expect(
+      client.readResource({ uri: 'nr-observe://session/audit-log' }),
+    ).rejects.not.toMatchObject({ code: ErrorCode.InvalidRequest });
+
+    const logged = stderrSpy.mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(
+      logged.some((l: string) => l.includes('Resource handler error') && l.includes('audit-log')),
+    ).toBe(true);
   });
 });

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -5,6 +5,7 @@ import {
   rmSync,
   readFileSync,
   readdirSync,
+  renameSync,
   writeFileSync,
   utimesSync,
   statSync,
@@ -327,6 +328,42 @@ describe('LocalStore', () => {
     });
   });
 
+  describe('drainBuffer() concurrent-write-during-drain race', () => {
+    it('a write landing between the claim-rename and the read is never lost or interleaved', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const store = new LocalStore(tmpDir);
+      const bufferPath = resolve(tmpDir, 'buffer.jsonl');
+      const drainPath = bufferPath + '.drain';
+
+      const inFlightEvent = makeEvent({ tool: 'in-flight' });
+      store.appendToBuffer(inFlightEvent);
+
+      // Mirror the first half of drainPath()'s rename-then-read: claim the
+      // buffer for draining, as if a drain were mid-flight but hadn't read
+      // the renamed file yet.
+      renameSync(bufferPath, drainPath);
+
+      // A concurrent collector append lands here, mid-drain — it must recreate
+      // a fresh bufferPath rather than touching the already-claimed .drain file.
+      const raceEvent = makeEvent({ tool: 'landed-during-drain' });
+      store.appendToBuffer(raceEvent);
+      expect(existsSync(bufferPath)).toBe(true);
+
+      // The claimed .drain file is exactly the pre-race snapshot, untouched
+      // by the new append that landed after the claim.
+      const claimed = readFileSync(drainPath, 'utf-8');
+      expect(JSON.parse(claimed.trim())).toEqual(inFlightEvent);
+
+      // The next poll's drainBuffer() recovers the still-present .drain file
+      // AND the freshly-appended buffer — both events come back intact,
+      // neither lost nor interleaved.
+      const drained = store.drainBuffer();
+      expect(drained.map((e) => e.tool)).toEqual(['in-flight', 'landed-during-drain']);
+      expect(existsSync(drainPath)).toBe(false);
+      expect(existsSync(bufferPath)).toBe(false);
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Directory permissions
   // ---------------------------------------------------------------------------
@@ -350,6 +387,39 @@ describe('LocalStore', () => {
         const mode = statSync(dir).mode & 0o777;
         expect(mode).toBe(0o700);
       }
+    });
+  });
+
+  describe('file permissions (CLAUDE.md storage-permission invariant)', () => {
+    it('writes the buffer file with mode 0o600', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const store = new LocalStore(tmpDir);
+      store.appendToBuffer(makeEvent({ tool: 'Read' }));
+
+      const mode = statSync(store.getBufferPath()).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it('writes the audit log file with mode 0o600', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+
+      const entry = makeAudit({ timestamp: Date.now() });
+      store.appendAuditLog(entry);
+
+      const dateStr = new Date(entry.timestamp).toISOString().slice(0, 10);
+      const filepath = resolve(tmpDir, 'audit', `${dateStr}.jsonl`);
+      const mode = statSync(filepath).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it('writes the heartbeat pid file with mode 0o600', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const store = new LocalStore(tmpDir, 'sess-perm-1');
+      store.writeHeartbeat(12345);
+
+      const mode = statSync(resolve(tmpDir, 'active-sess-perm-1.pid')).mode & 0o777;
+      expect(mode).toBe(0o600);
     });
   });
 

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -392,6 +392,53 @@ describe('SessionStore', () => {
     expect(sessions).toHaveLength(2);
     expect(sessions.map((s) => s.sessionId)).toEqual(['today-1', 'today-2']);
   });
+
+  it('loadSessionsOverlappingToday includes cross-midnight and endTime=0 sessions, excludes yesterday-only sessions', () => {
+    const store = new SessionStore({ storagePath: tmpDir });
+
+    // Use local midnight so the boundary is correct for any timezone
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const startOfToday = today.getTime();
+    const startOfYesterday = startOfToday - 86_400_000;
+
+    // Started and ended entirely yesterday — should be excluded.
+    store.saveSession(
+      makeSummary({
+        sessionId: 'yesterday-only',
+        startTime: startOfYesterday + 1000,
+        endTime: startOfYesterday + 5000,
+      }),
+    );
+
+    // Started yesterday evening, ended after today's local midnight — should
+    // be included via the endTime-overlap filter.
+    store.saveSession(
+      makeSummary({
+        sessionId: 'cross-midnight',
+        startTime: startOfYesterday + 80_000_000,
+        endTime: startOfToday + 1000,
+      }),
+    );
+
+    // Legacy/crashed session written without an endTime field at all —
+    // deserializes to endTime: 0 and should be included via the explicit
+    // endTime === 0 carve-out. Written directly to disk to simulate a file
+    // an older build produced (FullSessionSummary.endTime is required, so
+    // saveSession() itself cannot omit it).
+    const noEndTimeDate = today.toISOString().slice(0, 10);
+    const { endTime: _unused, ...withoutEndTime } = makeSummary({
+      sessionId: 'no-end-time',
+      startTime: startOfToday + 2000,
+    });
+    writeFileSync(
+      resolve(tmpDir, 'sessions', `${noEndTimeDate}_no-end-time.json`),
+      JSON.stringify(withoutEndTime),
+    );
+
+    const sessions = store.loadSessionsOverlappingToday();
+    expect(sessions.map((s) => s.sessionId).sort()).toEqual(['cross-midnight', 'no-end-time']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/storage/weekly-summary.test.ts
+++ b/src/storage/weekly-summary.test.ts
@@ -1,5 +1,13 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { resolve, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SessionStore } from './session-store.js';
@@ -352,5 +360,40 @@ describe('WeeklySummaryGenerator', () => {
     writeFileSync(join(tmpDir, 'weekly_summaries', '2026-W16.json'), 'NOT VALID JSON');
 
     expect(generator.getLatest()).toBeNull();
+  });
+
+  it('generate() returns the in-memory summary (not a throw) when the disk write fails', () => {
+    if (process.getuid?.() === 0) return; // root bypasses permission checks
+
+    const store = new SessionStore({ storagePath: tmpDir });
+    const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+    const { start } = getWeekDateRange('2026-W16');
+    store.saveSession(
+      makeSummary({ sessionId: 'write-fail-sess', startTime: start.getTime() + 1000 }),
+    );
+
+    const summariesDir = join(tmpDir, 'weekly_summaries');
+    // Read-only directory: writeFileSync(tmpFilepath) can't create the new
+    // tmp file inside it, forcing generate()'s write-failure fallback path.
+    chmodSync(summariesDir, 0o500);
+
+    try {
+      const summary = generator.generate('2026-W16');
+
+      expect(summary.week).toBe('2026-W16');
+      expect(summary.sessionCount).toBe(1);
+
+      const leftovers = readdirSync(summariesDir).filter((f) => f.includes('.tmp'));
+      expect(leftovers).toEqual([]);
+
+      const logged = stderrSpy.mock.calls.map((call: unknown[]) => String(call[0]));
+      expect(
+        logged.some(
+          (l: string) => l.includes('"error"') && l.includes('Failed to write weekly summary'),
+        ),
+      ).toBe(true);
+    } finally {
+      chmodSync(summariesDir, 0o700);
+    }
   });
 });

--- a/src/tools/analytics-tools.test.ts
+++ b/src/tools/analytics-tools.test.ts
@@ -1,0 +1,137 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { ContextWindowTracker } from '../metrics/context-window-tracker.js';
+import { ContextTrackerRegistry } from '../metrics/context-tracker.js';
+import { LatencyTracker } from '../metrics/latency-tracker.js';
+import { TaskCompletionTracker } from '../metrics/task-completion-tracker.js';
+import { ModelUsageTracker } from '../metrics/model-usage-tracker.js';
+import type { ToolCallRecord } from '../storage/types.js';
+import type { AiCodingTask } from '../metrics/task-detector.js';
+import {
+  handleGetContextEfficiency,
+  handleGetLatencyPercentiles,
+  handleGetTaskCompletionRate,
+  handleGetModelUsage,
+  handleGetContextTracking,
+} from './analytics-tools.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+});
+
+function makeRecord(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
+  return {
+    id: 'r1',
+    sessionId: 's1',
+    toolUseId: 'u1',
+    toolName: 'Read',
+    timestamp: Date.now(),
+    durationMs: 10,
+    success: true,
+    filePath: '/src/app.ts',
+    ...overrides,
+  } as ToolCallRecord;
+}
+
+function makeTask(overrides?: Partial<AiCodingTask>): AiCodingTask {
+  return {
+    taskId: 'task-001',
+    startTime: 1000,
+    endTime: 61000,
+    durationMs: 60000,
+    toolCallCount: 10,
+    toolCallsByType: {},
+    filesRead: [],
+    filesModified: [],
+    linesChanged: 50,
+    linesAdded: 50,
+    linesRemoved: 0,
+    bashCommandsRun: 2,
+    testsRun: 4,
+    testsPassed: 4,
+    buildRun: 1,
+    buildPassed: 1,
+    estimatedCostUsd: 0.5,
+    tokensUsed: 5000,
+    askedUserQuestions: 0,
+    ...overrides,
+  } as AiCodingTask;
+}
+
+describe('analytics-tools handlers', () => {
+  it('handleGetContextEfficiency returns the tracker metrics verbatim', () => {
+    const tracker = new ContextWindowTracker();
+    tracker.recordToolCall(makeRecord({ filePath: '/a.ts' }));
+    tracker.recordToolCall(makeRecord({ filePath: '/a.ts' }));
+    tracker.recordToolCall(makeRecord({ filePath: '/b.ts' }));
+
+    const result = handleGetContextEfficiency(tracker);
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed).toEqual(tracker.getMetrics());
+    expect(parsed.repeatedReadCount).toBe(1);
+  });
+
+  it('handleGetLatencyPercentiles returns the tracker metrics verbatim', () => {
+    const tracker = new LatencyTracker();
+    tracker.recordToolCall(makeRecord({ toolName: 'Bash', durationMs: 100 }));
+    tracker.recordToolCall(makeRecord({ toolName: 'Bash', durationMs: 200 }));
+
+    const result = handleGetLatencyPercentiles(tracker);
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed).toEqual(tracker.getMetrics());
+    expect(parsed.overall.count).toBe(2);
+  });
+
+  it('handleGetTaskCompletionRate returns the tracker metrics verbatim, ignoring the unused TaskDetector param', () => {
+    const tracker = new TaskCompletionTracker();
+    tracker.recordTask(makeTask());
+    tracker.recordTask(makeTask({ taskId: 'task-002', durationMs: 30000, toolCallCount: 6 }));
+
+    const withoutDetector = handleGetTaskCompletionRate(tracker);
+    const withDetector = handleGetTaskCompletionRate(tracker, undefined);
+
+    const parsed = JSON.parse(withoutDetector.content[0].text);
+    expect(parsed).toEqual(tracker.getMetrics());
+    expect(parsed.completedTasks).toBe(2);
+    // Passing (or omitting) the second arg must not change the result.
+    expect(JSON.parse(withDetector.content[0].text)).toEqual(parsed);
+  });
+
+  it('handleGetModelUsage returns the tracker metrics verbatim', () => {
+    const tracker = new ModelUsageTracker();
+    tracker.recordUsage('claude-sonnet-4', 1000, 200, 0.06);
+
+    const result = handleGetModelUsage(tracker);
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed).toEqual(tracker.getMetrics());
+    expect(parsed.mostUsedModel).toBe('claude-sonnet-4');
+  });
+
+  it('handleGetContextTracking returns the registry metrics verbatim', () => {
+    const registry = new ContextTrackerRegistry();
+    registry.recordTurn({
+      mode: 'token',
+      sessionId: 's1',
+      inputTokens: 1000,
+      outputTokens: 200,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      model: 'claude-sonnet-4',
+      timestamp: Date.now(),
+    });
+
+    const result = handleGetContextTracking(registry);
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed).toEqual(registry.getMetrics());
+    expect(parsed.turnCount).toBe(1);
+  });
+});

--- a/src/tools/cost-tools.test.ts
+++ b/src/tools/cost-tools.test.ts
@@ -3,8 +3,13 @@ import {
   handleReportTokens,
   REPORT_TOKENS_TOOL,
   handleGetPromptCacheHealth,
+  handleGetBudgetStatus,
+  handleGetCostForecast,
 } from './cost-tools.js';
 import { CostTracker } from '../metrics/cost-tracker.js';
+import { BudgetTracker } from '../metrics/budget-tracker.js';
+import { localDateKey } from '../lib/date.js';
+import { buildCostForecastFromInputs } from '../metrics/cost-forecast.js';
 import type { TokenReport } from './cost-tools.js';
 import type { CostMetrics } from '../metrics/cost-tracker.js';
 
@@ -293,5 +298,88 @@ describe('handleGetPromptCacheHealth()', () => {
     expect(body.total_savings_usd).toBe(0.25);
     expect(body.total_cache_read_tokens).toBe(6_000);
     expect(body.total_cache_creation_tokens).toBe(1_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleGetBudgetStatus
+// ---------------------------------------------------------------------------
+
+describe('handleGetBudgetStatus()', () => {
+  it('returns the budget tracker status as JSON, including fired threshold alerts', () => {
+    const tracker = new BudgetTracker({
+      sessionBudgetUsd: 10,
+      dailyBudgetUsd: null,
+      weeklyBudgetUsd: null,
+    });
+    tracker.updateCost(6, 0, 0); // 60% of session budget — crosses the 50% threshold
+
+    const result = handleGetBudgetStatus(tracker);
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body).toEqual(tracker.getStatus());
+    expect(body.session.pctUsed).toBe(60);
+    expect(body.session.exceeded).toBe(false);
+    expect(body.alerts).toHaveLength(1);
+    expect(body.alerts[0].thresholdPct).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleGetCostForecast
+// ---------------------------------------------------------------------------
+
+describe('handleGetCostForecast()', () => {
+  it('anchors the end-of-day forecast to getCostForDay()/getFirstActivityMsForDay(), not the full session spend', () => {
+    const tracker = new CostTracker();
+
+    // Backdated (but within the 48h late-arrival window) so it inflates the
+    // session-wide total without landing in today's day-bucket.
+    const yesterday = Date.now() - 25 * 60 * 60 * 1000;
+    tracker.recordTokenUsage(
+      {
+        inputTokens: 10_000_000,
+        outputTokens: 2_000_000,
+        thinkingTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        totalTokens: 12_000_000,
+      },
+      'claude-sonnet-4',
+      { timestampMs: yesterday },
+    );
+
+    // "Today's" spend — small, and reported with no ctx so it lands in today's bucket.
+    tracker.recordTokenUsage(
+      {
+        inputTokens: 1_000,
+        outputTokens: 200,
+        thinkingTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        totalTokens: 1_200,
+      },
+      'claude-sonnet-4',
+    );
+
+    const sessionStartMs = yesterday;
+    const result = handleGetCostForecast(tracker, sessionStartMs);
+    const body = JSON.parse(result.content[0].text);
+
+    const todayKey = localDateKey();
+    const sessionTotalCostUsd = tracker.getMetrics().sessionTotalCostUsd ?? 0;
+    const expected = buildCostForecastFromInputs({
+      sessionSpentUsd: sessionTotalCostUsd,
+      sessionStartMs,
+      dailySpentUsd: tracker.getCostForDay(todayKey),
+      dailyFirstActivityMs: tracker.getFirstActivityMsForDay(todayKey),
+    });
+
+    // If the handler regressed to anchoring the EoD baseline on the full
+    // session spend instead of today's day-bucket, `expected` (computed here
+    // from the correct daily-anchored inputs) would diverge sharply from
+    // `body` given the huge backdated "yesterday" spend above.
+    expect(body.forecastEndOfDayUsd).toBeCloseTo(expected.forecastEndOfDayUsd ?? 0, 2);
+    expect(sessionTotalCostUsd).toBeGreaterThan(tracker.getCostForDay(todayKey));
   });
 });

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SessionStore } from '../storage/session-store.js';
@@ -12,6 +12,7 @@ import { CostPerOutcomeAnalyzer } from '../metrics/cost-per-outcome.js';
 import { TaskDetector } from '../metrics/task-detector.js';
 import { PromptFeedbackEngine } from '../metrics/prompt-feedback.js';
 import { RecommendationEngine } from '../metrics/recommendation-engine.js';
+import { PersonalCoach } from '../metrics/personal-coach.js';
 import type { ToolCallRecord } from '../storage/types.js';
 import {
   handleGetSessionHistory,
@@ -23,6 +24,10 @@ import {
   handleGetRecommendations,
   handleGetPlatformComparison,
   handleGetTeamSummary,
+  handleSubscribeDigest,
+  handleUnsubscribeDigest,
+  handleSendDigest,
+  handleGetPersonalInsights,
   toFiniteNumber,
 } from './cross-session-tools.js';
 
@@ -917,6 +922,156 @@ describe('Cross-session tool handlers', () => {
 
     it('uses a custom fallback when provided', () => {
       expect(toFiniteNumber('abc', -1)).toBe(-1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleGetTeamSummary — success path (byDev construction + result assembly)
+  // -------------------------------------------------------------------------
+
+  describe('handleGetTeamSummary success path', () => {
+    it('merges rows from all 3 NRQL queries into developers/totals', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
+        const body = typeof init?.body === 'string' ? init.body : '';
+        let results: Array<Record<string, unknown>> = [];
+        if (body.includes('totalCost')) {
+          results = [
+            { developer: 'alice', totalCost: 12.5 },
+            { developer: 'bob', totalCost: 7.25 },
+          ];
+        } else if (body.includes('avgScore')) {
+          results = [
+            { developer: 'alice', avgScore: 0.8 },
+            { developer: 'bob', avgScore: 0.6 },
+          ];
+        } else if (body.includes('antiPatterns')) {
+          results = [
+            { developer: 'alice', antiPatterns: 3 },
+            { developer: 'bob', antiPatterns: 1 },
+          ];
+        }
+        return {
+          ok: true,
+          json: async () => ({ data: { actor: { account: { nrql: { results } } } } }),
+        } as Response;
+      });
+
+      try {
+        const result = await handleGetTeamSummary({
+          teamId: 'my-team',
+          accountId: '12345',
+          nrApiKey: 'test-key',
+        });
+        expect(result.isError).toBeUndefined();
+        const body = JSON.parse(result.content[0]!.text);
+
+        expect(body.developers).toEqual(
+          expect.arrayContaining([
+            { developer: 'alice', costUsd: 12.5, efficiencyScore: 0.8, antiPatterns: 3 },
+            { developer: 'bob', costUsd: 7.25, efficiencyScore: 0.6, antiPatterns: 1 },
+          ]),
+        );
+        expect(body.totals).toEqual({ costUsd: 19.75, developerCount: 2 });
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Digest subscribe / unsubscribe / send + personal insights
+  // -------------------------------------------------------------------------
+
+  describe('handleSubscribeDigest()', () => {
+    it('rejects a webhook URL that is not a Slack incoming webhook', () => {
+      const configFilePath = resolve(tmpDir, 'config.json');
+      const result = handleSubscribeDigest('https://evil.example.com/webhook', configFilePath);
+      expect(result.isError).toBe(true);
+      const body = JSON.parse(result.content[0]!.text);
+      expect(body.error).toMatch(/Slack incoming webhook/);
+      expect(existsSync(configFilePath)).toBe(false);
+    });
+
+    it('writes a valid Slack webhook URL to the config file, preserving existing keys', () => {
+      const configFilePath = resolve(tmpDir, 'config.json');
+      writeFileSync(configFilePath, JSON.stringify({ developer: 'alice' }), 'utf-8');
+
+      const webhookUrl = 'https://hooks.slack.com/services/T000/B000/XXXX';
+      const result = handleSubscribeDigest(webhookUrl, configFilePath);
+
+      expect(result.isError).toBeUndefined();
+      const written = JSON.parse(readFileSync(configFilePath, 'utf-8'));
+      expect(written.digestWebhookUrl).toBe(webhookUrl);
+      expect(written.developer).toBe('alice');
+    });
+  });
+
+  describe('handleUnsubscribeDigest()', () => {
+    it('removes digestWebhookUrl from an existing config file', () => {
+      const configFilePath = resolve(tmpDir, 'config.json');
+      writeFileSync(
+        configFilePath,
+        JSON.stringify({ developer: 'alice', digestWebhookUrl: 'https://hooks.slack.com/x' }),
+        'utf-8',
+      );
+
+      const result = handleUnsubscribeDigest(configFilePath);
+
+      expect(result.isError).toBeUndefined();
+      const written = JSON.parse(readFileSync(configFilePath, 'utf-8'));
+      expect(written.digestWebhookUrl).toBeUndefined();
+      expect(written.developer).toBe('alice');
+    });
+  });
+
+  describe('handleSendDigest()', () => {
+    it('returns the "call subscribe first" message when no webhook is configured', async () => {
+      const configFilePath = resolve(tmpDir, 'config.json');
+      const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+
+      const result = await handleSendDigest(generator, configFilePath);
+
+      const body = JSON.parse(result.content[0]!.text);
+      expect(body.error).toMatch(/Call nr_observe_subscribe_digest first/);
+    });
+
+    it('posts the formatted weekly digest via sendSlackDigest when a webhook is configured', async () => {
+      const configFilePath = resolve(tmpDir, 'config.json');
+      const webhookUrl = 'https://hooks.slack.com/services/T000/B000/XXXX';
+      writeFileSync(configFilePath, JSON.stringify({ digestWebhookUrl: webhookUrl }), 'utf-8');
+      store.saveSession(makeSummary({ sessionId: 'digest-week', estimatedCostUsd: 1.5 }));
+      const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+
+      const fetchSpy = jest
+        .spyOn(global, 'fetch')
+        .mockImplementation(async () => ({ ok: true }) as Response);
+
+      try {
+        const result = await handleSendDigest(generator, configFilePath);
+        const body = JSON.parse(result.content[0]!.text);
+
+        expect(body.ok).toBe(true);
+        expect(body.message).toBe('Digest sent successfully.');
+        expect(fetchSpy).toHaveBeenCalledWith(
+          webhookUrl,
+          expect.objectContaining({ method: 'POST' }),
+        );
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('handleGetPersonalInsights()', () => {
+    it('delegates to PersonalCoach.generate() and returns its result verbatim', () => {
+      store.saveSession(makeSummary({ sessionId: 'insights-1', developer: 'alice' }));
+      const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+
+      const result = handleGetPersonalInsights(generator, 'alice');
+      const body = JSON.parse(result.content[0]!.text);
+
+      const expected = new PersonalCoach(generator, 'alice').generate();
+      expect({ ...body, generatedAt: 0 }).toEqual({ ...expected, generatedAt: 0 });
     });
   });
 });

--- a/src/tools/session-stats.test.ts
+++ b/src/tools/session-stats.test.ts
@@ -1,9 +1,17 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { createServer, NrMcpServer } from '../server.js';
 import { SessionTracker } from '../metrics/session-tracker.js';
 import { CostTracker } from '../metrics/cost-tracker.js';
+import { BudgetTracker } from '../metrics/budget-tracker.js';
+import { ContextWindowTracker } from '../metrics/context-window-tracker.js';
+import { TaskDetector } from '../metrics/task-detector.js';
+import { SessionStore } from '../storage/session-store.js';
 import { FeedbackCollector } from './workflow-tools.js';
 import {
   handleGetSessionStats,
@@ -11,17 +19,16 @@ import {
   handleHealth,
   handleGetConfig,
   handleInstallHooks,
+  registerTools,
 } from './session-stats.js';
-import type { ConfigSummary } from './session-stats.js';
+import type { ConfigSummary, ToolRegistrationOptions } from './session-stats.js';
 import type { HeadlessInstallResult } from '../install/headless-install.js';
 import type { ToolCallRecord } from '../storage/types.js';
-import type { SessionStore } from '../storage/session-store.js';
 import type { WeeklySummaryGenerator } from '../storage/weekly-summary.js';
 import type { TrendAnalyzer } from '../metrics/trend-analyzer.js';
 import type { CollaborationProfiler } from '../metrics/collaboration-profile.js';
 import type { ClaudeMdTracker } from '../metrics/claudemd-tracker.js';
 import type { CostPerOutcomeAnalyzer } from '../metrics/cost-per-outcome.js';
-import type { TaskDetector } from '../metrics/task-detector.js';
 import type { RecommendationEngine } from '../metrics/recommendation-engine.js';
 
 // ---------------------------------------------------------------------------
@@ -880,5 +887,162 @@ describe('registerPendingTools()', () => {
 
     await client.close();
     await server.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP protocol integration — registerTools() dispatched directly (not via
+// createServer()/ServerOptions, which only wires a subset of trackers).
+// Covers a representative sample of the switch-case's un-validated `args`
+// casts and "tracker not available" branches for tools not otherwise
+// exercised through an actual client.callTool() round trip.
+// ---------------------------------------------------------------------------
+
+describe('MCP protocol integration — direct registerTools() dispatch', () => {
+  let server: Server;
+  let client: Client;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = resolve(
+      tmpdir(),
+      `nr-sstats-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await client?.close();
+    await server?.close();
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  async function connectDirect(options: ToolRegistrationOptions): Promise<void> {
+    server = new Server({ name: 'direct-test', version: '0.0.1' }, { capabilities: { tools: {} } });
+    registerTools(server, options);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'test-client', version: '1.0.0' });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  }
+
+  it('nr_observe_get_budget_status returns an explanatory error when BudgetTracker is absent', async () => {
+    await connectDirect({});
+    const result = await client.callTool({ name: 'nr_observe_get_budget_status', arguments: {} });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.error).toBe('BudgetTracker not available');
+  });
+
+  it('nr_observe_get_budget_status returns the real budget status when BudgetTracker is provided', async () => {
+    const budgetTracker = new BudgetTracker({
+      sessionBudgetUsd: 10,
+      dailyBudgetUsd: null,
+      weeklyBudgetUsd: null,
+    });
+    budgetTracker.updateCost(6, 0, 0);
+    await connectDirect({ budgetTracker });
+
+    const result = await client.callTool({ name: 'nr_observe_get_budget_status', arguments: {} });
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body).toEqual(budgetTracker.getStatus());
+    expect(body.session.pctUsed).toBe(60);
+  });
+
+  it('nr_observe_get_cost_forecast returns an explanatory error when sessionStartMs is not available', async () => {
+    const costTracker = new CostTracker();
+    await connectDirect({ costTracker });
+    const result = await client.callTool({ name: 'nr_observe_get_cost_forecast', arguments: {} });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.error).toBe('CostTracker or sessionStartMs not available');
+  });
+
+  it('nr_observe_get_cost_forecast returns a real forecast when CostTracker and sessionStartMs are provided', async () => {
+    const costTracker = new CostTracker();
+    costTracker.recordTokenUsage(
+      {
+        inputTokens: 1_000,
+        outputTokens: 200,
+        thinkingTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        totalTokens: 1_200,
+      },
+      'claude-sonnet-4',
+    );
+    await connectDirect({ costTracker, sessionStartMs: Date.now() - 20 * 60 * 1000 });
+
+    const result = await client.callTool({ name: 'nr_observe_get_cost_forecast', arguments: {} });
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(typeof body.confidenceNote).toBe('string');
+    expect(body.forecastEndOfDayUsd).toBeGreaterThanOrEqual(0);
+  });
+
+  it('nr_observe_get_session_history silently coerces a numeric "since" (documented as an ISO string) via new Date(number) instead of rejecting it', async () => {
+    const sessionStore = new SessionStore({ storagePath: tmpDir });
+    await connectDirect({ sessionStore });
+
+    const result = await client.callTool({
+      name: 'nr_observe_get_session_history',
+      arguments: { since: 1_700_000_000_000 },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.sessions).toEqual([]);
+    expect(body.count).toBe(0);
+  });
+
+  it('nr_observe_get_workflow_trace with a non-string task_id never matches (strict equality, no coercion) instead of crashing', async () => {
+    const taskDetector = new TaskDetector();
+    taskDetector.recordToolCall(makeRecord({ toolName: 'Read', sessionId: 'wf-1' }));
+    taskDetector.recordToolCall(makeRecord({ toolName: 'AskUserQuestion', sessionId: 'wf-1' }));
+    await connectDirect({ taskDetector });
+
+    const result = await client.callTool({
+      name: 'nr_observe_get_workflow_trace',
+      arguments: { task_id: 12345 },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.error).toBe('No matching task found');
+    expect(body.task_id).toBe(12345);
+  });
+
+  it('nr_observe_subscribe_digest writes a validated Slack webhook URL to the config file via the MCP boundary', async () => {
+    const configFilePath = resolve(tmpDir, 'config.json');
+    await connectDirect({ configFilePath });
+
+    const webhookUrl = 'https://hooks.slack.com/services/T000/B000/XXXX';
+    const result = await client.callTool({
+      name: 'nr_observe_subscribe_digest',
+      arguments: { webhookUrl },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const written = JSON.parse(readFileSync(configFilePath, 'utf-8'));
+    expect(written.digestWebhookUrl).toBe(webhookUrl);
+  });
+
+  it('nr_observe_get_context_efficiency returns the ContextWindowTracker metrics verbatim', async () => {
+    const contextWindowTracker = new ContextWindowTracker();
+    contextWindowTracker.recordToolCall(makeRecord({ toolName: 'Read', filePath: '/a.ts' }));
+    contextWindowTracker.recordToolCall(makeRecord({ toolName: 'Read', filePath: '/a.ts' }));
+    await connectDirect({ contextWindowTracker });
+
+    const result = await client.callTool({
+      name: 'nr_observe_get_context_efficiency',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body).toEqual(contextWindowTracker.getMetrics());
+    expect(body.repeatedReadCount).toBe(1);
   });
 });

--- a/src/tracing/mcp-tracer.test.ts
+++ b/src/tracing/mcp-tracer.test.ts
@@ -20,8 +20,10 @@ describe('mcp-tracer', () => {
     expect(tracer).not.toBeNull();
   });
 
-  test('getMcpTracer returns tracer without prior init', () => {
-    const tracer = getMcpTracer();
+  test('getMcpTracer returns tracer without prior init', async () => {
+    jest.resetModules();
+    const freshModule = await import('./mcp-tracer.js');
+    const tracer = freshModule.getMcpTracer();
     expect(tracer).not.toBeNull();
   });
 

--- a/src/tracing/session-span.test.ts
+++ b/src/tracing/session-span.test.ts
@@ -88,4 +88,21 @@ describe('SessionSpan', () => {
     const ctx = session.getContext();
     expect(ctx).toBe(context.active());
   });
+
+  test('end is a no-op when called before start', () => {
+    const session = new SessionSpan('test-session-id', 'test-developer');
+    session.end(0, 0);
+
+    expect(mockTracer.startSpan).not.toHaveBeenCalled();
+    expect(mockSpan.end).not.toHaveBeenCalled();
+  });
+
+  test('end is idempotent when called a second time', () => {
+    const session = new SessionSpan('test-session-id', 'test-developer');
+    session.start();
+    session.end(5, 2);
+    session.end(5, 2);
+
+    expect(mockSpan.end).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/transport/log-ingest.test.ts
+++ b/src/transport/log-ingest.test.ts
@@ -180,6 +180,20 @@ describe('LogIngestManager', () => {
     expect(sentLogs[0]!.message).toBe('important log');
   });
 
+  it('drops batch without re-queuing on non-retryable 4xx (400)', async () => {
+    mockSendLogs.mockResolvedValueOnce({ success: false, statusCode: 400, retryCount: 0 });
+
+    const manager = new LogIngestManager(makeLogIngestOptions());
+    manager.addAuditRecord(makeAuditRecord({ detail: 'bad payload' }));
+
+    await manager.flush();
+    expect(mockSendLogs).toHaveBeenCalledTimes(1);
+
+    // Batch was dropped, not re-queued — a second flush() has nothing to send.
+    await manager.flush();
+    expect(mockSendLogs).toHaveBeenCalledTimes(1);
+  });
+
   it('re-queues batch when sendLogsFn throws', async () => {
     mockSendLogs
       .mockRejectedValueOnce(new Error('network timeout'))

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -761,6 +761,43 @@ describe('NrIngestManager', () => {
       expect(metricNames).toContain('ai.session.duration_ms');
       expect(metricNames).toContain('ai.session.unique_files_read');
     });
+
+    it('emits aggregated proxy metrics (server_call_count, tool_popularity) sourced from proxyMetrics on stop', async () => {
+      const manager = new NrIngestManager(makeIngestOptions());
+
+      manager.ingestToolCall(
+        makeProxyRecord({ serverName: 'nr-mcp-server', toolName: 'nr_observe_get_session_stats' }),
+      );
+      manager.ingestToolCall(
+        makeProxyRecord({ serverName: 'nr-mcp-server', toolName: 'nr_observe_get_session_stats' }),
+      );
+      manager.ingestProxyRequest(
+        makeProxyRequestRecord({ serverName: 'nr-mcp-server', method: 'tools/list' }),
+      );
+
+      manager.start();
+      await manager.stop();
+
+      expect(mockSendMetrics).toHaveBeenCalled();
+      const sentMetrics = (mockSendMetrics.mock.calls[0] as unknown[])[0] as Array<{
+        name: string;
+        attributes?: Record<string, unknown>;
+        value: { sum: number };
+      }>;
+
+      // 2 tool calls (recordProxyCall) + 1 discovery request (recordProxyRequest) — both
+      // feed the same per-server call count.
+      const callCountMetric = sentMetrics.find((m) => m.name === 'ai.mcp.server_call_count');
+      expect(callCountMetric).toBeDefined();
+      expect(callCountMetric!.value.sum).toBe(3);
+      expect(callCountMetric!.attributes?.server).toBe('nr-mcp-server');
+
+      const popularityMetric = sentMetrics.find((m) => m.name === 'ai.mcp.tool_popularity');
+      expect(popularityMetric).toBeDefined();
+      expect(popularityMetric!.value.sum).toBe(2);
+      expect(popularityMetric!.attributes?.tool).toBe('nr_observe_get_session_stats');
+      expect(popularityMetric!.attributes?.server).toBe('nr-mcp-server');
+    });
   });
 
   describe('error handling', () => {

--- a/src/web/App.test.tsx
+++ b/src/web/App.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
 import { useLiveStore, type AlertEvent } from './store/liveStore';
@@ -62,6 +62,7 @@ describe('App shell', () => {
   afterEach(() => {
     resetStore();
     vi.restoreAllMocks();
+    window.history.pushState({}, '', '/');
   });
 
   it('renders the sidebar', () => {
@@ -89,5 +90,103 @@ describe('App shell', () => {
     const banner = screen.getByRole('alert');
     expect(banner).toBeInTheDocument();
     expect(banner.textContent).toContain('Boom');
+  });
+
+  it('navigates to the Git Efficiency view via the sidebar and renders its heading', async () => {
+    const gitEfficiencyPayload = {
+      totalGitCommands: 1,
+      mergeConflicts: 0,
+      rebaseConflicts: 0,
+      abortedOperations: 0,
+      forcePushes: 0,
+      resetHards: 0,
+      discardedChanges: 0,
+      pullCount: 0,
+      pushCount: 0,
+      commitCount: 0,
+      branchOperations: 0,
+      conflictResolutionRate: null,
+      avgConflictResolutionMs: null,
+      staleBranchPulls: 0,
+      gitCommandTimeline: [],
+      conflictHistory: [],
+      suggestions: [],
+      bestPractices: [],
+      preventionScore: null,
+      efficiencyScore: null,
+      riskIndicators: {
+        syncedBeforeEditing: null,
+        timeSinceLastSyncMs: null,
+        commitsSinceLastSync: 0,
+        pushRejections: 0,
+        forceAfterReject: 0,
+        hotFiles: [],
+        usesWorktrees: false,
+        usesForceWithLease: false,
+        avgCommitsBetweenSyncs: null,
+        commitsAheadOfMain: null,
+        commitsBehindMain: null,
+        sessionDurationMs: null,
+        quickConflictResolutions: 0,
+      },
+      velocityMetrics: {
+        avgTimeBetweenCommitsMs: null,
+        commitBurstCount: 0,
+        longestGapMs: null,
+        worktreeCount: 0,
+        buildBeforePush: null,
+        testBeforePush: null,
+      },
+      conflictResolutionStrategy: {
+        oursCount: 0,
+        theirsCount: 0,
+        manualMergeCount: 0,
+        cherryPickCount: 0,
+        totalResolutions: 0,
+      },
+      prMetrics: {
+        created: 0,
+        merged: 0,
+        checksViewed: 0,
+        prsUpdated: 0,
+        prActivity: [],
+        avgTimeToCreateMs: null,
+      },
+      repoContext: { repoName: null, branch: null, remoteName: null, defaultBranch: null },
+    };
+    globalThis.fetch = vi.fn((url: string) => {
+      if (url === '/api/git-efficiency') {
+        return Promise.resolve(
+          new Response(JSON.stringify(gitEfficiencyPayload), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url === '/api/git-efficiency/repos') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ repos: [], currentRepo: null }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as unknown as typeof fetch;
+
+    renderApp();
+    fireEvent.click(screen.getByRole('button', { name: 'Git' }));
+    expect(await screen.findByRole('heading', { name: 'Git Efficiency' })).toBeInTheDocument();
+  });
+
+  it('renders the "Not found" fallback for an unknown route', () => {
+    window.history.pushState({}, '', '/nope');
+    renderApp();
+    expect(screen.getByText('Not found')).toBeInTheDocument();
   });
 });

--- a/src/web/api/client.test.ts
+++ b/src/web/api/client.test.ts
@@ -2,9 +2,14 @@ import {
   fetchSessionCurrent,
   fetchAuditLog,
   fetchHealth,
+  fetchRecentAlerts,
+  fetchGitEfficiency,
+  fetchWorkflowDetail,
+  fetchSessionReplay,
   patchSettings,
   postDigestSend,
   qk,
+  NotFoundError,
 } from './client';
 
 describe('api/client', () => {
@@ -97,6 +102,190 @@ describe('api/client', () => {
         }),
       )) as typeof globalThis.fetch;
     const result = await fetchHealth();
+    expect(result).toEqual(payload);
+  });
+
+  it('fetchRecentAlerts rejects with a NotFoundError on 404 (cloud mode: no alert engine)', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response('Not Found', { status: 404 }))) as typeof globalThis.fetch;
+    await expect(fetchRecentAlerts()).rejects.toBeInstanceOf(NotFoundError);
+    await expect(fetchRecentAlerts()).rejects.toMatchObject({ name: 'NotFoundError' });
+  });
+
+  it('fetchGitEfficiency hits /api/git-efficiency and returns the full nested response', async () => {
+    let calledWith = '';
+    const payload = {
+      totalGitCommands: 12,
+      mergeConflicts: 1,
+      rebaseConflicts: 0,
+      abortedOperations: 0,
+      forcePushes: 0,
+      resetHards: 0,
+      discardedChanges: 0,
+      pullCount: 3,
+      pushCount: 2,
+      commitCount: 5,
+      branchOperations: 1,
+      conflictResolutionRate: 1,
+      avgConflictResolutionMs: 12000,
+      staleBranchPulls: 0,
+      gitCommandTimeline: [{ timestamp: 1, type: 'commit', success: true, durationMs: 100 }],
+      conflictHistory: [
+        { timestamp: 1, resolution: 'resolved', resolutionTimeMs: 12000, command: 'git merge' },
+      ],
+      suggestions: [{ severity: 'info', category: 'sync', message: 'msg', evidence: 'evidence' }],
+      bestPractices: [{ id: 'sync', label: 'Sync often', status: 'pass', detail: 'ok' }],
+      preventionScore: 90,
+      efficiencyScore: 85,
+      riskIndicators: {
+        syncedBeforeEditing: true,
+        timeSinceLastSyncMs: 1000,
+        commitsSinceLastSync: 1,
+        pushRejections: 0,
+        forceAfterReject: 0,
+        hotFiles: [],
+        usesWorktrees: false,
+        usesForceWithLease: false,
+        avgCommitsBetweenSyncs: 1,
+        commitsAheadOfMain: 0,
+        commitsBehindMain: 0,
+        sessionDurationMs: 60000,
+        quickConflictResolutions: 0,
+      },
+      velocityMetrics: {
+        avgTimeBetweenCommitsMs: 60000,
+        commitBurstCount: 0,
+        longestGapMs: 120000,
+        worktreeCount: 0,
+        buildBeforePush: true,
+        testBeforePush: true,
+      },
+      conflictResolutionStrategy: {
+        oursCount: 0,
+        theirsCount: 0,
+        manualMergeCount: 1,
+        cherryPickCount: 0,
+        totalResolutions: 1,
+      },
+      prMetrics: {
+        created: 1,
+        merged: 1,
+        checksViewed: 2,
+        prsUpdated: 1,
+        prActivity: [{ timestamp: 1, action: 'create', prNumber: '42' }],
+        avgTimeToCreateMs: 300000,
+      },
+      repoContext: {
+        repoName: 'nr-ai-observatory',
+        branch: 'main',
+        remoteName: 'origin',
+        defaultBranch: 'main',
+      },
+    };
+    globalThis.fetch = ((u: string) => {
+      calledWith = u;
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as unknown as typeof globalThis.fetch;
+    const result = await fetchGitEfficiency();
+    expect(calledWith).toBe('/api/git-efficiency');
+    expect(result).toEqual(payload);
+  });
+
+  it('fetchWorkflowDetail hits /api/workflows/:runId and returns the run+agents+topology shape', async () => {
+    let calledWith = '';
+    const payload = {
+      run: {
+        runId: 'run-1',
+        parentSessionId: 'sess-1',
+        taskId: 'task-1',
+        workflowName: 'my-workflow',
+        status: 'completed',
+        defaultModel: 'claude-sonnet-5',
+        startedAt: 1000,
+        durationMs: 5000,
+        agentCount: 2,
+        totalTokens: 1000,
+        totalUsd: 0.5,
+      },
+      agents: [
+        {
+          agentId: 'agent-1',
+          label: 'researcher',
+          phaseIndex: 0,
+          phaseTitle: 'research',
+          model: 'claude-sonnet-5',
+          state: 'completed',
+          attempt: 1,
+          durationMs: 2000,
+          tokens: 500,
+          toolCalls: 3,
+          startedAt: 1000,
+        },
+      ],
+      topology: {
+        workflowName: 'my-workflow',
+        declaredPhases: 1,
+        declaredPhaseCalls: 1,
+        declaredAgents: 2,
+        declaredParallelWidths: [2],
+      },
+    };
+    globalThis.fetch = ((u: string) => {
+      calledWith = u;
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as unknown as typeof globalThis.fetch;
+    const result = await fetchWorkflowDetail('run-1');
+    expect(calledWith).toBe('/api/workflows/run-1');
+    expect(result).toEqual(payload);
+  });
+
+  it('fetchSessionReplay hits /api/sessions/:id/replay and returns the timeline+segments shape', async () => {
+    let calledWith = '';
+    const payload = {
+      sessionId: 'sess-1',
+      timeline: [
+        { timestamp: 1, toolName: 'Read', durationMs: 10, success: true, filePath: 'a.ts' },
+      ],
+      segments: [
+        {
+          type: 'thrashing',
+          startIndex: 0,
+          endIndex: 2,
+          iterations: 3,
+          target: 'a.ts',
+          severity: 'warning',
+        },
+      ],
+      worstSegment: {
+        type: 'thrashing',
+        startIndex: 0,
+        endIndex: 2,
+        iterations: 3,
+        target: 'a.ts',
+        severity: 'warning',
+      },
+    };
+    globalThis.fetch = ((u: string) => {
+      calledWith = u;
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as unknown as typeof globalThis.fetch;
+    const result = await fetchSessionReplay('sess-1');
+    expect(calledWith).toBe('/api/sessions/sess-1/replay');
     expect(result).toEqual(payload);
   });
 });

--- a/src/web/components/ActivityHeatmap.test.tsx
+++ b/src/web/components/ActivityHeatmap.test.tsx
@@ -38,3 +38,19 @@ describe('ActivityHeatmap grid variant — timezone handling', () => {
     expect(rect).toHaveAttribute('y', '38');
   });
 });
+
+describe('ActivityHeatmap strip variant', () => {
+  it('renders one <rect> per bucket', () => {
+    const { container } = render(
+      <ActivityHeatmap variant="strip" buckets={[1, 2, 3, 0]} maxCount={3} />,
+    );
+    expect(container.querySelectorAll('rect')).toHaveLength(4);
+  });
+
+  it('maps a zero count to the lowest intensity color and the max count to the top level', () => {
+    const { container } = render(<ActivityHeatmap variant="strip" buckets={[0, 3]} maxCount={3} />);
+    const rects = container.querySelectorAll('rect');
+    expect(rects[0]).toHaveAttribute('fill', 'var(--color-heatmap-0)');
+    expect(rects[1]).toHaveAttribute('fill', 'var(--color-heatmap-4)');
+  });
+});

--- a/src/web/components/AgentSwimlanes.test.tsx
+++ b/src/web/components/AgentSwimlanes.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AgentSwimlanes, type AgentSpan } from './AgentSwimlanes';
+
+function makeAgent(overrides: Partial<AgentSpan> = {}): AgentSpan {
+  return {
+    agentId: 'a-1',
+    workflowRunId: 'run-1',
+    workflowName: 'Big run',
+    label: 'agent',
+    model: 'claude-sonnet',
+    startMs: 0,
+    endMs: 1000,
+    durationMs: 1000,
+    turnCount: 1,
+    totalTokens: 100,
+    usd: 0.01,
+    ...overrides,
+  };
+}
+
+describe('AgentSwimlanes', () => {
+  it('starts a group with more than 15 agents collapsed', () => {
+    const agents: AgentSpan[] = Array.from({ length: 16 }, (_, i) =>
+      makeAgent({ agentId: `a-${i}`, label: `agent-${i}`, startMs: i * 100, endMs: i * 100 + 50 }),
+    );
+    render(<AgentSwimlanes agents={agents} window={{ startMs: 0, endMs: 2000 }} />);
+    const groupHeader = screen.getByText('Big run').closest('button');
+    expect(groupHeader).not.toBeNull();
+    expect(groupHeader!.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('leaves a group with 15 or fewer agents expanded by default', () => {
+    const agents: AgentSpan[] = Array.from({ length: 15 }, (_, i) =>
+      makeAgent({ agentId: `a-${i}`, label: `agent-${i}`, startMs: i * 100, endMs: i * 100 + 50 }),
+    );
+    render(<AgentSwimlanes agents={agents} window={{ startMs: 0, endMs: 2000 }} />);
+    const groupHeader = screen.getByText('Big run').closest('button');
+    expect(groupHeader!.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('shows the empty-state message only when there are no agents and no parent lane', () => {
+    render(<AgentSwimlanes agents={[]} window={{ startMs: 0, endMs: 1000 }} />);
+    expect(screen.getByText('No subagents ran in this session.')).toBeInTheDocument();
+  });
+
+  it('does not show the empty-state message when a parent lane is supplied, even with zero agents', () => {
+    render(<AgentSwimlanes agents={[]} window={{ startMs: 0, endMs: 1000 }} parentEntries={[]} />);
+    expect(screen.queryByText('No subagents ran in this session.')).not.toBeInTheDocument();
+    expect(screen.getByText('Parent activity')).toBeInTheDocument();
+  });
+});

--- a/src/web/components/AgentTable.test.tsx
+++ b/src/web/components/AgentTable.test.tsx
@@ -55,4 +55,38 @@ describe('AgentTable sortable headers', () => {
     const agentHeader = screen.getByRole('columnheader', { name: 'Agent' });
     expect(agentHeader).toHaveAttribute('aria-sort', 'descending');
   });
+
+  it('changes row order after sorting the Tokens column ascending', async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentTable
+        agents={[
+          makeAgent({ agentId: 'a1', label: 'high', tokens: 200 }),
+          makeAgent({ agentId: 'a2', label: 'low', tokens: 100 }),
+        ]}
+      />,
+    );
+
+    // Default sort is tokens/desc: high (200) before low (100).
+    const rowsBefore = screen.getAllByRole('row').slice(1);
+    expect(rowsBefore.map((r) => r.textContent)).toEqual([
+      expect.stringContaining('high'),
+      expect.stringContaining('low'),
+    ]);
+
+    await user.click(screen.getByRole('button', { name: 'Tokens' }));
+
+    const rowsAfter = screen.getAllByRole('row').slice(1);
+    expect(rowsAfter.map((r) => r.textContent)).toEqual([
+      expect.stringContaining('low'),
+      expect.stringContaining('high'),
+    ]);
+  });
+});
+
+describe('AgentTable empty state', () => {
+  it('renders the empty-state message when agents is empty', () => {
+    render(<AgentTable agents={[]} />);
+    expect(screen.getByText('No agent data recorded for this run.')).toBeInTheDocument();
+  });
 });

--- a/src/web/components/ConcurrencyIndicator.test.tsx
+++ b/src/web/components/ConcurrencyIndicator.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ConcurrencyIndicator } from './ConcurrencyIndicator';
+
+const STORAGE_KEY = 'nr-observe-peak-concurrent';
+
+describe('ConcurrencyIndicator', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('shows "NEW RECORD!" and persists the new peak when allTimePeak exceeds the stored value', () => {
+    localStorage.setItem(STORAGE_KEY, '5');
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+    render(
+      <ConcurrencyIndicator
+        current={3}
+        peak={8}
+        allTimePeak={10}
+        bucketSizeMs={60_000}
+        startTimestamp={0}
+        buckets={[]}
+      />,
+    );
+
+    expect(screen.getByText('NEW RECORD!')).toBeInTheDocument();
+    expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY, '10');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('10');
+  });
+
+  it('does not celebrate when the peak does not exceed the stored value', () => {
+    localStorage.setItem(STORAGE_KEY, '10');
+
+    render(
+      <ConcurrencyIndicator
+        current={3}
+        peak={8}
+        allTimePeak={10}
+        bucketSizeMs={60_000}
+        startTimestamp={0}
+        buckets={[]}
+      />,
+    );
+
+    expect(screen.queryByText('NEW RECORD!')).not.toBeInTheDocument();
+  });
+});

--- a/src/web/components/ContextBar.test.tsx
+++ b/src/web/components/ContextBar.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ContextBar } from './ContextBar';
+import type { ContextResponse } from '../api/client';
+
+function renderContextBar(data: ContextResponse) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ContextBar data={data} />
+    </QueryClientProvider>,
+  );
+}
+
+function makeContext(overrides: Partial<ContextResponse> = {}): ContextResponse {
+  return {
+    turnCount: 1,
+    growth: { startTokens: 0, currentTokens: 100_000, deltaTokens: 100_000 },
+    currentBreakdown: { system: 10_000, tools: 20_000, user: 30_000, assistant: 40_000 },
+    fillPercent: 50,
+    contextWindow: 200_000,
+    toolContributions: [],
+    history: [],
+    ...overrides,
+  };
+}
+
+describe('ContextBar', () => {
+  it('flags the compacting state when currentTokens drops more than 30% from the previous render', () => {
+    const { container, rerender } = renderContextBar(makeContext());
+    const client = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    rerender(
+      <QueryClientProvider client={client}>
+        <ContextBar
+          data={makeContext({
+            growth: { startTokens: 0, currentTokens: 50_000, deltaTokens: -50_000 },
+            fillPercent: 25,
+          })}
+        />
+      </QueryClientProvider>,
+    );
+    expect(container.querySelector('.animate-compact-flash')).not.toBeNull();
+  });
+
+  it('does not flag compacting on a small drop (< 30%)', () => {
+    const { container, rerender } = renderContextBar(makeContext());
+    const client = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    rerender(
+      <QueryClientProvider client={client}>
+        <ContextBar
+          data={makeContext({
+            growth: { startTokens: 0, currentTokens: 90_000, deltaTokens: -10_000 },
+            fillPercent: 45,
+          })}
+        />
+      </QueryClientProvider>,
+    );
+    expect(container.querySelector('.animate-compact-flash')).toBeNull();
+  });
+
+  it('renders the "at capacity" pill only when fillPercent is at least 100', () => {
+    renderContextBar(makeContext({ fillPercent: 100 }));
+    expect(screen.getByText('at capacity')).toBeInTheDocument();
+  });
+
+  it('does not render the "at capacity" pill when fillPercent is below 100', () => {
+    renderContextBar(makeContext({ fillPercent: 99 }));
+    expect(screen.queryByText('at capacity')).not.toBeInTheDocument();
+  });
+});

--- a/src/web/components/DiscreteBlockChart.test.tsx
+++ b/src/web/components/DiscreteBlockChart.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { DiscreteBlockChart } from './DiscreteBlockChart';
+
+describe('DiscreteBlockChart', () => {
+  it('renders nothing when every item has a count of 0, even with a nonzero maxCount override', () => {
+    const { container } = render(
+      <DiscreteBlockChart
+        data={[
+          { count: 0, tooltip: 'a' },
+          { count: 0, tooltip: 'b' },
+        ]}
+        maxCount={5}
+        ariaLabel="empty chart"
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('colors the peak column with BLOCK_COLOR_PEAK and a shorter column with BLOCK_COLOR', () => {
+    const { container } = render(
+      <DiscreteBlockChart
+        data={[
+          { count: 1, tooltip: 'short' },
+          { count: 3, tooltip: 'tall' },
+        ]}
+        ariaLabel="chart"
+      />,
+    );
+    const rects = container.querySelectorAll('rect.heatmap-cell');
+    expect(rects.length).toBe(4);
+    // First column (count 1, not the peak) gets the base color.
+    expect(rects[0]!.getAttribute('fill')).toBe('var(--color-chart-block)');
+    // Second column (count 3 === effectiveMax) gets the peak color, including
+    // its topmost block.
+    expect(rects[1]!.getAttribute('fill')).toBe('var(--color-chart-block-peak)');
+    expect(rects[3]!.getAttribute('fill')).toBe('var(--color-chart-block-peak)');
+  });
+});

--- a/src/web/components/ErrorBoundary.test.tsx
+++ b/src/web/components/ErrorBoundary.test.tsx
@@ -1,9 +1,29 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi, type MockInstance } from 'vitest';
 import { ErrorBoundary } from './ErrorBoundary';
 
 function Boom({ message }: { message: string }): JSX.Element {
   throw new Error(message);
+}
+
+// Throws until the test explicitly flips it off — lets a test drive the
+// boundary into its error state and then observe recovery without needing
+// resetKey to change. The throw condition is controlled externally (not by a
+// side effect inside render) so it's unaffected by React re-invoking a
+// failing render to build a component stack in dev mode.
+function makeFlaky(): { Flaky: () => JSX.Element; setShouldThrow: (v: boolean) => void } {
+  let shouldThrow = true;
+  function Flaky(): JSX.Element {
+    if (shouldThrow) throw new Error('flaky');
+    return <div>recovered</div>;
+  }
+  return {
+    Flaky,
+    setShouldThrow: (v: boolean) => {
+      shouldThrow = v;
+    },
+  };
 }
 
 describe('ErrorBoundary', () => {
@@ -67,5 +87,23 @@ describe('ErrorBoundary', () => {
       'ErrorBoundary caught a render error',
       expect.objectContaining({ error: expect.any(Error) }),
     );
+  });
+
+  it('clears the error and re-renders children when the Dismiss button is clicked', async () => {
+    const user = userEvent.setup();
+    const { Flaky, setShouldThrow } = makeFlaky();
+
+    render(
+      <ErrorBoundary>
+        <Flaky />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    setShouldThrow(false);
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByText('recovered')).toBeInTheDocument();
   });
 });

--- a/src/web/components/GanttTimeline.test.tsx
+++ b/src/web/components/GanttTimeline.test.tsx
@@ -37,4 +37,24 @@ describe('GanttTimeline', () => {
     expect(screen.getByRole('img', { name: 'Edit · 240ms · success' })).toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'Bash · 80ms · failed' })).toBeInTheDocument();
   });
+
+  it('applies severity-based border-highlight classes to segmented rows', () => {
+    const entries = [
+      { timestamp: 0, toolName: 'Read', durationMs: 100, success: true },
+      { timestamp: 100, toolName: 'Edit', durationMs: 100, success: true },
+      { timestamp: 200, toolName: 'Bash', durationMs: 100, success: true },
+    ];
+    render(
+      <GanttTimeline
+        entries={entries}
+        segments={[
+          { type: 'thrashing', startIndex: 0, endIndex: 0, severity: 'critical' },
+          { type: 're_reading', startIndex: 1, endIndex: 1, severity: 'warning' },
+        ]}
+      />,
+    );
+    expect(screen.getByTitle('Read').parentElement).toHaveClass('border-l-accent-red');
+    expect(screen.getByTitle('Edit').parentElement).toHaveClass('border-l-accent-amber');
+    expect(screen.getByTitle('Bash').parentElement).toHaveClass('border-l-transparent');
+  });
 });

--- a/src/web/components/GeoBanner.test.tsx
+++ b/src/web/components/GeoBanner.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { GeoBanner, type BannerTheme } from './GeoBanner';
+
+const THEME_GRADIENT_IDS: Record<BannerTheme, string> = {
+  observatory: 'obsSky',
+  sessions: 'seaSky',
+  history: 'histSky',
+  audit: 'auditSky',
+  git: 'gitSky',
+};
+
+describe('GeoBanner', () => {
+  for (const [theme, id] of Object.entries(THEME_GRADIENT_IDS) as Array<[BannerTheme, string]>) {
+    it(`renders the ${theme}-unique banner (gradient #${id}) and no other theme's gradient`, () => {
+      const { container } = render(<GeoBanner theme={theme} />);
+      expect(container.querySelector(`#${id}`)).not.toBeNull();
+      for (const [otherTheme, otherId] of Object.entries(THEME_GRADIENT_IDS)) {
+        if (otherTheme === theme) continue;
+        expect(container.querySelector(`#${otherId}`)).toBeNull();
+      }
+    });
+  }
+
+  it('defaults to the observatory theme when no theme prop is given', () => {
+    const { container } = render(<GeoBanner />);
+    expect(container.querySelector('#obsSky')).not.toBeNull();
+  });
+});

--- a/src/web/components/HourlyCostBlocks.test.tsx
+++ b/src/web/components/HourlyCostBlocks.test.tsx
@@ -24,4 +24,13 @@ describe('HourlyCostBlocks', () => {
     render(<HourlyCostBlocks hours={hours} ariaLabel="Custom label" />);
     expect(screen.getByRole('img', { name: 'Custom label' })).toBeInTheDocument();
   });
+
+  it('renders nothing when a nonzero cost rounds to 0 blocks at every unit step', () => {
+    const hours = Array.from({ length: 24 }, (_, hour) => ({
+      hour,
+      cost: hour === 3 ? 0.001 : 0,
+    }));
+    const { container } = render(<HourlyCostBlocks hours={hours} />);
+    expect(container.firstChild).toBeNull();
+  });
 });

--- a/src/web/components/Kpi.test.tsx
+++ b/src/web/components/Kpi.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { Kpi } from './Kpi';
+import { formatUsd } from '../lib/format.js';
 
 describe('Kpi', () => {
   it('renders label and value', () => {
@@ -29,5 +30,26 @@ describe('Kpi', () => {
     render(<Kpi label="spend" value="$3.42" tone="good" />);
     const v = screen.getByText('$3.42');
     expect(v.className).toMatch(/text-accent-green/);
+  });
+
+  it('renders the animated/formatted value instead of the static value prop when animate is set', () => {
+    render(<Kpi label="spend" value="WRONG" animate numericValue={3.42} format={formatUsd} />);
+    expect(screen.getByText('$3.42')).toBeInTheDocument();
+    expect(screen.queryByText('WRONG')).not.toBeInTheDocument();
+  });
+
+  it('assembles prefix/suffix/decimals around the animated value when no format is given', () => {
+    render(
+      <Kpi
+        label="count"
+        value="ignored"
+        animate
+        numericValue={42}
+        prefix="+"
+        suffix=" pts"
+        decimals={1}
+      />,
+    );
+    expect(screen.getByText('+42.0 pts')).toBeInTheDocument();
   });
 });

--- a/src/web/components/SessionTrace.test.tsx
+++ b/src/web/components/SessionTrace.test.tsx
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 import { describe, expect, it, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { SessionTrace, type SessionTraceProps } from './SessionTrace';
 
 // Minimal valid props for a trace with one ad-hoc subagent group, so
@@ -47,5 +48,42 @@ describe('SessionTrace group controls', () => {
       const nestedInteractive = btn.querySelector('[role="button"], button, a[href]');
       expect(nestedInteractive).toBeNull();
     }
+  });
+});
+
+describe('SessionTrace three-level expand preset', () => {
+  it('the "Agents" preset collapses the parent lane, expands the subagent group, and drills into no agent calls', async () => {
+    const user = userEvent.setup();
+    render(
+      <SessionTrace
+        {...baseProps({
+          parentEntries: [{ timestamp: 0, toolName: 'Read', durationMs: 100, success: true }],
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Agents' }));
+
+    // Parent lane: shut (collapsedGroups contains PARENT_GROUP_ID).
+    const parentHeader = screen.getByText('Parent').closest('div');
+    expect(parentHeader?.querySelector('button[aria-expanded]')).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+
+    // Subagent group: open (not in collapsedGroups).
+    const groupHeader = screen.getByText('Reviewer workflow').closest('div');
+    expect(groupHeader?.querySelector('button[aria-expanded]')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+
+    // No per-agent calls drilled in: the agent's own disclosure stays collapsed
+    // and its lazy AgentCallsGantt query never mounts.
+    expect(screen.getByRole('button', { name: 'Expand calls for reviewer' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.queryByText(/loading calls|no calls recorded/i)).not.toBeInTheDocument();
   });
 });

--- a/src/web/components/ShortcutOverlay.test.tsx
+++ b/src/web/components/ShortcutOverlay.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ShortcutOverlay } from './ShortcutOverlay';
+
+describe('ShortcutOverlay', () => {
+  it('renders nothing when open is false', () => {
+    const { container } = render(<ShortcutOverlay open={false} onClose={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the shortcut list when open is true', () => {
+    render(<ShortcutOverlay open={true} onClose={() => {}} />);
+    expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
+  });
+
+  it('calls onClose when Escape is pressed while open', () => {
+    const onClose = vi.fn();
+    render(<ShortcutOverlay open={true} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const onClose = vi.fn();
+    const { container } = render(<ShortcutOverlay open={true} onClose={onClose} />);
+    fireEvent.click(container.firstElementChild!);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not call onClose when clicking inside the shortcut card (stopPropagation)', () => {
+    const onClose = vi.fn();
+    render(<ShortcutOverlay open={true} onClose={onClose} />);
+    fireEvent.click(screen.getByText('Keyboard Shortcuts'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/components/WorkflowRunDetail.test.tsx
+++ b/src/web/components/WorkflowRunDetail.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { WorkflowRunDetail } from './WorkflowRunDetail';
+import type { WorkflowRunDetailResponse, WorkflowRunInfo } from '../api/client';
+
+function makeRun(overrides: Partial<WorkflowRunInfo> = {}): WorkflowRunInfo {
+  return {
+    runId: 'run-1',
+    parentSessionId: 'session-1',
+    taskId: null,
+    workflowName: 'My Workflow',
+    status: 'completed',
+    defaultModel: 'claude-sonnet',
+    ...overrides,
+  };
+}
+
+function stubDetailResponse(response: WorkflowRunDetailResponse): void {
+  globalThis.fetch = vi.fn(
+    async () =>
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  ) as typeof fetch;
+}
+
+function renderRunDetail() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <WorkflowRunDetail runId="run-1" onClose={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('WorkflowRunDetail', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the failure reason for a failed run with a non-empty errorReason', async () => {
+    stubDetailResponse({
+      run: makeRun({ status: 'failed', errorReason: 'Agent crashed on tool call' }),
+      agents: [],
+      topology: null,
+    });
+    renderRunDetail();
+    await waitFor(() => expect(screen.getByText('Failure reason')).toBeInTheDocument());
+    expect(screen.getByText('Agent crashed on tool call')).toBeInTheDocument();
+  });
+
+  it('does not render a failure reason for a completed run, even with a stray errorReason', async () => {
+    stubDetailResponse({
+      run: makeRun({ status: 'completed', errorReason: 'this should be ignored' }),
+      agents: [],
+      topology: null,
+    });
+    renderRunDetail();
+    await waitFor(() => expect(screen.getByText('My Workflow')).toBeInTheDocument());
+    expect(screen.queryByText('Failure reason')).not.toBeInTheDocument();
+    expect(screen.queryByText('this should be ignored')).not.toBeInTheDocument();
+  });
+});

--- a/src/web/components/ui/Tabs.test.tsx
+++ b/src/web/components/ui/Tabs.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Tabs } from './Tabs';
+
+describe('Tabs', () => {
+  it('calls onChange with the clicked option value', () => {
+    const onChange = vi.fn();
+    render(
+      <Tabs
+        value="a"
+        onChange={onChange}
+        options={[
+          { value: 'a', label: 'Alpha' },
+          { value: 'b', label: 'Beta' },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Beta' }));
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('marks only the tab matching the value prop as selected', () => {
+    render(
+      <Tabs
+        value="a"
+        onChange={() => {}}
+        options={[
+          { value: 'a', label: 'Alpha' },
+          { value: 'b', label: 'Beta' },
+        ]}
+      />,
+    );
+    expect(screen.getByRole('tab', { name: 'Alpha' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'Beta' }).getAttribute('aria-selected')).toBe('false');
+  });
+});

--- a/src/web/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/web/hooks/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+
+function dispatchKeyDown(key: string, target: EventTarget = document): void {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+}
+
+describe('useKeyboardShortcuts', () => {
+  let navigate: (path: string) => void;
+  let onToggleHelp: () => void;
+  let onToggleTheme: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    navigate = vi.fn<(path: string) => void>();
+    onToggleHelp = vi.fn<() => void>();
+    onToggleTheme = vi.fn<() => void>();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('navigates to /sessions on g then s', () => {
+    renderHook(() => useKeyboardShortcuts({ navigate, onToggleHelp, onToggleTheme }));
+    dispatchKeyDown('g');
+    dispatchKeyDown('s');
+    expect(navigate).toHaveBeenCalledWith('/sessions');
+  });
+
+  it('expires the g-prefix window after 500ms, so a late second key does not navigate', () => {
+    renderHook(() => useKeyboardShortcuts({ navigate, onToggleHelp, onToggleTheme }));
+    dispatchKeyDown('g');
+    vi.advanceTimersByTime(600);
+    dispatchKeyDown('s');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('restarts the prefix window on g then g, staying in prefix mode', () => {
+    renderHook(() => useKeyboardShortcuts({ navigate, onToggleHelp, onToggleTheme }));
+    dispatchKeyDown('g');
+    vi.advanceTimersByTime(400);
+    dispatchKeyDown('g');
+    // Window restarted at t=400; advancing another 400ms (t=800, only 400ms
+    // since the restart) should still be within the window.
+    vi.advanceTimersByTime(400);
+    dispatchKeyDown('s');
+    expect(navigate).toHaveBeenCalledWith('/sessions');
+  });
+
+  it('exits prefix mode on an unmatched second key without navigating', () => {
+    renderHook(() => useKeyboardShortcuts({ navigate, onToggleHelp, onToggleTheme }));
+    dispatchKeyDown('g');
+    dispatchKeyDown('z');
+    expect(navigate).not.toHaveBeenCalled();
+    // Confirms prefix mode was exited (not left pending): a fresh g→s now works.
+    dispatchKeyDown('g');
+    dispatchKeyDown('s');
+    expect(navigate).toHaveBeenCalledWith('/sessions');
+  });
+
+  it('skips handling when focus is on an INPUT element', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    renderHook(() => useKeyboardShortcuts({ navigate, onToggleHelp, onToggleTheme }));
+    dispatchKeyDown('t', input);
+    expect(onToggleTheme).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it('skips handling when focus is on a contentEditable element', () => {
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'isContentEditable', { value: true });
+    document.body.appendChild(div);
+    renderHook(() => useKeyboardShortcuts({ navigate, onToggleHelp, onToggleTheme }));
+    dispatchKeyDown('t', div);
+    expect(onToggleTheme).not.toHaveBeenCalled();
+    document.body.removeChild(div);
+  });
+
+  it('skips handling when a modifier key is held', () => {
+    renderHook(() => useKeyboardShortcuts({ navigate, onToggleHelp, onToggleTheme }));
+    const event = new KeyboardEvent('keydown', {
+      key: 't',
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+    });
+    document.dispatchEvent(event);
+    expect(onToggleTheme).not.toHaveBeenCalled();
+  });
+
+  it('calls onToggleHelp on ?', () => {
+    renderHook(() => useKeyboardShortcuts({ navigate, onToggleHelp, onToggleTheme }));
+    dispatchKeyDown('?');
+    expect(onToggleHelp).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onToggleTheme on t when provided', () => {
+    renderHook(() => useKeyboardShortcuts({ navigate, onToggleHelp, onToggleTheme }));
+    dispatchKeyDown('t');
+    expect(onToggleTheme).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw on t when onToggleTheme is not provided', () => {
+    renderHook(() => useKeyboardShortcuts({ navigate, onToggleHelp }));
+    expect(() => dispatchKeyDown('t')).not.toThrow();
+  });
+
+  it('removes the listener and clears the pending timer on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useKeyboardShortcuts({ navigate, onToggleHelp, onToggleTheme }),
+    );
+    dispatchKeyDown('g');
+    unmount();
+    // After unmount, a stray keydown must not be handled by the removed listener.
+    dispatchKeyDown('s');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/hooks/useLiveEvents.test.tsx
+++ b/src/web/hooks/useLiveEvents.test.tsx
@@ -156,6 +156,48 @@ describe('useLiveEvents', () => {
     });
   });
 
+  describe('REST hydration of the tool call timeline', () => {
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('pushes toolCallTimeline entries with a derived id and durationMs ?? 0 fallback', async () => {
+      globalThis.fetch = vi.fn((url: string, _init?: RequestInit) => {
+        if (url === '/api/session/current') {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                sessionId: 'sess-1',
+                toolCallTimeline: [
+                  { timestamp: 1000, toolName: 'Read', durationMs: null, success: true },
+                ],
+              }),
+          } as Response);
+        }
+        return Promise.resolve({ ok: false } as Response);
+      }) as typeof globalThis.fetch;
+
+      renderHook(() => useLiveEvents());
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const calls = useLiveStore.getState().recentToolCalls;
+      expect(calls).toHaveLength(1);
+      expect(calls[0].id).toBe('1000-Read');
+      expect(calls[0].durationMs).toBe(0);
+      expect(calls[0].sessionId).toBe('sess-1');
+    });
+  });
+
   describe('staleness watchdog', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/src/web/lib/format.test.tsx
+++ b/src/web/lib/format.test.tsx
@@ -1,5 +1,43 @@
 import { describe, expect, it } from 'vitest';
-import { formatDuration } from './format';
+import { formatDuration, rateColor, shortToolName, formatTokensCompact } from './format';
+
+describe('rateColor()', () => {
+  it('returns the muted color for null (no data)', () => {
+    expect(rateColor(null)).toBe('text-ink-muted');
+  });
+
+  it('returns green at/above the good threshold', () => {
+    expect(rateColor(0.9)).toBe('text-accent-green');
+  });
+
+  it('returns amber between the warn and good thresholds', () => {
+    expect(rateColor(0.6)).toBe('text-accent-amber');
+  });
+
+  it('returns red below the warn threshold', () => {
+    expect(rateColor(0.3)).toBe('text-accent-red');
+  });
+});
+
+describe('shortToolName()', () => {
+  it('strips the mcp__<server>__ prefix', () => {
+    expect(shortToolName('mcp__nr-observe__nr_observe_health')).toBe('nr_observe_health');
+  });
+
+  it('passes non-MCP names through unchanged', () => {
+    expect(shortToolName('Read')).toBe('Read');
+  });
+});
+
+describe('formatTokensCompact()', () => {
+  it('renders the k tier at the 1,000 boundary', () => {
+    expect(formatTokensCompact(1_000)).toBe('1.0k');
+  });
+
+  it('renders the M tier at the 1,000,000 boundary', () => {
+    expect(formatTokensCompact(1_000_000)).toBe('1.0M');
+  });
+});
 
 describe('formatDuration()', () => {
   it('formats seconds', () => {

--- a/src/web/store/liveStore.test.ts
+++ b/src/web/store/liveStore.test.ts
@@ -3,6 +3,7 @@ import {
   selectVisibleFiringAlerts,
   selectMaxSeverity,
   type AlertEvent,
+  type WorkflowRunLiveState,
 } from './liveStore';
 
 function fireAlert(overrides: Partial<AlertEvent> = {}): AlertEvent {
@@ -279,5 +280,91 @@ describe('liveStore — setActiveSession', () => {
     pushToolCall({ id: 'legacy', tool: 'Read', durationMs: 1, costUsd: 0, ts: 1 });
     setActiveSession('sess-A');
     expect(useLiveStore.getState().recentToolCalls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertWorkflowRun / addSubagentTurn / setObservabilityHealth
+// ---------------------------------------------------------------------------
+
+function workflowRun(overrides: Partial<WorkflowRunLiveState> = {}): WorkflowRunLiveState {
+  return {
+    workflowRunId: 'run-1',
+    runSource: 'agent_tool',
+    workflowName: 'wf',
+    status: 'running',
+    agentCount: 1,
+    totalTokens: 100,
+    ts: 1,
+    ...overrides,
+  };
+}
+
+describe('liveStore — upsertWorkflowRun', () => {
+  beforeEach(() => {
+    useLiveStore.setState({ recentWorkflowRuns: [] });
+  });
+
+  it('replaces an existing entry with the same workflowRunId instead of duplicating it', () => {
+    useLiveStore.getState().upsertWorkflowRun(workflowRun({ status: 'running', totalTokens: 100 }));
+    useLiveStore
+      .getState()
+      .upsertWorkflowRun(workflowRun({ status: 'completed', totalTokens: 500 }));
+    const runs = useLiveStore.getState().recentWorkflowRuns;
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe('completed');
+    expect(runs[0].totalTokens).toBe(500);
+  });
+
+  it('caps at 50 entries, dropping the oldest', () => {
+    const { upsertWorkflowRun } = useLiveStore.getState();
+    for (let i = 0; i < 51; i++) {
+      upsertWorkflowRun(workflowRun({ workflowRunId: `run-${i}`, ts: i }));
+    }
+    const runs = useLiveStore.getState().recentWorkflowRuns;
+    expect(runs).toHaveLength(50);
+    expect(runs[0].workflowRunId).toBe('run-1');
+    expect(runs[49].workflowRunId).toBe('run-50');
+  });
+});
+
+describe('liveStore — addSubagentTurn', () => {
+  beforeEach(() => {
+    useLiveStore.setState({ todaySubagentUsd: 0, todaySubagentTurnCount: 0 });
+  });
+
+  it('accumulates the usd estimate and turn count', () => {
+    const { addSubagentTurn } = useLiveStore.getState();
+    addSubagentTurn(0.5);
+    addSubagentTurn(0.25);
+    const s = useLiveStore.getState();
+    expect(s.todaySubagentTurnCount).toBe(2);
+    expect(s.todaySubagentUsd).toBe(0.75);
+  });
+
+  it('counts the turn but skips the usd accumulation when the estimate is null', () => {
+    const { addSubagentTurn } = useLiveStore.getState();
+    addSubagentTurn(1);
+    addSubagentTurn(null);
+    const s = useLiveStore.getState();
+    expect(s.todaySubagentTurnCount).toBe(2);
+    expect(s.todaySubagentUsd).toBe(1);
+  });
+});
+
+describe('liveStore — setObservabilityHealth', () => {
+  it('replaces the observability health snapshot', () => {
+    useLiveStore.getState().setObservabilityHealth({
+      filesWatched: 12,
+      parseErrors: 0,
+      watcherDisabledByLock: false,
+      ts: 1000,
+    });
+    expect(useLiveStore.getState().observabilityHealth).toEqual({
+      filesWatched: 12,
+      parseErrors: 0,
+      watcherDisabledByLock: false,
+      ts: 1000,
+    });
   });
 });

--- a/src/web/views/Alerts.test.tsx
+++ b/src/web/views/Alerts.test.tsx
@@ -77,6 +77,72 @@ describe('Alerts view', () => {
     await waitFor(() => expect(screen.getByText('Not configured')).toBeInTheDocument());
     expect(input).toHaveValue('');
   });
+
+  it('saves an edited threshold and shows the "Saved" confirmation', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    const patchBodies: unknown[] = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      if (url === '/api/budget') return jsonResponse(DEFAULT_BUDGET);
+      if (url === '/api/settings' && init?.method === 'PATCH') {
+        patchBodies.push(JSON.parse(String(init.body)));
+        return jsonResponse({ ok: true, restartRequired: false });
+      }
+      if (url === '/api/settings') return jsonResponse(BASE_SETTINGS);
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <Alerts />
+      </QueryClientProvider>,
+    );
+
+    const label = await screen.findByText('Daily cost ($)');
+    const input = label.closest('div')!.querySelector('input')!;
+    fireEvent.change(input, { target: { value: '42' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save thresholds' }));
+
+    await waitFor(() => expect(patchBodies).toHaveLength(1));
+    expect(patchBodies[0]).toEqual({ alerts: { personal: { dailyCostUsd: 42 } } });
+
+    expect(await screen.findByText(/Saved\. Run `npm run deploy:alerts`/)).toBeInTheDocument();
+  });
+});
+
+describe('Alerts view — Recent Warnings', () => {
+  it('renders pct/period/spent values from budget.alerts', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    const budgetWithAlert = {
+      ...DEFAULT_BUDGET,
+      alerts: [
+        {
+          thresholdPct: 80,
+          period: 'daily',
+          spentUsd: 8,
+          budgetUsd: 10,
+          timestamp: Date.now(),
+        },
+      ],
+    };
+    globalThis.fetch = (async (url: string) => {
+      if (url === '/api/budget') return jsonResponse(budgetWithAlert);
+      if (url === '/api/settings') return jsonResponse(BASE_SETTINGS);
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <Alerts />
+      </QueryClientProvider>,
+    );
+
+    const warningsHeading = await screen.findByText('Recent Warnings');
+    const warningsSection = warningsHeading.closest('div')!.parentElement as HTMLElement;
+    expect(within(warningsSection).getByText('80%')).toBeInTheDocument();
+    expect(within(warningsSection).getByText('daily')).toBeInTheDocument();
+    expect(within(warningsSection).getByText(/\$8\.00 \/ \$10\.00/)).toBeInTheDocument();
+  });
 });
 
 describe('Alerts view — error and loading states', () => {

--- a/src/web/views/Audit.test.tsx
+++ b/src/web/views/Audit.test.tsx
@@ -137,6 +137,23 @@ describe('Audit view', () => {
     expect(screen.queryByText(/showing first/i)).toBeNull();
   });
 
+  it('shows an error message when the audit log fetch fails', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response('Internal Server Error', { status: 500 }))) as typeof fetch;
+    render(
+      <QueryClientProvider client={qc}>
+        <Audit />
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByText('Error loading audit log.')).toBeInTheDocument();
+  });
+
+  it('shows "No matching entries." for a genuinely empty dataset', async () => {
+    renderAudit([]);
+    expect(await screen.findByText('No matching entries.')).toBeInTheDocument();
+  });
+
   it('exports only the filtered and capped rows, not the full unfiltered set', async () => {
     const user = userEvent.setup();
     const sensitiveRows = Array.from({ length: 250 }, (_, i) => ({

--- a/src/web/views/GitEfficiency.test.tsx
+++ b/src/web/views/GitEfficiency.test.tsx
@@ -1,0 +1,233 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+import { GitEfficiency } from './GitEfficiency';
+import type { GitEfficiencyData, GitEfficiencyReposResponse, BestPractice } from '../api/client';
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const EMPTY_REPOS: GitEfficiencyReposResponse = { repos: [], currentRepo: null };
+
+const BASE_DATA: GitEfficiencyData = {
+  totalGitCommands: 5,
+  mergeConflicts: 0,
+  rebaseConflicts: 0,
+  abortedOperations: 0,
+  forcePushes: 0,
+  resetHards: 0,
+  discardedChanges: 0,
+  pullCount: 1,
+  pushCount: 1,
+  commitCount: 1,
+  branchOperations: 0,
+  conflictResolutionRate: null,
+  avgConflictResolutionMs: null,
+  staleBranchPulls: 0,
+  gitCommandTimeline: [],
+  conflictHistory: [],
+  suggestions: [],
+  bestPractices: [],
+  preventionScore: null,
+  efficiencyScore: null,
+  riskIndicators: {
+    syncedBeforeEditing: null,
+    timeSinceLastSyncMs: null,
+    commitsSinceLastSync: 0,
+    pushRejections: 0,
+    forceAfterReject: 0,
+    hotFiles: [],
+    usesWorktrees: false,
+    usesForceWithLease: false,
+    avgCommitsBetweenSyncs: null,
+    commitsAheadOfMain: null,
+    commitsBehindMain: null,
+    sessionDurationMs: null,
+    quickConflictResolutions: 0,
+  },
+  velocityMetrics: {
+    avgTimeBetweenCommitsMs: null,
+    commitBurstCount: 0,
+    longestGapMs: null,
+    worktreeCount: 0,
+    buildBeforePush: null,
+    testBeforePush: null,
+  },
+  conflictResolutionStrategy: {
+    oursCount: 0,
+    theirsCount: 0,
+    manualMergeCount: 0,
+    cherryPickCount: 0,
+    totalResolutions: 0,
+  },
+  prMetrics: {
+    created: 0,
+    merged: 0,
+    checksViewed: 0,
+    prsUpdated: 0,
+    prActivity: [],
+    avgTimeToCreateMs: null,
+  },
+  repoContext: {
+    repoName: null,
+    branch: null,
+    remoteName: null,
+    defaultBranch: null,
+  },
+};
+
+function renderGitEfficiency(data: unknown, repos: unknown = EMPTY_REPOS) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+  globalThis.fetch = (async (url: string) => {
+    if (url === '/api/git-efficiency') return jsonResponse(data);
+    if (url === '/api/git-efficiency/repos') return jsonResponse(repos);
+    return jsonResponse({});
+  }) as typeof fetch;
+  return render(
+    <QueryClientProvider client={qc}>
+      <GitEfficiency />
+    </QueryClientProvider>,
+  );
+}
+
+describe('GitEfficiency view — empty state', () => {
+  it('shows "No Git activity yet" when totalGitCommands is 0', async () => {
+    renderGitEfficiency({ ...BASE_DATA, totalGitCommands: 0 });
+    expect(await screen.findByText('No Git activity yet')).toBeInTheDocument();
+  });
+
+  it('shows the Repos Today chips in the empty state when repos are known', async () => {
+    renderGitEfficiency(
+      { ...BASE_DATA, totalGitCommands: 0 },
+      { repos: ['org/repo-a', 'org/repo-b'], currentRepo: 'org/repo-a' },
+    );
+    expect(await screen.findByText('Repos Today:')).toBeInTheDocument();
+    expect(screen.getByText('repo-a')).toBeInTheDocument();
+    expect(screen.getByText('repo-b')).toBeInTheDocument();
+  });
+});
+
+describe('GitEfficiency view — loading and error', () => {
+  it('shows a loading state while the query is pending', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = (() => new Promise<Response>(() => {})) as unknown as typeof fetch;
+    render(
+      <QueryClientProvider client={qc}>
+        <GitEfficiency />
+      </QueryClientProvider>,
+    );
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the query fails', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response('boom', { status: 500 }))) as typeof fetch;
+    render(
+      <QueryClientProvider client={qc}>
+        <GitEfficiency />
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByText('Error loading git efficiency data.')).toBeInTheDocument();
+  });
+});
+
+describe('GitEfficiency view — bestPractices filtering', () => {
+  const bestPractices: BestPractice[] = [
+    {
+      id: 'sync',
+      label: 'Synced before editing',
+      status: 'pass',
+      detail: 'Synced 2m before first edit.',
+    },
+    {
+      id: 'small-commits',
+      label: 'Small commits',
+      status: 'pass',
+      detail: 'Commits stayed small.',
+    },
+    {
+      id: 'force-with-lease',
+      label: 'Force-with-lease',
+      status: 'fail',
+      detail: 'Force push without --force-with-lease.',
+    },
+    {
+      id: 'build-before-push',
+      label: 'Build before push',
+      status: 'warn',
+      detail: 'No build run detected before push.',
+    },
+    { id: 'worktrees', label: 'Uses worktrees', status: 'unknown', detail: 'Not enough data yet.' },
+  ];
+
+  it('uses only known (non-unknown) entries as the denominator and pass entries as the numerator', async () => {
+    renderGitEfficiency({ ...BASE_DATA, bestPractices });
+    // known = 4 (excludes the 1 'unknown' entry), passing = 2 ('pass' entries).
+    expect(await screen.findByText('2/4 passing')).toBeInTheDocument();
+  });
+
+  it('renders pass entries as compact chips and unknown entries as neutral chips', async () => {
+    renderGitEfficiency({ ...BASE_DATA, bestPractices });
+    await screen.findByText('2/4 passing');
+    expect(screen.getByText(/Synced before editing/)).toBeInTheDocument();
+    expect(screen.getByText(/Small commits/)).toBeInTheDocument();
+    expect(screen.getByText(/Uses worktrees/)).toBeInTheDocument();
+  });
+
+  it('renders fail and warn entries as expanded detail cards with their detail text', async () => {
+    renderGitEfficiency({ ...BASE_DATA, bestPractices });
+    await screen.findByText('2/4 passing');
+    expect(screen.getByText('Force push without --force-with-lease.')).toBeInTheDocument();
+    expect(screen.getByText('No build run detected before push.')).toBeInTheDocument();
+  });
+
+  it('shows "No data yet" when every bestPractice entry is unknown', async () => {
+    renderGitEfficiency({
+      ...BASE_DATA,
+      bestPractices: [{ id: 'a', label: 'A', status: 'unknown', detail: 'n/a' }],
+    });
+    expect(await screen.findByText('No data yet')).toBeInTheDocument();
+  });
+});
+
+describe('GitEfficiency view — hero KPIs and gated sections', () => {
+  it('renders hero KPI values from the response', async () => {
+    renderGitEfficiency({
+      ...BASE_DATA,
+      commitCount: 7,
+      prMetrics: { ...BASE_DATA.prMetrics, created: 3, merged: 2 },
+      riskIndicators: { ...BASE_DATA.riskIndicators, commitsBehindMain: 12 },
+    });
+    expect(await screen.findByText('commits today')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('2 merged')).toBeInTheDocument();
+    expect(screen.getByText('rebase soon')).toBeInTheDocument();
+  });
+
+  it('hides the Conflict Resolution section when there are no conflicts', async () => {
+    renderGitEfficiency(BASE_DATA);
+    await screen.findByText('Git Efficiency');
+    expect(screen.queryByText('Conflict Resolution')).toBeNull();
+  });
+
+  it('shows the Conflict Resolution section when conflicts are present', async () => {
+    renderGitEfficiency({ ...BASE_DATA, mergeConflicts: 2, abortedOperations: 1 });
+    expect(await screen.findByText('Conflict Resolution')).toBeInTheDocument();
+  });
+
+  it('hides the Destructive Operations section when all destructive counts are zero', async () => {
+    renderGitEfficiency(BASE_DATA);
+    await screen.findByText('Git Efficiency');
+    expect(screen.queryByText('Destructive Operations')).toBeNull();
+  });
+
+  it('shows the Destructive Operations section when a force push occurred', async () => {
+    renderGitEfficiency({ ...BASE_DATA, forcePushes: 1 });
+    expect(await screen.findByText('Destructive Operations')).toBeInTheDocument();
+  });
+});

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -570,3 +570,66 @@ describe('Sessions view — workflow consolidation', () => {
     window.location = original;
   });
 });
+
+describe('Sessions view — subagent fetch failure fallback', () => {
+  // Documented fallback in SessionTraceSection: when the /subagents fetch
+  // fails (retry: false, so a 404 or network error settles immediately as
+  // isError), the section must still render the parent tool-call trace
+  // (agents={[]}) rather than going blank.
+  it('still renders the parent trace when /api/sessions/:id/subagents 404s', async () => {
+    const detail = {
+      sessionId: 's1',
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+    };
+    const subagentsCalls: string[] = [];
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = ((url: string) => {
+      if (url.includes('/subagents')) {
+        subagentsCalls.push(url);
+        return Promise.resolve(
+          new Response('{"error":"not_found"}', {
+            status: 404,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.includes('/replay')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ timeline: detail.timeline, segments: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/sessions/')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(detail), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(SAMPLE_LIST), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as typeof globalThis.fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <Sessions />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText(/s1/)).toBeInTheDocument());
+    fireEvent.click(screen.getAllByText(/s1/)[0]);
+
+    // The parent lane's own group header must render — proof the section
+    // fell through to the fallback SessionTrace render rather than blanking.
+    await waitFor(() => expect(screen.getByText('Parent')).toBeInTheDocument());
+    expect(screen.queryByText('Loading subagents')).toBeNull();
+    await waitFor(() => expect(subagentsCalls.length).toBeGreaterThan(0));
+  });
+});

--- a/src/web/views/Settings.test.tsx
+++ b/src/web/views/Settings.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Settings } from './Settings.js';
 
@@ -118,5 +118,33 @@ describe('Subagent watcher status', () => {
     wrap(<Settings />);
     expect(await screen.findByText('enabled')).toBeInTheDocument();
     expect(await screen.findByText(/5 files watched, 1 parse errors/i)).toBeInTheDocument();
+  });
+});
+
+describe('Identity & Account save flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('saves an edited developer name and shows the restart banner', async () => {
+    wrap(<Settings />);
+    const input = await screen.findByDisplayValue('dev');
+    fireEvent.change(input, { target: { value: 'newdev' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save identity' }));
+
+    await waitFor(() => expect(client.patchSettings).toHaveBeenCalledWith({ developer: 'newdev' }));
+    expect(
+      await screen.findByText('Saved. Restart the server for changes to take effect.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the red saveError banner when the save mutation rejects', async () => {
+    vi.mocked(client.patchSettings).mockRejectedValueOnce(new Error('disk full'));
+    wrap(<Settings />);
+    const input = await screen.findByDisplayValue('dev');
+    fireEvent.change(input, { target: { value: 'newdev' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save identity' }));
+
+    expect(await screen.findByText(/disk full/)).toBeInTheDocument();
   });
 });

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Today } from './Today';
 import { useLiveStore } from '../store/liveStore';
@@ -174,7 +174,13 @@ describe('Today view', () => {
     // has settled — the "spend today" KPI moves off its loading ellipsis to
     // a real dollar value. This is the exact moment `noActivityToday` would
     // flip to true if `concurrencyPending` weren't part of the gate.
-    await waitFor(() => expect(screen.getByText('$0.00')).toBeInTheDocument());
+    // Scoped to the "spend today" tile specifically — the "subagent spend"
+    // KPI also renders "$0.00" in this fixture state, so an unscoped
+    // `getByText('$0.00')` would throw on multiple-element ambiguity.
+    await waitFor(() => {
+      const spendTile = screen.getByText('spend today').closest('.px-1') as HTMLElement;
+      expect(within(spendTile).getByText('$0.00')).toBeInTheDocument();
+    });
 
     // The empty state must still be suppressed, because /api/concurrency is
     // still pending.


### PR DESCRIPTION
## Summary

Closes #221.

Adds test coverage for behavior that previously worked but was unverified, and fixes one flaky test assertion.

- Added test coverage across the MCP server's session and hook handling, metric trackers, platform adapters, proxy and transport layer, storage, alerting, and MCP tool handlers, plus the web dashboard's components, views, and API client — covering error paths, malformed-input handling, and edge-case behavior.
- Corrected an ambiguous assertion in the Today view's test suite that could match either of two KPI tiles rendering the same displayed value, instead of the one it was meant to check.
- Version bump to 1.5.4, see CHANGELOG.md.

No production code changed except the test-assertion fix above.

## Test plan

- [x] `npm test` — 4502/4505 passing (3 pre-existing skips), 0 failures
- [x] `npx vitest run` — 398/398 passing, 0 failures
- [x] `npm run lint` — 0 errors/0 warnings
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
