### PR TITLE
Fix: serve live workflow-run detail instead of 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2026-07-17
+
+### Fixed
+
+- Opening a workflow run's detail view while the run was still in progress showed "Failed to load run details" instead of live progress. The detail view now shows in-progress agent activity and automatically upgrades to the final summary once the run completes.
+
 ## [1.5.4] - 2026-07-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/live-workflow-detail.integration.test.ts
+++ b/src/dashboard/live-workflow-detail.integration.test.ts
@@ -1,0 +1,202 @@
+/**
+ * End-to-end integration test for the live workflow-run detail path.
+ *
+ * Reproduces the exact production scenario that used to 404 ("Failed to load
+ * run details"): a workflow that is STILL RUNNING has its per-agent subagent
+ * transcripts on disk under `subagents/workflows/<runId>/agent-*.jsonl`, but NO
+ * `workflows/<runId>.json` rollup yet (that file is written only at
+ * termination). The swimlane makes the run lane clickable from those
+ * transcripts, so `GET /api/workflows/:runId` must serve a running detail.
+ *
+ * Unlike the mocked route tests in routes/api-handler.test.ts, this wires the
+ * REAL WorkflowStore + SubagentTimelineStore against a real temp
+ * `~/.claude/projects` tree and drives the REAL createApiHandler route — so it
+ * exercises actual filesystem discovery, transcript parsing, script/topology
+ * resolution, and JSON serialization together.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { IncomingMessage, ServerResponse } from 'node:http';
+
+import { createApiHandler } from './routes/api-handler.js';
+import { WorkflowStore } from './workflow-store.js';
+import { SubagentTimelineStore } from './subagent-timeline-store.js';
+
+const STDERR_WRITE = process.stderr.write;
+const SLUG = 'project-slug';
+const SESSION = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const RUN_ID = 'wf_live1234-abc';
+const AGENT_A = 'a1111111111111111';
+const AGENT_B = 'a2222222222222222';
+const KNOWN_MODEL = 'claude-opus-4-7';
+
+function assistantLine(opts: { ts: string; input?: number; output?: number }): string {
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: opts.ts,
+    uuid: 'u-' + opts.ts,
+    message: {
+      id: 'msg-' + opts.ts,
+      model: KNOWN_MODEL,
+      stop_reason: 'end_turn',
+      usage: {
+        input_tokens: opts.input ?? 0,
+        output_tokens: opts.output ?? 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  });
+}
+
+function fakeRes(): {
+  res: ServerResponse;
+  status: () => number;
+  body: () => string;
+} {
+  let status = 0;
+  let body = '';
+  const res = {
+    writeHead: (s: number) => {
+      status = s;
+    },
+    setHeader: () => {},
+    end: (chunk?: string | Buffer) => {
+      if (chunk) body += chunk.toString();
+    },
+    headersSent: false,
+  } as unknown as ServerResponse;
+  return { res, status: () => status, body: () => body };
+}
+
+describe('live workflow-run detail (integration: real stores + real route)', () => {
+  let projectsDir: string;
+  let sessionDir: string;
+  let wfRunTranscriptsDir: string;
+
+  beforeEach(() => {
+    process.stderr.write = jest.fn(() => true) as unknown as typeof process.stderr.write;
+    projectsDir = mkdtempSync(join(tmpdir(), 'live-wf-detail-'));
+    sessionDir = join(projectsDir, SLUG, SESSION);
+    // Live transcripts exist mid-run; the rollup (workflows/<runId>.json) does NOT.
+    wfRunTranscriptsDir = join(sessionDir, 'subagents', 'workflows', RUN_ID);
+    mkdirSync(wfRunTranscriptsDir, { recursive: true });
+    writeFileSync(
+      join(wfRunTranscriptsDir, `agent-${AGENT_A}.jsonl`),
+      [
+        assistantLine({ ts: '2026-07-07T12:00:00.000Z', input: 100, output: 50 }),
+        assistantLine({ ts: '2026-07-07T12:00:30.000Z', input: 200, output: 80 }),
+      ].join('\n') + '\n',
+    );
+    writeFileSync(
+      join(wfRunTranscriptsDir, `agent-${AGENT_B}.jsonl`),
+      assistantLine({ ts: '2026-07-07T12:00:10.000Z', input: 40, output: 20 }) + '\n',
+    );
+    // Persisted orchestration script → declared topology + workflow name.
+    const scriptsDir = join(sessionDir, 'workflows', 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(
+      join(scriptsDir, `live-fix-demo-${RUN_ID}.js`),
+      "export const meta = { name: 'live-fix-demo', description: 'x', " +
+        "phases: [{ title: 'Scan' }, { title: 'Fix' }] }\nawait agent('go');\n",
+    );
+  });
+
+  afterEach(() => {
+    process.stderr.write = STDERR_WRITE;
+    rmSync(projectsDir, { recursive: true, force: true });
+  });
+
+  function makeHandler(): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+    // Real stores — they structurally satisfy the (minimal) dep interfaces, so
+    // pass the instances directly rather than re-wrapping each method.
+    const workflowStore = new WorkflowStore({ projectsDir });
+    const subagentTimeline = new SubagentTimelineStore({ projectsDir });
+    return createApiHandler({
+      workflowStore,
+      subagentTimeline,
+    } as unknown as Parameters<typeof createApiHandler>[0]) as unknown as (
+      req: IncomingMessage,
+      res: ServerResponse,
+    ) => Promise<void>;
+  }
+
+  it('has NO rollup on disk but DOES have live transcripts (precondition)', () => {
+    const workflowStore = new WorkflowStore({ projectsDir });
+    const subagentTimeline = new SubagentTimelineStore({ projectsDir });
+    // The regression: getRun returns null for a still-running run …
+    expect(workflowStore.getRun(RUN_ID)).toBeNull();
+    // … while getRunLive can reconstruct it from the transcripts.
+    const live = subagentTimeline.getRunLive(RUN_ID);
+    expect(live).not.toBeNull();
+    expect(live!.agentCount).toBe(2);
+  });
+
+  it('serves a running detail (200) for a live run with no rollup — the bug fix', async () => {
+    const handler = makeHandler();
+    const req = { method: 'GET', url: `/api/workflows/${RUN_ID}` } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+
+    expect(status()).toBe(200); // was 404 before the fix
+    const parsed = JSON.parse(body());
+    expect(parsed.run.runId).toBe(RUN_ID);
+    expect(parsed.run.status).toBe('running');
+    expect(parsed.run.incomplete).toBe(true);
+    expect(parsed.run.parentSessionId).toBe(SESSION);
+    expect(parsed.run.workflowName).toBe('live-fix-demo'); // resolved from the script
+    expect(parsed.run.workflowJsonPath).toBe(''); // no rollup file
+    // Agent A: (100+50)+(200+80)=430; Agent B: (40+20)=60 → 490.
+    expect(parsed.run.totalTokens).toBe(490);
+    expect(parsed.run.totalUsd).toBeGreaterThan(0); // priced model
+    // Agents assembled from both transcripts, sorted by start time.
+    expect(parsed.agents).toHaveLength(2);
+    expect(parsed.agents[0].agentId).toBe(AGENT_A);
+    expect(parsed.agents.every((a: { state: string }) => a.state === 'running')).toBe(true);
+    // Declared topology surfaced from the script.
+    expect(parsed.topology.declaredPhases).toBe(2);
+    expect(parsed.run.declaredPhases).toBe(2);
+  });
+
+  it('prefers the on-disk rollup once the run terminates (auto-upgrade)', async () => {
+    // Simulate the run finishing: write the rollup the harness emits at the end.
+    writeFileSync(
+      join(sessionDir, 'workflows', `${RUN_ID}.json`),
+      JSON.stringify({
+        runId: RUN_ID,
+        workflowName: 'live-fix-demo',
+        status: 'completed',
+        defaultModel: KNOWN_MODEL,
+        startTime: Date.parse('2026-07-07T12:00:00.000Z'),
+        durationMs: 45_000,
+        agentCount: 2,
+        totalTokens: 590,
+        workflowProgress: [],
+      }),
+    );
+
+    const handler = makeHandler();
+    const req = { method: 'GET', url: `/api/workflows/${RUN_ID}` } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body());
+    // Now the terminal rollup wins over the live fallback.
+    expect(parsed.run.status).toBe('completed');
+    expect(parsed.run.incomplete).toBe(false);
+    expect(parsed.run.workflowJsonPath).not.toBe('');
+  });
+
+  it('404s for a run with neither a rollup nor live transcripts', async () => {
+    const handler = makeHandler();
+    const req = { method: 'GET', url: '/api/workflows/wf_ghost0000-xyz' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(404);
+    expect(JSON.parse(body())).toEqual({ error: 'not_found' });
+  });
+});

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -3615,3 +3615,185 @@ describe('api-handler GET /api/activity-heatmap', () => {
     expect(JSON.parse(body())).toEqual({ error: 'internal_error' });
   });
 });
+
+describe('api-handler GET /api/workflows/:runId', () => {
+  const RUN_ID = 'wf_abc12345-6dd';
+  const SESSION = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+  type Deps = Parameters<typeof createApiHandler>[0];
+
+  it('serves the on-disk rollup (200) when the run has terminated', async () => {
+    const handler = createApiHandler({
+      workflowStore: {
+        listRuns: () => [],
+        getRun: (id: string) => {
+          expect(id).toBe(RUN_ID);
+          return {
+            workflow_run_id: RUN_ID,
+            parent_session_id: SESSION,
+            workflow_name: 'demo',
+            status: 'completed',
+            incomplete: false,
+            default_model: 'claude-opus-4-7',
+            started_at: 1000,
+            duration_ms: 5000,
+            agent_count: 1,
+            total_tokens: 430,
+            total_usd: 0.02,
+            observed_phases: 2,
+            declared_parallel_widths: [],
+            token_reconciliation_delta: 0,
+            run_source: 'script',
+            workflow_json_path: '/x/wf.json',
+            agents: [],
+            topology: null,
+          };
+        },
+      } as unknown as Deps['workflowStore'],
+    });
+    const req = { method: 'GET', url: `/api/workflows/${RUN_ID}` } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body());
+    expect(parsed.run.status).toBe('completed');
+    expect(parsed.run.runId).toBe(RUN_ID);
+  });
+
+  it('falls back to a live detail (200, status running) when no rollup exists yet', async () => {
+    const handler = createApiHandler({
+      workflowStore: {
+        listRuns: () => [],
+        getRun: () => null, // still running → no rollup on disk
+      } as unknown as Deps['workflowStore'],
+      subagentTimeline: {
+        getSubagentsForSession: () => ({ window: { startMs: 0, endMs: 0 }, agents: [] }),
+        getAgentCalls: () => ({ calls: [] }),
+        getRunLive: (id: string) => {
+          expect(id).toBe(RUN_ID);
+          return {
+            runId: RUN_ID,
+            parentSessionId: SESSION,
+            workflowName: 'live-demo',
+            defaultModel: 'claude-opus-4-7',
+            startedAt: 1000,
+            durationMs: 20000,
+            agentCount: 1,
+            totalTokens: 430,
+            totalUsd: 0.02,
+            scriptPath: '/x/scripts/live-demo-wf_abc12345-6dd.js',
+            topology: {
+              workflowName: 'live-demo',
+              declaredPhases: 2,
+              declaredPhaseCalls: 2,
+              declaredAgents: 1,
+              declaredParallelWidths: [],
+            },
+            agents: [
+              {
+                agentId: 'a45d96d201bf2f1ef',
+                label: 'agent a45d96d2',
+                model: 'claude-opus-4-7',
+                durationMs: 20000,
+                tokens: 430,
+                toolCalls: 3,
+                startedAt: 1000,
+              },
+            ],
+          };
+        },
+      } as unknown as Deps['subagentTimeline'],
+    });
+    const req = { method: 'GET', url: `/api/workflows/${RUN_ID}` } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body());
+    expect(parsed.run.status).toBe('running');
+    expect(parsed.run.incomplete).toBe(true);
+    expect(parsed.run.runId).toBe(RUN_ID);
+    expect(parsed.run.workflowName).toBe('live-demo');
+    expect(parsed.run.workflowJsonPath).toBe('');
+    expect(parsed.agents).toHaveLength(1);
+    expect(parsed.agents[0].state).toBe('running');
+    expect(parsed.agents[0].toolCalls).toBe(3);
+    expect(parsed.topology.declaredPhases).toBe(2);
+  });
+
+  it('falls back to the runId as the name when the live script name is absent', async () => {
+    const handler = createApiHandler({
+      workflowStore: {
+        listRuns: () => [],
+        getRun: () => null,
+      } as unknown as Deps['workflowStore'],
+      subagentTimeline: {
+        getSubagentsForSession: () => ({ window: { startMs: 0, endMs: 0 }, agents: [] }),
+        getAgentCalls: () => ({ calls: [] }),
+        getRunLive: () => ({
+          runId: RUN_ID,
+          parentSessionId: SESSION,
+          workflowName: null,
+          defaultModel: '',
+          startedAt: 1000,
+          durationMs: 0,
+          agentCount: 1,
+          totalTokens: 10,
+          totalUsd: null,
+          scriptPath: null,
+          topology: null,
+          agents: [
+            {
+              agentId: 'a45d96d201bf2f1ef',
+              label: 'agent a45d96d2',
+              model: '',
+              durationMs: 0,
+              tokens: 10,
+              toolCalls: 0,
+              startedAt: 1000,
+            },
+          ],
+        }),
+      } as unknown as Deps['subagentTimeline'],
+    });
+    const req = { method: 'GET', url: `/api/workflows/${RUN_ID}` } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body());
+    expect(parsed.run.workflowName).toBe(RUN_ID);
+    expect(parsed.run.totalUsd).toBeNull();
+    expect(parsed.topology).toBeNull();
+  });
+
+  it('404s when neither a rollup nor live data exists', async () => {
+    const handler = createApiHandler({
+      workflowStore: {
+        listRuns: () => [],
+        getRun: () => null,
+      } as unknown as Deps['workflowStore'],
+      subagentTimeline: {
+        getSubagentsForSession: () => ({ window: { startMs: 0, endMs: 0 }, agents: [] }),
+        getAgentCalls: () => ({ calls: [] }),
+        getRunLive: () => null,
+      } as unknown as Deps['subagentTimeline'],
+    });
+    const req = { method: 'GET', url: `/api/workflows/${RUN_ID}` } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(404);
+    expect(JSON.parse(body())).toEqual({ error: 'not_found' });
+  });
+
+  it('404s when the run is absent and no subagentTimeline dep is wired', async () => {
+    const handler = createApiHandler({
+      workflowStore: {
+        listRuns: () => [],
+        getRun: () => null,
+      } as unknown as Deps['workflowStore'],
+    });
+    const req = { method: 'GET', url: `/api/workflows/${RUN_ID}` } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(404);
+  });
+});

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -15,7 +15,11 @@ import type { AntiPatternSegment } from './replay-analyzer.js';
 import type { ReplayTimelineEntry, ToolCallRecord } from '../../storage/types.js';
 import type { FullSessionSummary, SessionFileInfo } from '../../storage/session-store.js';
 import type { WorkflowRunRow, WorkflowAgentRow } from '../workflow-store.js';
-import type { SubagentTimeline, AgentCall } from '../subagent-timeline-store.js';
+import type {
+  SubagentTimeline,
+  AgentCall,
+  LiveWorkflowRunDetail,
+} from '../subagent-timeline-store.js';
 import type { CostForecast } from '../../metrics/cost-forecast.js';
 import type { AlertEvent } from '../live-event-bus.js';
 import type { BudgetStatus } from '../../metrics/budget-tracker.js';
@@ -256,6 +260,60 @@ function toWorkflowAgentDto(agent: unknown): WorkflowAgentDto {
   };
 }
 
+// Serialize a still-running workflow (assembled from live subagent transcripts,
+// no on-disk rollup) into the SAME `{ run, agents, topology }` wire shape the
+// completed path emits, so WorkflowRunDetail.tsx renders it unchanged. Fields
+// that only exist post-rollup are filled with running-run defaults: status
+// 'running', incomplete true, no error/task/reconciliation, and per-agent
+// phase/state placeholders (phaseIndex -1, phaseTitle '', state 'running').
+function toLiveWorkflowDetail(live: LiveWorkflowRunDetail): {
+  run: WorkflowRunDto;
+  agents: WorkflowAgentDto[];
+  topology: LiveWorkflowRunDetail['topology'];
+} {
+  const run: WorkflowRunDto = {
+    runId: live.runId,
+    parentSessionId: live.parentSessionId,
+    taskId: null,
+    // Fall back to the runId when the script (and thus meta.name) can't be read.
+    workflowName: live.workflowName ?? live.runId,
+    status: 'running',
+    errorReason: null,
+    defaultModel: live.defaultModel,
+    startedAt: live.startedAt,
+    durationMs: live.durationMs,
+    agentCount: live.agentCount,
+    totalTokens: live.totalTokens,
+    totalUsd: live.totalUsd,
+    declaredPhases: live.topology?.declaredPhases ?? null,
+    // No phase-title telemetry exists mid-run (that comes from the rollup's
+    // workflowProgress), so observed phases are unknown → 0.
+    observedPhases: 0,
+    declaredParallelWidths: live.topology?.declaredParallelWidths ?? [],
+    tokenReconciliationDelta: 0,
+    incomplete: true,
+    // wf_<hex> runIds are script/Workflow-tool orchestrations (agent_tool runs
+    // key off toolu_* ids), so this is always a 'script' run.
+    runSource: 'script',
+    scriptPath: live.scriptPath,
+    workflowJsonPath: '',
+  };
+  const agents: WorkflowAgentDto[] = live.agents.map((a) => ({
+    agentId: a.agentId,
+    label: a.label,
+    phaseIndex: -1,
+    phaseTitle: '',
+    model: a.model,
+    state: 'running',
+    attempt: 1,
+    durationMs: a.durationMs,
+    tokens: a.tokens,
+    toolCalls: a.toolCalls,
+    startedAt: a.startedAt,
+  }));
+  return { run, agents, topology: live.topology ?? null };
+}
+
 interface LiveSessionMetrics {
   readonly sessionId: string;
   readonly sessionName: string | null;
@@ -349,6 +407,13 @@ export interface ApiHandlerDeps {
   readonly subagentTimeline?: {
     getSubagentsForSession: (sessionId: string) => SubagentTimeline;
     getAgentCalls: (sessionId: string, agentId: string) => { calls: readonly AgentCall[] };
+    /**
+     * Live-run fallback for the workflow-detail route: a still-running workflow
+     * has no on-disk rollup, so `workflowStore.getRun` returns null; this
+     * assembles the detail from the run's live subagent transcripts instead.
+     * Optional so older fakes / mocks without it still type-check.
+     */
+    getRunLive?: (runId: string) => LiveWorkflowRunDetail | null;
   };
   /**
    * Snapshot of latest watcher health frames so the dashboard can render
@@ -1920,6 +1985,17 @@ export function createApiHandler(
         if (!deps.workflowStore) return unavailable(res, 'workflowStore');
         const run = deps.workflowStore.getRun(runId);
         if (run === null) {
+          // Live fallback: a still-running workflow has no on-disk `wf_*.json`
+          // rollup yet (that is written only at termination), but its subagent
+          // transcripts already exist and the swimlane surfaces the run as
+          // clickable. Synthesize a 'running' detail from those transcripts so
+          // the drawer shows live progress instead of "Failed to load run
+          // details." Falls through to 404 only when no live data exists either.
+          const live = deps.subagentTimeline?.getRunLive?.(runId) ?? null;
+          if (live !== null) {
+            jsonOk(res, toLiveWorkflowDetail(live));
+            return;
+          }
           res.writeHead(404, { 'content-type': 'application/json' });
           res.end(JSON.stringify({ error: 'not_found' }));
           return;

--- a/src/dashboard/subagent-timeline-store.test.ts
+++ b/src/dashboard/subagent-timeline-store.test.ts
@@ -576,3 +576,180 @@ describe('SubagentTimelineStore.getAgentCalls', () => {
     expect(second.calls).toHaveLength(1);
   });
 });
+
+describe('SubagentTimelineStore.getRunLive', () => {
+  let projectsDir: string;
+  let wfRunDir: string;
+
+  beforeEach(() => {
+    process.stderr.write = jest.fn(() => true) as unknown as typeof process.stderr.write;
+    projectsDir = mkTmp();
+    // A live run's per-agent transcripts exist here; the wf_*.json rollup does
+    // NOT (that is written only at termination).
+    wfRunDir = join(projectsDir, SLUG, SESSION, 'subagents', 'workflows', WF_RUN_ID);
+    mkdirSync(wfRunDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    process.stderr.write = STDERR_WRITE;
+    rmSync(projectsDir, { recursive: true, force: true });
+  });
+
+  it('assembles a running run from live transcripts when no rollup exists', () => {
+    writeFileSync(
+      join(wfRunDir, `agent-${WF_AGENT}.jsonl`),
+      [
+        assistantLine({ timestamp: '2026-06-16T12:00:00.000Z', input: 100, output: 50 }),
+        assistantLine({ timestamp: '2026-06-16T12:00:20.000Z', input: 200, output: 80 }),
+      ].join('\n') + '\n',
+    );
+
+    const store = new SubagentTimelineStore({ projectsDir });
+    const live = store.getRunLive(WF_RUN_ID);
+
+    expect(live).not.toBeNull();
+    expect(live!.runId).toBe(WF_RUN_ID);
+    expect(live!.parentSessionId).toBe(SESSION);
+    expect(live!.defaultModel).toBe(KNOWN_MODEL);
+    expect(live!.agentCount).toBe(1);
+    expect(live!.agents).toHaveLength(1);
+    expect(live!.agents[0]!.agentId).toBe(WF_AGENT);
+    // No rollup mid-run → the same `agent <id8>` label fallback the swimlane uses.
+    expect(live!.agents[0]!.label).toBe(`agent ${WF_AGENT.slice(0, 8)}`);
+    expect(live!.startedAt).toBe(Date.parse('2026-06-16T12:00:00.000Z'));
+    expect(live!.durationMs).toBe(20_000);
+    expect(live!.totalTokens).toBe(430);
+    expect(live!.totalUsd).toBeGreaterThan(0); // KNOWN_MODEL is priced
+    expect(live!.workflowName).toBeNull(); // no script → no declared name
+    expect(live!.topology).toBeNull();
+  });
+
+  it('reports null cost when every agent model is unpriced', () => {
+    writeFileSync(
+      join(wfRunDir, `agent-${WF_AGENT}.jsonl`),
+      assistantLine({
+        timestamp: '2026-06-16T12:00:00.000Z',
+        model: UNKNOWN_MODEL,
+        input: 10,
+        output: 5,
+      }) + '\n',
+    );
+    const store = new SubagentTimelineStore({ projectsDir });
+    const live = store.getRunLive(WF_RUN_ID);
+    expect(live!.totalUsd).toBeNull();
+  });
+
+  it('counts real per-agent tool calls (not turns)', () => {
+    writeFileSync(
+      join(wfRunDir, `agent-${WF_AGENT}.jsonl`),
+      [
+        assistantToolUseLine({
+          timestamp: '2026-06-16T12:00:00.000Z',
+          uses: [
+            { id: 'tu_1', name: 'Read' },
+            { id: 'tu_2', name: 'Bash' },
+          ],
+        }),
+        userToolResultLine({
+          timestamp: '2026-06-16T12:00:01.000Z',
+          results: [{ toolUseId: 'tu_1' }, { toolUseId: 'tu_2' }],
+        }),
+      ].join('\n') + '\n',
+    );
+    const store = new SubagentTimelineStore({ projectsDir });
+    const live = store.getRunLive(WF_RUN_ID);
+    expect(live!.agents[0]!.toolCalls).toBe(2);
+  });
+
+  it('picks defaultModel deterministically (most-recently-active agent, not directory order)', () => {
+    // Written first (so a naive "last file iterated wins" implementation would
+    // pick the OTHER agent's model on filesystems that list entries in
+    // creation order) but has the LATER turn — the correct `defaultModel` is
+    // driven by endMs, not by write/iteration order.
+    writeFileSync(
+      join(wfRunDir, `agent-${AGENT_A}.jsonl`),
+      assistantLine({
+        timestamp: '2026-06-16T12:10:00.000Z',
+        model: 'model-late',
+        input: 10,
+        output: 5,
+      }) + '\n',
+    );
+    writeFileSync(
+      join(wfRunDir, `agent-${AGENT_B}.jsonl`),
+      assistantLine({
+        timestamp: '2026-06-16T12:05:00.000Z',
+        model: 'model-early',
+        input: 10,
+        output: 5,
+      }) + '\n',
+    );
+
+    const store = new SubagentTimelineStore({ projectsDir });
+    const live = store.getRunLive(WF_RUN_ID);
+
+    expect(live!.defaultModel).toBe('model-late');
+  });
+
+  it('reuses the cached run location on repeated polls (consistent results)', () => {
+    writeFileSync(
+      join(wfRunDir, `agent-${WF_AGENT}.jsonl`),
+      assistantLine({ timestamp: '2026-06-16T12:00:00.000Z', input: 10, output: 5 }) + '\n',
+    );
+    const store = new SubagentTimelineStore({ projectsDir });
+    const first = store.getRunLive(WF_RUN_ID);
+    const second = store.getRunLive(WF_RUN_ID);
+    expect(second).toEqual(first);
+    expect(second!.agentCount).toBe(1);
+  });
+
+  it('invalidates the cached run location and returns null once the run dir is gone', () => {
+    writeFileSync(
+      join(wfRunDir, `agent-${WF_AGENT}.jsonl`),
+      assistantLine({ timestamp: '2026-06-16T12:00:00.000Z', input: 10, output: 5 }) + '\n',
+    );
+    const store = new SubagentTimelineStore({ projectsDir });
+    expect(store.getRunLive(WF_RUN_ID)).not.toBeNull(); // resolves + caches the location
+    rmSync(wfRunDir, { recursive: true, force: true });
+    expect(store.getRunLive(WF_RUN_ID)).toBeNull(); // cache entry re-validated, falls through
+  });
+
+  it('resolves workflowName + declared topology from the persisted script', () => {
+    writeFileSync(
+      join(wfRunDir, `agent-${WF_AGENT}.jsonl`),
+      assistantLine({ timestamp: '2026-06-16T12:00:00.000Z', input: 10, output: 5 }) + '\n',
+    );
+    const scriptsDir = join(projectsDir, SLUG, SESSION, 'workflows', 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(
+      join(scriptsDir, `live-demo-${WF_RUN_ID}.js`),
+      "export const meta = { name: 'live-demo', description: 'x', " +
+        "phases: [{ title: 'A' }, { title: 'B' }] }\nawait agent('go');\n",
+    );
+
+    const store = new SubagentTimelineStore({ projectsDir });
+    const live = store.getRunLive(WF_RUN_ID);
+
+    expect(live!.workflowName).toBe('live-demo');
+    expect(live!.topology?.declaredPhases).toBe(2);
+    expect(live!.scriptPath).toContain(`live-demo-${WF_RUN_ID}.js`);
+  });
+
+  it('returns null for an unknown run id', () => {
+    const store = new SubagentTimelineStore({ projectsDir });
+    expect(store.getRunLive('wf_does-not-exist')).toBeNull();
+  });
+
+  it('returns null for a malformed run id (no path traversal / non-wf id)', () => {
+    const store = new SubagentTimelineStore({ projectsDir });
+    expect(store.getRunLive('../../etc/passwd')).toBeNull();
+    expect(store.getRunLive('not-a-wf-id')).toBeNull();
+  });
+
+  it('returns null when the run dir has no valid agent transcripts', () => {
+    // wfRunDir exists (created in beforeEach) but is empty → no agents → null,
+    // so the detail route falls through to its 404.
+    const store = new SubagentTimelineStore({ projectsDir });
+    expect(store.getRunLive(WF_RUN_ID)).toBeNull();
+  });
+});

--- a/src/dashboard/subagent-timeline-store.ts
+++ b/src/dashboard/subagent-timeline-store.ts
@@ -36,12 +36,13 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import { calculateCost, createLogger, type TokenUsage } from '../shared/index.js';
+import { findWorkflowScriptPath, WorkflowStore } from './workflow-store.js';
+import { parseWorkflowScript, type DeclaredTopology } from '../hooks/workflow-script-parser.js';
 import type {
   RawTranscriptEntry,
   RawAssistantMessage,
   RawUsage,
 } from '../hooks/transcript-types.js';
-import { WorkflowStore } from './workflow-store.js';
 
 const logger = createLogger('subagent-timeline-store');
 
@@ -58,6 +59,12 @@ const MAX_CACHE_ENTRIES = 4096;
 const MAX_AGENTS_PER_SESSION = 500;
 /** Hard cap on individual tool calls returned for a single agent. */
 const MAX_CALLS_PER_AGENT = 2000;
+/**
+ * Hard cap on distinct runIds retained in `runLocationCache` — mirrors
+ * WorkflowStore's MAX_RUNS so the resolved-location cache can't grow
+ * unbounded on a long-running dashboard server.
+ */
+const MAX_RUN_LOCATION_CACHE_ENTRIES = 500;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -100,6 +107,45 @@ export interface SubagentTimelineWindow {
 export interface SubagentTimeline {
   readonly window: SubagentTimelineWindow;
   readonly agents: readonly AgentSpan[];
+}
+
+/**
+ * One agent of a still-running workflow, synthesized from its live transcript.
+ * A running workflow has NO on-disk `wf_*.json` rollup yet (that is written
+ * only at termination), so there are no declared per-agent labels/phases/state
+ * to read — the detail route fills those with running-run defaults. Carries
+ * only declarative timing/token/tool-count data (NFR-2).
+ */
+export interface LiveAgentRow {
+  readonly agentId: string;
+  readonly label: string;
+  readonly model: string;
+  readonly durationMs: number;
+  readonly tokens: number;
+  readonly toolCalls: number;
+  readonly startedAt: number;
+}
+
+/**
+ * A running workflow's detail, assembled from its live subagent transcripts
+ * (which exist mid-run) plus the persisted orchestration script (topology).
+ * Returned by `getRunLive` so `GET /api/workflows/:runId` can serve an
+ * in-progress run instead of 404ing before its rollup lands.
+ */
+export interface LiveWorkflowRunDetail {
+  readonly runId: string;
+  readonly parentSessionId: string;
+  readonly workflowName: string | null;
+  /** Model of the most-recently-active agent (highest `endMs`); '' when none observed yet. */
+  readonly defaultModel: string;
+  readonly startedAt: number;
+  readonly durationMs: number;
+  readonly agentCount: number;
+  readonly totalTokens: number;
+  readonly totalUsd: number | null;
+  readonly scriptPath: string | null;
+  readonly topology: DeclaredTopology | null;
+  readonly agents: readonly LiveAgentRow[];
 }
 
 /**
@@ -150,6 +196,25 @@ interface DiscoveredAgentFile {
   readonly workflowRunId: string | null;
 }
 
+/** The owning session + agent transcripts for a single live workflow run. */
+interface DiscoveredRun {
+  readonly parentSessionId: string;
+  /** `<project>/<sessionId>/workflows` dir, for resolving the script/topology. */
+  readonly workflowsDir: string;
+  readonly files: readonly DiscoveredAgentFile[];
+}
+
+/**
+ * A resolved run's on-disk location, cached by runId so repeated polls of a
+ * live run's detail (the drawer refetches every 5s while open) skip the full
+ * projects/sessions scan after the first resolution.
+ */
+interface RunLocation {
+  readonly parentSessionId: string;
+  readonly workflowsDir: string;
+  readonly wfRunDir: string;
+}
+
 /** Aggregate produced by parsing one agent transcript. */
 interface ParsedAgentFile {
   readonly startMs: number;
@@ -193,6 +258,8 @@ export class SubagentTimelineStore {
   private readonly cache = new Map<string, CacheEntry>();
   /** mtime-gated per-file tool-call cache, keyed by absolute file path. */
   private readonly callsCache = new Map<string, CallsCacheEntry>();
+  /** Resolved run → directory location cache, keyed by runId. See `RunLocation`. */
+  private readonly runLocationCache = new Map<string, RunLocation>();
 
   constructor(options: SubagentTimelineStoreOptions = {}) {
     this.projectsDir = options.projectsDir ?? join(homedir(), PROJECTS_DIR_NAME);
@@ -296,6 +363,110 @@ export class SubagentTimelineStore {
   }
 
   /**
+   * Assemble a still-running workflow's detail from its live subagent
+   * transcripts. Returns null when no `subagents/workflows/<runId>/` transcripts
+   * exist for the run (in which case the caller 404s). The on-disk `wf_*.json`
+   * rollup is written only at termination, so this is the ONLY source of a
+   * live run's per-agent breakdown — without it the detail drawer 404s on any
+   * workflow the user opens before it finishes.
+   *
+   * Token/tool/timing data mirrors `getSubagentsForSession`; per-agent labels,
+   * phases, and state don't exist pre-rollup and are left to the route's
+   * running-run defaults. Never throws.
+   */
+  getRunLive(runId: string): LiveWorkflowRunDetail | null {
+    if (!WORKFLOW_RUN_ID_RE.test(runId)) return null;
+
+    let discovered: DiscoveredRun | null;
+    try {
+      discovered = this.discoverRunAgentFiles(runId);
+    } catch (err) {
+      this.recordError('discover live run', err);
+      return null;
+    }
+    if (discovered === null || discovered.files.length === 0) return null;
+
+    const agents: LiveAgentRow[] = [];
+    let startedAt = Infinity;
+    let endMs = -Infinity;
+    let totalTokens = 0;
+    let totalUsd = 0;
+    let anyPriced = false;
+    let defaultModel = '';
+    // Tracks the endMs of whichever agent currently backs `defaultModel`, so
+    // the choice is deterministic (most-recently-active agent) rather than
+    // dependent on readdir's unspecified file-listing order.
+    let defaultModelEndMs = -Infinity;
+
+    for (const file of discovered.files) {
+      if (agents.length >= MAX_AGENTS_PER_SESSION) break;
+      const parsed = this.parseAgentFile(file.path);
+      if (parsed === null) continue;
+
+      totalTokens += parsed.totalTokens;
+      const usd = computeUsd(parsed.usage, parsed.model);
+      if (usd !== null) {
+        totalUsd += usd;
+        anyPriced = true;
+      }
+      if (parsed.startMs < startedAt) startedAt = parsed.startMs;
+      if (parsed.endMs > endMs) endMs = parsed.endMs;
+      if (parsed.model.length > 0 && parsed.endMs > defaultModelEndMs) {
+        defaultModel = parsed.model;
+        defaultModelEndMs = parsed.endMs;
+      }
+
+      agents.push({
+        agentId: file.agentId,
+        // No rollup labels exist mid-run — same `agent <id8>` fallback the
+        // live swimlane uses.
+        label: `agent ${file.agentId.slice(0, 8)}`,
+        model: parsed.model,
+        durationMs: Math.max(0, parsed.endMs - parsed.startMs),
+        tokens: parsed.totalTokens,
+        toolCalls: this.parseAgentCalls(file.path).length,
+        startedAt: parsed.startMs,
+      });
+    }
+    if (agents.length === 0) return null;
+
+    agents.sort((a, b) => a.startedAt - b.startedAt);
+
+    // Declared topology + workflow name from the persisted script (best-effort;
+    // the script is written at Workflow-tool invocation, so it usually exists
+    // while the run is live).
+    let scriptPath: string | null = null;
+    let topology: DeclaredTopology | null = null;
+    try {
+      scriptPath = findWorkflowScriptPath(discovered.workflowsDir, runId);
+      if (scriptPath !== null) {
+        const result = parseWorkflowScript(scriptPath);
+        if (result.status === 'ok') topology = result.topology;
+      }
+    } catch (err) {
+      this.recordError('resolve live topology', err);
+    }
+
+    const start = Number.isFinite(startedAt) ? startedAt : 0;
+    const end = Number.isFinite(endMs) ? endMs : start;
+
+    return {
+      runId,
+      parentSessionId: discovered.parentSessionId,
+      workflowName: topology?.workflowName ?? null,
+      defaultModel,
+      startedAt: start,
+      durationMs: Math.max(0, end - start),
+      agentCount: agents.length,
+      totalTokens,
+      totalUsd: anyPriced ? totalUsd : null,
+      scriptPath,
+      topology,
+      agents,
+    };
+  }
+
+  /**
    * Return ONE subagent's individual tool calls, for the attributed
    * session-trace view. Always returns a value — `{ calls: [] }` for a bad
    * session/agent id, a missing transcript, an oversized file, or any error.
@@ -369,6 +540,85 @@ export class SubagentTimelineStore {
       }
     }
     return out;
+  }
+
+  /**
+   * Locate a single workflow run's live transcripts by scanning every project
+   * for a session that owns `subagents/workflows/<runId>/agent-*.jsonl`. A given
+   * runId lives under exactly one session, so the first match wins. Returns null
+   * when the run has no transcripts (unknown or not-yet-started run).
+   *
+   * The resolved location is cached by runId (see `runLocationCache`) so the
+   * detail drawer's 5s poll of a still-live run only pays for the full
+   * projects/sessions scan once; subsequent polls go straight to the known
+   * directory. A cache hit is re-validated with `existsSync` and dropped if
+   * the directory is gone (e.g. session pruned), falling back to a fresh scan.
+   */
+  private discoverRunAgentFiles(runId: string): DiscoveredRun | null {
+    const cached = this.runLocationCache.get(runId);
+    if (cached !== undefined) {
+      if (existsSync(cached.wfRunDir)) {
+        const files: DiscoveredAgentFile[] = [];
+        this.collectAgentFiles(cached.wfRunDir, runId, files);
+        if (files.length > 0) {
+          return {
+            parentSessionId: cached.parentSessionId,
+            workflowsDir: cached.workflowsDir,
+            files,
+          };
+        }
+      }
+      this.runLocationCache.delete(runId);
+    }
+
+    if (!existsSync(this.projectsDir)) return null;
+
+    let projectEntries: string[];
+    try {
+      projectEntries = readdirSync(this.projectsDir);
+    } catch (err) {
+      this.recordError('readdir projects (live run)', err);
+      return null;
+    }
+
+    for (const project of projectEntries) {
+      const projectPath = join(this.projectsDir, project);
+      let sessionEntries: string[];
+      try {
+        if (!statSync(projectPath).isDirectory()) continue;
+        sessionEntries = readdirSync(projectPath);
+      } catch {
+        continue;
+      }
+      for (const sessionId of sessionEntries) {
+        if (!SESSION_ID_RE.test(sessionId)) continue;
+        // runId is validated against WORKFLOW_RUN_ID_RE by the caller, so it
+        // carries no path separators or `..` — safe as a path segment.
+        const wfRunDir = join(projectPath, sessionId, 'subagents', 'workflows', runId);
+        if (!existsSync(wfRunDir)) continue;
+        try {
+          if (!statSync(wfRunDir).isDirectory()) continue;
+        } catch {
+          continue;
+        }
+        const files: DiscoveredAgentFile[] = [];
+        this.collectAgentFiles(wfRunDir, runId, files);
+        if (files.length === 0) continue;
+        const workflowsDir = join(projectPath, sessionId, 'workflows');
+        SubagentTimelineStore.boundedSet(
+          this.runLocationCache,
+          runId,
+          { parentSessionId: sessionId, workflowsDir, wfRunDir },
+          MAX_RUN_LOCATION_CACHE_ENTRIES,
+        );
+        return {
+          parentSessionId: sessionId,
+          workflowsDir,
+          files,
+        };
+      }
+    }
+    return null;
   }
 
   /** Push every well-named `agent-<id>.jsonl` in `dir` onto `out`. */

--- a/src/dashboard/workflow-store.ts
+++ b/src/dashboard/workflow-store.ts
@@ -31,6 +31,27 @@ const PROJECTS_DIR_NAME = '.claude/projects';
 // written across all projects/sessions with no upper bound.
 const MAX_RUNS = 500;
 
+/**
+ * Locate the persisted orchestration script for a run inside a session's
+ * `workflows/scripts/` dir. The Workflow tool writes `<name>-<runId>.js`, so we
+ * match on the `-<runId>.js` suffix. Returns the absolute path or null. Shared
+ * by the on-disk rollup reader (below) and the live-run reader in
+ * SubagentTimelineStore so a still-running workflow can resolve its declared
+ * topology before its rollup exists. Never throws.
+ */
+export function findWorkflowScriptPath(workflowsDir: string, runId: string): string | null {
+  const scriptsDir = join(workflowsDir, 'scripts');
+  if (!existsSync(scriptsDir)) return null;
+  try {
+    for (const name of readdirSync(scriptsDir)) {
+      if (name.endsWith(`-${runId}.js`)) return join(scriptsDir, name);
+    }
+  } catch {
+    /* skip */
+  }
+  return null;
+}
+
 export interface WorkflowRunRow {
   readonly workflow_run_id: string;
   readonly parent_session_id: string;
@@ -293,20 +314,7 @@ export class WorkflowStore {
     // Topology from script (best-effort)
     let scriptPath = typeof parsed.scriptPath === 'string' ? parsed.scriptPath : null;
     if (!scriptPath) {
-      const wfDir = dirname(path);
-      const scriptsDir = join(wfDir, 'scripts');
-      if (existsSync(scriptsDir)) {
-        try {
-          for (const name of readdirSync(scriptsDir)) {
-            if (name.endsWith(`-${runId}.js`)) {
-              scriptPath = join(scriptsDir, name);
-              break;
-            }
-          }
-        } catch {
-          /* skip */
-        }
-      }
+      scriptPath = findWorkflowScriptPath(dirname(path), runId);
     }
     // Security: `parsed.scriptPath` is read verbatim from an untrusted on-disk
     // wf_*.json. Before reading it, require the resolved path to stay under

--- a/src/index.ts
+++ b/src/index.ts
@@ -1213,6 +1213,9 @@ async function main(): Promise<void> {
             getSubagentsForSession: (id: string) =>
               subagentTimelineInstance.getSubagentsForSession(id),
             getAgentCalls: (s: string, a: string) => subagentTimelineInstance.getAgentCalls(s, a),
+            // Live-run fallback so GET /api/workflows/:runId serves a still-
+            // running workflow (no rollup on disk yet) instead of 404ing.
+            getRunLive: (runId: string) => subagentTimelineInstance.getRunLive(runId),
           },
           // Wire the observability-health snapshot so GET
           // /api/observability-health returns live watcher state instead of


### PR DESCRIPTION
## Summary

Fixes #223.

A running workflow has no on-disk rollup file until it terminates, but the session-trace swimlane makes every run lane clickable from its live subagent transcripts, which exist mid-run. Opening the detail drawer for the most recent (still-running) run therefore always hit the terminal-only rollup lookup, got nothing back, and showed "Failed to load run details."

This adds a live fallback: when the rollup lookup finds nothing, the detail route synthesizes a running-status detail from the run's live subagent transcripts — per-agent tokens/tool-calls/timing, summed totals, and the declared topology/name resolved from the persisted orchestration script. It emits the same wire shape as the completed path, so the drawer renders unchanged and automatically upgrades to the final summary once the run terminates.

Also includes two follow-up fixes from review:
- The live view's reported default model is now chosen deterministically (the most recently active agent) rather than depending on unspecified directory-listing order.
- The run's on-disk location is cached so repeated polls of a still-running run's detail don't repeat the full directory scan.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` — no new issues
- [x] `npm run format:check` clean
- [x] `npm test` — full suite green
- [x] New unit tests for the live-detail assembly (cost/token/tool-call correctness, deterministic default model, run-location cache reuse/invalidation, script/topology resolution, malformed/unknown run ids)
- [x] New route tests for the live-fallback branch (rollup path, live fallback, name fallback, 404, missing dependency)
- [x] New end-to-end integration test wiring the real stores against a real temp filesystem tree
