### PR TITLE
Feat: track cost per 1M tokens (session-blended + per-model)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-07-17
+
+### Added
+
+- A normalized cost-rate metric, cost per million tokens, so spend can be compared across sessions and models independent of raw token volume. A session-blended rate (across input, output, thinking, cache-read, and cache-creation tokens) is available from `nr_observe_get_cost_breakdown`, and a per-model rate (input+output tokens) is available from `nr_observe_get_model_usage` and shown in the dashboard's Today and History views.
+
 ## [1.5.6] - 2026-07-17
 
 ### Fixed

--- a/docs/COMMANDS_TABLE.md
+++ b/docs/COMMANDS_TABLE.md
@@ -241,6 +241,7 @@ Session cost breakdown by task, model, and efficiency.
   "by_task": [{ "task_id": "task-001", "cost_usd": 0.25, "tokens_used": 15000 }],
   "cost_per_line_of_code": 0.003,
   "cost_per_file_modified": 0.065,
+  "cost_per_million_tokens": 7.43,
   "tokens": { "input": 50000, "output": 20000, "thinking": 10000 }
 }
 ```
@@ -254,6 +255,7 @@ Session cost breakdown by task, model, and efficiency.
 - `by_task` — maps `TaskDetector.getCompletedTasks()` to their `estimatedCostUsd` and `tokensUsed`
 - `cost_per_line_of_code` — `totalCost / totalLinesChanged` (null if no lines changed)
 - `cost_per_file_modified` — `totalCost / uniqueFilesWritten` (null if no files modified)
+- `cost_per_million_tokens` — blended session rate: `(totalCost / totalTokens) * 1_000_000`, summed across input, output, thinking, cache-read, and cache-creation tokens (null if no tokens reported). Not shipped as its own NR metric — it's a pure ratio of `ai.cost.session_total_usd` and the `ai.cost.tokens_*` counts already emitted, so it's more flexibly computed in NRQL at query time (`sum(cost)/sum(tokens)*1e6`, facetable by any dimension) than as a pre-baked gauge.
 - `tokens` — running totals by token type from all reports
 
 **Requires:** `CostTracker`; `TaskDetector` for per-task breakdown
@@ -1132,34 +1134,46 @@ Which AI model was used per request and cost-efficiency per model.
 
 ```json
 {
-  "model_distribution": {
+  "byModel": {
     "claude-sonnet-4-6": {
-      "request_count": 25,
-      "total_cost": 0.42,
-      "avg_cost": 0.017,
-      "efficiency_score": 0.82
+      "requestCount": 25,
+      "totalInputTokens": 120000,
+      "totalOutputTokens": 45000,
+      "totalCostUsd": 0.42,
+      "costPerOutputToken": 0.0000093,
+      "costPerMillionTokens": 2.55,
+      "avgOutputTokensPerRequest": 1800
     },
     "claude-opus-4-7": {
-      "request_count": 3,
-      "total_cost": 0.18,
-      "avg_cost": 0.06,
-      "efficiency_score": 0.88
+      "requestCount": 3,
+      "totalInputTokens": 20000,
+      "totalOutputTokens": 8000,
+      "totalCostUsd": 0.18,
+      "costPerOutputToken": 0.0000225,
+      "costPerMillionTokens": 6.43,
+      "avgOutputTokensPerRequest": 2666.67
     }
   },
-  "total_requests": 28,
-  "total_cost": 0.6,
-  "cost_per_request": 0.021
+  "mostUsedModel": "claude-sonnet-4-6",
+  "mostEfficientModel": "claude-sonnet-4-6",
+  "totalModelsUsed": 2
 }
 ```
+
+**Field notes:**
+
+- `costPerOutputToken` — `totalCostUsd / totalOutputTokens` (null if no output tokens)
+- `costPerMillionTokens` — per-model rate: `(totalCostUsd / (totalInputTokens + totalOutputTokens)) * 1_000_000` (null if no tokens). Only counts input+output tokens — narrower than `nr_observe_get_cost_breakdown`'s session-blended `cost_per_million_tokens`, which also folds in thinking/cache-read/cache-creation tokens. The two figures are not directly comparable.
+- `mostUsedModel` — the model with the highest `requestCount`
+- `mostEfficientModel` — the model with the lowest `costPerOutputToken`
 
 **Data source:** `ModelUsageTracker`
 
 **How it works:**
 
 - Tracks `model` field from each request (e.g., "claude-sonnet-4-6")
-- Aggregates cost per model
-- Computes `efficiency_score` for each model: `(completedTasks / failedAttempts) / (costPerRequest / averageCostPerRequest)`
-- Helps identify cost-effectiveness of model choices
+- Aggregates request count, input/output tokens, and cost per model
+- Picks `mostUsedModel` (highest request count) and `mostEfficientModel` (lowest `costPerOutputToken`)
 
 **Requires:** `ModelUsageTracker`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.5.6",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -3268,6 +3268,7 @@ describe('api-handler GET /api/model-usage', () => {
           totalOutputTokens: 500,
           totalCostUsd: 3.2,
           costPerOutputToken: 0.0064,
+          costPerMillionTokens: 2133.33,
           avgOutputTokensPerRequest: 12.5,
         },
       },

--- a/src/metrics/cost-tracker.test.ts
+++ b/src/metrics/cost-tracker.test.ts
@@ -337,6 +337,54 @@ describe('CostTracker', () => {
     });
   });
 
+  describe('costPerMillionTokens', () => {
+    it('computes the blended session rate across input/output tokens', () => {
+      const tracker = new CostTracker();
+
+      // claude-sonnet-4: 500k*3/1M + 500k*15/1M = 1.5 + 7.5 = 9.0 for 1M tokens
+      tracker.recordTokenUsage(
+        makeUsage({ inputTokens: 500_000, outputTokens: 500_000, totalTokens: 1_000_000 }),
+        'claude-sonnet-4',
+      );
+
+      expect(tracker.getMetrics().costPerMillionTokens).toBeCloseTo(9.0, 2);
+    });
+
+    it('returns null when no tokens have been reported', () => {
+      const tracker = new CostTracker();
+      expect(tracker.getMetrics().costPerMillionTokens).toBeNull();
+    });
+
+    it('includes thinking, cache-read, and cache-creation tokens in the blended denominator', () => {
+      const tracker = new CostTracker();
+      tracker.recordTokenUsage(
+        makeUsage({
+          inputTokens: 100_000,
+          outputTokens: 50_000,
+          thinkingTokens: 20_000,
+          cacheReadTokens: 30_000,
+          cacheCreationTokens: 10_000,
+          totalTokens: 210_000,
+        }),
+        'claude-sonnet-4',
+      );
+
+      const metrics = tracker.getMetrics();
+      const totalTokensAllTypes =
+        metrics.totalInputTokens +
+        metrics.totalOutputTokens +
+        metrics.totalThinkingTokens +
+        metrics.totalCacheReadTokens +
+        metrics.totalCacheCreationTokens;
+
+      expect(totalTokensAllTypes).toBe(210_000);
+      expect(metrics.costPerMillionTokens).toBeCloseTo(
+        (metrics.sessionTotalCostUsd! / totalTokensAllTypes) * 1_000_000,
+        6,
+      );
+    });
+  });
+
   describe('null fields when no data', () => {
     it('returns null for cost fields when no tokens reported', () => {
       const tracker = new CostTracker();
@@ -345,6 +393,7 @@ describe('CostTracker', () => {
       expect(metrics.sessionTotalCostUsd).toBeNull();
       expect(metrics.costPerLineOfCode).toBeNull();
       expect(metrics.costPerFileModified).toBeNull();
+      expect(metrics.costPerMillionTokens).toBeNull();
       expect(metrics.costByTask).toBeNull();
       expect(metrics.model).toBeNull();
       expect(metrics.latestCostBreakdown).toBeNull();
@@ -499,6 +548,21 @@ describe('CostTracker', () => {
       expect(names).toContain('ai.cost.cost_per_line_of_code');
       expect(names).toContain('ai.cost.report_count');
       expect(names).toContain('ai.cost.estimation_count');
+    });
+
+    it('never emits a per_million_tokens metric — it is derivable in NRQL from session_total_usd and the tokens_* counts already emitted', () => {
+      const tracker = new CostTracker();
+
+      tracker.recordTokenUsage(
+        makeUsage({ inputTokens: 10_000, outputTokens: 2_000, totalTokens: 12_000 }),
+        'claude-sonnet-4',
+      );
+
+      const aggregator = new MetricAggregator();
+      tracker.emitMetrics(aggregator);
+
+      const names = aggregator.harvest(60_000).map((m) => m.name);
+      expect(names).not.toContain('ai.cost.per_million_tokens');
     });
 
     it('emits cost_per_file_modified when session tracker has file data', () => {

--- a/src/metrics/cost-tracker.ts
+++ b/src/metrics/cost-tracker.ts
@@ -58,6 +58,12 @@ export interface CostMetrics {
   readonly costByModel: Record<string, number>;
   readonly costPerLineOfCode: number | null;
   readonly costPerFileModified: number | null;
+  /**
+   * Blended session cost rate: totalCostUsd / totalTokens (all types) * 1M.
+   * Broader than ModelUsageTracker's per-model `costPerMillionTokens`, which
+   * only counts input+output tokens — the two are not directly comparable.
+   */
+  readonly costPerMillionTokens: number | null;
   readonly model: string | null;
   readonly totalInputTokens: number;
   readonly totalOutputTokens: number;
@@ -365,6 +371,13 @@ export class CostTracker {
       costByWorkflowRunId[runId] = Object.fromEntries(dayMap);
     }
 
+    const totalTokensAllTypes =
+      this.totalInputTokens +
+      this.totalOutputTokens +
+      this.totalThinkingTokens +
+      this.totalCacheReadTokens +
+      this.totalCacheCreationTokens;
+
     return {
       sessionTotalCostUsd: hasData ? this.totalCostUsd : null,
       costByTask: null,
@@ -373,6 +386,10 @@ export class CostTracker {
         hasData && this.totalLinesChanged > 0 ? this.totalCostUsd / this.totalLinesChanged : null,
       costPerFileModified:
         hasData && uniqueFilesWritten > 0 ? this.totalCostUsd / uniqueFilesWritten : null,
+      costPerMillionTokens:
+        hasData && totalTokensAllTypes > 0
+          ? (this.totalCostUsd / totalTokensAllTypes) * 1_000_000
+          : null,
       model: this.currentModel,
       totalInputTokens: this.totalInputTokens,
       totalOutputTokens: this.totalOutputTokens,
@@ -396,6 +413,14 @@ export class CostTracker {
       attrs.model = this.currentModel;
     }
 
+    // Deliberately not emitted as its own NR metric: cost-per-million-tokens
+    // is a pure ratio of session_total_usd and the tokens_* counts already
+    // emitted below, so NRQL can compute it at query time
+    // (sum(cost)/sum(tokens)*1e6) with full facet/time-window flexibility —
+    // a pre-baked gauge scoped to today's attrs would be strictly less
+    // flexible and adds ingest volume for no analytical benefit. It's still
+    // computed locally (see getMetrics().costPerMillionTokens) for the MCP
+    // tool responses and local dashboard, which have no NRQL alternative.
     aggregator.record('ai.cost.session_total_usd', this.totalCostUsd, attrs);
     aggregator.record('ai.cost.tokens_input', this.totalInputTokens, attrs);
     aggregator.record('ai.cost.tokens_output', this.totalOutputTokens, attrs);

--- a/src/metrics/model-usage-tracker.test.ts
+++ b/src/metrics/model-usage-tracker.test.ts
@@ -57,6 +57,19 @@ describe('ModelUsageTracker', () => {
     expect(t.getMetrics().byModel['model-a']?.costPerOutputToken).toBeNull();
   });
 
+  it('computes costPerMillionTokens correctly', () => {
+    const t = new ModelUsageTracker();
+    t.recordUsage('model-a', 500_000, 500_000, 1.0);
+    const stats = t.getMetrics().byModel['model-a'];
+    expect(stats?.costPerMillionTokens).toBeCloseTo(1.0);
+  });
+
+  it('costPerMillionTokens is null when no tokens are recorded', () => {
+    const t = new ModelUsageTracker();
+    t.recordUsage('model-a', 0, 0, 0);
+    expect(t.getMetrics().byModel['model-a']?.costPerMillionTokens).toBeNull();
+  });
+
   it('avgOutputTokensPerRequest is correct', () => {
     const t = new ModelUsageTracker();
     t.recordUsage('model-a', 0, 200, 0);

--- a/src/metrics/model-usage-tracker.ts
+++ b/src/metrics/model-usage-tracker.ts
@@ -4,6 +4,13 @@ export interface ModelStats {
   readonly totalOutputTokens: number;
   readonly totalCostUsd: number;
   readonly costPerOutputToken: number | null;
+  /**
+   * Per-model rate: totalCostUsd / (totalInputTokens + totalOutputTokens) * 1M.
+   * Narrower than CostTracker's session-blended `costPerMillionTokens`, which
+   * also folds in thinking/cache-read/cache-creation tokens — the two are not
+   * directly comparable.
+   */
+  readonly costPerMillionTokens: number | null;
   readonly avgOutputTokensPerRequest: number | null;
 }
 
@@ -46,6 +53,9 @@ export class ModelUsageTracker {
     for (const [model, stats] of this.byModel) {
       const costPerOutputToken =
         stats.totalOutputTokens > 0 ? stats.totalCostUsd / stats.totalOutputTokens : null;
+      const totalTokens = stats.totalInputTokens + stats.totalOutputTokens;
+      const costPerMillionTokens =
+        totalTokens > 0 ? (stats.totalCostUsd / totalTokens) * 1_000_000 : null;
       const avgOutputTokensPerRequest =
         stats.requestCount > 0 ? stats.totalOutputTokens / stats.requestCount : null;
 
@@ -55,6 +65,7 @@ export class ModelUsageTracker {
         totalOutputTokens: stats.totalOutputTokens,
         totalCostUsd: stats.totalCostUsd,
         costPerOutputToken,
+        costPerMillionTokens,
         avgOutputTokensPerRequest,
       };
 

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -831,6 +831,7 @@ describe('buildSessionSummary', () => {
       costByModel: {},
       costPerLineOfCode: null,
       costPerFileModified: null,
+      costPerMillionTokens: null,
       model: 'claude-sonnet-4-6',
       totalInputTokens: 3_000,
       totalOutputTokens: 1_000,

--- a/src/tools/cost-tools.test.ts
+++ b/src/tools/cost-tools.test.ts
@@ -5,6 +5,7 @@ import {
   handleGetPromptCacheHealth,
   handleGetBudgetStatus,
   handleGetCostForecast,
+  handleGetCostBreakdown,
 } from './cost-tools.js';
 import { CostTracker } from '../metrics/cost-tracker.js';
 import { BudgetTracker } from '../metrics/budget-tracker.js';
@@ -199,6 +200,34 @@ describe('handleReportTokens()', () => {
 });
 
 // ---------------------------------------------------------------------------
+// handleGetCostBreakdown
+// ---------------------------------------------------------------------------
+
+describe('handleGetCostBreakdown()', () => {
+  it('includes cost_per_million_tokens in the response', () => {
+    const tracker = new CostTracker();
+    handleReportTokens(tracker, {
+      input_tokens: 500_000,
+      output_tokens: 500_000,
+      model: 'claude-sonnet-4',
+    });
+
+    const result = handleGetCostBreakdown(tracker);
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.cost_per_million_tokens).toBeCloseTo(9.0, 2);
+  });
+
+  it('returns null cost_per_million_tokens when no tokens reported', () => {
+    const tracker = new CostTracker();
+    const result = handleGetCostBreakdown(tracker);
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.cost_per_million_tokens).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // handleGetPromptCacheHealth
 // ---------------------------------------------------------------------------
 
@@ -213,6 +242,7 @@ describe('handleGetPromptCacheHealth()', () => {
       costByModel: {},
       costPerLineOfCode: null,
       costPerFileModified: null,
+      costPerMillionTokens: null,
       model: null,
       totalInputTokens: 0,
       totalOutputTokens: 0,

--- a/src/tools/cost-tools.ts
+++ b/src/tools/cost-tools.ts
@@ -159,6 +159,7 @@ export function handleGetCostBreakdown(costTracker: CostTracker, taskDetector?: 
     by_task: byTask,
     cost_per_line_of_code: metrics.costPerLineOfCode,
     cost_per_file_modified: metrics.costPerFileModified,
+    cost_per_million_tokens: metrics.costPerMillionTokens,
     tokens: {
       input: metrics.totalInputTokens,
       output: metrics.totalOutputTokens,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -161,6 +161,8 @@ export interface SessionListEntry {
   readonly model?: string | null;
   readonly toolSuccessRate?: number | null;
   readonly efficiencyScore?: number | null;
+  readonly tokensInput?: number;
+  readonly tokensOutput?: number;
 }
 
 export interface LiveSessionEntry {
@@ -186,6 +188,7 @@ export interface CostMetrics {
   readonly costByModel: Record<string, number>;
   readonly costPerLineOfCode: number | null;
   readonly costPerFileModified: number | null;
+  readonly costPerMillionTokens: number | null;
   readonly model: string | null;
   readonly totalInputTokens: number;
   readonly totalOutputTokens: number;
@@ -590,6 +593,7 @@ export interface ModelStats {
   readonly totalOutputTokens: number;
   readonly totalCostUsd: number;
   readonly costPerOutputToken: number | null;
+  readonly costPerMillionTokens: number | null;
   readonly avgOutputTokensPerRequest: number | null;
 }
 

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -846,6 +846,57 @@ describe('aggregateModelPerformance', () => {
     expect(opus.flagged).toBe(false);
   });
 
+  it('computes costPerMillionTokens as a blended rate across all sessions for the model', () => {
+    const sessions = [
+      {
+        sessionId: 's1',
+        model: 'claude-opus-4-6',
+        estimatedCostUsd: 6.0,
+        tokensInput: 400_000,
+        tokensOutput: 200_000,
+      },
+      {
+        sessionId: 's2',
+        model: 'claude-opus-4-6',
+        estimatedCostUsd: 3.0,
+        tokensInput: 300_000,
+        tokensOutput: 100_000,
+      },
+    ];
+    const result = aggregateModelPerformance(sessions);
+    // totalCost=9.0, totalTokens=1_000_000 -> 9.0 / 1_000_000 * 1e6 = 9.0
+    expect(result[0].costPerMillionTokens).toBeCloseTo(9.0);
+  });
+
+  it('returns null costPerMillionTokens when no token counts are present', () => {
+    const sessions = [{ sessionId: 's1', model: 'claude-opus-4-6', estimatedCostUsd: 1.0 }];
+    const result = aggregateModelPerformance(sessions);
+    expect(result[0].costPerMillionTokens).toBeNull();
+  });
+
+  it("excludes a session's cost from costPerMillionTokens when it has no token counts yet", () => {
+    const sessions = [
+      // Persisted session: cost and tokens both known.
+      {
+        sessionId: 's1',
+        model: 'claude-opus-4-6',
+        estimatedCostUsd: 9.0,
+        tokensInput: 800_000,
+        tokensOutput: 200_000,
+      },
+      // Live session stub: cost already reported, but token counts haven't
+      // persisted yet. Including its cost without matching tokens would
+      // inflate the blended rate above the true 9.0 for this model.
+      {
+        sessionId: 's2-live',
+        model: 'claude-opus-4-6',
+        estimatedCostUsd: 5.0,
+      },
+    ];
+    const result = aggregateModelPerformance(sessions);
+    expect(result[0].costPerMillionTokens).toBeCloseTo(9.0);
+  });
+
   it('flags models that have sessions below 85% success rate', () => {
     const sessions = [
       { sessionId: 's1', model: 'claude-opus-4-6', toolSuccessRate: 0.95 },

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -42,6 +42,8 @@ interface SessionRow {
   readonly efficiencyScore?: number | null;
   readonly toolCallCount?: number;
   readonly toolBreakdown?: Record<string, number>;
+  readonly tokensInput?: number;
+  readonly tokensOutput?: number;
 }
 
 const TICK_STYLE = { fill: 'var(--color-ink-muted)', fontSize: 10 };
@@ -303,6 +305,7 @@ export function History(): JSX.Element {
                     <th className="text-right pb-1">Eff.</th>
                     <th className="text-right pb-1">Success</th>
                     <th className="text-right pb-1">Avg $</th>
+                    <th className="text-right pb-1">$/1M tok</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -323,6 +326,9 @@ export function History(): JSX.Element {
                           : '—'}
                       </td>
                       <td className="py-1 text-right tabular-nums">{formatUsdOrDash(m.avgCost)}</td>
+                      <td className="py-1 text-right tabular-nums text-ink-subtle">
+                        {formatUsdOrDash(m.costPerMillionTokens)}
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -555,6 +561,14 @@ export interface ModelPerformanceRow {
   readonly avgEfficiency: number | null;
   readonly avgSuccessRate: number | null;
   readonly avgCost: number | null;
+  // Blended rate across sessions for this model that report both cost and
+  // token counts — (totalCost / totalTokens) * 1e6, input+output tokens only
+  // (matching ModelUsageTracker's server-side per-model figure, which is a
+  // different token set than CostTracker's session-blended rate). Unlike
+  // avgCost (a mean of per-session costs), this is stable across sessions of
+  // very different size, so it's the more meaningful number for comparing
+  // models' actual spend efficiency.
+  readonly costPerMillionTokens: number | null;
   readonly flagged: boolean;
 }
 
@@ -571,6 +585,8 @@ export function aggregateModelPerformance(rows: SessionRow[]): ModelPerformanceR
       successCount: number;
       costSum: number;
       costCount: number;
+      blendedCostSum: number;
+      blendedTokensSum: number;
       lowSuccessSessions: number;
     }
   >();
@@ -587,6 +603,8 @@ export function aggregateModelPerformance(rows: SessionRow[]): ModelPerformanceR
         successCount: 0,
         costSum: 0,
         costCount: 0,
+        blendedCostSum: 0,
+        blendedTokensSum: 0,
         lowSuccessSessions: 0,
       };
       byModel.set(model, entry);
@@ -606,6 +624,14 @@ export function aggregateModelPerformance(rows: SessionRow[]): ModelPerformanceR
     if (r.estimatedCostUsd != null) {
       entry.costSum += r.estimatedCostUsd;
       entry.costCount++;
+      // Only blend cost and tokens from the same session — a live session row
+      // can carry a cost before its token counts have been persisted, which
+      // would otherwise inflate costPerMillionTokens by counting cost against
+      // fewer tokens than were actually spent.
+      if (r.tokensInput != null || r.tokensOutput != null) {
+        entry.blendedCostSum += r.estimatedCostUsd;
+        entry.blendedTokensSum += (r.tokensInput ?? 0) + (r.tokensOutput ?? 0);
+      }
     }
   }
 
@@ -617,6 +643,8 @@ export function aggregateModelPerformance(rows: SessionRow[]): ModelPerformanceR
       avgEfficiency: e.effCount > 0 ? e.effSum / e.effCount : null,
       avgSuccessRate: e.successCount > 0 ? e.successSum / e.successCount : null,
       avgCost: e.costCount > 0 ? e.costSum / e.costCount : null,
+      costPerMillionTokens:
+        e.blendedTokensSum > 0 ? (e.blendedCostSum / e.blendedTokensSum) * 1_000_000 : null,
       flagged: e.lowSuccessSessions > 0,
     });
   }

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -51,6 +51,7 @@ import {
   fmtTimeOfDay,
   formatNumber,
   formatUsd,
+  formatUsdOrDash,
   rateColor,
   scoreColor,
   shortToolName,
@@ -660,6 +661,7 @@ interface ModelStats {
   readonly requestCount: number;
   readonly totalCostUsd: number;
   readonly costPerOutputToken: number | null;
+  readonly costPerMillionTokens: number | null;
 }
 
 interface ModelUsageMetrics {
@@ -700,6 +702,9 @@ function ModelUsagePanel(): JSX.Element {
               <span className="text-ink-muted truncate">{model}</span>
               <div className="flex gap-3 shrink-0 tabular-nums">
                 <span className="text-ink-subtle">{s.requestCount}req</span>
+                <span className="text-ink-subtle">
+                  {formatUsdOrDash(s.costPerMillionTokens)}/1M tok
+                </span>
                 <span className="text-ink-base">{formatUsd(s.totalCostUsd)}</span>
               </div>
             </div>


### PR DESCRIPTION
Fixes #228

## Summary
- Adds a normalized cost-rate metric, cost per million tokens, so spend can be compared across sessions and models independent of raw token volume.
- `CostTracker`: session-blended rate across all token types (input/output/thinking/cache-read/cache-creation), exposed via `nr_observe_get_cost_breakdown` (`cost_per_million_tokens` field). Not shipped as its own NR metric — it's a pure ratio of the cost/token metrics already emitted, so it's more flexibly computed in NRQL at query time.
- `ModelUsageTracker`: per-model rate (input+output tokens) on `ModelStats`, exposed via `nr_observe_get_model_usage` and shown in the dashboard's Today and History views.
- Updated `docs/COMMANDS_TABLE.md`, including a correction to the `nr_observe_get_model_usage` entry's documented response shape to match the handler's actual output.

## Test plan
- [x] `npm run build && npm test` — full suite passes
- [x] `npm run lint` — 0 errors/warnings
- [x] `npx vitest run` — web test suite passes
- [x] New/updated unit tests for the blended-rate math, the per-model rate, and the live-session cost/token accounting edge case
