### PR TITLE
Fix #122: real message counts for nr_observe_get_collaboration_profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-07-18
+
+### Fixed
+
+- Developer collaboration profiles previously showed the same values for every developer because real conversation activity wasn't being counted. Message and correction counts are now derived from the actual session transcript, so specificity, autonomy, and correction-rate scores reflect real usage. This also corrects the correction-rate figure surfaced in CLAUDE.md impact analysis and in prompt-engineering recommendations.
+
 ## [1.6.0] - 2026-07-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/transcript-types.ts
+++ b/src/hooks/transcript-types.ts
@@ -12,6 +12,16 @@ export interface RawTranscriptEntry {
   readonly message?: unknown;
   readonly uuid?: string;
   readonly timestamp?: string;
+  /** True for harness-injected synthetic entries (e.g. local-command caveats). */
+  readonly isMeta?: boolean;
+  /** True for subagent/Task-tool turns inlined into the main transcript. */
+  readonly isSidechain?: boolean;
+  /** True for context-compaction continuation-summary entries. */
+  readonly isCompactSummary?: boolean;
+  /** Present on `type: 'user'` entries that are actually a tool result echoed back, not a real message. */
+  readonly toolUseResult?: unknown;
+  /** Present on some harness-injected entries (e.g. background task notifications). */
+  readonly origin?: { readonly kind?: string };
 }
 
 /** The `message` field of an assistant-turn transcript entry. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import {
   GitEfficiencyTracker,
   parseDefaultBranchFromSymbolicRef,
 } from './metrics/git-efficiency-tracker.js';
+import { TranscriptMessageTracker } from './metrics/transcript-message-tracker.js';
 import { WorkflowRunTracker } from './metrics/workflow-run-tracker.js';
 import { SubagentWatcher } from './hooks/subagent-watcher.js';
 import { WorkflowWatcher } from './hooks/workflow-watcher.js';
@@ -823,6 +824,7 @@ async function main(): Promise<void> {
     // Kept dormant; would need new hook wiring or an LLM-facing proxy to fix for real.
     const latencyDecompositionTracker: LatencyDecompositionTracker | undefined = undefined;
     const decisionTracker = new DecisionTracker({ recordContent: config.recordContent });
+    const transcriptMessageTracker = new TranscriptMessageTracker();
     const instructionDriftTracker = new InstructionDriftTracker();
     const toolSelectionScorer = new ToolSelectionScorer();
     const qualityProxyTracker = new QualityProxyTracker();
@@ -1432,6 +1434,9 @@ async function main(): Promise<void> {
         const turnNumber = turnTracker.getCurrentTurnNumber();
         turnCostAttributor.recordToolCall(rawRecord, turnId);
         decisionTracker.recordToolCall(rawRecord);
+        transcriptMessageTracker.observeTranscriptPath(
+          rawRecord.transcriptPath as string | undefined,
+        );
         instructionDriftTracker.recordToolCall(rawRecord);
         gitEfficiencyTracker.recordToolCall(rawRecord);
 
@@ -1722,12 +1727,14 @@ async function main(): Promise<void> {
     persistSession = (opts?: { periodic?: boolean }) => {
       if (!sessionStore || !sessionTracker || !taskDetector || !config) return;
       try {
+        transcriptMessageTracker.refresh();
         const summary = buildSessionSummary({
           sessionTracker,
           costTracker,
           taskDetector,
           antiPatternDetector,
           efficiencyScorer,
+          transcriptMessageTracker,
           developer: config.developer ?? 'unknown',
           repoName: currentRepoName,
           // A periodic checkpoint is a live, in-progress session — persisting it

--- a/src/metrics/transcript-message-tracker.test.ts
+++ b/src/metrics/transcript-message-tracker.test.ts
@@ -1,0 +1,264 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { existsSync, mkdirSync, rmSync, writeFileSync, appendFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { TranscriptMessageTracker } from './transcript-message-tracker.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+let tmpDir: string;
+let transcriptPath: string;
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  tmpDir = resolve(
+    tmpdir(),
+    `nr-transcript-msg-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(tmpDir, { recursive: true });
+  transcriptPath = resolve(tmpDir, 'transcript.jsonl');
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  if (existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+function userLine(content: unknown, overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type: 'user',
+    message: { role: 'user', content },
+    uuid: `u-${Math.random().toString(36).slice(2)}`,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  });
+}
+
+function assistantLine(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      model: 'claude-opus-4-6',
+      content: [{ type: 'text', text: 'ok' }],
+    },
+    uuid: `a-${Math.random().toString(36).slice(2)}`,
+    timestamp: '2026-01-01T00:00:01.000Z',
+    ...overrides,
+  });
+}
+
+function writeLines(lines: string[]): void {
+  writeFileSync(transcriptPath, lines.join('\n') + '\n');
+}
+
+function appendLines(lines: string[]): void {
+  appendFileSync(transcriptPath, lines.join('\n') + '\n');
+}
+
+describe('TranscriptMessageTracker', () => {
+  it('counts a real user message', () => {
+    writeLines([userLine('please fix the bug')]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(1);
+  });
+
+  it('counts a real assistant message', () => {
+    writeLines([assistantLine()]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().assistantMessages).toBe(1);
+  });
+
+  it.each([
+    ['tool_result echo', userLine('irrelevant', { toolUseResult: { some: 'result' } })],
+    [
+      'isMeta caveat',
+      userLine('<local-command-caveat>caveat text</local-command-caveat>', { isMeta: true }),
+    ],
+    [
+      'isCompactSummary continuation',
+      userLine('This session is being continued...', { isCompactSummary: true }),
+    ],
+    [
+      'task-notification origin',
+      userLine('<task-notification>...</task-notification>', {
+        origin: { kind: 'task-notification' },
+      }),
+    ],
+    ['isSidechain user turn', userLine('subagent internal turn', { isSidechain: true })],
+    ['command-name echo (no structural marker)', userLine('<command-name>/clear</command-name>')],
+    [
+      'local-command-stdout (no structural marker)',
+      userLine('<local-command-stdout>output</local-command-stdout>'),
+    ],
+    [
+      'teammate-message injection (no structural marker)',
+      userLine('Another Claude session sent a message:\nhi'),
+    ],
+  ])('excludes %s from userMessages', (_label, line) => {
+    writeLines([line]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(0);
+  });
+
+  it('excludes isSidechain assistant turns from assistantMessages', () => {
+    writeLines([assistantLine({ isSidechain: true })]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().assistantMessages).toBe(0);
+  });
+
+  it('excludes assistant entries with model <synthetic>', () => {
+    writeLines([
+      assistantLine({
+        message: {
+          role: 'assistant',
+          model: '<synthetic>',
+          content: [{ type: 'text', text: 'x' }],
+        },
+      }),
+    ]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().assistantMessages).toBe(0);
+  });
+
+  it('counts a real user message with array content (attachment-shaped)', () => {
+    writeLines([userLine([{ type: 'text', text: 'see attached' }])]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(1);
+  });
+
+  it.each([
+    ["No. I told you we'd do it differently."],
+    ["  no, that's not right"],
+    ['Stop. I did not approve that.'],
+    ["That's wrong, please redo it."],
+  ])('detects a correction for %j', (text) => {
+    writeLines([userLine(text)]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().userCorrections).toBe(1);
+  });
+
+  it('does not count an ordinary message as a correction', () => {
+    writeLines([userLine('please add a new endpoint')]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().userCorrections).toBe(0);
+  });
+
+  it('only processes new lines across multiple refresh() calls (no double-counting)', () => {
+    writeLines([userLine('first message')]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(1);
+
+    appendLines([userLine('second message')]);
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(2);
+  });
+
+  it('waits for a complete trailing line before counting it', () => {
+    writeFileSync(transcriptPath, userLine('first message') + '\n');
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(1);
+
+    // Append a partial line with no trailing newline yet.
+    appendFileSync(transcriptPath, userLine('second message').slice(0, 20));
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(1);
+
+    // Completing the line on the next append should get it counted.
+    appendFileSync(transcriptPath, userLine('second message').slice(20) + '\n');
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(2);
+  });
+
+  it('resets the read offset when the file shrinks (rotation)', () => {
+    writeLines([userLine('a'), userLine('b')]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(2);
+
+    writeLines([userLine('fresh after rotation')]);
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(3);
+  });
+
+  it('is a no-op when no transcript path has been observed', () => {
+    const tracker = new TranscriptMessageTracker();
+    tracker.refresh();
+    expect(tracker.getMetrics()).toEqual({
+      userMessages: 0,
+      assistantMessages: 0,
+      userCorrections: 0,
+    });
+  });
+
+  it('is a no-op when the transcript file does not exist', () => {
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(resolve(tmpDir, 'does-not-exist.jsonl'));
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(0);
+  });
+
+  it('keeps the first non-empty transcript path and ignores later calls', () => {
+    writeLines([userLine('hello')]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.observeTranscriptPath(resolve(tmpDir, 'does-not-exist.jsonl'));
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(1);
+  });
+
+  it('makes forward progress past an oversized line (>1MB) instead of stalling', () => {
+    writeLines([
+      userLine('first message'),
+      userLine('x'.repeat(1_100_000)),
+      userLine('second message'),
+    ]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    for (let i = 0; i < 5; i++) tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(2);
+  });
+
+  it('reset() clears counters, path, and offset', () => {
+    writeLines([userLine('hello')]);
+    const tracker = new TranscriptMessageTracker();
+    tracker.observeTranscriptPath(transcriptPath);
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(1);
+
+    tracker.reset();
+    expect(tracker.getMetrics()).toEqual({
+      userMessages: 0,
+      assistantMessages: 0,
+      userCorrections: 0,
+    });
+
+    // After reset, the tracker has forgotten the path — refresh() is a no-op
+    // until observeTranscriptPath() is called again.
+    tracker.refresh();
+    expect(tracker.getMetrics().userMessages).toBe(0);
+  });
+});

--- a/src/metrics/transcript-message-tracker.ts
+++ b/src/metrics/transcript-message-tracker.ts
@@ -1,0 +1,215 @@
+import { openSync, closeSync, readSync, statSync, constants as fsConstants } from 'node:fs';
+
+import type { RawTranscriptEntry, RawAssistantMessage } from '../hooks/transcript-types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TranscriptMessageMetrics {
+  readonly userMessages: number;
+  readonly assistantMessages: number;
+  readonly userCorrections: number;
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Content-prefix markers for synthetic `type: 'user'` entries that carry no
+ * structural field (isMeta/isCompactSummary/origin/toolUseResult) to key off
+ * of. Best-effort and non-exhaustive — new harness-injected message shapes
+ * may need to be added here as they're discovered.
+ */
+const SYNTHETIC_TEXT_PREFIXES = [
+  '<local-command-caveat>',
+  '<local-command-stdout>',
+  '<command-name>',
+  '<command-message>',
+  '<task-notification>',
+  '<system-reminder>',
+  'Another Claude session sent a message:',
+];
+
+const CORRECTION_RE =
+  /^(no|nope|not\b|stop|don't|wrong|incorrect|actually|that's not|that's wrong|undo|revert)\b/i;
+
+/** A content block carrying a `text` field — narrows before reading `.text`. */
+function hasStringText(block: unknown): block is { text: string } {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    'text' in block &&
+    typeof (block as { text?: unknown }).text === 'string'
+  );
+}
+
+/**
+ * `message.content` is either a plain string, or an array of content blocks
+ * (e.g. an attachment/paste) where the first block may carry `.text`. Returns
+ * null when there's no text to classify.
+ */
+function getEffectiveText(message: unknown): string | null {
+  if (message === null || typeof message !== 'object') return null;
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content) && content.length > 0 && hasStringText(content[0])) {
+    return content[0].text;
+  }
+  return null;
+}
+
+function isSyntheticText(text: string): boolean {
+  return SYNTHETIC_TEXT_PREFIXES.some((prefix) => text.startsWith(prefix));
+}
+
+/** Returns the entry's real message text, or null if it isn't a real human-typed message. */
+function classifyUserEntry(entry: RawTranscriptEntry): string | null {
+  if (entry.isSidechain === true) return null;
+  if (entry.toolUseResult !== undefined) return null;
+  if (entry.isMeta === true) return null;
+  if (entry.isCompactSummary === true) return null;
+  if (entry.origin?.kind === 'task-notification') return null;
+
+  const text = getEffectiveText(entry.message);
+  if (text === null || isSyntheticText(text)) return null;
+  return text;
+}
+
+function isRealAssistantEntry(entry: RawTranscriptEntry): boolean {
+  if (entry.isSidechain === true) return false;
+  const message = entry.message as RawAssistantMessage | undefined;
+  return message?.model !== '<synthetic>';
+}
+
+// ---------------------------------------------------------------------------
+// TranscriptMessageTracker
+// ---------------------------------------------------------------------------
+
+/** Cap on bytes read per refresh() call — bounds worst-case disk I/O per checkpoint. */
+const READ_CAP_BYTES = 1_048_576; // 1 MB
+
+export class TranscriptMessageTracker {
+  private transcriptPath: string | null = null;
+  private offset = 0;
+  private skippingOversizedLine = false;
+  private userMessages = 0;
+  private assistantMessages = 0;
+  private userCorrections = 0;
+
+  /** Cheap; captures the first non-empty path seen and ignores later calls. No I/O. */
+  observeTranscriptPath(path: string | undefined): void {
+    if (this.transcriptPath === null && typeof path === 'string' && path.length > 0) {
+      this.transcriptPath = path;
+    }
+  }
+
+  /** Incrementally reads and classifies any transcript growth since the last call. */
+  refresh(): void {
+    if (this.transcriptPath === null) return;
+
+    let size: number;
+    try {
+      size = statSync(this.transcriptPath).size;
+    } catch {
+      return;
+    }
+
+    if (size < this.offset) {
+      // File was rotated/truncated — restart from the beginning.
+      this.offset = 0;
+      this.skippingOversizedLine = false;
+    }
+    if (size <= this.offset) return;
+
+    const readSize = Math.min(size - this.offset, READ_CAP_BYTES);
+    let fd: number;
+    try {
+      fd = openSync(this.transcriptPath, fsConstants.O_RDONLY);
+    } catch {
+      return;
+    }
+
+    try {
+      const buffer = Buffer.alloc(readSize);
+      const bytesRead = readSync(fd, buffer, 0, readSize, this.offset);
+      const chunk = buffer.toString('utf-8', 0, bytesRead);
+
+      if (this.skippingOversizedLine) {
+        const lineEnd = chunk.indexOf('\n');
+        if (lineEnd === -1) {
+          // Still inside the oversized line — discard this chunk and keep skipping.
+          this.offset += Buffer.byteLength(chunk, 'utf-8');
+          return;
+        }
+        // Found the end of the oversized line — resume normal reads after it.
+        this.offset += Buffer.byteLength(chunk.slice(0, lineEnd + 1), 'utf-8');
+        this.skippingOversizedLine = false;
+        return;
+      }
+
+      const lastNewline = chunk.lastIndexOf('\n');
+      if (lastNewline === -1) {
+        if (readSize === READ_CAP_BYTES) {
+          // A full read-cap's worth of data with no newline means the current
+          // line is at least READ_CAP_BYTES long — discard it and skip past it
+          // incrementally rather than stalling forever waiting for its end.
+          this.offset += Buffer.byteLength(chunk, 'utf-8');
+          this.skippingOversizedLine = true;
+        }
+        return; // No complete line yet — wait for more data.
+      }
+
+      const completeChunk = chunk.slice(0, lastNewline + 1);
+      for (const line of completeChunk.split('\n')) {
+        if (line.length > 0) this.processLine(line);
+      }
+      this.offset += Buffer.byteLength(completeChunk, 'utf-8');
+    } catch {
+      // Best-effort — leave offset unchanged so the next refresh() retries.
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  private processLine(line: string): void {
+    let entry: RawTranscriptEntry;
+    try {
+      entry = JSON.parse(line) as RawTranscriptEntry;
+    } catch {
+      return;
+    }
+
+    if (entry.type === 'user') {
+      const text = classifyUserEntry(entry);
+      if (text !== null) {
+        this.userMessages++;
+        if (CORRECTION_RE.test(text.trim())) {
+          this.userCorrections++;
+        }
+      }
+    } else if (entry.type === 'assistant') {
+      if (isRealAssistantEntry(entry)) {
+        this.assistantMessages++;
+      }
+    }
+  }
+
+  getMetrics(): TranscriptMessageMetrics {
+    return {
+      userMessages: this.userMessages,
+      assistantMessages: this.assistantMessages,
+      userCorrections: this.userCorrections,
+    };
+  }
+
+  reset(): void {
+    this.transcriptPath = null;
+    this.offset = 0;
+    this.skippingOversizedLine = false;
+    this.userMessages = 0;
+    this.assistantMessages = 0;
+    this.userCorrections = 0;
+  }
+}

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -14,6 +14,7 @@ import { CostTracker } from '../metrics/cost-tracker.js';
 import type { CostMetrics } from '../metrics/cost-tracker.js';
 import type { TaskDetector } from '../metrics/task-detector.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
+import type { TranscriptMessageTracker } from '../metrics/transcript-message-tracker.js';
 import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -585,6 +586,79 @@ describe('buildSessionSummary', () => {
     expect(summary.agentSpawns).toBe(1);
     expect(summary.toolSuccessRate).toBe(0.9);
     expect(summary.outcome).toBe('completed');
+  });
+
+  it('reads userMessages/assistantMessages/userCorrections from transcriptMessageTracker', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 0,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: null,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+
+    const mockTranscriptMessageTracker = {
+      getMetrics: () => ({
+        userMessages: 4,
+        assistantMessages: 6,
+        userCorrections: 1,
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      transcriptMessageTracker: mockTranscriptMessageTracker as unknown as TranscriptMessageTracker,
+      developer: 'alice',
+    });
+
+    expect(summary.userMessages).toBe(4);
+    expect(summary.assistantMessages).toBe(6);
+    expect(summary.userCorrections).toBe(1);
+  });
+
+  it('defaults userMessages/assistantMessages/userCorrections to 0 when transcriptMessageTracker is absent', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 0,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: null,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      developer: 'alice',
+    });
+
+    expect(summary.userMessages).toBe(0);
+    expect(summary.assistantMessages).toBe(0);
+    expect(summary.userCorrections).toBe(0);
   });
 
   it("persists the provided outcome (periodic checkpoints write 'in progress')", () => {

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -22,6 +22,7 @@ import type { CostTracker } from '../metrics/cost-tracker.js';
 import type { TaskDetector } from '../metrics/task-detector.js';
 import type { AntiPatternDetector } from '../metrics/anti-patterns.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
+import type { TranscriptMessageTracker } from '../metrics/transcript-message-tracker.js';
 import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
 
 const logger = createLogger('session-store');
@@ -267,6 +268,7 @@ export interface BuildSessionSummarySources {
   taskDetector?: TaskDetector;
   antiPatternDetector?: AntiPatternDetector;
   efficiencyScorer?: EfficiencyScorer;
+  transcriptMessageTracker?: TranscriptMessageTracker;
   developer: string;
   repoName?: string | null;
   /**
@@ -294,6 +296,7 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
   const sessionMetrics = sessionTracker.getMetrics();
   const costMetrics = costTracker?.getMetrics() ?? null;
   const taskMetrics = taskDetector?.getMetrics() ?? null;
+  const transcriptMessageMetrics = sources.transcriptMessageTracker?.getMetrics();
 
   // Aggregate task-level data
   const allFilesRead = new Set<string>();
@@ -402,9 +405,9 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     toolSuccessRate: sessionMetrics.toolSuccessRate,
     contextCompressions: 0,
     agentSpawns: totalAgentSpawns,
-    userMessages: 0,
-    assistantMessages: 0,
-    userCorrections: 0,
+    userMessages: transcriptMessageMetrics?.userMessages ?? 0,
+    assistantMessages: transcriptMessageMetrics?.assistantMessages ?? 0,
+    userCorrections: transcriptMessageMetrics?.userCorrections ?? 0,
     outcome: sources.outcome ?? 'completed',
     platform: sources.platform,
     instructionPromptHash: sources.instructionPromptHash ?? null,


### PR DESCRIPTION
## Summary

`nr_observe_get_collaboration_profile` returned the same fixed fallback values for every developer because `buildSessionSummary()` hardcoded `userMessages`/`assistantMessages`/`userCorrections` to `0` on every persisted session. This also degraded `nr_observe_get_claudemd_impact`'s `avgCorrectionRate` and `nr_observe_get_recommendations`'s prompt-engineering category.

- Adds `TranscriptMessageTracker`, which incrementally tails the Claude Code transcript JSONL file and classifies each `type: 'user'`/`type: 'assistant'` line as a real human/model message vs. one of several synthetic entry types the harness also writes (tool-result echoes, local-command caveats, context-compaction summaries, task notifications, subagent sidechain turns, and a few content-prefix-matched cases with no structural marker).
- Wires the tracker into `buildSessionSummary()` and the MCP server's session lifecycle, refreshing on the existing 30s periodic checkpoint and at shutdown — not per tool call.
- Platforms without `transcript_path` (Cursor, Windsurf, etc.) see unchanged all-zero behavior — no regression.
- Includes a fix for a stall bug found during review: the transcript reader would permanently stop making progress if a single transcript line exceeded the 1MB read cap (realistic for large tool outputs); it now skips forward past an oversized line instead.

Bumps the version to 1.6.1 and adds a CHANGELOG entry.

Fixes #122

## Test plan

- [x] `npm run build && npm test && npm run lint` — clean, 0 lint errors/warnings
- [x] New unit tests for `TranscriptMessageTracker` covering every synthetic-entry pattern (tool-result echoes, `isMeta`, `isCompactSummary`, `task-notification` origin, `isSidechain`, content-prefix cases, correction regex, incremental refresh, file rotation, oversized-line skip-mode, reset)
- [x] Extended `buildSessionSummary` tests for tracker present/absent cases

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>