### PR TITLE
Fix #225: centralize synthetic session-id filtering at the producer boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-07-18
+
+### Fixed
+
+- Internal bookkeeping session IDs from `--local` and proxy mode could occasionally still show up in the session list, live sessions view, or concurrency chart, since each dashboard endpoint filtered them independently and inconsistently. That filtering is now applied once, centrally, wherever session data is loaded, so it can no longer be missed for any given view.
+
 ## [1.6.1] - 2026-07-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1316,24 +1316,6 @@ describe('api-handler GET /api/sessions/live', () => {
     expect(parsed[0]!.lastActivity).toBe(9_000_000);
   });
 
-  it('filters synthetic session IDs (local- and proxy- prefixes) from the response', async () => {
-    const ids = ['local-1234567890', 'real-session-abc', 'proxy-9876543210'];
-    const handler = createApiHandler({
-      liveSessionRegistry: {
-        getLiveSessions: () => ids,
-        getSessionName: () => null,
-        getLastActivity: () => null,
-      },
-      toolCallBuffer: { getRecords: () => [] },
-    });
-    const req = { method: 'GET', url: '/api/sessions/live' } as IncomingMessage;
-    const { res, status, body } = fakeRes();
-    await handler(req, res);
-    expect(status()).toBe(200);
-    const parsed = JSON.parse(body()) as Array<{ sessionId: string }>;
-    expect(parsed.map((p) => p.sessionId)).toEqual(['real-session-abc']);
-  });
-
   it('returns 503 when liveSessionRegistry is missing', async () => {
     const handler = createApiHandler({});
     const req = { method: 'GET', url: '/api/sessions/live' } as IncomingMessage;
@@ -2071,33 +2053,6 @@ describe('api-handler GET /api/concurrency (96-bucket grid)', () => {
     expect(result.buckets[44].count).toBe(1);
   });
 
-  it('excludes synthetic-id (local-/proxy-) persisted sessions from bucket counts', async () => {
-    const todaySessions = [
-      // Synthetic id — must be filtered out, contributes 0.
-      { sessionId: 'local-abc123', timeline: makeTimeline(0, 17) },
-      // Real id — should still contribute.
-      { sessionId: 'real-session-1', timeline: makeTimeline(0, 17) },
-    ];
-    const handler = createApiHandler({
-      concurrencyTracker: makeConcurrencyTracker(),
-      liveSessionRegistry: makeLiveRegistry(),
-      sessionStore: {
-        loadTodaySessions: () => todaySessions,
-        loadAllSessions: () => [],
-        listSessions: () => [],
-        loadSession: () => null,
-      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
-    });
-    const req = { method: 'GET', url: '/api/concurrency' } as IncomingMessage;
-    const { res, status, body } = fakeRes();
-    await handler(req, res);
-    expect(status()).toBe(200);
-    const result = JSON.parse(body());
-    // Bucket 0 should see only the one real session, not both → count=1.
-    expect(result.buckets[0].count).toBe(1);
-    expect(result.buckets[1].count).toBe(1);
-  });
-
   it('does not inflate the next bucket when a session ends exactly at a bucket boundary', async () => {
     // Regression: events deferred via `ts < bucketEnd` (not `<=`) left the
     // session's -1 to be processed at the START of the next bucket, after
@@ -2197,33 +2152,6 @@ describe('api-handler GET /api/concurrency (96-bucket grid)', () => {
     const maxBucket = Math.max(...result.buckets.map((b: { count: number }) => b.count));
     expect(maxBucket).toBe(1);
     expect(result.peak).toBe(1);
-  });
-
-  it('excludes synthetic-id sessions from allTimePeak, matching the filtering already applied to peak', async () => {
-    // Both all-time sessions are synthetic (local-mode). allTimePeak must
-    // exclude them just like `peak`/`historicalPeak` already exclude
-    // synthetic ids from today's buckets — otherwise allTimePeak could
-    // report a number driven by sessions invisible everywhere else in the UI.
-    const allSessions = [
-      { sessionId: 'local-abc', timeline: makeTimeline(0, 5) },
-      { sessionId: 'local-def', timeline: makeTimeline(0, 5) },
-    ];
-    const handler = createApiHandler({
-      concurrencyTracker: makeConcurrencyTracker(),
-      liveSessionRegistry: makeLiveRegistry(),
-      sessionStore: {
-        loadTodaySessions: () => [],
-        loadAllSessions: () => allSessions,
-        listSessions: () => [],
-        loadSession: () => null,
-      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
-    });
-    const req = { method: 'GET', url: '/api/concurrency' } as IncomingMessage;
-    const { res, status, body } = fakeRes();
-    await handler(req, res);
-    expect(status()).toBe(200);
-    const result = JSON.parse(body());
-    expect(result.allTimePeak).toBe(0);
   });
 
   it('preserves view=history branch unchanged', async () => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -920,22 +920,26 @@ export function createApiHandler(
     const allSessions = deps.sessionStore.loadAllSessions
       ? deps.sessionStore.loadAllSessions()
       : deps.sessionStore.listSessions();
-    // Filter synthetic IDs (`local-<ts>`, `proxy-<ts>`) from the historical
-    // list. They're MCP-internal bookkeeping IDs persisted incidentally by
-    // older builds; they appear as confusing "duplicate" rows next to real
-    // Claude Code sessions. The synthetic-shutdown filter in src/index.ts
-    // prevents new ones from being persisted, but stale ones from before
-    // that filter shipped need to be hidden at read time.
+    // `allSessions` comes from SessionStore.loadAllSessions(), which already
+    // excludes synthetic IDs (`local-<ts>`, `proxy-<ts>`, `pending-<ts>`) —
+    // MCP-internal bookkeeping from --local / proxy modes that would
+    // otherwise appear as confusing "duplicate" rows next to real Claude
+    // Code sessions.
     const withActivity = (allSessions as readonly SessionIdentityLike[]).filter((s) => {
-      const sid = s.sessionId;
       const calls = s.toolCallCount ?? 0;
-      return calls > 0 && (!sid || !isSyntheticSessionId(sid));
+      return calls > 0;
     });
     const sliced = withActivity.slice(-limit);
 
     // Append the current live session so it appears in the list before
-    // shutdown — but skip synthetic sessionTraceIds from --local / proxy
-    // modes (the same filter as for persisted entries above).
+    // shutdown. Unlike `allSessions` above, `live.sessionId` comes straight
+    // from this process's own SessionTracker, not SessionStore or
+    // LiveSessionRegistry — there's no shared producer boundary to push this
+    // check into, since --local / proxy mode's own session ID is synthetic
+    // for its entire lifetime and SessionTracker must keep reporting it
+    // unfiltered (persistSession() in src/index.ts depends on the real,
+    // unfiltered ID to decide whether to skip persisting). So this filter
+    // stays here.
     if (deps.sessionTracker) {
       const live = deps.sessionTracker.getMetrics();
       const alreadyPersisted = sliced.some(
@@ -1023,15 +1027,12 @@ export function createApiHandler(
   // yet, startTime defaults to lastActivity (or now() if both are missing).
   routes.set('GET /api/sessions/live', (_req, res) => {
     if (!deps.liveSessionRegistry) return unavailable(res, 'liveSessionRegistry');
-    // Filter out synthetic session identities used by --local / proxy modes
-    // (`local-<ts>`, `proxy-<ts>`). They're MCP-internal bookkeeping IDs,
-    // not real Claude Code sessions, so they shouldn't appear as clickable
-    // rows in the dashboard's live-sessions selector. The real user sessions
-    // (with proper session_ids resolved via the breadcrumb / CLAUDE_JOB_DIR
-    // path) are what users want to see and click.
-    const ids = deps.liveSessionRegistry
-      .getLiveSessions()
-      .filter((id) => !isSyntheticSessionId(id));
+    // getLiveSessions() already excludes synthetic session identities used by
+    // --local / proxy modes (`local-<ts>`, `proxy-<ts>`, `pending-<ts>`) —
+    // MCP-internal bookkeeping IDs, not real Claude Code sessions, so they
+    // shouldn't appear as clickable rows in the dashboard's live-sessions
+    // selector.
+    const ids = deps.liveSessionRegistry.getLiveSessions();
     const records = deps.toolCallBuffer?.getRecords() ?? [];
     const perSession = new Map<string, { firstTs: number; lastTs: number }>();
     for (const r of records) {
@@ -1549,25 +1550,19 @@ export function createApiHandler(
         return;
       }
 
-      // Synthetic session ids (`local-*`, `proxy-*`) are hidden from
-      // /api/sessions and /api/sessions/live. Exclude them here too so
-      // `allTimePeak` can't be inflated by sessions that never appear
-      // anywhere else in the UI — it must stay comparable to `peak`, which
-      // is filtered the same way below.
+      // loadAllSessions() already excludes synthetic session ids (`local-*`,
+      // `proxy-*`, `pending-*`) — same producer-level guarantee that keeps
+      // them out of /api/sessions and /api/sessions/live — so `allTimePeak`
+      // stays comparable to `peak` below without re-filtering here.
       const allSessions = deps.sessionStore?.loadAllSessions?.() ?? [];
-      const filteredAllSessions = (allSessions as readonly SessionIdentityLike[]).filter(
-        (s) => !isSyntheticSessionId(s.sessionId),
-      );
       const allTimePeak = computeTodayPeakConcurrency(
-        filteredAllSessions as readonly SessionActivityLike[],
+        allSessions as readonly SessionActivityLike[],
       );
 
-      // Synthetic session ids (`local-*`, `proxy-*`) are hidden from
-      // /api/sessions and /api/sessions/live. Exclude them from the chart
-      // buckets below so they agree with the session list shown alongside
-      // the chart.
+      // loadTodaySessions() already excludes synthetic session ids, so the
+      // chart buckets below agree with the session list shown alongside the
+      // chart without re-filtering here.
       const todaySessions = deps.sessionStore?.loadTodaySessions() ?? [];
-      const filteredTodaySessions = todaySessions.filter((s) => !isSyntheticSessionId(s.sessionId));
 
       // 96 × 15-minute fixed-grid buckets covering today (local midnight →
       // local midnight + 24h). Each bucket holds the peak concurrent
@@ -1575,13 +1570,10 @@ export function createApiHandler(
       // renders cleanly at any zoom level. Replaces the prior unbounded
       // 30-second rolling timeSeries.
       const startTimestamp = localStartOfDay();
+      // getLiveSessions() already excludes synthetic session ids too.
       const liveIds = deps.liveSessionRegistry?.getLiveSessions() ?? [];
       const bufferRecords = deps.toolCallBuffer?.getRecords() ?? [];
-      const windows = collectTodayActivityWindows(
-        filteredTodaySessions,
-        liveIds.filter((id) => !isSyntheticSessionId(id)),
-        bufferRecords,
-      );
+      const windows = collectTodayActivityWindows(todaySessions, liveIds, bufferRecords);
       const buckets = computeTodayConcurrencyBuckets(windows, startTimestamp);
       // Derive the headline "today peak" from the SAME buckets shown in the
       // chart — rather than from an independent computation over a

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -471,6 +471,28 @@ describe('setupDashboardPostBind()', () => {
     clearInterval(handle);
   });
 
+  it('requests synthetic session ids from the registry so their buffers survive GC', () => {
+    // getLiveSessions() now defaults to filtering out local-*/proxy-*/pending-
+    // ids for dashboard display, but the orphan-buffer GC pass must keep
+    // seeing every live session — including synthetic ones still mid-flight
+    // in --local / proxy mode — or it would delete their active buffer files.
+    const { store, gcOrphanBuffers } = makeLocalStore();
+    const getLiveSessions = jest.fn(
+      (_options?: { includeSynthetic?: boolean }) => new Set(['proxy-1234567890']),
+    );
+    const liveSessionRegistry = {
+      getLiveSessions,
+    } as unknown as Parameters<typeof setupDashboardPostBind>[1]['liveSessionRegistry'];
+    const handle = setupDashboardPostBind(
+      { address: '127.0.0.1', port: 7777 },
+      { localStore: store, liveSessionRegistry, openOnStart: false, isLocalMode: false },
+    );
+    expect(getLiveSessions).toHaveBeenCalledWith({ includeSynthetic: true });
+    const liveArg = gcOrphanBuffers.mock.calls[0]?.[0] as Set<string>;
+    expect(liveArg.has('proxy-1234567890')).toBe(true);
+    clearInterval(handle);
+  });
+
   it('writes the local-dashboard pid file when isLocalMode is true', () => {
     const { store, writeLocalDashboardPid } = makeLocalStore();
     const handle = setupDashboardPostBind(

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,7 +282,9 @@ export function setupDashboardPostBind(
       localStore.gcDeadLocalInstances();
       const live = localStore.getActiveSessionIdsFromHeartbeats();
       if (liveSessionRegistry) {
-        for (const id of liveSessionRegistry.getLiveSessions()) live.add(id);
+        for (const id of liveSessionRegistry.getLiveSessions({ includeSynthetic: true })) {
+          live.add(id);
+        }
       }
       localStore.gcOrphanBuffers(live);
     } catch (err) {

--- a/src/metrics/live-session-registry.test.ts
+++ b/src/metrics/live-session-registry.test.ts
@@ -61,6 +61,39 @@ describe('LiveSessionRegistry', () => {
     expect(reg.getLiveSessions()).toEqual([]);
   });
 
+  it('getLiveSessions excludes synthetic session IDs by default', () => {
+    const reg = new LiveSessionRegistry();
+    reg.touch('real-session');
+    reg.touch('local-1234567890');
+    reg.touch('proxy-9876543210');
+    reg.touch('pending-1111111111');
+    expect(reg.getLiveSessions()).toEqual(['real-session']);
+  });
+
+  it('getLiveSessions({ includeSynthetic: true }) returns every live session', () => {
+    const reg = new LiveSessionRegistry();
+    reg.touch('real-session');
+    reg.touch('local-1234567890');
+    const all = reg.getLiveSessions({ includeSynthetic: true });
+    expect(all).toEqual(expect.arrayContaining(['real-session', 'local-1234567890']));
+    expect(all).toHaveLength(2);
+  });
+
+  it('getPeakConcurrent() still counts synthetic sessions (unfiltered internal tracking)', () => {
+    const reg = new LiveSessionRegistry(5000);
+    reg.touch('local-a');
+    reg.touch('local-b');
+    reg.touch('real-c');
+    expect(reg.getPeakConcurrent()).toBe(3);
+  });
+
+  it('getConcurrentCount() still counts synthetic sessions (unfiltered internal tracking)', () => {
+    const reg = new LiveSessionRegistry(5000);
+    reg.touch('local-a');
+    reg.touch('proxy-b');
+    expect(reg.getConcurrentCount()).toBe(2);
+  });
+
   it('reset() clears all tracked sessions', () => {
     const reg = new LiveSessionRegistry();
     reg.touch('sess-a');

--- a/src/metrics/live-session-registry.ts
+++ b/src/metrics/live-session-registry.ts
@@ -4,6 +4,7 @@
  */
 
 import { basename } from 'node:path';
+import { isSyntheticSessionId } from '../hooks/session-resolver.js';
 
 const DEFAULT_STALE_THRESHOLD_MS = 180_000; // 3 minutes
 const MAX_CONCURRENCY_SAMPLES = 2880; // 24h at 30s intervals
@@ -34,7 +35,7 @@ export class LiveSessionRegistry {
         this.sessionNames.set(sessionId, name);
       }
     }
-    const liveCount = this.getLiveSessions().length;
+    const liveCount = this.getLiveSessions({ includeSynthetic: true }).length;
     if (liveCount > this.peakConcurrent) {
       this.peakConcurrent = liveCount;
     }
@@ -52,7 +53,7 @@ export class LiveSessionRegistry {
     return this.lastActivity.get(sessionId) ?? null;
   }
 
-  getLiveSessions(): string[] {
+  getLiveSessions(options?: { includeSynthetic?: boolean }): string[] {
     const now = Date.now();
     const live: string[] = [];
     const stale: string[] = [];
@@ -67,7 +68,12 @@ export class LiveSessionRegistry {
       this.lastActivity.delete(id);
       this.sessionNames.delete(id);
     }
-    return live;
+    // Synthetic session IDs (`local-*`, `proxy-*`, `pending-*`) are
+    // MCP-internal bookkeeping from --local / proxy modes, not real Claude
+    // Code sessions — dashboard consumers shouldn't see them as clickable
+    // rows. Default to filtered; internal peak/count tracking opts into
+    // `includeSynthetic: true` to keep its numbers unchanged.
+    return options?.includeSynthetic ? live : live.filter((id) => !isSyntheticSessionId(id));
   }
 
   reset(): void {
@@ -89,7 +95,7 @@ export class LiveSessionRegistry {
   startSampling(): void {
     if (this.samplingInterval) return;
     this.samplingInterval = setInterval(() => {
-      const count = this.getLiveSessions().length;
+      const count = this.getLiveSessions({ includeSynthetic: true }).length;
       this.concurrencyTimeSeries.push({ timestamp: Date.now(), count });
       if (this.concurrencyTimeSeries.length > MAX_CONCURRENCY_SAMPLES) {
         this.concurrencyTimeSeries.shift();
@@ -106,7 +112,7 @@ export class LiveSessionRegistry {
   }
 
   getConcurrentCount(): number {
-    return this.getLiveSessions().length;
+    return this.getLiveSessions({ includeSynthetic: true }).length;
   }
 
   getPeakConcurrent(): number {

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -323,6 +323,59 @@ describe('SessionStore', () => {
     expect(all.map((s) => s.sessionId)).toEqual(['s1', 's3', 's2']);
   });
 
+  it('loadAllSessions excludes synthetic session IDs (local-/proxy-/pending- prefixes)', () => {
+    const store = new SessionStore({ storagePath: tmpDir });
+
+    store.saveSession(makeSummary({ sessionId: 'real-session-1', startTime: Date.now() - 3000 }));
+    store.saveSession(makeSummary({ sessionId: 'local-1234567890', startTime: Date.now() - 2000 }));
+    store.saveSession(makeSummary({ sessionId: 'proxy-9876543210', startTime: Date.now() - 1500 }));
+    store.saveSession(
+      makeSummary({ sessionId: 'pending-1111111111', startTime: Date.now() - 1000 }),
+    );
+    store.saveSession(makeSummary({ sessionId: 'real-session-2', startTime: Date.now() - 500 }));
+
+    const all = store.loadAllSessions();
+    expect(all.map((s) => s.sessionId).sort()).toEqual(['real-session-1', 'real-session-2']);
+  });
+
+  it('loadTodaySessions excludes synthetic session IDs', () => {
+    const store = new SessionStore({ storagePath: tmpDir });
+    const now = Date.now();
+
+    store.saveSession(makeSummary({ sessionId: 'real-today', startTime: now - 1000 }));
+    store.saveSession(makeSummary({ sessionId: 'local-today', startTime: now - 500 }));
+
+    const sessions = store.loadTodaySessions();
+    expect(sessions.map((s) => s.sessionId)).toEqual(['real-today']);
+  });
+
+  it('loadSessionsOverlappingToday excludes synthetic session IDs', () => {
+    const store = new SessionStore({ storagePath: tmpDir });
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const startOfToday = today.getTime();
+
+    // Started yesterday, ends after today's midnight — real overlapping session.
+    store.saveSession(
+      makeSummary({
+        sessionId: 'real-overlap',
+        startTime: startOfToday - 3_600_000,
+        endTime: startOfToday + 3_600_000,
+      }),
+    );
+    // Same overlap window, but a synthetic ID — must still be excluded.
+    store.saveSession(
+      makeSummary({
+        sessionId: 'proxy-overlap',
+        startTime: startOfToday - 3_600_000,
+        endTime: startOfToday + 3_600_000,
+      }),
+    );
+
+    const sessions = store.loadSessionsOverlappingToday();
+    expect(sessions.map((s) => s.sessionId)).toEqual(['real-overlap']);
+  });
+
   it('saveSession rejects sessionId containing path traversal and writes no file', () => {
     const store = new SessionStore({ storagePath: tmpDir });
 

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -16,6 +16,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { join, resolve, sep } from 'node:path';
 import { createLogger } from '../shared/index.js';
 import { redactSensitive } from '../config.js';
+import { isSyntheticSessionId } from '../hooks/session-resolver.js';
 import type { SessionSummary, ReplayTimelineEntry } from './types.js';
 import type { SessionTracker } from '../metrics/session-tracker.js';
 import type { CostTracker } from '../metrics/cost-tracker.js';
@@ -216,6 +217,16 @@ export class SessionStore {
         const raw = readFileSync(join(this.sessionsDir, file), 'utf-8');
         const session = deserializeSession(raw);
         if (!session) continue;
+
+        // Synthetic session IDs (`local-*`, `proxy-*`, `pending-*`) are
+        // MCP-internal bookkeeping from --local / proxy modes, never a real
+        // Claude Code session. persistSession() in src/index.ts already
+        // refuses to write new ones; any that still exist on disk are stale
+        // artifacts from before that guard shipped. Filtering them here
+        // means every consumer of this loader (and of loadTodaySessions() /
+        // loadSessionsOverlappingToday(), which both delegate to it) gets
+        // clean data without re-implementing the same check.
+        if (isSyntheticSessionId(session.sessionId)) continue;
 
         if (options?.developer && session.developer !== options.developer) continue;
 


### PR DESCRIPTION
## Summary

- Filters synthetic session IDs (`local-*`, `proxy-*`, `pending-*`) inside `SessionStore.loadAllSessions()` instead of at each call site — `loadTodaySessions()` and `loadSessionsOverlappingToday()` both delegate to it, so they're fixed for free.
- Adds an `includeSynthetic` option to `LiveSessionRegistry.getLiveSessions()`, defaulting to filtered; internal peak/count/time-series tracking (`touch()`, `getConcurrentCount()`, `startSampling()`) explicitly opts into `{ includeSynthetic: true }` so those numbers are unchanged.
- Fixes the orphan-buffer GC pass in `src/index.ts` to request `{ includeSynthetic: true }`, so it keeps protecting still-live synthetic-ID session buffers from deletion now that the default is filtered.
- Removes the ad-hoc `isSyntheticSessionId()` filtering from 5 of 6 call sites in `src/dashboard/routes/api-handler.ts`, now that the producers guarantee clean data. The 6th (the current-live-session push in `GET /api/sessions`) reads `SessionTracker`'s own unfiltered sessionId — not backed by either centralized producer — and is left as-is with an explanatory comment.

## Test plan

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)