### PR TITLE
Docs: comment audit cleanup across the codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2026-07-18
+
+### Changed
+
+- Cleaned up outdated, duplicated, and unclear comments across the entire codebase — the metrics engine, MCP server tools and installer, platform adapters, storage, proxy, alerting, transport, security, tracing, digest delivery, and the web dashboard — for accuracy. No user-visible behavior change.
+
 ## [1.6.2] - 2026-07-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/alerts/alert-log.ts
+++ b/src/alerts/alert-log.ts
@@ -50,14 +50,14 @@ export class AlertLog {
     this.pending = this.pending.then(async () => {
       try {
         await this.ensureInitialized();
-        // rotateIfNeeded() can rename log.jsonl → log.jsonl.1 and
-        // a process crash before the appendFile below would lose the
-        // current event (not in .1, not in the new file). Acceptable for
-        // Acceptable trade-off: (a) rotation is rare — tens of MB of alert
-        // history per device — so the crash window is small; (b) the
-        // alternative (write-temp + rename + append) doubles the I/O
-        // cost on every append. Revisit if audit-trail compliance ever
-        // demands stronger durability than "best-effort tail".
+        // rotateIfNeeded() can rename log.jsonl → log.jsonl.1, and a process
+        // crash before the appendFile below would lose the current event
+        // (not in .1, not in the new file). Acceptable trade-off: (a)
+        // rotation is rare — tens of MB of alert history per device — so
+        // the crash window is small; (b) the alternative (write-temp +
+        // rename + append) doubles the I/O cost on every append. Revisit if
+        // audit-trail compliance ever demands stronger durability than
+        // "best-effort tail".
         await this.rotateIfNeeded();
         const line = JSON.stringify(event) + '\n';
         await fs.appendFile(this.path, line, { mode: 0o600 });

--- a/src/alerts/local-alert-engine.ts
+++ b/src/alerts/local-alert-engine.ts
@@ -492,8 +492,11 @@ export class LocalAlertEngine {
       const day = String(d.getDate()).padStart(2, '0');
       return `${y}-${m}-${day}`;
     }
-    // ISO 8601 week — mirrors BudgetTracker.currentPeriodId() exactly so
-    // period keys match when comparing alert engine state to budget thresholds.
+    // ISO 8601 week — the day/week boundary math intentionally matches
+    // BudgetTracker.currentPeriodId() so a period rolls over here at the same
+    // moment BudgetTracker considers it rolled over. The string format itself
+    // doesn't need to match: this key is only ever compared against its own
+    // prior output (above), never against BudgetTracker's period id.
     const utc = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
     const dayOfWeek = utc.getUTCDay() || 7; // 1=Mon … 7=Sun
     utc.setUTCDate(utc.getUTCDate() + 4 - dayOfWeek); // nearest Thursday

--- a/src/alerts/local-alert-rule.ts
+++ b/src/alerts/local-alert-rule.ts
@@ -48,11 +48,13 @@ const antiPatternTypeSchema = z.enum([
 
 const percentileSchema = z.union([z.literal(50), z.literal(95), z.literal(99)]);
 
-// Default to 'session' because the snapshot collector only populates
-// sessionUsd — today/week always read 0 and any rule asking for those
-// periods silently never fires. parseLocalAlertRules logs a warning when
-// today/week is configured so users editing rules.json don't get a silent
-// no-op..
+// Default to 'session'. today/week periods need the snapshot collector to
+// be constructed with a `budgetTracker` dep (see AlertSnapshotCollectorDeps
+// in alert-snapshot-collector.ts) — without it, today/week read 0 forever
+// and the rule silently never fires. loadAlertRulesFromDisk (src/index.ts)
+// still unconditionally warns on any non-'session' costPeriod even though
+// production now wires the budgetTracker dep — that warning predates the
+// fix and hasn't been reconciled with it.
 const costPeriodSchema = z.enum(['session', 'today', 'week']).default('session');
 
 // ---------------------------------------------------------------------------

--- a/src/alerts/os-notifier.ts
+++ b/src/alerts/os-notifier.ts
@@ -110,8 +110,10 @@ export class OsNotifier {
           return;
       }
     } catch (err) {
-      // Defensive: notifyXxx() already routes failures through the logger.
-      // Reaching here means an unexpected synchronous throw in our own code.
+      // notifyLinux and notifyWin32 fully catch (and log) their own failures
+      // and never propagate here. notifyDarwin has no try/catch of its own,
+      // so an osascript failure (missing binary, script error) legitimately
+      // reaches here as an async rejection — not just a synchronous throw.
       this.log.warn('os-notifier: unexpected error', {
         error: err instanceof Error ? err.message : String(err),
         platform: this.platform,
@@ -199,9 +201,11 @@ export class OsNotifier {
           if (err) {
             // ENOENT: missing binary (e.g. notify-send not installed).
             // We do NOT log here — the caller decides whether the failure
-            // is interesting. notifyDarwin/notifyLinux propagate to the
-            // try/catch in notify(); notifyWin32 uses the rejection to
-            // pick its fallback.
+            // is interesting. notifyDarwin has no try/catch of its own, so
+            // its rejection propagates up to the try/catch in notify();
+            // notifyLinux and notifyWin32 each catch (and log) their own
+            // failures here and never propagate — notifyWin32 uses the
+            // rejection to pick its fallback.
             rejectFn(err);
             return;
           }

--- a/src/dashboard/live-event-bus.ts
+++ b/src/dashboard/live-event-bus.ts
@@ -114,12 +114,14 @@ export type LiveEventMap = {
   alert: AlertEvent;
   // Forward-declared, not yet wired: nothing calls bus.emit() for these three
   // event names today, and src/dashboard/routes/sse-handler.ts only
-  // subscribes ('on'/'onWithSeq') the six names above. Reconnecting clients
-  // would still see buffered instances via replayFrom() (which streams every
-  // buffered type regardless of subscription), but a live client connected
-  // when one of these first fires would silently miss it. Before wiring an
-  // emitter for any of these three, also add the matching bus.on(...)/
-  // bus.onWithSeq(...) subscription (and SSE frame forwarding) in
+  // subscribes ('on'/'onWithSeq') 'tool-call', 'cost-update', 'anti-pattern',
+  // 'context-update', and 'alert' — 'heartbeat' isn't a bus subscription at
+  // all; sse-handler generates it locally via its own setInterval. Reconnecting
+  // clients would still see buffered instances via replayFrom() (which streams
+  // every buffered type regardless of subscription), but a live client
+  // connected when one of these first fires would silently miss it. Before
+  // wiring an emitter for any of these three, also add the matching
+  // bus.on(...)/bus.onWithSeq(...) subscription (and SSE frame forwarding) in
   // sse-handler.ts — see its 'tool-call'/'cost-update'/etc. wiring for the
   // pattern to follow.
   'subagent-turn': SubagentTurnEvent;

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1471,7 +1471,7 @@ export function createApiHandler(
   routes.set('GET /api/alerts/recent', async (_req, res) => {
     // 404 (not 503) when alerts are not configured — the route does not
     // exist as a logical resource in cloud-only mode or when alerts are
-    // disabled. Plan §8 acceptance criterion calls for 404.
+    // disabled.
     if (!deps.alertLog) {
       res.writeHead(404, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ error: 'not_found' }));

--- a/src/dashboard/subagent-timeline-store.test.ts
+++ b/src/dashboard/subagent-timeline-store.test.ts
@@ -435,7 +435,7 @@ describe('SubagentTimelineStore.getAgentCalls', () => {
     expect(grep.durationMs).toBeNull();
   });
 
-  it('emits ONLY toolName/timestamp/durationMs/success — no tool inputs or outputs leak (NFR-2)', () => {
+  it('emits ONLY toolName/timestamp/durationMs/success — no tool inputs or outputs leak', () => {
     writeFileSync(
       join(subDir, `agent-${AGENT_A}.jsonl`),
       [

--- a/src/dashboard/subagent-timeline-store.ts
+++ b/src/dashboard/subagent-timeline-store.ts
@@ -114,7 +114,8 @@ export interface SubagentTimeline {
  * A running workflow has NO on-disk `wf_*.json` rollup yet (that is written
  * only at termination), so there are no declared per-agent labels/phases/state
  * to read — the detail route fills those with running-run defaults. Carries
- * only declarative timing/token/tool-count data (NFR-2).
+ * only declarative timing/token/tool-count data — never message content or
+ * prompt text.
  */
 export interface LiveAgentRow {
   readonly agentId: string;

--- a/src/dashboard/workflow-store.test.ts
+++ b/src/dashboard/workflow-store.test.ts
@@ -91,7 +91,7 @@ describe('WorkflowStore', () => {
     expect(row!.agents![0].agent_id).toBe('a45d96d201bf2f1ef');
   });
 
-  it('NEVER exposes user-content fields on agent rows (NFR-2)', () => {
+  it('never exposes user-content fields on agent rows', () => {
     writeFileSync(join(wfDir, 'wf_abc12345-6dd.json'), makeWfJson());
     const store = new WorkflowStore({ projectsDir });
     const row = store.getRun('wf_abc12345-6dd');

--- a/src/dashboard/workflow-store.ts
+++ b/src/dashboard/workflow-store.ts
@@ -8,7 +8,7 @@
  * `--stdio` mode emits the same data to NR; this reader is the local-side
  * mirror so the dashboard works offline.
  *
- * Cheap by construction: stat-then-read with a 24h cutoff and an in-memory
+ * Cheap by construction: stat-then-read with a 30-day cutoff and an in-memory
  * mtime cache. Doesn't load script files (script parsing happens in the
  * watcher and is shipped as part of the NR event; the dashboard reads the
  * declared topology back via NR / live SSE).

--- a/src/digest/digest-sender.ts
+++ b/src/digest/digest-sender.ts
@@ -8,6 +8,9 @@ export async function sendSlackDigest(
   } catch {
     throw new Error('Invalid webhook URL: must be a valid https://hooks.slack.com/ URL');
   }
+  // Pin to Slack's own domain — a misconfigured or tampered `digestWebhookUrl`
+  // must not be able to redirect the weekly summary payload to an arbitrary
+  // HTTPS endpoint.
   if (parsed.protocol !== 'https:' || parsed.hostname !== 'hooks.slack.com') {
     throw new Error('Invalid webhook URL: must be a valid https://hooks.slack.com/ URL');
   }

--- a/src/hooks/subagent-watcher.test.ts
+++ b/src/hooks/subagent-watcher.test.ts
@@ -373,7 +373,7 @@ describe('SubagentWatcher', () => {
     expect(tokenLines[1].messageId).toBe('msg_second');
   });
 
-  it('NFR-2: emitted subagent_token events contain no message content or prompt text', () => {
+  it('emitted subagent_token events contain no message content or prompt text', () => {
     // The source JSONL line contains a full `message` object with content blocks.
     // The emitted event must strip all content fields — only metadata/counts allowed.
     writeFileSync(

--- a/src/hooks/subagent-watcher.ts
+++ b/src/hooks/subagent-watcher.ts
@@ -5,8 +5,8 @@
  *
  * This closes a cost-correctness gap: subagent tokens (visible only
  * inside `~/.claude/projects/<slug>/<sessionId>/subagents/agent-*.jsonl`) never
- * reached `CostTracker.recordTokenUsage()` because the existing collector at
- * `collector-script.ts:178-219 readLastAssistantUsage()` only tails the parent
+ * reached `CostTracker.recordTokenUsage()` because the existing collector's
+ * `readLastAssistantUsage()` in collector-script.ts only tails the parent
  * session's transcript.
  *
  * Watches two paths under each session directory:
@@ -834,8 +834,8 @@ export class SubagentWatcher {
       if (!existsSync(this.storagePath)) {
         mkdirSync(this.storagePath, { recursive: true, mode: 0o700 });
       }
-      // Trim entries older than the re-emission window so the file does not
-      // grow unbounded.
+      // Trim entries older than 24x the re-emission window (24h, since
+      // SCHEMA_FINGERPRINT_REEMIT_MS is 1h) so the file does not grow unbounded.
       const now = Date.now();
       const out: Record<string, number> = {};
       for (const [k, v] of this.seenFingerprints) {

--- a/src/hooks/workflow-script-parser.test.ts
+++ b/src/hooks/workflow-script-parser.test.ts
@@ -121,8 +121,8 @@ describe('parseWorkflowScriptSource', () => {
 
   it('does not count nested parallel inside pipeline() at top level as a separate site', () => {
     // The pipeline() call wraps parallel() — the parser still finds it (regex-only, no AST)
-    // but the PRD §FR-5 contract only promises that top-level literal-array widths are
-    // counted as integers; a nested parallel whose args start with a non-'[' char yields 'dynamic'.
+    // but only top-level literal-array widths are counted as integers; a nested parallel
+    // whose args start with a non-'[' char yields 'dynamic'.
     const src = `
       export const meta = { name: 'nested', phases: [{title:'a',detail:''}] };
       await pipeline(

--- a/src/hooks/workflow-script-parser.ts
+++ b/src/hooks/workflow-script-parser.ts
@@ -14,8 +14,10 @@
  *     number of literal-array thunks if the source is `[a,b,c]`,
  *     otherwise `'dynamic'`.
  *
- * Only **top-level** `parallel()` calls are counted:
- * nested-in-pipeline, `parallel(arr.map(...))`, `Array.from(...)`, and any
+ * Every `parallel(...)` call site found by the flat regex scan is classified
+ * by its own argument syntax, regardless of whether it's nested inside
+ * `pipeline(...)`: a literal array (`parallel([a, b, c])`) counts its
+ * elements; `parallel(arr.map(...))`, `Array.from(...)`, and any other
  * scope-dependent expression yields `'dynamic'`.
  */
 
@@ -151,9 +153,9 @@ export function parseWorkflowScriptSource(source: string): ParseResult {
  *   - `parallel([a, b, c])` → 3 (literal array, count the top-level commas)
  *   - anything else (`.map`, `Array.from`, identifiers, expressions) → 'dynamic'
  *
- * Nested-in-pipeline calls are still counted as separate parallel sites; the
- * top-level-only rule is enforced upstream by skipping the literal
- * count when the parallel call sits inside a pipeline.
+ * A `parallel(...)` call nested inside `pipeline(...)` is found and
+ * classified the same way as any other — there is no pipeline-awareness
+ * here, only argument-syntax matching.
  */
 function extractParallelWidths(body: string): Array<number | 'dynamic'> {
   const out: Array<number | 'dynamic'> = [];

--- a/src/install/install-helper.ts
+++ b/src/install/install-helper.ts
@@ -1,7 +1,9 @@
 /**
- * Pure logic for generating and merging Claude Code hook/MCP settings.
+ * Logic for generating and merging Claude Code hook/MCP settings.
  *
- * All functions are side-effect-free — file I/O happens in the CLI layer (cli.ts).
+ * Most functions are pure/side-effect-free, with file I/O happening in the
+ * CLI layer (cli.ts) or the caller of `readAndCheckHooks`, the one exception
+ * that reads a settings file directly.
  */
 
 import { dirname, join, resolve } from 'node:path';

--- a/src/metrics/anti-patterns.ts
+++ b/src/metrics/anti-patterns.ts
@@ -55,6 +55,10 @@ export interface AntiPatternOptions {
 // Defaults
 // ---------------------------------------------------------------------------
 
+// 3 chosen consistently across all five pattern types as a low-friction
+// threshold — few enough repeats that a flag still means something, but not
+// so few that normal iteration (e.g. one legitimate retry) gets flagged.
+// Tune per-detector via AntiPatternOptions if a specific pattern is too noisy.
 const DEFAULT_THRASH_THRESHOLD = 3;
 const DEFAULT_RE_READ_THRESHOLD = 3;
 const DEFAULT_STUCK_LOOP_THRESHOLD = 3;
@@ -293,6 +297,10 @@ export class AntiPatternDetector {
         (call.isTestCommand || call.isBuildCommand || call.isLintCommand)
       ) {
         if (call.success) {
+          // A successful verification clears streaks for every file, not just
+          // the one being edited — a passing test/build/lint run typically
+          // verifies the whole batch of pending changes at once, not one
+          // file in isolation.
           editStreaks.clear();
         }
       }

--- a/src/metrics/budget-tracker.ts
+++ b/src/metrics/budget-tracker.ts
@@ -102,6 +102,11 @@ export class BudgetTracker {
     return '';
   }
 
+  // A threshold that already fired for a past period (e.g. yesterday's
+  // "daily_80") must not suppress it firing again once a new period starts —
+  // otherwise a session/day/week that repeatedly crosses 50/80/100% would
+  // only ever alert once, ever. Drop any fired-threshold entry whose stored
+  // period ID no longer matches the current one so it's free to fire again.
   private pruneStaleThresholds(): void {
     for (const [key, periodId] of this.firedThresholds.entries()) {
       const period = key.split('_')[0] as BudgetPeriod;

--- a/src/metrics/cost-forecast.ts
+++ b/src/metrics/cost-forecast.ts
@@ -115,6 +115,8 @@ export function buildCostForecastFromInputs(
   const msUntilEndOfWeek = ((7 - isoDay) % 7) * 86_400_000 + msUntilEndOfDay;
   const forecastEndOfWeekUsd = effectiveBaseUsd + effectiveRateUsdPerMs * msUntilEndOfWeek;
 
+  // Assumes a full 8-hour workday as the session-end horizon — there's no
+  // real "end of session" signal to anchor this forecast to otherwise.
   const SESSION_TARGET_MS = 8 * 60 * 60 * 1000;
   const msUntilSessionEnd = Math.max(0, SESSION_TARGET_MS - elapsedMs);
   const forecastSessionEndUsd = sessionSpentUsd + sessionRateUsdPerMs * msUntilSessionEnd;

--- a/src/metrics/cost-per-outcome.ts
+++ b/src/metrics/cost-per-outcome.ts
@@ -70,6 +70,10 @@ export interface TaskOutcomeEvent {
 // Constants
 // ---------------------------------------------------------------------------
 
+// Rough, deliberately conservative estimates of developer hours an AI-assisted
+// task of this outcome type would otherwise take by hand — there's no way to
+// measure this directly, so ROI figures derived from it are an approximation,
+// not a precise measurement. Callers can override via the constructor.
 const DEFAULT_HOURS_SAVED: Record<OutcomeType, number> = {
   bug_fix: 2,
   feature: 4,
@@ -249,9 +253,6 @@ export class CostPerOutcomeAnalyzer {
     };
   }
 
-  /**
-   * Emit outcome metrics to New Relic.
-   */
   emitMetrics(aggregator: MetricAggregator, tasks: AiCodingTask[], developer: string): void {
     const attribution = this.attributeCosts(tasks);
 
@@ -307,20 +308,34 @@ export interface SessionOutcomeInputs {
 }
 
 export function classifySessionOutcome(s: SessionOutcomeInputs): OutcomeType {
+  // Mirrors classifyOutcome's priority order (see its own per-branch
+  // comments above for the full rationale), adapted to session-level
+  // aggregates instead of a per-task tool-call sequence.
+
+  // Priority 1: failed_attempt — tests ran and never passed.
   if (s.testRunCount > 0 && s.testPassCount === 0) return 'failed_attempt';
+  // Priority 2: bug_fix — tests ran and passed, with files modified. Can't
+  // detect the precise "fail → edit → pass" ordering from aggregates alone
+  // (see SessionOutcomeInputs doc above), so any passing-test session with
+  // edits is treated as bug_fix.
   if (s.testRunCount > 0 && s.testPassCount > 0 && s.filesModified.length > 0) return 'bug_fix';
 
+  // Priority 3: feature — new files created.
   const writeCount = s.toolBreakdown['Write'] ?? 0;
   if (writeCount >= 1 && s.filesModified.length > 0) return 'feature';
 
+  // Priority 4: configuration — only config files modified.
   if (s.filesModified.length > 0 && s.filesModified.every((f) => CONFIG_EXTENSIONS.test(f))) {
     return 'configuration';
   }
+  // Priority 5: documentation — only .md files modified.
   if (s.filesModified.length > 0 && s.filesModified.every((f) => DOC_EXTENSIONS.test(f))) {
     return 'documentation';
   }
+  // Priority 6: refactor — files modified, no test regressions.
   if (s.filesModified.length > 0) return 'refactor';
 
+  // Priority 7: investigation — mostly read/search tools.
   if (s.toolCallCount > 0) {
     const readCount =
       (s.toolBreakdown['Read'] ?? 0) +
@@ -329,6 +344,7 @@ export function classifySessionOutcome(s: SessionOutcomeInputs): OutcomeType {
     if (readCount / s.toolCallCount >= 0.8) return 'investigation';
   }
 
+  // Default
   return 'feature';
 }
 

--- a/src/metrics/decision-tracker.ts
+++ b/src/metrics/decision-tracker.ts
@@ -146,6 +146,11 @@ export class DecisionTracker {
   }
 
   recordOutcome(turnNumber: number, success: boolean): void {
+    // DecisionBranch's fields are `readonly` in its public type (consumers
+    // shouldn't mutate a branch they read out via getMetrics()/getBranches()),
+    // but this class itself needs to fill in the outcome after the branch is
+    // created and its eventual tool result is known — the mapped-type cast
+    // below strips `readonly` for that one internal mutation.
     // Tag the most recent branch at or before this turn
     for (let i = this.branches.length - 1; i >= 0; i--) {
       const branch = this.branches[i];

--- a/src/metrics/git-efficiency-tracker.ts
+++ b/src/metrics/git-efficiency-tracker.ts
@@ -39,6 +39,9 @@ const CHERRY_PICK_ABORT_RE = /\bgit\s+cherry-pick\s+--abort\b/;
 const GIT_PULL_RE = /\bgit\s+pull\b/;
 const GIT_FETCH_RE = /\bgit\s+fetch\b/;
 const GIT_PUSH_RE = /\bgit\s+push\b/;
+// `(?!-)` excludes `--force-with-lease` — without it, a lease-protected force
+// push would also match this plain "unsafe force push" pattern, since
+// "--force-with-lease" starts with the literal text "--force".
 const GIT_PUSH_FORCE_RE = /\bgit\s+push\s+.*--force(?!-)|\bgit\s+push\s+-f\b/;
 const GIT_PUSH_FORCE_LEASE_RE = /--force-with-lease\b/;
 const GIT_MERGE_RE = /\bgit\s+merge\b/;
@@ -550,6 +553,10 @@ export class GitEfficiencyTracker {
   // Internals
   // -------------------------------------------------------------------------
 
+  // Order matters: several patterns overlap (e.g. a force-push-with-lease
+  // command also matches the plain push/force-push patterns), so more
+  // specific checks must run before the more general ones they'd otherwise
+  // be shadowed by.
   private classifyGitCommand(command: string, record: ToolCallRecord): GitEvent {
     const base = {
       timestamp: record.timestamp,
@@ -757,6 +764,10 @@ export class GitEfficiencyTracker {
     }
   }
 
+  // A pull immediately followed by a conflict means the branch had already
+  // diverged enough that even the act of syncing produced a conflict — a
+  // stronger signal of a stale branch than a conflict from, say, a later
+  // merge or rebase attempted well after the pull.
   private countStaleBranchPulls(): number {
     let staleCount = 0;
     for (let i = 0; i < this.events.length - 1; i++) {
@@ -1286,6 +1297,9 @@ export class GitEfficiencyTracker {
 
     let score = 100;
 
+    // All per-event penalties and caps below are hand-tuned weights reflecting
+    // relative severity (e.g. a conflict is worse than a discard), not derived
+    // from data. Tune here if the resulting score reads as too harsh/lenient.
     const conflictPenalty = Math.min((stats.mergeConflicts + stats.rebaseConflicts) * 10, 40);
     score -= conflictPenalty;
 
@@ -1335,6 +1349,10 @@ export class GitEfficiencyTracker {
       buildBeforePush: this.buildBeforePush,
       // Use the push-time snapshot rather than comparing current timestamps, which go
       // stale when new builds run after the push.
+      // Intentionally the same value as buildBeforePush, not a separate signal:
+      // recordToolCall() tracks build and test commands as one combined
+      // "verification happened" timestamp (isTestCommand || isBuildCommand),
+      // so there's no way to distinguish "tested" from "built" after the fact.
       testBeforePush: this.buildBeforePush,
     };
   }

--- a/src/metrics/instruction-drift-tracker.ts
+++ b/src/metrics/instruction-drift-tracker.ts
@@ -1,3 +1,13 @@
+/**
+ * Instruction Drift Tracking — correlates changes to the active instruction
+ * prompt (CLAUDE.md / system prompt, identified by content hash) with the
+ * outcomes of sessions run under each version, to flag whether a prompt
+ * change measurably helped or hurt. Distinct from ClaudeMdTracker's
+ * before/after window comparison: this tracks per-session outcomes tagged
+ * by exact prompt hash, so it can compare across many prompt variants, not
+ * just the single most recent change.
+ */
+
 import { createHash } from 'node:crypto';
 import { createLogger } from '../shared/index.js';
 import { ClaudeMdTracker } from './claudemd-tracker.js';
@@ -272,6 +282,9 @@ export class InstructionDriftTracker {
         ? toAvg.efficiency - fromAvg.efficiency
         : null;
 
+    // Thresholds below are hand-picked "big enough to matter" cutoffs, not
+    // derived from data — any one signal crossing its threshold is enough to
+    // call the change degraded/improved.
     let verdict: DriftCorrelation['verdict'] = 'neutral';
     if (successDelta !== null) {
       if (successDelta < -0.1 || thrashingDelta > 0.5 || tokensDelta > 5000) {

--- a/src/metrics/latency-decomposition.ts
+++ b/src/metrics/latency-decomposition.ts
@@ -1,3 +1,12 @@
+/**
+ * Latency Decomposition — splits each turn's wall-clock time into where it
+ * was actually spent: waiting on the LLM API, running tool calls, or
+ * `overhead` (everything else — internal processing, queueing, etc. that
+ * isn't directly attributable to either). `overhead` isn't measured
+ * directly; it's the remainder after subtracting the other two from the
+ * turn's total wall-clock duration.
+ */
+
 import type { MetricAggregator } from '../shared/index.js';
 import { computePercentile } from './percentile.js';
 
@@ -75,6 +84,9 @@ export class LatencyDecompositionTracker {
     const wallClockMs = report.turnEndMs - report.turnStartMs;
     const llmApiMs = report.llmApiMs;
     const toolExecutionMs = report.toolExecutionMs;
+    // Clamp at 0 — imprecise/overlapping timing between the LLM API and tool
+    // execution measurements could otherwise sum to slightly more than the
+    // observed wall-clock time, producing a nonsensical negative overhead.
     const overheadMs = Math.max(0, wallClockMs - llmApiMs - toolExecutionMs);
 
     this.llmSamples.push(llmApiMs);

--- a/src/metrics/model-usage-tracker.ts
+++ b/src/metrics/model-usage-tracker.ts
@@ -74,6 +74,11 @@ export class ModelUsageTracker {
         mostUsedModel = model;
       }
 
+      // On an exact tie, prefer the alphabetically-first model name for a
+      // deterministic result regardless of Map iteration order. '￿' (U+FFFF)
+      // sorts after every realistic model name, so `mostEfficientModel ?? '￿'`
+      // always loses the very first comparison and lets the first real
+      // candidate win.
       if (
         costPerOutputToken !== null &&
         (costPerOutputToken < lowestCostPerOutputToken ||

--- a/src/metrics/personal-coach.ts
+++ b/src/metrics/personal-coach.ts
@@ -49,6 +49,8 @@ export type PersonalInsightsResult = PersonalInsightsReport | PersonalInsightsIn
 // ---------------------------------------------------------------------------
 
 const WEEKS_REQUIRED = 2;
+// ~2 months of history — enough for a meaningful baseline mean without
+// diluting it with data old enough to no longer reflect current habits.
 const WEEKS_TO_LOAD = 8;
 
 export class PersonalCoach {
@@ -199,6 +201,10 @@ export class PersonalCoach {
     };
   }
 
+  // buildHighlights/buildRegressions/buildTopRecommendation below gate on
+  // hand-picked deltas (5 points, 15%, 20%, 25%, etc.) chosen to surface
+  // changes big enough to be worth mentioning in a weekly narrative, not
+  // thresholds derived from data. Tune them here if they read as noisy.
   private buildHighlights(
     thisWeek: PersonalWeekMetrics,
     lastWeek: PersonalWeekMetrics | null,

--- a/src/metrics/prompt-feedback.ts
+++ b/src/metrics/prompt-feedback.ts
@@ -86,6 +86,8 @@ export class PromptFeedbackEngine {
    */
   correlatePromptStyleWithOutcomes(
     developer: string,
+    // ~2 months of history — enough sessions for a meaningful with/without
+    // comparison per behavior without diluting it with stale history.
     windowWeeks: number = 8,
   ): PromptCorrelation[] {
     const since = new Date(Date.now() - windowWeeks * 7 * 86_400_000);
@@ -98,6 +100,10 @@ export class PromptFeedbackEngine {
       test: (s: FullSessionSummary) => boolean;
     }> = [
       {
+        // Proxy signal: when the developer names the target file(s) upfront,
+        // the AI doesn't need many Read calls to locate them before editing —
+        // low read-to-total-calls ratio alongside actual file modifications
+        // is treated as evidence the prompt already supplied the path(s).
         name: 'provides file paths',
         test: (s) => {
           if (s.toolCallCount === 0) return false;

--- a/src/metrics/quality-proxy-tracker.ts
+++ b/src/metrics/quality-proxy-tracker.ts
@@ -1,3 +1,16 @@
+/**
+ * Quality Proxy Tracking — since there's no ground-truth "was this good code"
+ * signal, this infers quality from cheap proxy signals observable from tool
+ * calls alone: clean diff applications, test pass/fail, backtracking (re-
+ * reading a file whose edit just failed or broke a test), and self-correction
+ * (re-editing the same file shortly after a test failure).
+ *
+ * Signals are bucketed by turn range so `degradationDetected` can flag a
+ * session whose quality ratio drops significantly from its early buckets to
+ * its late ones — a proxy for "this session went off the rails partway
+ * through," without needing to understand the actual code changes.
+ */
+
 import type { MetricAggregator } from '../shared/index.js';
 import type { ToolCallRecord } from '../storage/types.js';
 
@@ -51,6 +64,9 @@ export interface QualityProxyOptions {
 
 const DEFAULT_BUCKET_SIZE = 10;
 const DEFAULT_MAX_EVENTS = 500;
+// A 30-point drop in quality ratio between the early and late thirds of a
+// session is treated as a meaningful regression, not noise — smaller swings
+// are common turn-to-turn and would make this trigger too often to be useful.
 const DEFAULT_DEGRADATION_THRESHOLD = 0.3;
 
 // ---------------------------------------------------------------------------

--- a/src/metrics/recommendation-engine.ts
+++ b/src/metrics/recommendation-engine.ts
@@ -117,6 +117,8 @@ export class RecommendationEngine {
 
   /**
    * Team-level recommendations aggregating patterns across developers.
+   * Like the per-developer collectors below, the thresholds here are
+   * hand-picked judgment calls, not derived from data.
    */
   generateTeamRecommendations(options?: { since?: Date }): Recommendation[] {
     const recs: Recommendation[] = [];
@@ -174,6 +176,12 @@ export class RecommendationEngine {
 
   // -------------------------------------------------------------------------
   // Sub-analyzer recommendation collectors
+  //
+  // Each method below gates its recommendation behind a hand-picked numeric
+  // threshold (waste ratio, cost delta, efficiency drop, etc.) — these are
+  // heuristic judgment calls about what's worth surfacing to a developer,
+  // not thresholds derived from data. Tune them here if they fire too often
+  // or too rarely in practice.
   // -------------------------------------------------------------------------
 
   private getCostRecommendations(

--- a/src/metrics/retry-detector.ts
+++ b/src/metrics/retry-detector.ts
@@ -1,3 +1,11 @@
+/**
+ * Retry/Thrashing Detection — flags a sliding window of recent tool calls
+ * where the same tool is either failing repeatedly or being called with
+ * near-identical input, both signs of retrying the same broken approach
+ * instead of changing strategy. Similarity between calls is measured with
+ * Levenshtein distance over each call's serialized (non-metadata) fields.
+ */
+
 import type { MetricAggregator } from '../shared/index.js';
 import { createLogger } from '../shared/index.js';
 import type { ToolCallRecord } from '../storage/types.js';
@@ -37,6 +45,10 @@ export interface RetryDetectorOptions {
 const DEFAULT_MIN_OCCURRENCES = 3;
 const DEFAULT_WINDOW_SIZE = 5;
 const DEFAULT_SIMILARITY_THRESHOLD = 0.8;
+// Same rough chars-per-token heuristic used elsewhere in this codebase for
+// estimating token counts without an actual tokenizer (see CostTracker's
+// recordEstimatedTokens). Only used here to estimate wasted tokens for
+// reporting, not for billing, so the approximation is acceptable.
 const BYTES_PER_TOKEN_ESTIMATE = 4;
 
 // ---------------------------------------------------------------------------
@@ -216,6 +228,10 @@ export class RetryDetector {
     return comparisons > 0 ? totalSimilarity / comparisons : 0;
   }
 
+  // Excludes per-call metadata that varies even when the actual tool
+  // input/arguments are identical (timestamps, ids, sizes, error details) —
+  // without stripping these, every call would serialize as "different" and
+  // similarity would never detect a genuine repeated-input retry.
   private serializeInput(record: ToolCallRecord): string {
     const {
       id: _id,

--- a/src/metrics/session-tracker.ts
+++ b/src/metrics/session-tracker.ts
@@ -148,6 +148,8 @@ export class SessionTracker {
     if (record.durationMs !== null && record.durationMs !== undefined) {
       const durations = this.toolDurationsByTool.get(tool);
       if (durations) {
+        // Bounds memory per tool — 500 samples is already far more than
+        // needed for a stable p95 within one session.
         if (durations.length < 500) durations.push(record.durationMs);
       } else {
         this.toolDurationsByTool.set(tool, [record.durationMs]);

--- a/src/metrics/turn-cost-attributor.ts
+++ b/src/metrics/turn-cost-attributor.ts
@@ -38,8 +38,17 @@ export interface CostAttributionMetrics {
 // Constants
 // ---------------------------------------------------------------------------
 
+// Tool calls within this gap of each other are treated as one "turn" (one
+// LLM response driving a burst of tool use). Chosen to bridge normal
+// back-to-back tool latency without merging genuinely separate turns.
 const TURN_GAP_MS = 2_000;
+// A token event is attributed to the pending turn only if it arrives within
+// this window after the turn's last tool call — token usage is reported
+// asynchronously, so some slack is needed, but too much risks attributing
+// a later turn's tokens to this one.
 const TOKEN_MATCH_WINDOW_MS = 5_000;
+// Bounds memory for long sessions; only the most recent turns are needed for
+// the cost-by-tool-type breakdown this class serves.
 const MAX_TURNS = 200;
 
 // ---------------------------------------------------------------------------
@@ -88,6 +97,10 @@ export class TurnCostAttributor {
   recordTokenEvent(event: TokenEvent): void {
     if (!this.pendingTurn) return;
 
+    // A token event outside the match window can't be reliably tied to the
+    // pending turn — silently drop it rather than risk mis-attributing cost
+    // to the wrong turn. Dropped events show up as a lower `attributionRate`
+    // in getMetrics(), not as an error.
     const timeSinceLastTool = event.timestamp - this.pendingTurn.endTime;
     if (timeSinceLastTool < 0 || timeSinceLastTool > TOKEN_MATCH_WINDOW_MS) return;
 

--- a/src/metrics/turn-tracker.ts
+++ b/src/metrics/turn-tracker.ts
@@ -28,7 +28,13 @@ export interface TurnMetrics {
   readonly turnsByToolCount: Record<number, number>;
 }
 
+// Tool calls within this gap of each other are grouped into the same "turn"
+// (one LLM response driving a burst of tool use) rather than starting a new
+// one. Chosen to bridge normal back-to-back tool latency.
 const DEFAULT_GAP_THRESHOLD_MS = 2000;
+// When a call's real duration isn't known yet, assume it occupies this much
+// time for the purposes of gap/parallelism computation — an unmeasured call
+// shouldn't be treated as if it ended instantly.
 const NULL_DURATION_BUFFER_MS = 500;
 const MAX_RECENT_TURNS = 20;
 

--- a/src/metrics/workflow-run-tracker.ts
+++ b/src/metrics/workflow-run-tracker.ts
@@ -386,8 +386,8 @@ export class WorkflowRunTracker {
   /**
    * Find the most-recently-started run in the same session whose
    * [started_at, started_at + duration_ms] window encloses `timestamp`.
-   * Falls back to the most recent run that started before `timestamp` when
-   * no window encloses it (best-effort attribution).
+   * Returns null (no attribution) when no run's window encloses it — this is
+   * a strict window check, not a nearest-run fallback.
    */
   private findEnclosingRun(sessionId: string, timestamp: number): MutableRun | null {
     let best: MutableRun | null = null;

--- a/src/platforms/generic-mcp-adapter.ts
+++ b/src/platforms/generic-mcp-adapter.ts
@@ -91,7 +91,6 @@ export function validateReportToolCallInput(raw: unknown): ReportToolCallInput {
   if (typeof obj.success !== 'boolean') {
     throw new Error('Missing required field: success');
   }
-  // Validate optional numeric fields
   if (obj.input_size_bytes !== undefined && typeof obj.input_size_bytes !== 'number') {
     throw new Error('Field input_size_bytes must be a number when present');
   }
@@ -104,11 +103,9 @@ export function validateReportToolCallInput(raw: unknown): ReportToolCallInput {
   if (obj.timestamp !== undefined && typeof obj.timestamp !== 'number') {
     throw new Error('Field timestamp must be a number when present');
   }
-  // Validate optional string fields
   if (obj.error !== undefined && typeof obj.error !== 'string') {
     throw new Error('Field error must be a string when present');
   }
-  // Validate optional input object
   if (obj.input !== undefined && (typeof obj.input !== 'object' || obj.input === null)) {
     throw new Error('Field input must be an object when present');
   }

--- a/src/proxy/otlp-receiver.ts
+++ b/src/proxy/otlp-receiver.ts
@@ -324,11 +324,11 @@ export class OtlpReceiver {
       timestamps.shift();
     }
 
-    // Check if rate limit exceeded. Every distinct source IP that ever makes
-    // one request would otherwise leave a permanent (if empty) entry in
-    // this.rateLimiter for the process lifetime — delete rather than
-    // re-insert an empty array before throwing, so a rejected/aged-out IP
-    // doesn't occupy a Map slot forever.
+    // Check if rate limit exceeded. This only reaches a genuinely empty
+    // `timestamps` when rateLimitPerMinute is configured at or below 0
+    // (deny-all) — delete rather than re-insert that empty array before
+    // throwing, so a permanently-rejected IP doesn't occupy a Map slot
+    // for the process lifetime.
     if (timestamps.length >= rateLimitPerMinute) {
       if (timestamps.length === 0) {
         this.rateLimiter.delete(remoteAddr);

--- a/src/security/audit-trail.ts
+++ b/src/security/audit-trail.ts
@@ -132,8 +132,10 @@ function buildDetail(record: ToolCallRecord): string {
 
   // Redact at the source so every downstream egress (NR Events API,
   // NR Logs API, persisted on-disk audit log) sees only scrubbed strings.
-  // detectSecurityAlert runs against the raw record before this is invoked,
-  // so pattern matching still works correctly against unredacted input.
+  // Call-order-independent: this only reads record.filePath/command and
+  // returns a new string — it never mutates `record` itself, so
+  // detectSecurityAlert() (called separately against the same `record`)
+  // still sees the original unredacted values no matter which runs first.
   if (filePath) return `${tool} ${redactSensitive(filePath)}`;
   if (command) return `${tool}: ${redactSensitive(command)}`;
   if (agentDescription) return `${tool}: ${redactSensitive(agentDescription)}`;

--- a/src/tools/analytics-tools.ts
+++ b/src/tools/analytics-tools.ts
@@ -6,6 +6,7 @@
  *   - nr_observe_get_latency_percentiles — tool call latency percentiles
  *   - nr_observe_get_task_completion_rate — task lifecycle metrics
  *   - nr_observe_get_model_usage — per-model usage and efficiency
+ *   - nr_observe_get_context_tracking — per-turn context token growth and breakdown
  */
 
 import type { ContextWindowTracker } from '../metrics/context-window-tracker.js';

--- a/src/tools/cost-tools.ts
+++ b/src/tools/cost-tools.ts
@@ -4,6 +4,9 @@
  * Defines:
  *   - `nr_observe_report_tokens` — self-report token usage for cost tracking
  *   - `nr_observe_get_cost_breakdown` — session cost breakdown by task
+ *   - `nr_observe_get_budget_status` — spend vs. configured budget caps
+ *   - `nr_observe_get_cost_forecast` — projected spend for day/week/session
+ *   - `nr_observe_get_prompt_cache_health` — cache hit rate and recommendation
  */
 
 import type { CostTracker } from '../metrics/cost-tracker.js';

--- a/src/tools/cross-session-tools.ts
+++ b/src/tools/cross-session-tools.ts
@@ -6,7 +6,8 @@
  *   nr_observe_get_claudemd_impact, nr_observe_get_cost_per_outcome,
  *   nr_observe_get_recommendations, nr_observe_get_platform_comparison,
  *   nr_observe_get_team_summary, nr_observe_subscribe_digest,
- *   nr_observe_unsubscribe_digest, nr_observe_send_digest
+ *   nr_observe_unsubscribe_digest, nr_observe_send_digest,
+ *   nr_observe_get_personal_insights
  *
  * Tool defs and handlers are exported for integration into the main
  * registerTools() in session-stats.ts.

--- a/src/tools/session-stats.ts
+++ b/src/tools/session-stats.ts
@@ -1,10 +1,11 @@
 /**
- * MCP tool handlers for session observability and cost tracking.
- *
- * Registers tools based on which trackers are provided:
- *   - nr_observe_get_session_stats  — current session metrics snapshot
- *   - nr_observe_get_session_timeline — recent tool call timeline
- *   - nr_observe_report_tokens — self-report token usage for cost tracking
+ * `registerTools()` — the MCP server's main tool registry. Builds the
+ * `tools/list` response and `tools/call` dispatch from whichever trackers
+ * were constructed for this session (session stats/timeline, health,
+ * config, install-hooks, git efficiency, and every cost/workflow/cross-session/
+ * analytics/extended-analytics tool re-exported from the sibling files in
+ * this directory) — each tool is only advertised when its backing tracker
+ * is present.
  */
 
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -148,7 +148,7 @@ export interface TodayAggregateResponse {
 
 // /api/sessions returns a heterogeneous mix of full persisted session
 // summaries and small live-session stub objects (see the route handler at
-// api-handler.ts:641) — only sessionId is guaranteed present on every item.
+// api-handler.ts:911) — only sessionId is guaranteed present on every item.
 export interface SessionListEntry {
   readonly sessionId: string;
   readonly sessionName?: string | null;
@@ -412,8 +412,7 @@ export const fetchRecentAlerts = (): Promise<AlertEvent[]> =>
   getJson<AlertEvent[]>('/api/alerts/recent');
 export const fetchSessionReplay = (id: string): Promise<SessionReplayResponse> =>
   getJson<SessionReplayResponse>(`/api/sessions/${encodeURIComponent(id)}/replay`);
-// Mirrors GET /api/sessions/:sessionId/subagents `agents[]`. Readonly to
-// match the dashboard's immutable-data-shape convention.
+// Mirrors GET /api/sessions/:sessionId/subagents `agents[]`.
 export interface AgentSpan {
   readonly agentId: string;
   readonly workflowRunId: string | null;
@@ -438,7 +437,7 @@ export interface SessionSubagentsResponse {
 export const fetchSessionSubagents = (id: string): Promise<SessionSubagentsResponse> =>
   getJson<SessionSubagentsResponse>(`/api/sessions/${encodeURIComponent(id)}/subagents`);
 
-// GET /api/sessions/:id/agents/:agentId/calls → { calls: [...] }. No
+// GET /api/sessions/:id/subagents/:agentId/calls → { calls: [...] }. No
 // file/command detail in this wire shape (kept lean for the per-agent
 // fetch); GanttTimeline tolerates the missing optional fields.
 export interface AgentCall {
@@ -925,7 +924,6 @@ export const qk = {
   modelUsage: ['model-usage'] as const,
   cacheHealth: ['cache-health'] as const,
   settings: ['settings'] as const,
-  // Query keys for live session and today aggregate endpoints
   sessionsLive: ['sessions', 'live'] as const,
   sessionsTodayAggregate: ['sessions', 'today', 'aggregate'] as const,
   workflows: ['workflows'] as const,

--- a/src/web/components/GanttTimeline.tsx
+++ b/src/web/components/GanttTimeline.tsx
@@ -22,22 +22,24 @@ interface GanttTimelineProps {
   readonly segments: GanttSegment[];
   // Optional shared time window. When BOTH are provided, bars are positioned by
   // absolute timestamp within [windowStartMs, windowEndMs] and ticks are based
-  // on that window — used to align this gantt against another chart (e.g. the
-  // subagent swimlane) on a single shared x-scale. When omitted, the timeline
+  // on that window — used to align this gantt with its sibling GanttTimeline
+  // instances (the parent lane plus every subagent's nested calls) under
+  // SessionTrace's single shared TraceAxis. When omitted, the timeline
   // self-computes its window from first..last entry (unchanged legacy behavior).
   readonly windowStartMs?: number;
   readonly windowEndMs?: number;
   // When false, the top tick-axis row is omitted so this gantt can be embedded
   // UNDER a shared axis owned by a sibling timeline (e.g. nested agent calls in
-  // SessionTrace, where only the parent gantt draws ticks). Defaults to true,
-  // which keeps the legacy standalone behavior (Today view, replay, etc.)
-  // byte-for-byte identical for any caller that doesn't pass it.
+  // SessionTrace, where only the parent gantt draws ticks). Defaults to true;
+  // SessionTrace (the only production caller) always passes false, so the
+  // `true` standalone layout is currently exercised only by this component's
+  // own tests.
   readonly showTicks?: boolean;
   // Tailwind width class for the left gutter (axis spacer + row label column).
-  // Defaults to 'w-24' so standalone callers (Today view, replay) keep their
-  // exact layout. SessionTrace passes a wider gutter so its (longer) agent
-  // labels don't truncate AND so every chart it renders — parent lane, nested
-  // agent-call ganttes — column-aligns with its own axis and collapsed bars.
+  // Defaults to 'w-24'. SessionTrace (the only production caller) always
+  // passes a wider gutter so its (longer) agent labels don't truncate AND so
+  // every chart it renders — parent lane, nested agent-call ganttes —
+  // column-aligns with its own axis and collapsed bars.
   readonly gutterClass?: string;
 }
 
@@ -145,8 +147,10 @@ export function GanttTimeline({
   const MAX_TICKS = 8;
   const candidates = [10_000, 30_000, 60_000, 120_000, 300_000, 600_000, 900_000, 1_800_000];
   // Find the smallest candidate that gives <= MAX_TICKS ticks.
-  // Fall back to ceil(totalDuration / MAX_TICKS) so short sessions still
-  // get tick marks rather than rendering a blank axis.
+  // Fall back to ceil(totalDuration / MAX_TICKS) for sessions longer than the
+  // largest candidate can support (30 min * MAX_TICKS = 4h) — otherwise the
+  // axis would be capped at that coarsest fixed interval and render far more
+  // than MAX_TICKS ticks.
   const tickIntervalMs =
     candidates.find((c) => totalDuration / c <= MAX_TICKS) ?? Math.ceil(totalDuration / MAX_TICKS);
 

--- a/src/web/components/SessionTrace.tsx
+++ b/src/web/components/SessionTrace.tsx
@@ -208,11 +208,12 @@ export function SessionTrace({
     }
   };
 
-  // Reflect the current sets back to a level for aria-pressed. "expanded" when
-  // no group is collapsed AND every agent's calls are open; "agents" when no
-  // group is collapsed and no agent is expanded; otherwise "collapsed" is the
-  // active preset only when every group is shut. When the state matches none of
-  // the presets (mixed manual toggling), no button reads as pressed.
+  // Reflect the current sets back to a level for aria-pressed. "collapsed" when
+  // every group is shut and no agent is expanded; "expanded" when no group is
+  // collapsed AND every agent's calls are open; "agents" when the parent is
+  // shut, every subagent group is open, and no agent is expanded (see below).
+  // When the state matches none of the presets (mixed manual toggling), no
+  // button reads as pressed.
   const activeLevel = useMemo<TraceLevel | null>(() => {
     const hasParent = parentEntries.length > 0;
     const subagentGroupIds = allGroupIds.filter((id) => id !== PARENT_GROUP_ID);
@@ -1070,9 +1071,6 @@ function AgentCallsList({
   );
 }
 
-// Shared collapsible group header used by both views (parent + subagent
-// groups). Accessible <button> with aria-expanded and a lucide chevron. An
-// optional workflow-run status icon renders after the count when supplied.
 // Compact rolled-up metrics cluster shown on the right of a List-mode group or
 // parent header — mirrors the per-agent row columns (turns · tokens · cost ·
 // time). Only the provided fields render, so the Parent line (no per-call
@@ -1102,6 +1100,9 @@ function RollupMetrics({
   );
 }
 
+// Shared collapsible group header used by both views (parent + subagent
+// groups). Accessible <button> with aria-expanded and a lucide chevron. An
+// optional workflow-run status icon renders after the count when supplied.
 function GroupHeader({
   collapsed,
   onToggle,

--- a/src/web/lib/format.ts
+++ b/src/web/lib/format.ts
@@ -91,13 +91,16 @@ export function formatDuration(ms: number): string {
  *
  * - Non-finite values render as the em-dash placeholder used elsewhere in
  *   the SPA so a NaN doesn't bleed into the UI.
- * - Magnitudes ≥ 100 round to whole units; below 100 we keep two decimals
- *   for readability except for clean integers which render bare.
+ * - Magnitudes ≥ 100 round to whole units.
+ * - 10 ≤ magnitude < 100 render with one decimal, smoothing the jump at the
+ *   100 boundary.
+ * - Below 10, clean integers render bare; non-integers keep two decimals
+ *   for readability.
  */
 export function formatNumber(n: number): string {
   if (!Number.isFinite(n)) return '—';
   if (Math.abs(n) >= 100) return n.toFixed(0);
-  if (Math.abs(n) >= 10) return n.toFixed(1); // Smooth 1-decimal tier prevents jump at 100 boundary
+  if (Math.abs(n) >= 10) return n.toFixed(1);
   if (Number.isInteger(n)) return String(n);
   return n.toFixed(2);
 }

--- a/src/web/store/liveStore.ts
+++ b/src/web/store/liveStore.ts
@@ -30,9 +30,10 @@ export interface AntiPatternEvent {
   readonly count: number;
 }
 
-// Mirror of the AlertEvent shape from src/dashboard/live-event-bus.ts. Kept
-// local to the SPA to keep the web bundle decoupled from the server tree —
-// see CLAUDE.md "Type imports" guidance.
+// Mirror of the AlertEvent shape from src/dashboard/live-event-bus.ts, minus
+// its optional `sessionId` — alerts aren't session-scoped client-side (every
+// firing alert is shown regardless of which session triggered it). Kept
+// local to the SPA to keep the web bundle decoupled from the server tree.
 export interface AlertEvent {
   readonly id: string;
   readonly state: 'firing' | 'cleared';

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -524,8 +524,8 @@ export function buildOutcomeData(
 /**
  * Pad daily-cost data to a fixed window of `days` columns ending today.
  * Days with no recorded cost are emitted with `cost: 0` so the chart
- * renders a 30-column bar chart instead of stretching a single bar to
- * fill the entire plot area.
+ * renders a full `days`-column bar chart instead of stretching a single
+ * bar to fill the entire plot area.
  */
 export function padDailyCostWindow(
   data: Array<{ day: string; cost: number }>,
@@ -669,8 +669,9 @@ export function aggregateToolUsage(rows: SessionRow[]): Array<{ tool: string; co
 // Tooltip positioning here was previously `left: tooltip.x` (raw px in
 // viewBox units), which misaligned by hundreds of pixels at any non-native
 // render width. Routing through the shared `DiscreteBlockChart` fixes that
-// for free — the shared component uses %-based positioning that survives
-// the SVG's `xMidYMax meet` scaling.
+// for free — the shared component measures the rendered column via
+// `getBoundingClientRect` instead of deriving position from the viewBox,
+// so it survives the SVG's `xMidYMax meet` scaling.
 function ConcurrencyBlockChart({
   data,
 }: {

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -136,8 +136,9 @@ function readSessionParam(search: string): string | null {
   let raw: string | null;
   try {
     const params = new URLSearchParams(search);
-    // `?session=` is the cross-view contract with the Workflows view; `?id=`
-    // is the pre-existing param this view already honored.
+    // `?session=` was the contract with the former Workflows view (since
+    // consolidated into this one); `?id=` is the pre-existing param this
+    // view already honored. Both still work for deep-linking in.
     raw = params.get('session') ?? params.get('id');
   } catch {
     return null;
@@ -198,7 +199,7 @@ export function Sessions(): JSX.Element {
   const [runSourceFilter, setRunSourceFilter] = useState<RunSource>('all');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
 
-  // 6a: in-place workflow-run drawer. Opening a run anywhere in this view sets
+  // In-place workflow-run drawer. Opening a run anywhere in this view sets
   // this id and overlays WorkflowRunDetail at the Sessions root rather than
   // navigating to the Workflows route — closing it returns the user to the
   // exact session they were viewing.
@@ -213,8 +214,8 @@ export function Sessions(): JSX.Element {
   const [expandedSessions, setExpandedSessions] = useState<Set<string>>(() => new Set());
   const [expandedRuns, setExpandedRuns] = useState<Set<string>>(() => new Set());
 
-  // React to query-param changes after mount, so deep-linking in from the
-  // Workflows view (?session=<id>) selects the right session even when this
+  // React to query-param changes after mount, so deep-linking in via
+  // ?session=<id> (or ?id=<id>) selects the right session even when this
   // view is already mounted.
   const sessionParam = useMemo(() => readSessionParam(search), [search]);
   useEffect(() => {
@@ -342,7 +343,7 @@ export function Sessions(): JSX.Element {
     });
   }, []);
 
-  // 6a: open the run as an in-place overlay drawer (no route change) so closing
+  // Opens the run as an in-place overlay drawer (no route change) so closing
   // it returns the user to the session they were viewing.
   const openRun = useCallback((runId: string): void => {
     setOpenRunId(runId);
@@ -536,7 +537,7 @@ export function Sessions(): JSX.Element {
         </div>
       </div>
 
-      {/* 6a: in-place workflow-run drawer. Self-contains its backdrop, ESC and
+      {/* In-place workflow-run drawer. Self-contains its backdrop, ESC and
           focus trap (fixed z-50 overlay); we only mount/unmount it. */}
       {openRunId != null && (
         <WorkflowRunDetail runId={openRunId} onClose={() => setOpenRunId(null)} />
@@ -566,7 +567,7 @@ interface SessionListRowProps {
 // A single session row in the master list. Renders the selectable summary
 // button plus a SEPARATE chevron disclosure: clicking the chevron toggles the
 // session's workflow-run subtree and stops propagation so the detail-pane
-// selection is untouched. Workflow runs are lazily fetched only while expanded.
+// selection is untouched.
 function SessionListRow({
   row,
   isLive,
@@ -999,15 +1000,16 @@ function SessionTimeline({
 //   - endMs   = max(last parent activity end, subagents.window.endMs)
 // Guards: parent timeline may be empty (use the subagent window) and the
 // subagent window may be degenerate. Computed unconditionally to keep hook
-// order stable; only consumed on the success branch.
+// order stable; both the fallback (isError/no-data) and success render
+// branches below consume it, each with a different fallback value.
 //
 // Three-state rendering of the subagent fetch (mirrors the loading/error/empty
 // pattern the prior SessionSubagents card used):
 //   - isLoading            → loading affordance.
-//   - isError / no data    → "Subagent timeline unavailable" EmptyState. The
-//     query runs with retry:false, so a disabled subagent watcher (a documented
-//     opt-in v0 state) or a failed fetch settles here. We still render the
-//     parent trace (agents={[]}) so the parent tool calls remain visible.
+//   - isError / no data    → still renders the parent trace (agents={[]})
+//     rather than blanking the section. The query runs with retry:false, so
+//     a disabled subagent watcher (a documented opt-in v0 state) or a failed
+//     fetch settles here immediately.
 //   - success (data set)   → unified SessionTrace (parent lane + subagents) on
 //     the shared window.
 function SessionTraceSection({
@@ -1028,9 +1030,9 @@ function SessionTraceSection({
     refetchInterval: isLive ? 10_000 : false,
   });
 
-  // 6b: workflow run statuses for this session, keyed by runId, so the trace
-  // can badge each run lane with its current status. Reuses the shared
-  // workflows query/key (same cache as SessionWorkflows / the master list).
+  // Workflow run statuses for this session, keyed by runId, so the trace
+  // can badge each run lane with its current status. Reuses the same
+  // qk.workflows query/key as the KPI strip and master-list run tree above.
   const { data: rawWorkflows } = useQuery({
     queryKey: qk.workflows,
     queryFn: fetchWorkflows,
@@ -1052,8 +1054,9 @@ function SessionTraceSection({
 
   // Shared time window spanning both the parent tool-call timeline and the
   // subagent fan-out, so SessionTrace's parent lane + subagent lanes share one
-  // x-scale. Computed unconditionally to keep hook order stable; only consumed
-  // on the success branch.
+  // x-scale. Computed unconditionally to keep hook order stable; both the
+  // fallback (isError/no-data) and success render branches below consume it,
+  // each with a different fallback value.
   const sharedWindow = useMemo<{ startMs: number; endMs: number } | null>(() => {
     const hasAgents = data !== undefined && (data.agents?.length ?? 0) > 0;
     const subStart = hasAgents ? data!.window.startMs : null;

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -918,9 +918,10 @@ function LiveSessionPane({
     }
   }, [replay?.timeline.length, isLive]);
 
-  // Sort today's sessions by startTime descending (newest first), then merge
-  // in any live sessions that haven't yet persisted to disk so the selector
-  // shows them immediately. A session counts as "today" if it started today
+  // Filter to sessions that count as "today", then merge in any live
+  // sessions that haven't yet persisted to disk so the selector shows them
+  // immediately (sort order is applied below, by last activity). A session
+  // counts as "today" if it started today
   // OR is currently live OR had recent activity today (last activity within
   // RECENT_ACTIVITY_MS of now AND falling on today's calendar date).
   //


### PR DESCRIPTION
Closes #234

## Summary

- Cleaned up outdated, duplicated, and unclear comments across the codebase — the metrics engine, MCP server tools and installer, platform adapters, storage, proxy, alerting, transport, security, tracing, digest delivery, and the web dashboard — for accuracy.
- No user-visible behavior change. This is a comment-only change: no logic, no APIs, no tests altered beyond a couple of test-name string fixes.
- Version bump to 1.6.3 with a matching CHANGELOG entry, bundled with this sync per the usual release process.

## Test plan

- [x] npm run build
- [x] npm test
- [x] npm run lint
- [x] npm run format:check