### PR TITLE
Fix TypeScript type errors in the web dashboard source (v1.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.4] - 2026-07-19
+
+### Fixed
+
+- Resolved a batch of TypeScript type errors in the web dashboard's source code that weren't being caught by the project's normal build and lint checks. No user-visible behavior change.
+
 ## [1.6.3] - 2026-07-18
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import type { JSX } from 'react';
 import { Route, Switch, useLocation } from 'wouter';
 import { Sidebar } from './components/Sidebar';
 import { AlertBannerStack } from './components/AlertBannerStack';

--- a/src/web/components/ActivityHeatmap.tsx
+++ b/src/web/components/ActivityHeatmap.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import type { JSX } from 'react';
 
 export interface ActivityHeatmapProps {
   readonly variant: 'strip' | 'grid';

--- a/src/web/components/AgentSwimlanes.tsx
+++ b/src/web/components/AgentSwimlanes.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import type { JSX } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { formatNumber, formatDuration, formatUsdOrDash, shortToolName } from '../lib/format.js';
 import {

--- a/src/web/components/AgentTable.tsx
+++ b/src/web/components/AgentTable.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { JSX } from 'react';
 import { ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
 
 import { formatDuration } from '../lib/format.js';

--- a/src/web/components/AlertBanner.tsx
+++ b/src/web/components/AlertBanner.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent } from 'react';
+import type { JSX, KeyboardEvent } from 'react';
 import { X } from 'lucide-react';
 
 import type { AlertEvent } from '../store/liveStore';

--- a/src/web/components/AlertBannerStack.tsx
+++ b/src/web/components/AlertBannerStack.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import type { JSX } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { AlertBanner } from './AlertBanner';
 import { useLiveAlerts } from '../hooks/useLiveAlerts';

--- a/src/web/components/AnimatedCard.tsx
+++ b/src/web/components/AnimatedCard.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 
 interface AnimatedCardProps {
   readonly children: ReactNode;

--- a/src/web/components/ConcurrencyIndicator.tsx
+++ b/src/web/components/ConcurrencyIndicator.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import type { JSX } from 'react';
 import { DiscreteBlockChart, type DiscreteBlockChartItem } from './DiscreteBlockChart';
 
 import { Card, Eyebrow } from './ui';

--- a/src/web/components/ContextBar.tsx
+++ b/src/web/components/ContextBar.tsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState } from 'react';
+import type { JSX } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchContext, qk, type ContextResponse } from '../api/client';

--- a/src/web/components/DiscreteBlockChart.tsx
+++ b/src/web/components/DiscreteBlockChart.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import type { JSX } from 'react';
 
 /**
  * Shared discrete-block chart used by the Today view's `ConcurrencyIndicator`

--- a/src/web/components/EmptyState.tsx
+++ b/src/web/components/EmptyState.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 type EmptyIcon = 'radar' | 'code' | 'timeline' | 'checkmark' | 'clock';
 
 type EmptyStateVariant = 'empty' | 'loading';

--- a/src/web/components/ErrorBoundary.test.tsx
+++ b/src/web/components/ErrorBoundary.test.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, type MockInstance } from 'vitest';

--- a/src/web/components/GanttTimeline.tsx
+++ b/src/web/components/GanttTimeline.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import type { JSX } from 'react';
 import { shortToolName } from '../lib/format.js';
 
 interface GanttTimelineEntry {

--- a/src/web/components/GeoBanner.tsx
+++ b/src/web/components/GeoBanner.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 export type BannerTheme = 'observatory' | 'sessions' | 'history' | 'audit' | 'git';
 
 export function GeoBanner({ theme = 'observatory' }: { theme?: BannerTheme }): JSX.Element {

--- a/src/web/components/HourlyCostBlocks.tsx
+++ b/src/web/components/HourlyCostBlocks.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { JSX } from 'react';
 
 import { formatUsd } from '../lib/format.js';
 

--- a/src/web/components/Kpi.tsx
+++ b/src/web/components/Kpi.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { useAnimatedValue } from '../hooks/useAnimatedValue';
 
 export type KpiTone = 'neutral' | 'good' | 'warn' | 'bad';

--- a/src/web/components/SessionTrace.tsx
+++ b/src/web/components/SessionTrace.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import type { JSX } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronDown, ChevronRight, CheckCircle2, XCircle, Loader2, Clock } from 'lucide-react';
 

--- a/src/web/components/ShortcutOverlay.tsx
+++ b/src/web/components/ShortcutOverlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import type { JSX } from 'react';
 import { X } from 'lucide-react';
 
 import { Button } from './ui';

--- a/src/web/components/Sidebar.tsx
+++ b/src/web/components/Sidebar.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import {
   Home,
   Clock,

--- a/src/web/components/WorkflowRunDetail.tsx
+++ b/src/web/components/WorkflowRunDetail.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
+import type { JSX } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { X, CheckCircle2, XCircle, Clock, Loader2 } from 'lucide-react';
 import {

--- a/src/web/components/ui/Button.tsx
+++ b/src/web/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import type { ButtonHTMLAttributes, JSX, ReactNode } from 'react';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
 export type ButtonSize = 'sm' | 'md';

--- a/src/web/components/ui/Card.tsx
+++ b/src/web/components/ui/Card.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 
 export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
 export type CardTone = 'default' | 'elevated' | 'static' | 'danger' | 'warning';

--- a/src/web/components/ui/Eyebrow.tsx
+++ b/src/web/components/ui/Eyebrow.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 
 export type EyebrowAs = 'div' | 'h2' | 'h3';
 

--- a/src/web/components/ui/LiveBadge.tsx
+++ b/src/web/components/ui/LiveBadge.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 export type LiveBadgeSize = 'sm' | 'md';
 
 export interface LiveBadgeProps {

--- a/src/web/components/ui/Pill.tsx
+++ b/src/web/components/ui/Pill.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import type { HTMLAttributes, JSX, ReactNode } from 'react';
 
 export type PillTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger';
 export type PillSize = 'sm' | 'md';

--- a/src/web/components/ui/SectionHeader.tsx
+++ b/src/web/components/ui/SectionHeader.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 
 export interface SectionHeaderProps {
   readonly title: ReactNode;

--- a/src/web/components/ui/Tabs.tsx
+++ b/src/web/components/ui/Tabs.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 export type TabsSize = 'sm' | 'md';
 export type TabsTone = 'green' | 'cyan';
 

--- a/src/web/views/Alerts.tsx
+++ b/src/web/views/Alerts.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { JSX } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'wouter';
 

--- a/src/web/views/Audit.tsx
+++ b/src/web/views/Audit.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { JSX } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchAuditLog, qk, type AuditEntry } from '../api/client';
 import { EmptyState } from '../components/EmptyState';

--- a/src/web/views/GitEfficiency.tsx
+++ b/src/web/views/GitEfficiency.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { useQuery } from '@tanstack/react-query';
 import {
   fetchGitEfficiency,

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -932,7 +932,7 @@ describe('aggregateModelPerformance', () => {
 
 describe('aggregateToolUsage', () => {
   it('merges tool breakdowns across sessions and returns top 8', () => {
-    const sessions = [
+    const sessions: Parameters<typeof aggregateToolUsage>[0] = [
       { sessionId: 's1', toolBreakdown: { Read: 10, Edit: 5, Bash: 3 } },
       { sessionId: 's2', toolBreakdown: { Read: 8, Edit: 7, Write: 2 } },
     ];

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { useQuery } from '@tanstack/react-query';
 import {
   ResponsiveContainer,
@@ -207,7 +209,7 @@ export function History(): JSX.Element {
                     empty days. The tooltip already labels the date. */}
                 <Tooltip
                   contentStyle={TOOLTIP_STYLE}
-                  labelFormatter={shortMonthDay}
+                  labelFormatter={(label) => shortMonthDay(String(label))}
                   cursor={false}
                 />
                 <Bar dataKey="cost" fill="url(#costGradient)" radius={[3, 3, 0, 0]} />
@@ -366,7 +368,10 @@ export function History(): JSX.Element {
                     stroke={GRID_STROKE}
                     width={120}
                   />
-                  <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={shortToolName} />
+                  <Tooltip
+                    contentStyle={TOOLTIP_STYLE}
+                    labelFormatter={(label) => shortToolName(String(label))}
+                  />
                   <Bar dataKey="count" radius={[0, 3, 3, 0]}>
                     {topTools.map((entry) => (
                       <Cell

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -564,10 +564,10 @@ describe('Sessions view — workflow consolidation', () => {
     const original = window.location;
     // @ts-expect-error -- test-only reassignment of a read-only global
     delete window.location;
-    window.location = { ...original, search: '?session=sess-b' } as Location;
+    window.location = { ...original, search: '?session=sess-b' } as unknown as string & Location;
     renderSessionsFull(SESSIONS, RUNS);
     await waitFor(() => expect(screen.getByText(/sess-b/)).toBeInTheDocument());
-    window.location = original;
+    window.location = original as unknown as string & Location;
   });
 });
 

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
+import type { JSX } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useSearch } from 'wouter';
 import { ChevronRight, ChevronDown } from 'lucide-react';

--- a/src/web/views/Settings.tsx
+++ b/src/web/views/Settings.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { JSX } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import {

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -716,7 +716,7 @@ describe('Today view — Recent alerts panel', () => {
 
   it('calls /api/alerts/recent and renders an empty state when the log is empty', async () => {
     const fetchSpy = vi.fn(
-      async () =>
+      async (_url: RequestInfo | URL) =>
         new Response(JSON.stringify([]), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -803,7 +803,7 @@ describe('Today view — Recent alerts panel', () => {
   // `retry: false` from Today.tsx would still pass with the default helper.
   it('renders nothing (no error banner) when /api/alerts/recent returns 404', async () => {
     const fetchSpy = vi.fn(
-      async () =>
+      async (_url: RequestInfo | URL) =>
         new Response('{"error":"not_found"}', {
           status: 404,
           headers: { 'content-type': 'application/json' },

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useRef, useEffect } from 'react';
+import type { JSX } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useLocation } from 'wouter';
 import {

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -16,7 +16,7 @@
     "resolveJsonModule": true,
     "useDefineForClassFields": true,
     "noEmit": true,
-    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+    "types": ["node", "vite/client", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src/web/**/*.ts", "src/web/**/*.tsx"]
 }


### PR DESCRIPTION
Fixes #236

## Summary

`npx tsc --noEmit -p tsconfig.web.json` reported 99 pre-existing type errors across 38 files in the web dashboard's source, invisible to the normal build and lint commands.

- `@types/react` 19 removed the global `JSX` namespace in favor of a per-module `React.JSX`, breaking every `JSX.Element` return-type annotation. Fixed by adding `import type { JSX } from 'react';` to each affected file.
- A handful of unrelated type errors fixed alongside it: a missing Node type in the dashboard's tsconfig, two Recharts formatter type mismatches, a test fixture's inferred type, a `window.location` test cast, and two under-typed `fetch` mocks.
- Version bumped to 1.6.4 with a matching CHANGELOG entry.

No user-visible behavior change.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.web.json` → 0 errors (was 99)
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)