### PR TITLE
Fix: Unify secret-redaction patterns, evictedKey leak, recordContent gate (v1.6.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.7] - 2026-07-20
+
+### Security
+
+- The hook collector binary's secret-redaction pattern list had fallen out of sync with the canonical list used elsewhere in the server, missing coverage for database connection strings with embedded credentials, Stripe/PyPI/HuggingFace tokens, Twilio SIDs, and Azure SAS tokens. Both now import from a single shared pattern list, so the two can no longer drift.
+
+### Fixed
+
+- The "Evicting non-orphan pre-event due to capacity overflow" warning was masking the actual pending-event identifier behind `***`, for the same reason as the 1.6.6 fix — the log field's own name was treated as sensitive by the secret-redaction logic. The warning now shows the real identifier.
+- The `recordContent` gate (which `highSecurity` forces off) was implemented independently in two places with duplicated logic. Both now call one shared function so the behavior can't diverge between them.
+
 ## [1.6.6] - 2026-07-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.6",
+      "version": "1.6.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,8 @@ import type { CliOptions } from './types.js';
 import type { UpstreamConfig } from './proxy/types.js';
 import type { PersonalAlertThresholds } from './alerts/types.js';
 import { DEFAULT_PERSONAL_THRESHOLDS } from './alerts/types.js';
+import { REDACTION_PATTERNS as DEFAULT_REDACTION_PATTERNS } from './redaction-patterns.js';
+import { resolveRecordContent } from './record-content-gate.js';
 
 const logger = createLogger('mcp-config');
 
@@ -85,25 +87,6 @@ export interface McpServerConfig {
 export const DEFAULT_STORAGE_PATH = resolve(homedir(), '.newrelic-preflight');
 
 export type PlatformTarget = 'native' | 'wsl-windows-cc' | 'wsl-linux-cc';
-
-const DEFAULT_REDACTION_PATTERNS: RegExp[] = [
-  /(?<![a-zA-Z])(?:API_KEY|SECRET|TOKEN|PASSWORD|PASSPHRASE|PRIVATE_KEY)(?![a-zA-Z])[\s]*[=:]\s*\S+/gi,
-  /(?:sk-|ghp_|gho_|ghs_|github_pat_|xoxb-|xoxp-|Bearer\s+)[A-Za-z0-9_-]{20,200}/g,
-  /-----BEGIN[^-\n]{0,100}-----[A-Za-z0-9+/=\r\n. ]{0,65536}-----END[^-\n]{0,100}-----/g,
-  /\bAKIA[0-9A-Z]{16}\b/g,
-  /\bAIzaSy[0-9A-Za-z_-]{33}\b/g,
-  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g,
-  /\bnpm_[A-Za-z0-9]{36}\b/g,
-  /\bxox[a-z]-[0-9A-Za-z-]+/g,
-  /\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{24,}\b/g,
-  /\bpypi-[A-Za-z0-9_-]{20,}\b/g,
-  /\bhf_[A-Za-z0-9]{30,}\b/g,
-  /(?:mongodb(?:\+srv)?|postgres(?:ql)?|mysql|redis):\/\/[^:\/\s]+:[^\@\/\s]+@[^\s\/]+/gi,
-  /https?:\/\/[^\s:\/]+:[^\s@\/]+@[^\s\/]+/gi,
-  /\b(?:AC|SK)[a-f0-9]{32}\b/g,
-  /(?:[?&])(?:sig|se|sp|srt|ss|sv|st)=[A-Za-z0-9%_-]+/gi,
-  /\b(?:vercel_|heroku_|dd_|pk_)[A-Za-z0-9_-]{20,}\b/gi,
-];
 
 export const ConfigFileSchema = z
   .object({
@@ -608,13 +591,13 @@ export function loadMcpConfig(cliOptions?: Partial<CliOptions>): Readonly<McpSer
 
     highSecurity,
 
-    // highSecurity forces recordContent off regardless of other settings
-    recordContent: highSecurity
-      ? false
-      : envBool(
-          'NEW_RELIC_AI_MCP_RECORD_CONTENT',
-          typeof file.recordContent === 'boolean' ? file.recordContent : false,
-        ),
+    recordContent: resolveRecordContent(
+      highSecurity,
+      envBool(
+        'NEW_RELIC_AI_MCP_RECORD_CONTENT',
+        typeof file.recordContent === 'boolean' ? file.recordContent : false,
+      ),
+    ),
 
     redactionPatterns: DEFAULT_REDACTION_PATTERNS,
 

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -972,6 +972,17 @@ describe('collector-script', () => {
       expect(redact('function hello() { return 42; }')).toBe('function hello() { return 42; }');
     });
 
+    it('redact() replaces database connection strings with embedded credentials', () => {
+      const connStr = 'postgres://admin:s3cr3tpass@db.internal.example.com:5432/mydb';
+      expect(redact(connStr)).toContain('[REDACTED]');
+      expect(redact(connStr)).not.toContain('s3cr3tpass');
+    });
+
+    it('redact() replaces Stripe live secret keys', () => {
+      const key = 'sk_live_' + 'a'.repeat(24);
+      expect(redact(key)).toBe('[REDACTED]');
+    });
+
     it('hashInput() produces a 16-char hex string', () => {
       const hash = hashInput({ file_path: '/tmp/test' });
       expect(hash).toHaveLength(16);

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -26,6 +26,8 @@ import {
 import { resolve, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
+import { REDACTION_PATTERNS } from '../redaction-patterns.js';
+import { resolveRecordContent } from '../record-content-gate.js';
 
 import type { RawTranscriptEntry, RawAssistantMessage } from './transcript-types.js';
 
@@ -82,9 +84,10 @@ function getHighSecurity(): boolean {
 }
 
 function getRecordContent(): boolean {
-  const highSecurity = getHighSecurity();
-  if (highSecurity) return false;
-  return process.env.NEW_RELIC_AI_MCP_RECORD_CONTENT === 'true';
+  return resolveRecordContent(
+    getHighSecurity(),
+    process.env.NEW_RELIC_AI_MCP_RECORD_CONTENT === 'true',
+  );
 }
 
 function getMaxContentLength(): number {
@@ -95,19 +98,8 @@ function getMaxContentLength(): number {
 }
 
 // ---------------------------------------------------------------------------
-// Inline redaction (mirrors config.ts DEFAULT_REDACTION_PATTERNS)
+// Inline redaction (patterns shared with config.ts via ../redaction-patterns.js)
 // ---------------------------------------------------------------------------
-
-const REDACTION_PATTERNS: RegExp[] = [
-  /(?<![a-zA-Z])(?:API_KEY|SECRET|TOKEN|PASSWORD|PASSPHRASE|PRIVATE_KEY)(?![a-zA-Z])[\s]*[=:]\s*\S+/gi,
-  /(?:sk-|ghp_|gho_|ghs_|github_pat_|xoxb-|xoxp-|Bearer\s+)[A-Za-z0-9_-]{20,200}/g,
-  /-----BEGIN[^-\n]{0,100}-----[A-Za-z0-9+/=\r\n. ]{0,65536}-----END[^-\n]{0,100}-----/g,
-  /\bAKIA[0-9A-Z]{16}\b/g,
-  /\bAIzaSy[0-9A-Za-z_-]{33}\b/g,
-  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g,
-  /\bnpm_[A-Za-z0-9]{36}\b/g,
-  /\bxox[a-z]-[0-9A-Za-z-]+/g,
-];
 
 const MAX_REDACT_BYTES = 1_048_576; // 1 MB
 

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -496,6 +496,25 @@ describe('HookEventProcessor', () => {
       expect(output).toContain('Evicting non-orphan pre-event due to capacity overflow');
     });
 
+    it('does not redact the evicted identifier value in the warning output', () => {
+      const processor = new HookEventProcessor({
+        store,
+        onRecord,
+        maxPendingEvents: 2,
+        orphanTimeoutMs: 1000,
+      });
+
+      const now = Date.now();
+      // 'a' is the oldest non-orphan pre-event and gets evicted when 'c' arrives.
+      processor.processEvents([makePreEvent({ toolUseId: 'a', timestamp: now })]);
+      processor.processEvents([makePreEvent({ toolUseId: 'b', timestamp: now })]);
+      processor.processEvents([makePreEvent({ toolUseId: 'c', timestamp: now })]);
+
+      const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+      expect(output).toContain('"a"');
+      expect(output).not.toContain('***');
+    });
+
     it('uses DEFAULT_MAX_PENDING (2000) when maxPendingEvents is not specified', () => {
       const processor = new HookEventProcessor({ store, onRecord });
 

--- a/src/hooks/event-processor.ts
+++ b/src/hooks/event-processor.ts
@@ -337,20 +337,24 @@ export class HookEventProcessor {
     if (this.pending.size >= this.maxPendingEvents) {
       // Prefer evicting events that are already past the orphan timeout
       const now = Date.now();
-      let evictedKey: string | undefined;
+      // Named to avoid shared/redact.ts's SECRET_KEY_RE (which matches any key
+      // name containing "key") — that would silently blank this diagnostic value.
+      let evictedPairingId: string | undefined;
       for (const [key, pendingEvent] of this.pending) {
         if (now - pendingEvent.timestamp >= this.orphanTimeoutMs) {
-          evictedKey = key;
+          evictedPairingId = key;
           break;
         }
       }
-      if (evictedKey === undefined) {
-        evictedKey = this.pending.keys().next().value as string | undefined;
-        logger.warn('Evicting non-orphan pre-event due to capacity overflow', { evictedKey });
+      if (evictedPairingId === undefined) {
+        evictedPairingId = this.pending.keys().next().value as string | undefined;
+        logger.warn('Evicting non-orphan pre-event due to capacity overflow', {
+          evictedPairingId,
+        });
       }
-      if (evictedKey) {
-        const evicted = this.pending.get(evictedKey)!;
-        this.pending.delete(evictedKey);
+      if (evictedPairingId) {
+        const evicted = this.pending.get(evictedPairingId)!;
+        this.pending.delete(evictedPairingId);
         // Emit a synthetic timeout record so the eviction is visible in metrics,
         // matching the behavior of sweepOrphans() and flushPending().
         const toolFields = parseToolSpecificFields(evicted.tool, evicted.toolInput, undefined);
@@ -358,7 +362,7 @@ export class HookEventProcessor {
           id: randomUUID(),
           sessionId: evicted.sessionId ?? null,
           toolName: evicted.tool,
-          toolUseId: evicted.toolUseId ?? evictedKey,
+          toolUseId: evicted.toolUseId ?? evictedPairingId,
           timestamp: evicted.timestamp,
           durationMs: null,
           success: false,

--- a/src/record-content-gate.test.ts
+++ b/src/record-content-gate.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from '@jest/globals';
+import { resolveRecordContent } from './record-content-gate.js';
+
+describe('resolveRecordContent', () => {
+  it('forces false when highSecurity is true, regardless of the explicit value', () => {
+    expect(resolveRecordContent(true, true)).toBe(false);
+  });
+
+  it('returns the explicit value when highSecurity is false', () => {
+    expect(resolveRecordContent(false, true)).toBe(true);
+    expect(resolveRecordContent(false, false)).toBe(false);
+  });
+});

--- a/src/record-content-gate.ts
+++ b/src/record-content-gate.ts
@@ -1,0 +1,6 @@
+// Shared by src/config.ts (McpServerConfig) and src/hooks/collector-script.ts (the hook
+// binary) so the "highSecurity forcibly disables content recording" rule can't drift
+// between them — each file previously reimplemented this check independently.
+export function resolveRecordContent(highSecurity: boolean, explicitValue: boolean): boolean {
+  return highSecurity ? false : explicitValue;
+}

--- a/src/redaction-patterns.ts
+++ b/src/redaction-patterns.ts
@@ -1,0 +1,25 @@
+// Canonical secret-redaction patterns. Shared by src/config.ts's redactSensitive()
+// (used across the MCP server) and src/hooks/collector-script.ts's redact() (the hot-path
+// hook binary, <5ms budget per invocation — this array literal has no runtime cost beyond
+// what each consumer already pays). Previously these were two independently-maintained
+// copies that silently drifted: collector-script.ts's list fell 8 patterns behind this one.
+// Import from here rather than redefining — a single source of truth makes that drift
+// structurally impossible.
+export const REDACTION_PATTERNS: readonly RegExp[] = [
+  /(?<![a-zA-Z])(?:API_KEY|SECRET|TOKEN|PASSWORD|PASSPHRASE|PRIVATE_KEY)(?![a-zA-Z])[\s]*[=:]\s*\S+/gi,
+  /(?:sk-|ghp_|gho_|ghs_|github_pat_|xoxb-|xoxp-|Bearer\s+)[A-Za-z0-9_-]{20,200}/g,
+  /-----BEGIN[^-\n]{0,100}-----[A-Za-z0-9+/=\r\n. ]{0,65536}-----END[^-\n]{0,100}-----/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bAIzaSy[0-9A-Za-z_-]{33}\b/g,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g,
+  /\bnpm_[A-Za-z0-9]{36}\b/g,
+  /\bxox[a-z]-[0-9A-Za-z-]+/g,
+  /\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{24,}\b/g,
+  /\bpypi-[A-Za-z0-9_-]{20,}\b/g,
+  /\bhf_[A-Za-z0-9]{30,}\b/g,
+  /(?:mongodb(?:\+srv)?|postgres(?:ql)?|mysql|redis):\/\/[^:\/\s]+:[^\@\/\s]+@[^\s\/]+/gi,
+  /https?:\/\/[^\s:\/]+:[^\s@\/]+@[^\s\/]+/gi,
+  /\b(?:AC|SK)[a-f0-9]{32}\b/g,
+  /(?:[?&])(?:sig|se|sp|srt|ss|sv|st)=[A-Za-z0-9%_-]+/gi,
+  /\b(?:vercel_|heroku_|dd_|pk_)[A-Za-z0-9_-]{20,}\b/gi,
+];


### PR DESCRIPTION
## Summary

- Unified two independently-maintained secret-redaction pattern lists into a single shared module, `src/redaction-patterns.ts`. The hook collector — the highest-volume raw-content capture point — was missing coverage for DB connection strings, Stripe/PyPI/HuggingFace tokens, Twilio SIDs, and Azure SAS tokens.
- Fixed `evictedKey` diagnostic field being silently redacted to `***` by the logger's key-name-based secret detection (same bug class fixed for `unknownKeys`→`unknownFields` in 1.6.6). Renamed to `evictedPairingId`.
- Consolidated two independently-implemented copies of the `highSecurity → recordContent=false` gate behind one shared helper, `src/record-content-gate.ts`.
- Version 1.6.6 → 1.6.7 + CHANGELOG entry.

Closes #241

## Test plan

- [x] `npx tsc -b .` — no errors
- [x] `npm run lint` / `npm run format:check` — clean
- [x] Full suite passes