### PR TITLE
Fix: Reconcile metric tracker reset()/recordToolCall contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.8] - 2026-07-20
+
+### Fixed
+
+- Metric tracker `reset()` signatures had drifted across `src/metrics/`: some took zero arguments, some silently ignored their `sessionId` parameter, and one tracker had no `reset()` at all — a generic session-boundary dispatch loop couldn't type-check across trackers. All ten affected trackers now implement a shared `Resettable` interface with a consistent `reset(sessionId: string): void` signature.
+- `TaskDetector`'s per-task cost/token delta silently clamped to zero when `CostTracker`'s cumulative totals decreased between a task's start and close (e.g. from an out-of-order `reset()`), with no diagnostic trail. That case now logs a warning with the raw delta before clamping.
+- `TaskCompletionTracker.recordToolCall()` was a literal no-op with no visibility into why; it now logs at debug level.
+
 ## [1.6.7] - 2026-07-20
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,23 +213,26 @@ Logger writes to stderr as JSON. Never write to stdout (reserved for MCP stdio t
 
 ## Metric Tracker Pattern
 
-All metric trackers in `src/metrics/` follow the same shape:
+Trackers in `src/metrics/` do not share one input shape — they fall into four families depending on how data reaches them:
 
-```typescript
-class XxxTracker {
-  constructor(options?: XxxOptions);
-  recordToolCall(record: ToolCallRecord): void; // or similar input method
-  getMetrics(): XxxMetrics; // returns current state
-  reset(sessionId: string): void; // clears state for new session
-}
-```
+- **Streaming push (void)** — `recordToolCall(record: ToolCallRecord): void`. The majority shape: `SessionTracker`, `TaskDetector`, `WorkflowRunTracker`, `ContextTracker`, `GitEfficiencyTracker`, and most others.
+- **Streaming push (signaling)** — `recordToolCall(record: ToolCallRecord): T`, returning a value the caller acts on immediately instead of only accumulating: `TurnTracker` (returns the turn id), `RetryDetector` (returns `ThrashingAlert | null`).
+- **Primitive accumulator** — a domain-named method taking specific values instead of a full `ToolCallRecord`, because the input is self-reported (tokens, cost) rather than a raw tool call: `ModelUsageTracker.recordUsage(model, inputTokens, outputTokens, costUsd)`, `CostTracker.recordTokenUsage(usage, model, ctx?)` / `recordEstimatedTokens(...)`, `BudgetTracker.updateCost(...)`.
+- **Batch/pull analyzer** — invoked periodically over accumulated history rather than per-call: `AntiPatternDetector.analyze(toolCalls: ToolCallRecord[])`, `EfficiencyScorer.computeScore(task, antiPatterns?)` / `updateScore(...)`.
 
-Each tracker:
+Whichever family a tracker belongs to, it still:
 
-- Receives `ToolCallRecord` objects from the event processor
 - Maintains internal state (maps, counters, arrays)
 - Exposes a `getMetrics()` method returning a typed snapshot
 - Has a corresponding `*.test.ts` file with factory helpers
+
+### `reset()` and the `Resettable` interface
+
+`reset(sessionId: string): void` (the `Resettable` interface, `src/metrics/tracker-contracts.ts`) has no production caller today — no dispatch loop currently calls it. It exists so a future session-boundary dispatcher can clear tracker state without type-checking against each tracker individually, and so tests can reset a tracker between cases. Trackers that implement it: `SessionTracker`, `CostTracker`, `TaskDetector`, `ModelUsageTracker`, `WorkflowRunTracker`, `AntiPatternDetector`, `TaskCompletionTracker`, `TurnTracker`, `RetryDetector`, `EfficiencyScorer`.
+
+### Cross-tracker reads require dispatch order
+
+`TaskDetector` reads `CostTracker.getMetrics()` at task-start and task-close to compute a per-task cost/token delta; `CostTracker` reads `SessionTracker.getMetrics().uniqueFilesWritten` for `costPerFileModified`. Both assume the read-from tracker's cumulative totals only move forward between reads — resetting one tracker independently of the other (e.g. `CostTracker.reset()` while a `TaskDetector` task is active) is logged as a warning rather than allowed to fail silently, but the delta is still clamped to 0 in that case. See the JSDoc on `TaskDetectorOptions.costTracker` and `CostTracker`'s constructor.
 
 ## Platform Adapter Pattern
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.7",
+      "version": "1.6.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/metrics/anti-patterns.test.ts
+++ b/src/metrics/anti-patterns.test.ts
@@ -821,4 +821,21 @@ describe('Edge cases', () => {
     expect(patterns2).toEqual(result2.patterns);
     expect(patterns2).toHaveLength(0); // Empty call list produces no patterns
   });
+
+  it('reset() clears patterns accumulated from a prior analyze call', () => {
+    const detector = new AntiPatternDetector();
+
+    const calls: ToolCallRecord[] = [
+      makeRecord({ toolName: 'Read', filePath: '/a.ts' }),
+      makeRecord({ toolName: 'Read', filePath: '/a.ts' }),
+      makeRecord({ toolName: 'Read', filePath: '/a.ts' }),
+      makeRecord({ toolName: 'Read', filePath: '/a.ts' }),
+    ];
+    detector.analyze(calls);
+    expect(detector.getCurrentPatterns().length).toBeGreaterThan(0);
+
+    detector.reset('sess-001');
+
+    expect(detector.getCurrentPatterns()).toEqual([]);
+  });
 });

--- a/src/metrics/anti-patterns.ts
+++ b/src/metrics/anti-patterns.ts
@@ -9,12 +9,15 @@
  *   4. Blind editing: multiple edits without verification
  *   5. Over-delegation: spawning too many sub-agents
  *
- * The detector is stateless: `analyze(toolCalls)` returns detected patterns
- * for a given sequence (typically one task's worth of tool calls).
+ * `analyze(toolCalls)` is pure — it returns detected patterns for a given
+ * sequence (typically one task's worth of tool calls) without depending on
+ * prior calls. The detector does cache the last result (for
+ * `getCurrentPatterns()`/`reset()`), so the instance itself is not stateless.
  */
 
 import type { MetricAggregator } from '../shared/index.js';
 import type { ToolCallRecord } from '../storage/types.js';
+import type { Resettable } from './tracker-contracts.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -88,7 +91,7 @@ function stuckLoopSuggestion(bashCategory: string | undefined): string {
 // AntiPatternDetector
 // ---------------------------------------------------------------------------
 
-export class AntiPatternDetector {
+export class AntiPatternDetector implements Resettable {
   private readonly thrashThreshold: number;
   private readonly reReadThreshold: number;
   private readonly stuckLoopThreshold: number;
@@ -126,6 +129,10 @@ export class AntiPatternDetector {
 
   getCurrentPatterns(): readonly AntiPattern[] {
     return this.lastMetrics?.patterns ?? [];
+  }
+
+  reset(_sessionId: string): void {
+    this.lastMetrics = null;
   }
 
   emitMetrics(aggregator: MetricAggregator, patterns: AntiPattern[]): void {

--- a/src/metrics/cost-tracker.test.ts
+++ b/src/metrics/cost-tracker.test.ts
@@ -412,7 +412,7 @@ describe('CostTracker', () => {
       );
       tracker.recordLinesChanged(50);
 
-      tracker.reset();
+      tracker.reset('test-session');
 
       const metrics = tracker.getMetrics();
       expect(metrics.sessionTotalCostUsd).toBeNull();
@@ -659,7 +659,7 @@ describe('CostTracker', () => {
         makeUsage({ inputTokens: 1_000, cacheReadTokens: 2_000, totalTokens: 1_000 }),
         'claude-sonnet-4-6',
       );
-      tracker.reset();
+      tracker.reset('test-session');
       expect(tracker.getMetrics().cacheHitRate).toBeNull();
       expect(tracker.getMetrics().totalCacheSavingsUsd).toBe(0);
     });
@@ -772,7 +772,7 @@ describe('CostTracker', () => {
       const dayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
       expect(tracker.getCostForDay(dayKey)).toBeGreaterThan(0);
 
-      tracker.reset();
+      tracker.reset('test-session');
 
       expect(tracker.getCostForDay(dayKey)).toBe(0);
       expect(tracker.getFirstActivityMsForDay(dayKey)).toBeNull();
@@ -891,7 +891,7 @@ describe('CostTracker', () => {
         'claude-sonnet-4',
         { workflowRunId: 'wf_a' },
       );
-      tracker.reset();
+      tracker.reset('test-session');
       expect(tracker.getCostForWorkflowRun('wf_a')).toBe(0);
       expect(tracker.getSubagentMetrics().subagentUsd).toBe(0);
       expect(tracker.getSubagentMetrics().parentUsd).toBe(0);

--- a/src/metrics/cost-tracker.ts
+++ b/src/metrics/cost-tracker.ts
@@ -12,6 +12,7 @@ import type { TokenUsage, CostBreakdown, MetricAggregator } from '../shared/inde
 import { calculateCost, createLogger } from '../shared/index.js';
 import { localDateKey } from '../lib/date.js';
 import type { SessionTracker } from './session-tracker.js';
+import type { Resettable } from './tracker-contracts.js';
 
 const logger = createLogger('cost-tracker');
 
@@ -99,7 +100,7 @@ export interface SubagentMetrics {
 // CostTracker
 // ---------------------------------------------------------------------------
 
-export class CostTracker {
+export class CostTracker implements Resettable {
   private sessionTracker: SessionTracker | null;
 
   private totalCostUsd = 0;
@@ -142,6 +143,14 @@ export class CostTracker {
   private parentCostUsd = 0;
   private totalLinesChanged = 0;
 
+  /**
+   * @param sessionTracker Optional. When provided, `getMetrics().costPerFileModified`
+   *   and the `ai.cost.cost_per_file_modified` metric are derived from its
+   *   live `uniqueFilesWritten` count. Must track the same session as this
+   *   CostTracker — if the two are reset independently (e.g. one on a
+   *   session boundary and the other not), the ratio silently blends two
+   *   different session histories.
+   */
   constructor(sessionTracker?: SessionTracker) {
     this.sessionTracker = sessionTracker ?? null;
   }
@@ -451,7 +460,7 @@ export class CostTracker {
     aggregator.record('ai.cost.parent_usd', this.parentCostUsd, attrs);
   }
 
-  reset(): void {
+  reset(_sessionId: string): void {
     this.totalCostUsd = 0;
     this.totalInputTokens = 0;
     this.totalOutputTokens = 0;

--- a/src/metrics/efficiency-score.test.ts
+++ b/src/metrics/efficiency-score.test.ts
@@ -424,7 +424,7 @@ describe('getScores() and reset()', () => {
     scorer.computeScore(makeTask());
     expect(scorer.getScores()).toHaveLength(1);
 
-    scorer.reset();
+    scorer.reset('test-session');
     expect(scorer.getScores()).toHaveLength(0);
     expect(scorer.getSessionAverage()).toBeNull();
   });
@@ -590,7 +590,7 @@ describe('scores cap (MAX_SCORES = 1000)', () => {
     const agg1 = { record() {} } as unknown as import('../shared/index.js').MetricAggregator;
     scorer.emitMetrics(agg1);
 
-    scorer.reset();
+    scorer.reset('test-session');
 
     scorer.computeScore(makeTask({ taskId: 't2' }));
 

--- a/src/metrics/efficiency-score.ts
+++ b/src/metrics/efficiency-score.ts
@@ -13,6 +13,7 @@
 import type { MetricAggregator } from '../shared/index.js';
 import type { AiCodingTask } from './task-detector.js';
 import type { AntiPattern } from './anti-patterns.js';
+import type { Resettable } from './tracker-contracts.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -56,7 +57,7 @@ const MAX_SCORES = 1_000;
 // EfficiencyScorer
 // ---------------------------------------------------------------------------
 
-export class EfficiencyScorer {
+export class EfficiencyScorer implements Resettable {
   private readonly speedWeight: number;
   private readonly correctnessWeight: number;
   private readonly autonomyWeight: number;
@@ -192,7 +193,7 @@ export class EfficiencyScorer {
     this.lastEmittedIndex = this.scores.length;
   }
 
-  reset(): void {
+  reset(_sessionId: string): void {
     this.scores.length = 0;
     this.lastEmittedIndex = 0;
   }

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,3 +1,4 @@
+export type { Resettable } from './tracker-contracts.js';
 export { SessionTracker } from './session-tracker.js';
 export type { SessionMetrics, DurationStats, TimelineEntry } from './session-tracker.js';
 export { CostTracker } from './cost-tracker.js';

--- a/src/metrics/model-usage-tracker.ts
+++ b/src/metrics/model-usage-tracker.ts
@@ -28,7 +28,9 @@ interface MutableModelStats {
   totalCostUsd: number;
 }
 
-export class ModelUsageTracker {
+import type { Resettable } from './tracker-contracts.js';
+
+export class ModelUsageTracker implements Resettable {
   private byModel = new Map<string, MutableModelStats>();
 
   recordUsage(model: string, inputTokens: number, outputTokens: number, costUsd: number): void {

--- a/src/metrics/retry-detector.ts
+++ b/src/metrics/retry-detector.ts
@@ -9,6 +9,7 @@
 import type { MetricAggregator } from '../shared/index.js';
 import { createLogger } from '../shared/index.js';
 import type { ToolCallRecord } from '../storage/types.js';
+import type { Resettable } from './tracker-contracts.js';
 
 const logger = createLogger('retry-detector');
 
@@ -99,7 +100,7 @@ function levenshteinDistance(a: string, b: string): number {
 // RetryDetector
 // ---------------------------------------------------------------------------
 
-export class RetryDetector {
+export class RetryDetector implements Resettable {
   private readonly minOccurrences: number;
   private readonly windowSize: number;
   private readonly similarityThreshold: number;

--- a/src/metrics/session-tracker.ts
+++ b/src/metrics/session-tracker.ts
@@ -10,6 +10,7 @@ import { basename } from 'node:path';
 import type { MetricAggregator } from '../shared/index.js';
 import type { ToolCallRecord } from '../storage/types.js';
 import { computePercentile } from './percentile.js';
+import type { Resettable } from './tracker-contracts.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -93,7 +94,7 @@ export function computeDurationStats(durations: number[]): DurationStats {
 // SessionTracker
 // ---------------------------------------------------------------------------
 
-export class SessionTracker {
+export class SessionTracker implements Resettable {
   private sessionId: string;
   private sessionName: string | null = null;
   private sessionStartTime: number;

--- a/src/metrics/task-completion-tracker.test.ts
+++ b/src/metrics/task-completion-tracker.test.ts
@@ -72,7 +72,7 @@ describe('TaskCompletionTracker', () => {
   it('reset clears all state', () => {
     const t = new TaskCompletionTracker();
     t.recordTask(makeTask());
-    t.reset();
+    t.reset('test-session');
     const m = t.getMetrics();
     expect(m.completedTasks).toBe(0);
     expect(m.avgTaskDurationMs).toBeNull();

--- a/src/metrics/task-completion-tracker.ts
+++ b/src/metrics/task-completion-tracker.ts
@@ -1,5 +1,9 @@
+import { createLogger } from '../shared/index.js';
 import type { AiCodingTask } from './task-detector.js';
 import type { ToolCallRecord } from '../storage/types.js';
+import type { Resettable } from './tracker-contracts.js';
+
+const logger = createLogger('task-completion-tracker');
 
 interface TaskSummary {
   readonly durationMs: number;
@@ -12,12 +16,14 @@ export interface TaskCompletionMetrics {
   readonly avgToolCallsPerTask: number | null;
 }
 
-export class TaskCompletionTracker {
+export class TaskCompletionTracker implements Resettable {
   private completed: TaskSummary[] = [];
 
   // No-op: this tracker is fed via recordTask() called by TaskDetector.
   // recordToolCall exists for compatibility with the standard tracker pattern.
-  recordToolCall(_record: ToolCallRecord): void {}
+  recordToolCall(_record: ToolCallRecord): void {
+    logger.debug('recordToolCall is a no-op on this tracker; fed via recordTask()');
+  }
 
   recordTask(task: AiCodingTask): void {
     this.completed.push({ durationMs: task.durationMs, toolCallCount: task.toolCallCount });
@@ -43,7 +49,7 @@ export class TaskCompletionTracker {
     };
   }
 
-  reset(): void {
+  reset(_sessionId: string): void {
     this.completed = [];
   }
 }

--- a/src/metrics/task-detector.test.ts
+++ b/src/metrics/task-detector.test.ts
@@ -465,7 +465,7 @@ describe('Cost tracking integration', () => {
     detector.recordToolCall(makeRecord({ toolName: 'Read' }));
 
     // Reset wipes the cumulative total to 0 while the task is still active
-    costTracker.reset();
+    costTracker.reset('test-session');
 
     // Close task
     jest.advanceTimersByTime(30_000);
@@ -474,6 +474,13 @@ describe('Cost tracking integration', () => {
     // Before fix this would be negative; after fix it must be >= 0
     expect(task!.estimatedCostUsd).toBeGreaterThanOrEqual(0);
     expect(task!.tokensUsed).toBeGreaterThanOrEqual(0);
+
+    // The ordering violation (CostTracker reset mid-task) must be surfaced,
+    // not just silently clamped.
+    const warnLogged = stderrSpy.mock.calls.some((c: unknown[]) =>
+      String(c[0]).includes('negative cost/token delta'),
+    );
+    expect(warnLogged).toBe(true);
 
     detector.dispose();
   });
@@ -657,7 +664,7 @@ describe('reset()', () => {
     expect(detector.getCurrentTask()).not.toBeNull();
 
     // Reset
-    detector.reset();
+    detector.reset('test-session');
 
     expect(detector.getCompletedTasks()).toHaveLength(0);
     expect(detector.getCurrentTask()).toBeNull();
@@ -772,7 +779,7 @@ describe('drainNewlyCompletedTasks()', () => {
     detector.recordToolCall(makeRecord({ toolName: 'Read' }));
     detector.recordToolCall(makeRecord({ toolName: 'AskUserQuestion' }));
 
-    detector.reset();
+    detector.reset('test-session');
 
     expect(detector.drainNewlyCompletedTasks()).toHaveLength(0);
     expect(detector.getCompletedTasks()).toHaveLength(0);

--- a/src/metrics/task-detector.ts
+++ b/src/metrics/task-detector.ts
@@ -13,8 +13,12 @@
 
 import { randomUUID } from 'node:crypto';
 import type { MetricAggregator } from '../shared/index.js';
+import { createLogger } from '../shared/index.js';
 import type { ToolCallRecord } from '../storage/types.js';
 import type { CostTracker } from './cost-tracker.js';
+import type { Resettable } from './tracker-contracts.js';
+
+const logger = createLogger('task-detector');
 
 // ---------------------------------------------------------------------------
 // Types
@@ -55,6 +59,13 @@ export interface TaskMetrics {
 
 export interface TaskDetectorOptions {
   readonly idleTimeoutMs?: number;
+  /**
+   * When provided, TaskDetector reads this tracker's cumulative totals at
+   * task-start and task-close to compute a per-task cost/token delta. Those
+   * totals must only increase between the two reads — calling
+   * `CostTracker.reset()` while a task is active silently zeroes that task's
+   * delta (a warning is logged; see `computeCostDelta()`).
+   */
   readonly costTracker?: CostTracker;
   readonly maxCompletedTasks?: number;
 }
@@ -187,7 +198,7 @@ class ActiveTask {
 const DEFAULT_IDLE_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_COMPLETED_TASKS = 100;
 
-export class TaskDetector {
+export class TaskDetector implements Resettable {
   private readonly idleTimeoutMs: number;
   private readonly costTracker: CostTracker | null;
   private readonly maxCompletedTasks: number;
@@ -301,7 +312,7 @@ export class TaskDetector {
     }
   }
 
-  reset(): void {
+  reset(_sessionId: string): void {
     this.clearIdleTimer();
     this.activeTask = null;
     this.completedTasks = [];
@@ -374,9 +385,22 @@ export class TaskDetector {
     const currentTokens =
       metrics.totalInputTokens + metrics.totalOutputTokens + metrics.totalThinkingTokens;
 
+    const rawCostDelta = currentCost - this.costAtTaskStart;
+    const rawTokenDelta = currentTokens - this.tokensAtTaskStart;
+
+    if (rawCostDelta < 0 || rawTokenDelta < 0) {
+      // See TaskDetectorOptions.costTracker: this only happens if the
+      // CostTracker was reset (or otherwise had its totals decrease) while
+      // this task was active.
+      logger.warn('TaskDetector: negative cost/token delta clamped to 0', {
+        rawCostDelta,
+        rawTokenDelta,
+      });
+    }
+
     return {
-      costUsd: Math.max(0, currentCost - this.costAtTaskStart),
-      tokens: Math.max(0, currentTokens - this.tokensAtTaskStart),
+      costUsd: Math.max(0, rawCostDelta),
+      tokens: Math.max(0, rawTokenDelta),
     };
   }
 

--- a/src/metrics/tracker-contracts.ts
+++ b/src/metrics/tracker-contracts.ts
@@ -1,0 +1,12 @@
+/**
+ * Implemented by session-scoped trackers that must clear their state when a
+ * session boundary is crossed. Not currently invoked by any production
+ * dispatch loop (`reset()` has no production call sites as of 2026-07) —
+ * this exists so a future session-boundary dispatcher can type-check across
+ * trackers without special-casing each one. See CLAUDE.md's "Metric Tracker
+ * Pattern" section for the families of tracker shapes this does and doesn't
+ * cover.
+ */
+export interface Resettable {
+  reset(sessionId: string): void;
+}

--- a/src/metrics/turn-tracker.ts
+++ b/src/metrics/turn-tracker.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { ToolCallRecord } from '../storage/types.js';
+import type { Resettable } from './tracker-contracts.js';
 
 export interface ConversationTurn {
   readonly turnId: string;
@@ -50,7 +51,7 @@ export interface TurnTrackerOptions {
   gapThresholdMs?: number;
 }
 
-export class TurnTracker {
+export class TurnTracker implements Resettable {
   private readonly gapThresholdMs: number;
   private turns: ConversationTurn[] = [];
   private turnCounter = 0;

--- a/src/metrics/workflow-run-tracker.ts
+++ b/src/metrics/workflow-run-tracker.ts
@@ -18,6 +18,7 @@
 
 import { createLogger } from '../shared/index.js';
 import type { ToolCallRecord } from '../storage/types.js';
+import type { Resettable } from './tracker-contracts.js';
 
 const logger = createLogger('workflow-run-tracker');
 
@@ -163,7 +164,7 @@ function readBoolean(record: ToolCallRecord, key: string): boolean {
 // WorkflowRunTracker
 // ---------------------------------------------------------------------------
 
-export class WorkflowRunTracker {
+export class WorkflowRunTracker implements Resettable {
   private readonly descriptionMaxLength: number;
   private readonly maxOpenRuns: number;
   private readonly maxCompletedRuns: number;


### PR DESCRIPTION
## Summary

- Adds a shared `Resettable` interface (`src/metrics/tracker-contracts.ts`, `reset(sessionId: string): void`) and aligns 10 trackers to it — `SessionTracker`, `CostTracker`, `TaskDetector`, `ModelUsageTracker`, `WorkflowRunTracker`, `AntiPatternDetector` (previously had no `reset()` at all), `TaskCompletionTracker`, `TurnTracker`, `RetryDetector`, `EfficiencyScorer`.
- Rewrites CLAUDE.md's "Metric Tracker Pattern" section to document the real 4 input-shape families (streaming push void / streaming push signaling / primitive accumulator / batch-pull analyzer) instead of claiming one universal shape.
- Replaces `TaskCompletionTracker.recordToolCall()`'s silent no-op with a debug log.
- `TaskDetector.computeCostDelta()` now logs a warning with the raw (pre-clamp) delta when `CostTracker`'s cumulative totals decrease mid-task, instead of silently clamping to 0 with no diagnostic trail. JSDoc on `TaskDetectorOptions.costTracker` and `CostTracker`'s constructor documents the dispatch-order assumptions.
- Version bump 1.6.7 → 1.6.8 + CHANGELOG entry.

Closes #242

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — full suite green (4604 passed, 3 skipped)
- [x] `npm run lint` / `npm run format:check` — clean
- [x] Independent code-review subagent verdict on the source PR: ready to merge, no Critical/Important issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)