### PR TITLE
Refactor: Give src/tools/ a per-feature MCP registration seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.9] - 2026-07-20
+
+### Changed
+
+- The MCP server's tool registration was centralized in one 1476-line file: a single function built the `tools/list` array from a ~30-condition if-chain and dispatched `tools/call` through a ~760-line switch, referencing tool definitions and handlers scattered across five sibling files that had no registration logic of their own. Each sibling file now exports its own `registerXTools()` — a small declarative list of its tools, their availability conditions, and their handlers — and the main registry composes all of them into the server's single `tools/list`/`tools/call` handler pair. No user-visible behavior change.
+- The ~40 near-identical "tracker not available" error blocks in that dispatch switch are now built from two shared helpers (`requireTracker`/`requireAvailable`) instead of being copy-pasted per tool.
+
 ## [1.6.8] - 2026-07-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/tools/analytics-tools.test.ts
+++ b/src/tools/analytics-tools.test.ts
@@ -12,6 +12,7 @@ import {
   handleGetTaskCompletionRate,
   handleGetModelUsage,
   handleGetContextTracking,
+  registerAnalyticsTools,
 } from './analytics-tools.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -133,5 +134,41 @@ describe('analytics-tools handlers', () => {
 
     expect(parsed).toEqual(registry.getMetrics());
     expect(parsed.turnCount).toBe(1);
+  });
+});
+
+describe('registerAnalyticsTools()', () => {
+  it('lists no tools and returns explanatory errors when no deps are provided', async () => {
+    const { tools, handlers } = registerAnalyticsTools({});
+    expect(tools).toEqual([]);
+    expect(Object.keys(handlers).sort()).toEqual([
+      'nr_observe_get_context_efficiency',
+      'nr_observe_get_context_tracking',
+      'nr_observe_get_latency_percentiles',
+      'nr_observe_get_model_usage',
+      'nr_observe_get_task_completion_rate',
+    ]);
+    const result = await handlers.nr_observe_get_model_usage!(undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      error: 'ModelUsageTracker not available',
+    });
+  });
+
+  it('lists every tool once its backing tracker is present', () => {
+    const { tools } = registerAnalyticsTools({
+      contextWindowTracker: new ContextWindowTracker(),
+      contextTracker: new ContextTrackerRegistry(),
+      latencyTracker: new LatencyTracker(),
+      taskCompletionTracker: new TaskCompletionTracker(),
+      modelUsageTracker: new ModelUsageTracker(),
+    });
+    expect(tools.map((t: { name: string }) => t.name).sort()).toEqual([
+      'nr_observe_get_context_efficiency',
+      'nr_observe_get_context_tracking',
+      'nr_observe_get_latency_percentiles',
+      'nr_observe_get_model_usage',
+      'nr_observe_get_task_completion_rate',
+    ]);
   });
 });

--- a/src/tools/analytics-tools.ts
+++ b/src/tools/analytics-tools.ts
@@ -15,6 +15,7 @@ import type { LatencyTracker } from '../metrics/latency-tracker.js';
 import type { TaskCompletionTracker } from '../metrics/task-completion-tracker.js';
 import type { ModelUsageTracker } from '../metrics/model-usage-tracker.js';
 import type { TaskDetector } from '../metrics/task-detector.js';
+import { requireTracker, buildToolSet, type RegisteredToolSet } from './tool-registry.js';
 
 // ---------------------------------------------------------------------------
 // Tool definitions (for tools/list)
@@ -103,4 +104,67 @@ export function handleGetContextTracking(tracker: ContextTrackerRegistry): {
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(tracker.getMetrics(), null, 2) }],
   };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export interface AnalyticsToolsDeps {
+  contextWindowTracker?: ContextWindowTracker;
+  contextTracker?: ContextTrackerRegistry;
+  latencyTracker?: LatencyTracker;
+  taskCompletionTracker?: TaskCompletionTracker;
+  modelUsageTracker?: ModelUsageTracker;
+  taskDetector?: TaskDetector;
+}
+
+export function registerAnalyticsTools(deps: AnalyticsToolsDeps): RegisteredToolSet {
+  return buildToolSet([
+    {
+      definition: CONTEXT_EFFICIENCY_TOOL,
+      available: !!deps.contextWindowTracker,
+      handle: () => {
+        const check = requireTracker(deps.contextWindowTracker, 'ContextWindowTracker');
+        if (!check.ok) return check.result;
+        return handleGetContextEfficiency(check.value);
+      },
+    },
+    {
+      definition: CONTEXT_TRACKING_TOOL,
+      available: !!deps.contextTracker,
+      handle: () => {
+        const check = requireTracker(deps.contextTracker, 'ContextTracker');
+        if (!check.ok) return check.result;
+        return handleGetContextTracking(check.value);
+      },
+    },
+    {
+      definition: LATENCY_PERCENTILES_TOOL,
+      available: !!deps.latencyTracker,
+      handle: () => {
+        const check = requireTracker(deps.latencyTracker, 'LatencyTracker');
+        if (!check.ok) return check.result;
+        return handleGetLatencyPercentiles(check.value);
+      },
+    },
+    {
+      definition: TASK_COMPLETION_TOOL,
+      available: !!deps.taskCompletionTracker,
+      handle: () => {
+        const check = requireTracker(deps.taskCompletionTracker, 'TaskCompletionTracker');
+        if (!check.ok) return check.result;
+        return handleGetTaskCompletionRate(check.value, deps.taskDetector);
+      },
+    },
+    {
+      definition: MODEL_USAGE_TOOL,
+      available: !!deps.modelUsageTracker,
+      handle: () => {
+        const check = requireTracker(deps.modelUsageTracker, 'ModelUsageTracker');
+        if (!check.ok) return check.result;
+        return handleGetModelUsage(check.value);
+      },
+    },
+  ]);
 }

--- a/src/tools/cost-tools.test.ts
+++ b/src/tools/cost-tools.test.ts
@@ -6,6 +6,7 @@ import {
   handleGetBudgetStatus,
   handleGetCostForecast,
   handleGetCostBreakdown,
+  registerCostTools,
 } from './cost-tools.js';
 import { CostTracker } from '../metrics/cost-tracker.js';
 import { BudgetTracker } from '../metrics/budget-tracker.js';
@@ -411,5 +412,56 @@ describe('handleGetCostForecast()', () => {
     // `body` given the huge backdated "yesterday" spend above.
     expect(body.forecastEndOfDayUsd).toBeCloseTo(expected.forecastEndOfDayUsd ?? 0, 2);
     expect(sessionTotalCostUsd).toBeGreaterThan(tracker.getCostForDay(todayKey));
+  });
+});
+
+describe('registerCostTools()', () => {
+  it('lists no tools and returns explanatory errors when no deps are provided', async () => {
+    const { tools, handlers } = registerCostTools({});
+    expect(tools).toEqual([]);
+    expect(Object.keys(handlers).sort()).toEqual([
+      'nr_observe_get_budget_status',
+      'nr_observe_get_cost_breakdown',
+      'nr_observe_get_cost_forecast',
+      'nr_observe_get_prompt_cache_health',
+      'nr_observe_report_tokens',
+    ]);
+    const result = await handlers.nr_observe_get_budget_status!(undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ error: 'BudgetTracker not available' });
+  });
+
+  it('lists every tool once its backing deps are all present', () => {
+    const costTracker = new CostTracker();
+    const budgetTracker = new BudgetTracker({
+      sessionBudgetUsd: 10,
+      dailyBudgetUsd: null,
+      weeklyBudgetUsd: null,
+    });
+    const { tools } = registerCostTools({
+      costTracker,
+      budgetTracker,
+      sessionStartMs: Date.now(),
+    });
+    expect(tools.map((t: { name: string }) => t.name).sort()).toEqual([
+      'nr_observe_get_budget_status',
+      'nr_observe_get_cost_breakdown',
+      'nr_observe_get_cost_forecast',
+      'nr_observe_get_prompt_cache_health',
+      'nr_observe_report_tokens',
+    ]);
+  });
+
+  it('rejects an invalid token report the same way the raw handler does', async () => {
+    const costTracker = new CostTracker();
+    const { handlers } = registerCostTools({ costTracker });
+    const result = await handlers.nr_observe_report_tokens!({
+      input_tokens: -1,
+      output_tokens: 5,
+      model: 'claude-sonnet-4',
+    });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0]!.text);
+    expect(body.error).toContain('Invalid token report');
   });
 });

--- a/src/tools/cost-tools.ts
+++ b/src/tools/cost-tools.ts
@@ -9,6 +9,8 @@
  *   - `nr_observe_get_prompt_cache_health` — cache hit rate and recommendation
  */
 
+import { z } from 'zod';
+
 import type { CostTracker } from '../metrics/cost-tracker.js';
 import type { TaskDetector } from '../metrics/task-detector.js';
 import type { BudgetTracker } from '../metrics/budget-tracker.js';
@@ -16,6 +18,13 @@ import type { ModelUsageTracker } from '../metrics/model-usage-tracker.js';
 import { buildCostForecastFromInputs } from '../metrics/cost-forecast.js';
 import { localDateKey } from '../lib/date.js';
 import type { TokenUsage } from '../shared/index.js';
+import {
+  errorResult,
+  requireTracker,
+  requireAvailable,
+  buildToolSet,
+  type RegisteredToolSet,
+} from './tool-registry.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -307,4 +316,87 @@ export function handleGetPromptCacheHealth(costTracker: CostTracker): {
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
   };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+const TokenReportSchema = z.object({
+  model: z.string().min(1),
+  input_tokens: z.number().nonnegative(),
+  output_tokens: z.number().nonnegative(),
+  cache_creation_tokens: z.number().nonnegative().optional(),
+  cache_read_tokens: z.number().nonnegative().optional(),
+  thinking_tokens: z.number().nonnegative().optional(),
+});
+
+export interface CostToolsDeps {
+  costTracker?: CostTracker;
+  budgetTracker?: BudgetTracker;
+  taskDetector?: TaskDetector;
+  modelUsageTracker?: ModelUsageTracker;
+  sessionStartMs?: number;
+}
+
+export function registerCostTools(deps: CostToolsDeps): RegisteredToolSet {
+  return buildToolSet([
+    {
+      definition: REPORT_TOKENS_TOOL,
+      available: !!deps.costTracker,
+      handle: (args) => {
+        const check = requireTracker(deps.costTracker, 'CostTracker');
+        if (!check.ok) return check.result;
+        try {
+          const tokenReport = TokenReportSchema.parse(args);
+          return handleReportTokens(check.value, tokenReport, deps.modelUsageTracker);
+        } catch (err) {
+          const message =
+            err instanceof z.ZodError
+              ? err.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ')
+              : String(err);
+          return errorResult(`Invalid token report: ${message}`);
+        }
+      },
+    },
+    {
+      definition: COST_BREAKDOWN_TOOL,
+      available: !!deps.costTracker,
+      handle: () => {
+        const check = requireTracker(deps.costTracker, 'CostTracker');
+        if (!check.ok) return check.result;
+        return handleGetCostBreakdown(check.value, deps.taskDetector);
+      },
+    },
+    {
+      definition: PROMPT_CACHE_HEALTH_TOOL,
+      available: !!deps.costTracker,
+      handle: () => {
+        const check = requireTracker(deps.costTracker, 'CostTracker');
+        if (!check.ok) return check.result;
+        return handleGetPromptCacheHealth(check.value);
+      },
+    },
+    {
+      definition: BUDGET_STATUS_TOOL,
+      available: !!deps.budgetTracker,
+      handle: () => {
+        const check = requireTracker(deps.budgetTracker, 'BudgetTracker');
+        if (!check.ok) return check.result;
+        return handleGetBudgetStatus(check.value);
+      },
+    },
+    {
+      definition: COST_FORECAST_TOOL,
+      available: !!deps.costTracker && deps.sessionStartMs !== undefined,
+      handle: () => {
+        const missing = requireAvailable(
+          !!deps.costTracker && deps.sessionStartMs !== undefined,
+          'CostTracker or sessionStartMs not available',
+        );
+        if (missing) return missing;
+        return handleGetCostForecast(deps.costTracker!, deps.sessionStartMs!);
+      },
+    },
+  ]);
 }

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -29,6 +29,7 @@ import {
   handleSendDigest,
   handleGetPersonalInsights,
   toFiniteNumber,
+  registerCrossSessionTools,
 } from './cross-session-tools.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -1073,5 +1074,113 @@ describe('Cross-session tool handlers', () => {
       const expected = new PersonalCoach(generator, 'alice').generate();
       expect({ ...body, generatedAt: 0 }).toEqual({ ...expected, generatedAt: 0 });
     });
+  });
+});
+
+describe('registerCrossSessionTools()', () => {
+  it('lists no tools and returns explanatory errors when no deps are provided', async () => {
+    const { tools, handlers } = registerCrossSessionTools({});
+    expect(tools).toEqual([]);
+    expect(Object.keys(handlers).sort()).toEqual([
+      'nr_observe_get_claudemd_impact',
+      'nr_observe_get_collaboration_profile',
+      'nr_observe_get_cost_per_outcome',
+      'nr_observe_get_personal_insights',
+      'nr_observe_get_platform_comparison',
+      'nr_observe_get_recommendations',
+      'nr_observe_get_session_history',
+      'nr_observe_get_team_summary',
+      'nr_observe_get_trends',
+      'nr_observe_get_weekly_summary',
+      'nr_observe_send_digest',
+      'nr_observe_subscribe_digest',
+      'nr_observe_unsubscribe_digest',
+    ]);
+    const result = await handlers.nr_observe_get_session_history!(undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ error: 'SessionStore not available' });
+  });
+
+  it('gates nr_observe_get_team_summary on both teamId and nrApiKey with the "not configured" wording', async () => {
+    const { tools, handlers } = registerCrossSessionTools({ teamId: 'team-1' });
+    expect(tools.map((t: { name: string }) => t.name)).not.toContain('nr_observe_get_team_summary');
+    const result = await handlers.nr_observe_get_team_summary!(undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      error: 'teamId or nrApiKey not configured',
+    });
+  });
+
+  it('gates nr_observe_send_digest on both configFilePath and weeklySummaryGenerator', async () => {
+    const { tools, handlers } = registerCrossSessionTools({ configFilePath: '/tmp/x.json' });
+    expect(tools.map((t: { name: string }) => t.name)).not.toContain('nr_observe_send_digest');
+    const result = await handlers.nr_observe_send_digest!(undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      error: 'configFilePath or WeeklySummaryGenerator not available',
+    });
+  });
+
+  it('gates nr_observe_get_personal_insights on both weeklySummaryGenerator and developer', async () => {
+    const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+    const { tools, handlers } = registerCrossSessionTools({ weeklySummaryGenerator: generator });
+    expect(tools.map((t: { name: string }) => t.name)).not.toContain(
+      'nr_observe_get_personal_insights',
+    );
+    const result = await handlers.nr_observe_get_personal_insights!(undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      error: 'WeeklySummaryGenerator or developer not available',
+    });
+  });
+
+  it('lists every tool once its backing deps are all present', () => {
+    const generator = new WeeklySummaryGenerator({ storagePath: tmpDir, sessionStore: store });
+    const trendAnalyzer = new TrendAnalyzer({ sessionStore: store });
+    const collaborationProfiler = new CollaborationProfiler({ sessionStore: store });
+    const claudeMdTracker = new ClaudeMdTracker({ sessionStore: store });
+    const promptFeedbackEngine = new PromptFeedbackEngine({
+      sessionStore: store,
+      collaborationProfiler,
+      claudeMdTracker,
+    });
+    const costPerOutcomeAnalyzer = new CostPerOutcomeAnalyzer();
+    const { tools } = registerCrossSessionTools({
+      sessionStore: store,
+      weeklySummaryGenerator: generator,
+      trendAnalyzer,
+      collaborationProfiler,
+      claudeMdTracker,
+      costPerOutcomeAnalyzer,
+      taskDetector: new TaskDetector(),
+      recommendationEngine: new RecommendationEngine({
+        sessionStore: store,
+        trendAnalyzer,
+        collaborationProfiler,
+        claudeMdTracker,
+        promptFeedbackEngine,
+        costPerOutcomeAnalyzer,
+      }),
+      teamId: 'team-1',
+      nrApiKey: 'NRAK-test',
+      accountId: '12345',
+      configFilePath: resolve(tmpDir, 'config.json'),
+      developer: 'alice',
+    });
+    expect(tools.map((t: { name: string }) => t.name).sort()).toEqual([
+      'nr_observe_get_claudemd_impact',
+      'nr_observe_get_collaboration_profile',
+      'nr_observe_get_cost_per_outcome',
+      'nr_observe_get_personal_insights',
+      'nr_observe_get_platform_comparison',
+      'nr_observe_get_recommendations',
+      'nr_observe_get_session_history',
+      'nr_observe_get_team_summary',
+      'nr_observe_get_trends',
+      'nr_observe_get_weekly_summary',
+      'nr_observe_send_digest',
+      'nr_observe_subscribe_digest',
+      'nr_observe_unsubscribe_digest',
+    ]);
   });
 });

--- a/src/tools/cross-session-tools.ts
+++ b/src/tools/cross-session-tools.ts
@@ -27,6 +27,12 @@ import type { CostPerOutcomeAnalyzer } from '../metrics/cost-per-outcome.js';
 import type { TaskDetector } from '../metrics/task-detector.js';
 import type { RecommendationEngine } from '../metrics/recommendation-engine.js';
 import { PersonalCoach } from '../metrics/personal-coach.js';
+import {
+  requireTracker,
+  requireAvailable,
+  buildToolSet,
+  type RegisteredToolSet,
+} from './tool-registry.js';
 
 function getNerdgraphUrl(collectorHost: string | null): string {
   if (collectorHost === 'eu') return 'https://api.eu.newrelic.com/graphql';
@@ -990,4 +996,186 @@ export function handleGetPersonalInsights(
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
   };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export interface CrossSessionToolsDeps {
+  sessionStore?: SessionStore;
+  weeklySummaryGenerator?: WeeklySummaryGenerator;
+  trendAnalyzer?: TrendAnalyzer;
+  collaborationProfiler?: CollaborationProfiler;
+  claudeMdTracker?: ClaudeMdTracker;
+  costPerOutcomeAnalyzer?: CostPerOutcomeAnalyzer;
+  taskDetector?: TaskDetector;
+  recommendationEngine?: RecommendationEngine;
+  teamId?: string | null;
+  nrApiKey?: string | null;
+  accountId?: string;
+  collectorHost?: string | null;
+  configFilePath?: string;
+  developer?: string;
+}
+
+export function registerCrossSessionTools(deps: CrossSessionToolsDeps): RegisteredToolSet {
+  return buildToolSet([
+    {
+      definition: SESSION_HISTORY_TOOL,
+      available: !!deps.sessionStore,
+      handle: (args) => {
+        const check = requireTracker(deps.sessionStore, 'SessionStore');
+        if (!check.ok) return check.result;
+        return handleGetSessionHistory(check.value, {
+          since: args?.since as string | undefined,
+          developer: args?.developer as string | undefined,
+          limit: args?.limit as number | undefined,
+        });
+      },
+    },
+    {
+      definition: PLATFORM_COMPARISON_TOOL,
+      available: !!deps.sessionStore,
+      handle: (args) => {
+        const check = requireTracker(deps.sessionStore, 'SessionStore');
+        if (!check.ok) return check.result;
+        return handleGetPlatformComparison(check.value, {
+          metric: args?.metric as string | undefined,
+          weeks: args?.weeks as number | undefined,
+        });
+      },
+    },
+    {
+      definition: WEEKLY_SUMMARY_TOOL,
+      available: !!deps.weeklySummaryGenerator,
+      handle: (args) => {
+        const check = requireTracker(deps.weeklySummaryGenerator, 'WeeklySummaryGenerator');
+        if (!check.ok) return check.result;
+        return handleGetWeeklySummary(check.value, { week: args?.week as string | undefined });
+      },
+    },
+    {
+      definition: TRENDS_TOOL,
+      available: !!deps.trendAnalyzer,
+      handle: (args) => {
+        const check = requireTracker(deps.trendAnalyzer, 'TrendAnalyzer');
+        if (!check.ok) return check.result;
+        return handleGetTrends(check.value, {
+          metric: args?.metric as string | undefined,
+          developer: args?.developer as string | undefined,
+          weeks: args?.weeks as number | undefined,
+        });
+      },
+    },
+    {
+      definition: COLLABORATION_PROFILE_TOOL,
+      available: !!deps.collaborationProfiler,
+      handle: (args) => {
+        const check = requireTracker(deps.collaborationProfiler, 'CollaborationProfiler');
+        if (!check.ok) return check.result;
+        return handleGetCollaborationProfile(check.value, {
+          developer: args?.developer as string | undefined,
+        });
+      },
+    },
+    {
+      definition: CLAUDEMD_IMPACT_TOOL,
+      available: !!deps.claudeMdTracker,
+      handle: () => {
+        const check = requireTracker(deps.claudeMdTracker, 'ClaudeMdTracker');
+        if (!check.ok) return check.result;
+        return handleGetClaudeMdImpact(check.value);
+      },
+    },
+    {
+      definition: COST_PER_OUTCOME_TOOL,
+      available: !!deps.costPerOutcomeAnalyzer && !!deps.taskDetector,
+      handle: (args) => {
+        const missing = requireAvailable(
+          !!deps.costPerOutcomeAnalyzer && !!deps.taskDetector,
+          'CostPerOutcomeAnalyzer or TaskDetector not available',
+        );
+        if (missing) return missing;
+        return handleGetCostPerOutcome(deps.costPerOutcomeAnalyzer!, deps.taskDetector!, {
+          since: args?.since as string | undefined,
+        });
+      },
+    },
+    {
+      definition: RECOMMENDATIONS_TOOL,
+      available: !!deps.recommendationEngine,
+      handle: (args) => {
+        const check = requireTracker(deps.recommendationEngine, 'RecommendationEngine');
+        if (!check.ok) return check.result;
+        return handleGetRecommendations(check.value, {
+          developer: args?.developer as string | undefined,
+          topN: args?.topN as number | undefined,
+        });
+      },
+    },
+    {
+      definition: TEAM_SUMMARY_TOOL,
+      available: !!deps.teamId && !!deps.nrApiKey,
+      handle: (args) => {
+        const missing = requireAvailable(
+          !!deps.teamId && !!deps.nrApiKey,
+          'teamId or nrApiKey not configured',
+        );
+        if (missing) return missing;
+        return handleGetTeamSummary({
+          teamId: deps.teamId!,
+          accountId: deps.accountId ?? '',
+          nrApiKey: deps.nrApiKey!,
+          collectorHost: deps.collectorHost,
+          since: args?.since as string | undefined,
+        });
+      },
+    },
+    {
+      definition: SUBSCRIBE_DIGEST_TOOL,
+      available: !!deps.configFilePath,
+      handle: (args) => {
+        const missing = requireAvailable(!!deps.configFilePath, 'configFilePath not available');
+        if (missing) return missing;
+        return handleSubscribeDigest(
+          typeof args?.webhookUrl === 'string' ? args.webhookUrl : '',
+          deps.configFilePath!,
+        );
+      },
+    },
+    {
+      definition: UNSUBSCRIBE_DIGEST_TOOL,
+      available: !!deps.configFilePath,
+      handle: () => {
+        const missing = requireAvailable(!!deps.configFilePath, 'configFilePath not available');
+        if (missing) return missing;
+        return handleUnsubscribeDigest(deps.configFilePath!);
+      },
+    },
+    {
+      definition: SEND_DIGEST_TOOL,
+      available: !!deps.configFilePath && !!deps.weeklySummaryGenerator,
+      handle: () => {
+        const missing = requireAvailable(
+          !!deps.configFilePath && !!deps.weeklySummaryGenerator,
+          'configFilePath or WeeklySummaryGenerator not available',
+        );
+        if (missing) return missing;
+        return handleSendDigest(deps.weeklySummaryGenerator!, deps.configFilePath!);
+      },
+    },
+    {
+      definition: PERSONAL_INSIGHTS_TOOL,
+      available: !!deps.weeklySummaryGenerator && !!deps.developer,
+      handle: () => {
+        const missing = requireAvailable(
+          !!deps.weeklySummaryGenerator && !!deps.developer,
+          'WeeklySummaryGenerator or developer not available',
+        );
+        if (missing) return missing;
+        return handleGetPersonalInsights(deps.weeklySummaryGenerator!, deps.developer!);
+      },
+    },
+  ]);
 }

--- a/src/tools/extended-analytics-tools.test.ts
+++ b/src/tools/extended-analytics-tools.test.ts
@@ -6,6 +6,7 @@ import { InstructionDriftTracker } from '../metrics/instruction-drift-tracker.js
 import { ToolSelectionScorer } from '../metrics/tool-selection-scorer.js';
 import { QualityProxyTracker } from '../metrics/quality-proxy-tracker.js';
 import { ApiFailureTracker } from '../metrics/api-failure-tracker.js';
+import type { ToolCallRecord } from '../storage/types.js';
 import {
   handleGetRetryAlerts,
   handleGetContextComposition,
@@ -15,6 +16,7 @@ import {
   handleGetToolSelectionScore,
   handleGetQualityProxy,
   handleGetApiFailures,
+  registerExtendedAnalyticsTools,
 } from './extended-analytics-tools.js';
 
 jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -101,5 +103,91 @@ describe('extended-analytics-tools handlers', () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.totalFailures).toBe(0);
     expect(parsed.totalTokensLost).toBe(0);
+  });
+});
+
+describe('registerExtendedAnalyticsTools()', () => {
+  it('lists no tools and returns explanatory errors when no deps are provided', async () => {
+    const { tools, handlers } = registerExtendedAnalyticsTools({});
+    expect(tools).toEqual([]);
+    expect(Object.keys(handlers).sort()).toEqual([
+      'nr_observe_get_api_failures',
+      'nr_observe_get_context_composition',
+      'nr_observe_get_decision_tree',
+      'nr_observe_get_instruction_drift',
+      'nr_observe_get_latency_decomposition',
+      'nr_observe_get_quality_proxy',
+      'nr_observe_get_retry_alerts',
+      'nr_observe_get_tool_selection_score',
+    ]);
+    const result = await handlers.nr_observe_get_retry_alerts!(undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      error: 'RetryDetector not available',
+    });
+  });
+
+  it('requires both ToolSelectionScorer and toolCallBuffer for nr_observe_get_tool_selection_score', async () => {
+    const { tools, handlers } = registerExtendedAnalyticsTools({
+      toolSelectionScorer: new ToolSelectionScorer(),
+    });
+    expect(tools.map((t: { name: string }) => t.name)).not.toContain(
+      'nr_observe_get_tool_selection_score',
+    );
+    const result = await handlers.nr_observe_get_tool_selection_score!(undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      error: 'ToolSelectionScorer or toolCallBuffer not available',
+    });
+  });
+
+  it('nr_observe_get_latency_decomposition stays unlisted today (index.ts never wires a real tracker) and explains why when dispatched directly', async () => {
+    const { tools, handlers } = registerExtendedAnalyticsTools({});
+    expect(tools.map((t: { name: string }) => t.name)).not.toContain(
+      'nr_observe_get_latency_decomposition',
+    );
+    const result = await handlers.nr_observe_get_latency_decomposition!(undefined);
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0]!.text);
+    expect(body.error).toBe('nr_observe_get_latency_decomposition is not currently functional');
+    expect(body.note).toContain('This tool is intentionally not registered in tools/list.');
+  });
+
+  it('would list nr_observe_get_latency_decomposition and dispatch to the real handler if a tracker were ever wired up', async () => {
+    // Availability tracks the real dependency (not a hardcoded `false`) so
+    // this reactivates automatically if `index.ts` ever stops hardcoding the
+    // tracker to `undefined` — see the comment above the ToolSpec.
+    const { tools, handlers } = registerExtendedAnalyticsTools({
+      latencyDecompositionTracker: new LatencyDecompositionTracker(),
+    });
+    expect(tools.map((t: { name: string }) => t.name)).toContain(
+      'nr_observe_get_latency_decomposition',
+    );
+    const result = await handlers.nr_observe_get_latency_decomposition!(undefined);
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0]!.text).turnCount).toBe(0);
+  });
+
+  it('lists every other tool once its backing tracker is present', () => {
+    const toolCallBuffer = { getRecords: (): readonly ToolCallRecord[] => [] };
+    const { tools } = registerExtendedAnalyticsTools({
+      retryDetector: new RetryDetector(),
+      contextCompositionTracker: new ContextCompositionTracker(),
+      decisionTracker: new DecisionTracker(),
+      instructionDriftTracker: new InstructionDriftTracker(),
+      toolSelectionScorer: new ToolSelectionScorer(),
+      toolCallBuffer,
+      qualityProxyTracker: new QualityProxyTracker(),
+      apiFailureTracker: new ApiFailureTracker(),
+    });
+    expect(tools.map((t: { name: string }) => t.name).sort()).toEqual([
+      'nr_observe_get_api_failures',
+      'nr_observe_get_context_composition',
+      'nr_observe_get_decision_tree',
+      'nr_observe_get_instruction_drift',
+      'nr_observe_get_quality_proxy',
+      'nr_observe_get_retry_alerts',
+      'nr_observe_get_tool_selection_score',
+    ]);
   });
 });

--- a/src/tools/extended-analytics-tools.ts
+++ b/src/tools/extended-analytics-tools.ts
@@ -22,6 +22,12 @@ import type { InstructionDriftTracker } from '../metrics/instruction-drift-track
 import type { ToolSelectionScorer } from '../metrics/tool-selection-scorer.js';
 import type { QualityProxyTracker } from '../metrics/quality-proxy-tracker.js';
 import type { ApiFailureTracker } from '../metrics/api-failure-tracker.js';
+import {
+  requireTracker,
+  requireAvailable,
+  buildToolSet,
+  type RegisteredToolSet,
+} from './tool-registry.js';
 
 // ---------------------------------------------------------------------------
 // Tool definitions (for tools/list)
@@ -181,4 +187,124 @@ export function handleGetApiFailures(tracker: ApiFailureTracker): {
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(tracker.getMetrics(), null, 2) }],
   };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export interface ExtendedAnalyticsToolsDeps {
+  retryDetector?: RetryDetector;
+  contextCompositionTracker?: ContextCompositionTracker;
+  latencyDecompositionTracker?: LatencyDecompositionTracker;
+  decisionTracker?: DecisionTracker;
+  instructionDriftTracker?: InstructionDriftTracker;
+  toolSelectionScorer?: ToolSelectionScorer;
+  toolCallBuffer?: { getRecords(): readonly ToolCallRecord[] };
+  qualityProxyTracker?: QualityProxyTracker;
+  apiFailureTracker?: ApiFailureTracker;
+}
+
+export function registerExtendedAnalyticsTools(
+  deps: ExtendedAnalyticsToolsDeps,
+): RegisteredToolSet {
+  return buildToolSet([
+    {
+      definition: RETRY_ALERTS_TOOL,
+      available: !!deps.retryDetector,
+      handle: () => {
+        const check = requireTracker(deps.retryDetector, 'RetryDetector');
+        if (!check.ok) return check.result;
+        return handleGetRetryAlerts(check.value);
+      },
+    },
+    {
+      definition: CONTEXT_COMPOSITION_TOOL,
+      available: !!deps.contextCompositionTracker,
+      handle: () => {
+        const check = requireTracker(deps.contextCompositionTracker, 'ContextCompositionTracker');
+        if (!check.ok) return check.result;
+        return handleGetContextComposition(check.value);
+      },
+    },
+    // Permanently disabled: `index.ts` hardcodes this tracker to `undefined`
+    // (Preflight can't observe a true LLM-API-vs-tool-execution split in
+    // either stdio or proxy mode — see the comment above its instantiation
+    // there). `available` tracks the real dependency rather than a hardcoded
+    // `false` so this starts working automatically if that ever changes, but
+    // today it's never listed; dispatching it directly still explains why,
+    // instead of falling back to a generic "not available" message.
+    {
+      definition: LATENCY_DECOMPOSITION_TOOL,
+      available: !!deps.latencyDecompositionTracker,
+      handle: () => {
+        if (!deps.latencyDecompositionTracker) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  error: 'nr_observe_get_latency_decomposition is not currently functional',
+                  note: "Preflight cannot observe a true LLM-API-vs-tool-execution split in either stdio or proxy mode -- see the comment above the tracker's instantiation in index.ts for the full explanation. This tool is intentionally not registered in tools/list.",
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        return handleGetLatencyDecomposition(deps.latencyDecompositionTracker);
+      },
+    },
+    {
+      definition: DECISION_TREE_TOOL,
+      available: !!deps.decisionTracker,
+      handle: (args) => {
+        const check = requireTracker(deps.decisionTracker, 'DecisionTracker');
+        if (!check.ok) return check.result;
+        return handleGetDecisionTree(check.value, args?.post_mortem === true);
+      },
+    },
+    {
+      definition: INSTRUCTION_DRIFT_TOOL,
+      available: !!deps.instructionDriftTracker,
+      handle: () => {
+        const check = requireTracker(deps.instructionDriftTracker, 'InstructionDriftTracker');
+        if (!check.ok) return check.result;
+        return handleGetInstructionDrift(check.value);
+      },
+    },
+    {
+      definition: TOOL_SELECTION_SCORE_TOOL,
+      available: !!deps.toolSelectionScorer && !!deps.toolCallBuffer,
+      handle: () => {
+        const missing = requireAvailable(
+          !!deps.toolSelectionScorer && !!deps.toolCallBuffer,
+          'ToolSelectionScorer or toolCallBuffer not available',
+        );
+        if (missing) return missing;
+        return handleGetToolSelectionScore(
+          deps.toolSelectionScorer!,
+          deps.toolCallBuffer!.getRecords(),
+        );
+      },
+    },
+    {
+      definition: QUALITY_PROXY_TOOL,
+      available: !!deps.qualityProxyTracker,
+      handle: () => {
+        const check = requireTracker(deps.qualityProxyTracker, 'QualityProxyTracker');
+        if (!check.ok) return check.result;
+        return handleGetQualityProxy(check.value);
+      },
+    },
+    {
+      definition: API_FAILURES_TOOL,
+      available: !!deps.apiFailureTracker,
+      handle: () => {
+        const check = requireTracker(deps.apiFailureTracker, 'ApiFailureTracker');
+        if (!check.ok) return check.result;
+        return handleGetApiFailures(check.value);
+      },
+    },
+  ]);
 }

--- a/src/tools/session-stats.ts
+++ b/src/tools/session-stats.ts
@@ -1,11 +1,11 @@
 /**
- * `registerTools()` — the MCP server's main tool registry. Builds the
- * `tools/list` response and `tools/call` dispatch from whichever trackers
- * were constructed for this session (session stats/timeline, health,
- * config, install-hooks, git efficiency, and every cost/workflow/cross-session/
- * analytics/extended-analytics tool re-exported from the sibling files in
- * this directory) — each tool is only advertised when its backing tracker
- * is present.
+ * `registerTools()` — the MCP server's main tool registry. Composes the
+ * per-file `registerXTools(deps)` sets from `cost-tools.ts`, `workflow-tools.ts`,
+ * `cross-session-tools.ts`, `analytics-tools.ts`, and `extended-analytics-tools.ts`
+ * with this file's own "core" tools (health, config, install-hooks, session
+ * stats/timeline, git efficiency, cost-per-tool, turn analysis) into the
+ * server's single `tools/list`/`tools/call` handler pair — each tool is only
+ * advertised when its backing tracker is present, per `tool-registry.ts`.
  */
 
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -15,7 +15,6 @@ import {
   ErrorCode,
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
-import { z } from 'zod';
 import { createLogger } from '../shared/index.js';
 import { VERSION } from '../version.js';
 
@@ -33,57 +32,10 @@ import type { CollaborationProfiler } from '../metrics/collaboration-profile.js'
 import type { ClaudeMdTracker } from '../metrics/claudemd-tracker.js';
 import type { CostPerOutcomeAnalyzer } from '../metrics/cost-per-outcome.js';
 import type { RecommendationEngine } from '../metrics/recommendation-engine.js';
-import {
-  REPORT_TOKENS_TOOL,
-  handleReportTokens,
-  COST_BREAKDOWN_TOOL,
-  handleGetCostBreakdown,
-  BUDGET_STATUS_TOOL,
-  COST_FORECAST_TOOL,
-  handleGetBudgetStatus,
-  handleGetCostForecast,
-  PROMPT_CACHE_HEALTH_TOOL,
-  handleGetPromptCacheHealth,
-} from './cost-tools.js';
-import {
-  WORKFLOW_TRACE_TOOL,
-  ANTI_PATTERNS_TOOL,
-  EFFICIENCY_SCORE_TOOL,
-  REPORT_FEEDBACK_TOOL,
-  handleGetWorkflowTrace,
-  handleGetAntiPatterns,
-  handleGetEfficiencyScore,
-  handleReportFeedback,
-} from './workflow-tools.js';
+import { registerCostTools } from './cost-tools.js';
+import { registerWorkflowTools } from './workflow-tools.js';
 import type { FeedbackCollector } from './workflow-tools.js';
-import {
-  SESSION_HISTORY_TOOL,
-  WEEKLY_SUMMARY_TOOL,
-  TRENDS_TOOL,
-  COLLABORATION_PROFILE_TOOL,
-  CLAUDEMD_IMPACT_TOOL,
-  COST_PER_OUTCOME_TOOL,
-  RECOMMENDATIONS_TOOL,
-  PLATFORM_COMPARISON_TOOL,
-  TEAM_SUMMARY_TOOL,
-  SUBSCRIBE_DIGEST_TOOL,
-  UNSUBSCRIBE_DIGEST_TOOL,
-  SEND_DIGEST_TOOL,
-  PERSONAL_INSIGHTS_TOOL,
-  handleGetSessionHistory,
-  handleGetWeeklySummary,
-  handleGetTrends,
-  handleGetCollaborationProfile,
-  handleGetClaudeMdImpact,
-  handleGetCostPerOutcome,
-  handleGetRecommendations,
-  handleGetPlatformComparison,
-  handleGetTeamSummary,
-  handleSubscribeDigest,
-  handleUnsubscribeDigest,
-  handleSendDigest,
-  handleGetPersonalInsights,
-} from './cross-session-tools.js';
+import { registerCrossSessionTools } from './cross-session-tools.js';
 import type { ContextWindowTracker } from '../metrics/context-window-tracker.js';
 import type { ContextTrackerRegistry } from '../metrics/context-tracker.js';
 import type { LatencyTracker } from '../metrics/latency-tracker.js';
@@ -100,36 +52,15 @@ import type { ApiFailureTracker } from '../metrics/api-failure-tracker.js';
 import type { TurnCostAttributor } from '../metrics/turn-cost-attributor.js';
 import type { TurnTracker } from '../metrics/turn-tracker.js';
 import type { GitEfficiencyTracker } from '../metrics/git-efficiency-tracker.js';
+import { registerAnalyticsTools } from './analytics-tools.js';
+import { registerExtendedAnalyticsTools } from './extended-analytics-tools.js';
 import {
-  CONTEXT_EFFICIENCY_TOOL,
-  CONTEXT_TRACKING_TOOL,
-  LATENCY_PERCENTILES_TOOL,
-  TASK_COMPLETION_TOOL,
-  MODEL_USAGE_TOOL,
-  handleGetContextEfficiency,
-  handleGetContextTracking,
-  handleGetLatencyPercentiles,
-  handleGetTaskCompletionRate,
-  handleGetModelUsage,
-} from './analytics-tools.js';
-import {
-  RETRY_ALERTS_TOOL,
-  CONTEXT_COMPOSITION_TOOL,
-  LATENCY_DECOMPOSITION_TOOL,
-  DECISION_TREE_TOOL,
-  INSTRUCTION_DRIFT_TOOL,
-  TOOL_SELECTION_SCORE_TOOL,
-  QUALITY_PROXY_TOOL,
-  API_FAILURES_TOOL,
-  handleGetRetryAlerts,
-  handleGetContextComposition,
-  handleGetLatencyDecomposition,
-  handleGetDecisionTree,
-  handleGetInstructionDrift,
-  handleGetToolSelectionScore,
-  handleGetQualityProxy,
-  handleGetApiFailures,
-} from './extended-analytics-tools.js';
+  requireTracker,
+  requireAvailable,
+  buildToolSet,
+  mergeToolSets,
+  type RegisteredToolSet,
+} from './tool-registry.js';
 
 // ---------------------------------------------------------------------------
 // Tool definitions (for tools/list)
@@ -468,23 +399,112 @@ export interface ToolRegistrationOptions {
 }
 
 // ---------------------------------------------------------------------------
-// Input validation schemas
+// Core tools — no natural sibling file (health, config, install-hooks,
+// session stats/timeline, git efficiency, cost-per-tool, turn analysis)
 // ---------------------------------------------------------------------------
 
-const TokenReportSchema = z.object({
-  model: z.string().min(1),
-  input_tokens: z.number().nonnegative(),
-  output_tokens: z.number().nonnegative(),
-  cache_creation_tokens: z.number().nonnegative().optional(),
-  cache_read_tokens: z.number().nonnegative().optional(),
-  thinking_tokens: z.number().nonnegative().optional(),
-});
-
-const FeedbackSchema = z.object({
-  quality: z.enum(['good', 'bad', 'neutral']),
-  task_id: z.string().optional(),
-  notes: z.string().optional(),
-});
+function registerCoreTools(deps: ToolRegistrationOptions): RegisteredToolSet {
+  return buildToolSet([
+    {
+      definition: HEALTH_TOOL,
+      available: true,
+      handle: () =>
+        handleHealth({
+          sessionStartMs: deps.sessionStartMs,
+          developer: deps.developer,
+          sessionId: deps.sessionTracker?.getMetrics().sessionId,
+          hooksInstalledFn: deps.hooksInstalledFn,
+        }),
+    },
+    {
+      definition: INSTALL_HOOKS_TOOL,
+      available: true,
+      handle: () => handleInstallHooks(deps.headlessInstaller),
+    },
+    {
+      definition: CONFIG_TOOL,
+      available: !!deps.configSummary,
+      handle: () => {
+        const missing = requireAvailable(!!deps.configSummary, 'Config summary not available');
+        if (missing) return missing;
+        return handleGetConfig(deps.configSummary!);
+      },
+    },
+    {
+      definition: SESSION_STATS_TOOL,
+      available: !!deps.sessionTracker,
+      handle: () => {
+        const check = requireTracker(deps.sessionTracker, 'SessionTracker');
+        if (!check.ok) return check.result;
+        const { _stats: stats } = handleGetSessionStats(check.value, deps.sessionTraceId);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  identity: {
+                    developer: deps.developer ?? 'unknown',
+                    teamId: deps.teamId ?? null,
+                    projectId: deps.projectId ?? null,
+                  },
+                  ...stats,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      },
+    },
+    {
+      definition: SESSION_TIMELINE_TOOL,
+      available: !!deps.sessionTracker,
+      handle: (args) => {
+        const check = requireTracker(deps.sessionTracker, 'SessionTracker');
+        if (!check.ok) return check.result;
+        const lastN = args?.last_n;
+        return handleGetSessionTimeline(check.value, typeof lastN === 'number' ? lastN : 20);
+      },
+    },
+    {
+      definition: GIT_EFFICIENCY_TOOL,
+      available: !!deps.gitEfficiencyTracker,
+      handle: () => {
+        const check = requireTracker(deps.gitEfficiencyTracker, 'GitEfficiencyTracker');
+        if (!check.ok) return check.result;
+        return handleGetGitEfficiency(check.value);
+      },
+    },
+    {
+      definition: COST_PER_TOOL_TOOL,
+      available: !!deps.turnCostAttributor,
+      handle: () => {
+        const check = requireTracker(deps.turnCostAttributor, 'TurnCostAttributor');
+        if (!check.ok) return check.result;
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify(check.value.getMetrics(), null, 2) },
+          ],
+        };
+      },
+    },
+    {
+      definition: TURN_ANALYSIS_TOOL,
+      available: !!deps.turnTracker,
+      handle: () => {
+        const check = requireTracker(deps.turnTracker, 'TurnTracker');
+        if (!check.ok) return check.result;
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify(check.value.getMetrics(), null, 2) },
+          ],
+        };
+      },
+    },
+  ]);
+}
 
 // ---------------------------------------------------------------------------
 // Registration
@@ -545,917 +565,27 @@ export function registerPendingTools(
 }
 
 export function registerTools(server: Server, options: ToolRegistrationOptions): void {
-  const {
-    sessionTracker,
-    costTracker,
-    budgetTracker,
-    taskDetector,
-    antiPatternDetector,
-    efficiencyScorer,
-    feedbackCollector,
-    sessionStore,
-    weeklySummaryGenerator,
-    trendAnalyzer,
-    collaborationProfiler,
-    claudeMdTracker,
-    costPerOutcomeAnalyzer,
-    recommendationEngine,
-    contextWindowTracker,
-    contextTracker,
-    latencyTracker,
-    taskCompletionTracker,
-    modelUsageTracker,
-    retryDetector,
-    contextCompositionTracker,
-    latencyDecompositionTracker,
-    decisionTracker,
-    instructionDriftTracker,
-    toolSelectionScorer,
-    qualityProxyTracker,
-    apiFailureTracker,
-    turnCostAttributor,
-    turnTracker,
-    gitEfficiencyTracker,
-    sessionTraceId,
-    sessionStartMs,
-  } = options;
-
-  // Build combined tool list
-  const tools: (typeof SESSION_STATS_TOOL)[] = [HEALTH_TOOL];
-  tools.push(INSTALL_HOOKS_TOOL);
-  if (options.configSummary) {
-    tools.push(CONFIG_TOOL);
-  }
-  if (sessionTracker) {
-    tools.push(SESSION_STATS_TOOL, SESSION_TIMELINE_TOOL);
-  }
-  if (costTracker) {
-    tools.push(REPORT_TOKENS_TOOL, COST_BREAKDOWN_TOOL, PROMPT_CACHE_HEALTH_TOOL);
-  }
-  if (budgetTracker) {
-    tools.push(BUDGET_STATUS_TOOL);
-  }
-  if (costTracker && sessionStartMs !== undefined) {
-    tools.push(COST_FORECAST_TOOL);
-  }
-  if (taskDetector) {
-    tools.push(WORKFLOW_TRACE_TOOL);
-  }
-  if (antiPatternDetector && taskDetector) {
-    tools.push(ANTI_PATTERNS_TOOL);
-  }
-  if (efficiencyScorer) {
-    tools.push(EFFICIENCY_SCORE_TOOL);
-  }
-  if (feedbackCollector) {
-    tools.push(REPORT_FEEDBACK_TOOL);
-  }
-
-  // Cross-session tools — each registered only when its specific dependencies exist
-  if (sessionStore) {
-    tools.push(SESSION_HISTORY_TOOL, PLATFORM_COMPARISON_TOOL);
-  }
-  if (weeklySummaryGenerator) {
-    tools.push(WEEKLY_SUMMARY_TOOL);
-  }
-  if (trendAnalyzer) {
-    tools.push(TRENDS_TOOL);
-  }
-  if (collaborationProfiler) {
-    tools.push(COLLABORATION_PROFILE_TOOL);
-  }
-  if (claudeMdTracker) {
-    tools.push(CLAUDEMD_IMPACT_TOOL);
-  }
-  if (costPerOutcomeAnalyzer && taskDetector) {
-    tools.push(COST_PER_OUTCOME_TOOL);
-  }
-  if (recommendationEngine) {
-    tools.push(RECOMMENDATIONS_TOOL);
-  }
-  if (options.teamId && options.nrApiKey) {
-    tools.push(TEAM_SUMMARY_TOOL);
-  }
-  if (options.configFilePath) {
-    tools.push(SUBSCRIBE_DIGEST_TOOL, UNSUBSCRIBE_DIGEST_TOOL);
-  }
-  if (options.configFilePath && weeklySummaryGenerator) {
-    tools.push(SEND_DIGEST_TOOL);
-  }
-  if (weeklySummaryGenerator && options.developer) {
-    tools.push(PERSONAL_INSIGHTS_TOOL);
-  }
-
-  if (contextWindowTracker) {
-    tools.push(CONTEXT_EFFICIENCY_TOOL);
-  }
-  if (contextTracker) {
-    tools.push(CONTEXT_TRACKING_TOOL);
-  }
-  if (latencyTracker) {
-    tools.push(LATENCY_PERCENTILES_TOOL);
-  }
-  if (taskCompletionTracker) {
-    tools.push(TASK_COMPLETION_TOOL);
-  }
-  if (modelUsageTracker) {
-    tools.push(MODEL_USAGE_TOOL);
-  }
-  if (retryDetector) {
-    tools.push(RETRY_ALERTS_TOOL);
-  }
-  if (contextCompositionTracker) {
-    tools.push(CONTEXT_COMPOSITION_TOOL);
-  }
-  if (latencyDecompositionTracker) {
-    tools.push(LATENCY_DECOMPOSITION_TOOL);
-  }
-  if (decisionTracker) {
-    tools.push(DECISION_TREE_TOOL);
-  }
-  if (instructionDriftTracker) {
-    tools.push(INSTRUCTION_DRIFT_TOOL);
-  }
-  if (toolSelectionScorer && options.toolCallBuffer) {
-    tools.push(TOOL_SELECTION_SCORE_TOOL);
-  }
-  if (qualityProxyTracker) {
-    tools.push(QUALITY_PROXY_TOOL);
-  }
-  if (apiFailureTracker) {
-    tools.push(API_FAILURES_TOOL);
-  }
-  if (gitEfficiencyTracker) {
-    tools.push(GIT_EFFICIENCY_TOOL);
-  }
-  if (turnCostAttributor) {
-    tools.push(COST_PER_TOOL_TOOL);
-  }
-  if (turnTracker) {
-    tools.push(TURN_ANALYSIS_TOOL);
-  }
+  const { tools, handlers } = mergeToolSets(
+    registerCoreTools(options),
+    registerCostTools(options),
+    registerWorkflowTools(options),
+    registerCrossSessionTools(options),
+    registerAnalyticsTools(options),
+    registerExtendedAnalyticsTools(options),
+  );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
 
+    const handler = handlers[name];
+    if (!handler) {
+      throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
+    }
+
     try {
-      switch (name) {
-        case 'nr_observe_health': {
-          return handleHealth({
-            sessionStartMs,
-            developer: options.developer,
-            sessionId: sessionTracker?.getMetrics().sessionId,
-            hooksInstalledFn: options.hooksInstalledFn,
-          });
-        }
-
-        case 'nr_observe_install_hooks': {
-          return handleInstallHooks(options.headlessInstaller);
-        }
-
-        case 'nr_observe_get_config': {
-          if (!options.configSummary) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'Config summary not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetConfig(options.configSummary);
-        }
-
-        case 'nr_observe_get_session_stats': {
-          if (!sessionTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'SessionTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const result = handleGetSessionStats(sessionTracker, sessionTraceId);
-          // Use the raw stats object directly to avoid a JSON parse/stringify round-trip.
-          const stats = result._stats;
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify(
-                  {
-                    identity: {
-                      developer: options.developer ?? 'unknown',
-                      teamId: options.teamId ?? null,
-                      projectId: options.projectId ?? null,
-                    },
-                    ...stats,
-                  },
-                  null,
-                  2,
-                ),
-              },
-            ],
-          };
-        }
-
-        case 'nr_observe_get_session_timeline': {
-          if (!sessionTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'SessionTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const lastN = args?.last_n;
-          return handleGetSessionTimeline(sessionTracker, typeof lastN === 'number' ? lastN : 20);
-        }
-
-        case 'nr_observe_report_tokens': {
-          if (!costTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'CostTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          try {
-            const tokenReport = TokenReportSchema.parse(args);
-            return handleReportTokens(costTracker, tokenReport, modelUsageTracker);
-          } catch (err) {
-            const message =
-              err instanceof z.ZodError
-                ? err.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ')
-                : String(err);
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: `Invalid token report: ${message}` }),
-                },
-              ],
-              isError: true,
-            };
-          }
-        }
-
-        case 'nr_observe_get_cost_breakdown': {
-          if (!costTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'CostTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetCostBreakdown(costTracker, taskDetector);
-        }
-
-        case 'nr_observe_get_prompt_cache_health': {
-          if (!costTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'CostTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetPromptCacheHealth(costTracker);
-        }
-
-        case 'nr_observe_get_budget_status': {
-          if (!budgetTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'BudgetTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetBudgetStatus(budgetTracker);
-        }
-
-        case 'nr_observe_get_cost_forecast': {
-          if (!costTracker || sessionStartMs === undefined) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'CostTracker or sessionStartMs not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetCostForecast(costTracker, sessionStartMs);
-        }
-
-        case 'nr_observe_get_workflow_trace': {
-          if (!taskDetector) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'TaskDetector not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const taskId = args?.task_id as string | undefined;
-          return handleGetWorkflowTrace(
-            taskDetector,
-            antiPatternDetector,
-            efficiencyScorer,
-            taskId,
-          );
-        }
-
-        case 'nr_observe_get_anti_patterns': {
-          if (!antiPatternDetector || !taskDetector) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({
-                    error: 'AntiPatternDetector or TaskDetector not available',
-                  }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetAntiPatterns(taskDetector, antiPatternDetector);
-        }
-
-        case 'nr_observe_get_efficiency_score': {
-          if (!efficiencyScorer) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'EfficiencyScorer not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetEfficiencyScore(efficiencyScorer, taskDetector, antiPatternDetector);
-        }
-
-        case 'nr_observe_report_feedback': {
-          if (!feedbackCollector) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'FeedbackCollector not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          try {
-            const feedbackArgs = FeedbackSchema.parse(args);
-            return handleReportFeedback(feedbackCollector, feedbackArgs);
-          } catch (err) {
-            const message =
-              err instanceof z.ZodError
-                ? err.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ')
-                : String(err);
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: `Invalid feedback: ${message}` }),
-                },
-              ],
-              isError: true,
-            };
-          }
-        }
-
-        case 'nr_observe_get_session_history': {
-          if (!sessionStore) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'SessionStore not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const historyArgs: Record<string, unknown> = args ?? {};
-          return handleGetSessionHistory(sessionStore, {
-            since: historyArgs.since as string | undefined,
-            developer: historyArgs.developer as string | undefined,
-            limit: historyArgs.limit as number | undefined,
-          });
-        }
-
-        case 'nr_observe_get_weekly_summary': {
-          if (!weeklySummaryGenerator) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'WeeklySummaryGenerator not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const weekArgs: Record<string, unknown> = args ?? {};
-          return handleGetWeeklySummary(weeklySummaryGenerator, {
-            week: weekArgs.week as string | undefined,
-          });
-        }
-
-        case 'nr_observe_get_trends': {
-          if (!trendAnalyzer) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'TrendAnalyzer not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const trendArgs: Record<string, unknown> = args ?? {};
-          return handleGetTrends(trendAnalyzer, {
-            metric: trendArgs.metric as string | undefined,
-            developer: trendArgs.developer as string | undefined,
-            weeks: trendArgs.weeks as number | undefined,
-          });
-        }
-
-        case 'nr_observe_get_collaboration_profile': {
-          if (!collaborationProfiler) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'CollaborationProfiler not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const profileArgs: Record<string, unknown> = args ?? {};
-          return handleGetCollaborationProfile(collaborationProfiler, {
-            developer: profileArgs.developer as string | undefined,
-          });
-        }
-
-        case 'nr_observe_get_claudemd_impact': {
-          if (!claudeMdTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'ClaudeMdTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetClaudeMdImpact(claudeMdTracker);
-        }
-
-        case 'nr_observe_get_cost_per_outcome': {
-          if (!costPerOutcomeAnalyzer || !taskDetector) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({
-                    error: 'CostPerOutcomeAnalyzer or TaskDetector not available',
-                  }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const costArgs: Record<string, unknown> = args ?? {};
-          return handleGetCostPerOutcome(costPerOutcomeAnalyzer, taskDetector, {
-            since: costArgs.since as string | undefined,
-          });
-        }
-
-        case 'nr_observe_get_recommendations': {
-          if (!recommendationEngine) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'RecommendationEngine not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const recArgs: Record<string, unknown> = args ?? {};
-          return handleGetRecommendations(recommendationEngine, {
-            developer: recArgs.developer as string | undefined,
-            topN: recArgs.topN as number | undefined,
-          });
-        }
-
-        case 'nr_observe_get_platform_comparison': {
-          if (!sessionStore) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'SessionStore not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const pcArgs: Record<string, unknown> = args ?? {};
-          return handleGetPlatformComparison(sessionStore, {
-            metric: pcArgs.metric as string | undefined,
-            weeks: pcArgs.weeks as number | undefined,
-          });
-        }
-
-        case 'nr_observe_get_team_summary': {
-          if (!options.teamId || !options.nrApiKey) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'teamId or nrApiKey not configured' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const summaryArgs: Record<string, unknown> = args ?? {};
-          return handleGetTeamSummary({
-            teamId: options.teamId,
-            accountId: options.accountId ?? '',
-            nrApiKey: options.nrApiKey,
-            collectorHost: options.collectorHost,
-            since: summaryArgs.since as string | undefined,
-          });
-        }
-
-        case 'nr_observe_subscribe_digest': {
-          if (!options.configFilePath) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'configFilePath not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const digestArgs: Record<string, unknown> = args ?? {};
-          return handleSubscribeDigest(
-            typeof digestArgs.webhookUrl === 'string' ? digestArgs.webhookUrl : '',
-            options.configFilePath,
-          );
-        }
-
-        case 'nr_observe_unsubscribe_digest': {
-          if (!options.configFilePath) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'configFilePath not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleUnsubscribeDigest(options.configFilePath);
-        }
-
-        case 'nr_observe_send_digest': {
-          if (!options.configFilePath || !weeklySummaryGenerator) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({
-                    error: 'configFilePath or WeeklySummaryGenerator not available',
-                  }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleSendDigest(weeklySummaryGenerator, options.configFilePath);
-        }
-
-        case 'nr_observe_get_personal_insights': {
-          if (!weeklySummaryGenerator || !options.developer) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({
-                    error: 'WeeklySummaryGenerator or developer not available',
-                  }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetPersonalInsights(weeklySummaryGenerator, options.developer);
-        }
-
-        case 'nr_observe_get_context_efficiency': {
-          if (!contextWindowTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'ContextWindowTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetContextEfficiency(contextWindowTracker);
-        }
-
-        case 'nr_observe_get_context_tracking': {
-          if (!contextTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'ContextTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetContextTracking(contextTracker);
-        }
-
-        case 'nr_observe_get_latency_percentiles': {
-          if (!latencyTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'LatencyTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetLatencyPercentiles(latencyTracker);
-        }
-
-        case 'nr_observe_get_task_completion_rate': {
-          if (!taskCompletionTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'TaskCompletionTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetTaskCompletionRate(taskCompletionTracker, taskDetector);
-        }
-
-        case 'nr_observe_get_model_usage': {
-          if (!modelUsageTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'ModelUsageTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetModelUsage(modelUsageTracker);
-        }
-
-        case 'nr_observe_get_retry_alerts': {
-          if (!retryDetector) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'RetryDetector not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetRetryAlerts(retryDetector);
-        }
-
-        case 'nr_observe_get_context_composition': {
-          if (!contextCompositionTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'ContextCompositionTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetContextComposition(contextCompositionTracker);
-        }
-
-        case 'nr_observe_get_latency_decomposition': {
-          if (!latencyDecompositionTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({
-                    error: 'nr_observe_get_latency_decomposition is not currently functional',
-                    note: "Preflight cannot observe a true LLM-API-vs-tool-execution split in either stdio or proxy mode -- see the comment above the tracker's instantiation in index.ts for the full explanation. This tool is intentionally not registered in tools/list.",
-                  }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetLatencyDecomposition(latencyDecompositionTracker);
-        }
-
-        case 'nr_observe_get_decision_tree': {
-          if (!decisionTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'DecisionTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const dtArgs: Record<string, unknown> = args ?? {};
-          return handleGetDecisionTree(decisionTracker, dtArgs.post_mortem === true);
-        }
-
-        case 'nr_observe_get_instruction_drift': {
-          if (!instructionDriftTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'InstructionDriftTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetInstructionDrift(instructionDriftTracker);
-        }
-
-        case 'nr_observe_get_tool_selection_score': {
-          if (!toolSelectionScorer || !options.toolCallBuffer) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({
-                    error: 'ToolSelectionScorer or toolCallBuffer not available',
-                  }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetToolSelectionScore(
-            toolSelectionScorer,
-            options.toolCallBuffer.getRecords(),
-          );
-        }
-
-        case 'nr_observe_get_quality_proxy': {
-          if (!qualityProxyTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'QualityProxyTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetQualityProxy(qualityProxyTracker);
-        }
-
-        case 'nr_observe_get_api_failures': {
-          if (!apiFailureTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'ApiFailureTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetApiFailures(apiFailureTracker);
-        }
-
-        case 'nr_observe_get_cost_per_tool': {
-          if (!turnCostAttributor) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'TurnCostAttributor not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const costMetrics = turnCostAttributor.getMetrics();
-          return {
-            content: [{ type: 'text' as const, text: JSON.stringify(costMetrics, null, 2) }],
-          };
-        }
-
-        case 'nr_observe_get_turn_analysis': {
-          if (!turnTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'TurnTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          const turnMetrics = turnTracker.getMetrics();
-          return {
-            content: [{ type: 'text' as const, text: JSON.stringify(turnMetrics, null, 2) }],
-          };
-        }
-
-        case 'nr_observe_get_git_efficiency': {
-          if (!gitEfficiencyTracker) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ error: 'GitEfficiencyTracker not available' }),
-                },
-              ],
-              isError: true,
-            };
-          }
-          return handleGetGitEfficiency(gitEfficiencyTracker);
-        }
-
-        default:
-          throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
-      }
+      return await handler(args);
     } catch (err) {
       if (err instanceof McpError) throw err;
       logger.error('Tool handler threw unexpectedly', {

--- a/src/tools/tool-registry.test.ts
+++ b/src/tools/tool-registry.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  errorResult,
+  requireTracker,
+  requireAvailable,
+  buildToolSet,
+  mergeToolSets,
+  type ToolSpec,
+} from './tool-registry.js';
+
+describe('errorResult()', () => {
+  it('wraps a message in an isError content block', () => {
+    const result = errorResult('SomeTracker not available');
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ error: 'SomeTracker not available' });
+  });
+});
+
+describe('requireTracker()', () => {
+  it('returns ok:false with an explanatory error when the tracker is undefined', () => {
+    const check = requireTracker(undefined, 'BudgetTracker');
+    expect(check.ok).toBe(false);
+    if (!check.ok) {
+      expect(check.result.isError).toBe(true);
+      expect(JSON.parse(check.result.content[0]!.text)).toEqual({
+        error: 'BudgetTracker not available',
+      });
+    }
+  });
+
+  it('returns ok:true with the tracker value when it is present', () => {
+    const tracker = { getStatus: () => 'ok' };
+    const check = requireTracker(tracker, 'BudgetTracker');
+    expect(check.ok).toBe(true);
+    if (check.ok) {
+      expect(check.value).toBe(tracker);
+    }
+  });
+});
+
+describe('requireAvailable()', () => {
+  it('returns undefined when the condition is true', () => {
+    expect(requireAvailable(true, 'unused')).toBeUndefined();
+  });
+
+  it('returns an explanatory error result when the condition is false', () => {
+    const result = requireAvailable(false, 'teamId or nrApiKey not configured');
+    expect(result?.isError).toBe(true);
+    expect(JSON.parse(result!.content[0]!.text)).toEqual({
+      error: 'teamId or nrApiKey not configured',
+    });
+  });
+});
+
+describe('buildToolSet()', () => {
+  const availableSpec: ToolSpec = {
+    definition: { name: 'tool_a', description: 'A', inputSchema: { type: 'object' } },
+    available: true,
+    handle: () => ({ content: [{ type: 'text', text: 'a' }] }),
+  };
+  const unavailableSpec: ToolSpec = {
+    definition: { name: 'tool_b', description: 'B', inputSchema: { type: 'object' } },
+    available: false,
+    handle: () => ({ content: [{ type: 'text', text: 'b-unavailable' }], isError: true }),
+  };
+
+  it('only lists tool definitions whose spec is available', () => {
+    const { tools } = buildToolSet([availableSpec, unavailableSpec]);
+    expect(tools.map((t: { name: string }) => t.name)).toEqual(['tool_a']);
+  });
+
+  it('keeps every spec dispatchable regardless of availability', async () => {
+    const { handlers } = buildToolSet([availableSpec, unavailableSpec]);
+    expect(Object.keys(handlers).sort()).toEqual(['tool_a', 'tool_b']);
+    const result = await handlers.tool_b!(undefined);
+    expect(result.content[0]!.text).toBe('b-unavailable');
+  });
+});
+
+describe('mergeToolSets()', () => {
+  it('concatenates tools and merges handlers across multiple sets', () => {
+    const setA = buildToolSet([
+      {
+        definition: { name: 'tool_a', description: 'A', inputSchema: { type: 'object' } },
+        available: true,
+        handle: () => ({ content: [{ type: 'text', text: 'a' }] }),
+      },
+    ]);
+    const setB = buildToolSet([
+      {
+        definition: { name: 'tool_c', description: 'C', inputSchema: { type: 'object' } },
+        available: true,
+        handle: () => ({ content: [{ type: 'text', text: 'c' }] }),
+      },
+    ]);
+
+    const merged = mergeToolSets(setA, setB);
+
+    expect(merged.tools.map((t: { name: string }) => t.name)).toEqual(['tool_a', 'tool_c']);
+    expect(Object.keys(merged.handlers).sort()).toEqual(['tool_a', 'tool_c']);
+  });
+});

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared seam for per-file MCP tool registration.
+ *
+ * Each `src/tools/*.ts` file exports a `registerXTools(deps)` that builds a
+ * `ToolSpec[]` — one entry per tool it owns, declaring its `tools/list`
+ * availability and its `tools/call` handler in one place — and turns it into
+ * a `RegisteredToolSet` via `buildToolSet()`. `session-stats.ts`'s
+ * `registerTools()` composes every file's set with `mergeToolSets()` into the
+ * server's single `ListToolsRequestSchema`/`CallToolRequestSchema` pair.
+ *
+ * A spec's `available` flag only gates whether the tool is *listed* —
+ * its handler stays dispatchable either way, so a client that calls an
+ * unlisted tool still gets the tool's own explanatory error (see
+ * `requireTracker`/`requireAvailable`) instead of a generic unknown-tool
+ * error.
+ */
+
+export interface ToolDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Record<string, unknown>;
+  readonly annotations?: Record<string, unknown>;
+}
+
+export interface ToolCallResult {
+  readonly content: Array<{ type: 'text'; text: string }>;
+  readonly isError?: boolean;
+  // The MCP SDK's result schemas are all `z.core.$loose` (they carry an
+  // implicit `[x: string]: unknown` index signature). Fresh object literals
+  // get an exemption from needing one to satisfy that; a value passed
+  // through this named interface via a variable does not, so it needs one
+  // explicitly to remain assignable at the `setRequestHandler` boundary.
+  readonly [key: string]: unknown;
+}
+
+export type ToolHandlerFn = (
+  args: Record<string, unknown> | undefined,
+) => ToolCallResult | Promise<ToolCallResult>;
+
+export interface ToolSpec {
+  readonly definition: ToolDefinition;
+  readonly available: boolean;
+  readonly handle: ToolHandlerFn;
+}
+
+export interface RegisteredToolSet {
+  readonly tools: ToolDefinition[];
+  readonly handlers: Record<string, ToolHandlerFn>;
+}
+
+export function errorResult(message: string): ToolCallResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}
+
+export function requireTracker<T>(
+  tracker: T | undefined,
+  name: string,
+): { ok: true; value: T } | { ok: false; result: ToolCallResult } {
+  if (tracker === undefined) {
+    return { ok: false, result: errorResult(`${name} not available`) };
+  }
+  return { ok: true, value: tracker };
+}
+
+export function requireAvailable(condition: boolean, message: string): ToolCallResult | undefined {
+  return condition ? undefined : errorResult(message);
+}
+
+export function buildToolSet(specs: ToolSpec[]): RegisteredToolSet {
+  const tools: ToolDefinition[] = [];
+  const handlers: Record<string, ToolHandlerFn> = {};
+
+  for (const spec of specs) {
+    if (spec.available) {
+      tools.push(spec.definition);
+    }
+    handlers[spec.definition.name] = spec.handle;
+  }
+
+  return { tools, handlers };
+}
+
+export function mergeToolSets(...sets: RegisteredToolSet[]): RegisteredToolSet {
+  const tools: ToolDefinition[] = [];
+  const handlers: Record<string, ToolHandlerFn> = {};
+
+  for (const set of sets) {
+    tools.push(...set.tools);
+    Object.assign(handlers, set.handlers);
+  }
+
+  return { tools, handlers };
+}

--- a/src/tools/workflow-tools.test.ts
+++ b/src/tools/workflow-tools.test.ts
@@ -12,6 +12,7 @@ import {
   handleGetAntiPatterns,
   handleGetEfficiencyScore,
   handleReportFeedback,
+  registerWorkflowTools,
 } from './workflow-tools.js';
 import { handleGetCostBreakdown } from './cost-tools.js';
 import type { ToolCallRecord } from '../storage/types.js';
@@ -764,5 +765,62 @@ describe('MCP protocol integration — workflow tools', () => {
 
     expect(body.recorded).toBe(true);
     expect(body.quality).toBe('good');
+  });
+});
+
+describe('registerWorkflowTools()', () => {
+  it('lists no tools and returns explanatory errors when no deps are provided', async () => {
+    const { tools, handlers } = registerWorkflowTools({});
+    expect(tools).toEqual([]);
+    expect(Object.keys(handlers).sort()).toEqual([
+      'nr_observe_get_anti_patterns',
+      'nr_observe_get_efficiency_score',
+      'nr_observe_get_workflow_trace',
+      'nr_observe_report_feedback',
+    ]);
+    const result = await handlers.nr_observe_get_workflow_trace!(undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ error: 'TaskDetector not available' });
+  });
+
+  it('requires both AntiPatternDetector and TaskDetector for nr_observe_get_anti_patterns', async () => {
+    const taskDetector = new TaskDetector();
+    const { tools, handlers } = registerWorkflowTools({ taskDetector });
+    expect(tools.map((t: { name: string }) => t.name)).not.toContain(
+      'nr_observe_get_anti_patterns',
+    );
+    const result = await handlers.nr_observe_get_anti_patterns!(undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      error: 'AntiPatternDetector or TaskDetector not available',
+    });
+  });
+
+  it('lists every tool once its backing deps are all present', () => {
+    const taskDetector = new TaskDetector();
+    const antiPatternDetector = new AntiPatternDetector();
+    const efficiencyScorer = new EfficiencyScorer();
+    const feedbackCollector = new FeedbackCollector();
+    const { tools } = registerWorkflowTools({
+      taskDetector,
+      antiPatternDetector,
+      efficiencyScorer,
+      feedbackCollector,
+    });
+    expect(tools.map((t: { name: string }) => t.name).sort()).toEqual([
+      'nr_observe_get_anti_patterns',
+      'nr_observe_get_efficiency_score',
+      'nr_observe_get_workflow_trace',
+      'nr_observe_report_feedback',
+    ]);
+  });
+
+  it('rejects invalid feedback the same way the raw handler does', async () => {
+    const feedbackCollector = new FeedbackCollector();
+    const { handlers } = registerWorkflowTools({ feedbackCollector });
+    const result = await handlers.nr_observe_report_feedback!({ quality: 'terrible' });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0]!.text);
+    expect(body.error).toContain('Invalid feedback');
   });
 });

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -8,10 +8,19 @@
  *   - `nr_observe_report_feedback`     — record user quality feedback
  */
 
+import { z } from 'zod';
+
 import type { MetricAggregator } from '../shared/index.js';
 import type { TaskDetector, AiCodingTask } from '../metrics/task-detector.js';
 import type { AntiPatternDetector } from '../metrics/anti-patterns.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
+import {
+  errorResult,
+  requireTracker,
+  requireAvailable,
+  buildToolSet,
+  type RegisteredToolSet,
+} from './tool-registry.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -364,4 +373,80 @@ export function handleReportFeedback(
       },
     ],
   };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+const FeedbackSchema = z.object({
+  quality: z.enum(['good', 'bad', 'neutral']),
+  task_id: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+export interface WorkflowToolsDeps {
+  taskDetector?: TaskDetector;
+  antiPatternDetector?: AntiPatternDetector;
+  efficiencyScorer?: EfficiencyScorer;
+  feedbackCollector?: FeedbackCollector;
+}
+
+export function registerWorkflowTools(deps: WorkflowToolsDeps): RegisteredToolSet {
+  return buildToolSet([
+    {
+      definition: WORKFLOW_TRACE_TOOL,
+      available: !!deps.taskDetector,
+      handle: (args) => {
+        const check = requireTracker(deps.taskDetector, 'TaskDetector');
+        if (!check.ok) return check.result;
+        const taskId = args?.task_id as string | undefined;
+        return handleGetWorkflowTrace(
+          check.value,
+          deps.antiPatternDetector,
+          deps.efficiencyScorer,
+          taskId,
+        );
+      },
+    },
+    {
+      definition: ANTI_PATTERNS_TOOL,
+      available: !!deps.antiPatternDetector && !!deps.taskDetector,
+      handle: () => {
+        const missing = requireAvailable(
+          !!deps.antiPatternDetector && !!deps.taskDetector,
+          'AntiPatternDetector or TaskDetector not available',
+        );
+        if (missing) return missing;
+        return handleGetAntiPatterns(deps.taskDetector!, deps.antiPatternDetector!);
+      },
+    },
+    {
+      definition: EFFICIENCY_SCORE_TOOL,
+      available: !!deps.efficiencyScorer,
+      handle: () => {
+        const check = requireTracker(deps.efficiencyScorer, 'EfficiencyScorer');
+        if (!check.ok) return check.result;
+        return handleGetEfficiencyScore(check.value, deps.taskDetector, deps.antiPatternDetector);
+      },
+    },
+    {
+      definition: REPORT_FEEDBACK_TOOL,
+      available: !!deps.feedbackCollector,
+      handle: (args) => {
+        const check = requireTracker(deps.feedbackCollector, 'FeedbackCollector');
+        if (!check.ok) return check.result;
+        try {
+          const feedbackArgs = FeedbackSchema.parse(args);
+          return handleReportFeedback(check.value, feedbackArgs);
+        } catch (err) {
+          const message =
+            err instanceof z.ZodError
+              ? err.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ')
+              : String(err);
+          return errorResult(`Invalid feedback: ${message}`);
+        }
+      },
+    },
+  ]);
 }


### PR DESCRIPTION
## Summary

MCP tool registration was centralized in one 1476-line file: a ~30-condition if-chain building the `tools/list` array, and a ~760-line `switch` dispatching `tools/call`, both referencing consts/handlers scattered across five sibling files that had no registration logic of their own.

- New `src/tools/tool-registry.ts` — a small `ToolSpec`/`buildToolSet`/`mergeToolSets` seam, plus `requireTracker`/`requireAvailable` helpers.
- Each sibling file (`cost-tools.ts`, `workflow-tools.ts`, `cross-session-tools.ts`, `analytics-tools.ts`, `extended-analytics-tools.ts`) now exports its own `registerXTools(deps): RegisteredToolSet` — a declarative array of its tools, their availability conditions, and their handlers.
- `session-stats.ts`'s `registerTools()` shrinks to composing all six sets (five sibling files + its own local `registerCoreTools()`) into the server's single `tools/list`/`tools/call` handler pair.
- The ~40 near-identical "tracker not available" error blocks are replaced by two shared helpers instead of copy-pasted per tool.
- `nr_observe_get_latency_decomposition` (permanently disabled since it has no real backing tracker today) gets an explicit comment marking it as intentionally off, distinct from "not wired yet."

No behavior change: every tool's `tools/list` availability condition and dispatch error-message text is preserved exactly.

## Test plan

- [x] `npm run build && npm test` — 4631 tests passing, 0 failures
- [x] `npm run lint` and `npm run format:check` — clean

Closes #243