### PR TITLE
Fix: Give proxy-mode tool calls a real per-connection session id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.10] - 2026-07-20
+
+### Fixed
+
+- Proxy mode assigned every concurrent client the same fake shared session id (`sessionId: null` on every proxy tool call, one process-level id reused across all developers). Each proxy client's `AiMcpToolCall` events and per-tool metrics now carry a distinct per-connection session id, resolved from the MCP `Mcp-Session-Id` request header when present and otherwise generated per TCP connection.
+- Proxy mode emitted `ai.session.duration_ms`/`unique_files_read`/`unique_files_written` gauges reflecting a single never-populated session tracker (e.g. a week-long proxy process reporting a multi-day session duration with zero file activity). These gauges are no longer emitted in proxy mode.
+- The on-disk security audit log was never populated in proxy mode because no local store was wired up for it; proxied tool calls are now persisted to the audit log like stdio/local traffic.
+- Documented that the proxy's stdio upstream transport shares one child-process connection across all concurrent clients — safe for stateless MCP servers, not for stateful ones.
+
 ## [1.6.9] - 2026-07-20
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2203,6 +2203,14 @@ async function main(): Promise<void> {
             'Check that mode is not "local" or that cloud credentials are configured.',
         );
       }
+      // Unscoped LocalStore (mirrors --local mode) — proxy mode multiplexes
+      // many concurrent clients, so there's no single session id to scope a
+      // buffer file to. Passing it into NrIngestManager gives AuditTrailManager
+      // a disk backing so the security audit log is actually persisted for
+      // proxied traffic instead of silently living in memory only.
+      const proxyLocalStore = new LocalStore(config.storagePath);
+      proxyLocalStore.initialize();
+
       nrIngest = new NrIngestManager({
         licenseKey: config.licenseKey,
         transportOptions: {
@@ -2215,9 +2223,17 @@ async function main(): Promise<void> {
         projectId: config.projectId,
         orgId: config.orgId,
         sessionTracker: new SessionTracker(sessionTraceId),
+        localStore: proxyLocalStore,
         eventHarvestIntervalMs: config.harvestIntervalMs.events,
         metricHarvestIntervalMs: config.harvestIntervalMs.metrics,
         sessionTraceId,
+        // Proxy mode has no single coherent session — sessionTracker above is
+        // never fed per-client activity, so the ai.session.* gauges would
+        // otherwise report one process-wide fake session (e.g. a week-long
+        // proxy process reporting duration_ms≈604800000 with file-activity
+        // counts stuck at 0). Real per-client attribution instead flows
+        // through ProxyToolCallRecord.sessionId (see ProxyManager.resolveSessionId).
+        trackSessionGauges: false,
       });
       nrIngest.start();
     }

--- a/src/proxy/proxy-manager.test.ts
+++ b/src/proxy/proxy-manager.test.ts
@@ -627,6 +627,88 @@ describe('ProxyManager observability', () => {
     const expected = rec.durationMs - rec.upstreamLatencyMs;
     expect(rec.proxyOverheadMs).toBeCloseTo(expected, 1);
   });
+
+  it('uses the mcp-session-id request header as sessionId when present', async () => {
+    ({ server: mockServer, port: proxyPort } = await createMockMcpServer((_rpc, _req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"jsonrpc":"2.0","id":1,"result":{"content":[]}}');
+    }));
+    const mockPort = proxyPort;
+
+    const records: ProxyToolCallRecord[] = [];
+    await setupWithCallbacks(mockPort, { onToolCall: (r) => records.push(r) });
+
+    await httpRequest(`http://127.0.0.1:${proxyPort}/proxy/test-mcp`, {
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'read_file' },
+      }),
+      headers: { 'content-type': 'application/json', 'mcp-session-id': 'client-session-abc' },
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].sessionId).toBe('client-session-abc');
+  });
+
+  it('assigns a non-null generated sessionId when no mcp-session-id header is sent', async () => {
+    ({ server: mockServer, port: proxyPort } = await createMockMcpServer((_rpc, _req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"jsonrpc":"2.0","id":1,"result":{"content":[]}}');
+    }));
+    const mockPort = proxyPort;
+
+    const records: ProxyToolCallRecord[] = [];
+    await setupWithCallbacks(mockPort, { onToolCall: (r) => records.push(r) });
+
+    await httpRequest(`http://127.0.0.1:${proxyPort}/proxy/test-mcp`, {
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'read_file' },
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].sessionId).toBeTruthy();
+    expect(typeof records[0].sessionId).toBe('string');
+  });
+
+  it('assigns different sessionIds to requests from different connections', async () => {
+    ({ server: mockServer, port: proxyPort } = await createMockMcpServer((_rpc, _req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"jsonrpc":"2.0","id":1,"result":{"content":[]}}');
+    }));
+    const mockPort = proxyPort;
+
+    const records: ProxyToolCallRecord[] = [];
+    await setupWithCallbacks(mockPort, { onToolCall: (r) => records.push(r) });
+
+    const makeCall = () =>
+      httpRequest(`http://127.0.0.1:${proxyPort}/proxy/test-mcp`, {
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'read_file' },
+        }),
+        // Force a fresh TCP connection per call — Node's default agent pools
+        // keep-alive sockets, which would otherwise make both calls land on
+        // the same socket and defeat the point of this test.
+        headers: { 'content-type': 'application/json', connection: 'close' },
+      });
+
+    await makeCall();
+    await makeCall();
+
+    expect(records).toHaveLength(2);
+    expect(records[0].sessionId).toBeTruthy();
+    expect(records[1].sessionId).toBeTruthy();
+    expect(records[0].sessionId).not.toBe(records[1].sessionId);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/proxy/proxy-manager.ts
+++ b/src/proxy/proxy-manager.ts
@@ -4,6 +4,7 @@
  */
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
 import { randomUUID } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 import { createLogger } from '../shared/index.js';
@@ -80,6 +81,7 @@ function peekJsonRpc(body: Buffer): JsonRpcPeek | null {
 
 export class ProxyManager {
   private readonly upstreams = new Map<string, ProxyUpstream>();
+  private readonly connectionSessionIds = new WeakMap<Socket, string>();
   private httpServer: Server | null = null;
   private otlpReceiver: OtlpReceiver | null = null;
   private otlpReceiverStatus: OtlpReceiverStatus = 'disabled';
@@ -236,6 +238,34 @@ export class ProxyManager {
   }
 
   // -------------------------------------------------------------------------
+  // Session identity
+  // -------------------------------------------------------------------------
+
+  /**
+   * Resolve a per-client session id for observability attribution. Proxy mode
+   * multiplexes many concurrent developers' MCP clients through one process,
+   * so a single process-level id would collapse them all into one fake
+   * session. Prefers the MCP Streamable HTTP transport's `Mcp-Session-Id`
+   * header (the real per-client session id when the client/upstream sets
+   * one); otherwise falls back to an id generated once per underlying TCP
+   * socket, so repeated requests on the same keep-alive connection share an
+   * id while distinct connections don't. The WeakMap key means no manual
+   * cleanup is needed — entries are collected with the socket.
+   */
+  private resolveSessionId(req: IncomingMessage): string {
+    const header = req.headers['mcp-session-id'];
+    if (typeof header === 'string' && header.length > 0) return header;
+
+    const socket = req.socket;
+    const existing = this.connectionSessionIds.get(socket);
+    if (existing) return existing;
+
+    const generated = `proxy-conn-${randomUUID()}`;
+    this.connectionSessionIds.set(socket, generated);
+    return generated;
+  }
+
+  // -------------------------------------------------------------------------
   // Request handling
   // -------------------------------------------------------------------------
 
@@ -302,7 +332,8 @@ export class ProxyManager {
     }
 
     // Forward with interception
-    await this.forwardWithInterception(upstream, req, res, body);
+    const sessionId = this.resolveSessionId(req);
+    await this.forwardWithInterception(upstream, req, res, body, sessionId);
   }
 
   private async forwardWithInterception(
@@ -310,6 +341,7 @@ export class ProxyManager {
     req: IncomingMessage,
     res: ServerResponse,
     body: Buffer,
+    sessionId: string,
   ): Promise<void> {
     const rpc = peekJsonRpc(body);
     const isTracked = rpc !== null && TRACKED_METHODS.has(rpc.method);
@@ -324,7 +356,15 @@ export class ProxyManager {
     const proxyOverheadMs = Math.max(0, totalDurationMs - result.upstreamLatencyMs);
 
     if (rpc.method === 'tools/call') {
-      this.emitToolCallRecord(upstream, rpc, result, totalDurationMs, proxyOverheadMs, body);
+      this.emitToolCallRecord(
+        upstream,
+        rpc,
+        result,
+        totalDurationMs,
+        proxyOverheadMs,
+        body,
+        sessionId,
+      );
     } else {
       this.emitRequestRecord(upstream, rpc, result, totalDurationMs, proxyOverheadMs);
     }
@@ -337,6 +377,7 @@ export class ProxyManager {
     durationMs: number,
     proxyOverheadMs: number,
     body: Buffer,
+    sessionId: string,
   ): void {
     if (!this.onToolCall) return;
 
@@ -358,7 +399,7 @@ export class ProxyManager {
 
     const record: ProxyToolCallRecord = {
       id: randomUUID(),
-      sessionId: null,
+      sessionId,
       toolName,
       toolUseId: String(rpc.id ?? ''),
       timestamp: Date.now(),

--- a/src/proxy/upstream-stdio.ts
+++ b/src/proxy/upstream-stdio.ts
@@ -153,6 +153,15 @@ function writeJsonRpcError(
 // StdioUpstream
 // ---------------------------------------------------------------------------
 
+/**
+ * Bridges the proxy's HTTP layer to a single stdio-based MCP server child
+ * process. One child process is spawned per registered upstream (`connect()`)
+ * and shared across every concurrent proxy client that calls `forward()` —
+ * there is no per-client process pool. This is safe for stateless MCP
+ * servers (the common case). A stateful stdio upstream that keeps per-client
+ * state in memory (rather than deriving it from each request) will leak that
+ * state between unrelated developers sharing this proxy instance.
+ */
 export class StdioUpstream implements ProxyUpstream {
   readonly name: string;
   readonly transportType = 'stdio' as const;

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -445,6 +445,38 @@ describe('NrIngestManager', () => {
       expect(metricNames).toContain('ai.tool.duration_ms');
       expect(metricNames).toContain('ai.tool.success');
     });
+
+    it("tags proxy tool call metrics with the record's own sessionId, not sessionTraceId", async () => {
+      const manager = new NrIngestManager(makeIngestOptions({ sessionTraceId: 'proxy-trace-id' }));
+
+      manager.ingestToolCall(makeProxyRecord({ sessionId: 'proxy-conn-xyz' }));
+
+      manager.start();
+      await manager.stop();
+
+      const sentMetrics = (mockSendMetrics.mock.calls[0] as unknown[])[0] as Array<
+        Record<string, unknown>
+      >;
+      const callCountMetric = sentMetrics.find((m) => m.name === 'ai.tool.call_count')!;
+      const attrs = callCountMetric.attributes as Record<string, unknown>;
+      expect(attrs.session_id).toBe('proxy-conn-xyz');
+    });
+
+    it('still tags non-proxy tool call metrics with sessionTraceId (regression guard)', async () => {
+      const manager = new NrIngestManager(makeIngestOptions({ sessionTraceId: 'proxy-trace-id' }));
+
+      manager.ingestToolCall(makeRecord({ sessionId: 'hook-session-001' }));
+
+      manager.start();
+      await manager.stop();
+
+      const sentMetrics = (mockSendMetrics.mock.calls[0] as unknown[])[0] as Array<
+        Record<string, unknown>
+      >;
+      const callCountMetric = sentMetrics.find((m) => m.name === 'ai.tool.call_count')!;
+      const attrs = callCountMetric.attributes as Record<string, unknown>;
+      expect(attrs.session_id).toBe('proxy-trace-id');
+    });
   });
 
   describe('proxyRequestToNrEvent()', () => {
@@ -702,6 +734,30 @@ describe('NrIngestManager', () => {
       expect(metricNames).toContain('ai.session.duration_ms');
       expect(metricNames).toContain('ai.session.unique_files_read');
       expect(metricNames).toContain('ai.session.unique_files_written');
+    });
+
+    it('skips ai.session.* gauges when trackSessionGauges is false (proxy mode)', async () => {
+      const sessionTracker = new SessionTracker('proxy-gauge-session');
+      sessionTracker.recordToolCall(makeRecord({ toolName: 'Read', filePath: '/a.ts' }));
+
+      const manager = new NrIngestManager(
+        makeIngestOptions({ sessionTracker, trackSessionGauges: false }),
+      );
+
+      manager.start();
+      await manager.stop();
+
+      // Nothing else emits metrics in this scenario, so sendMetrics may not
+      // be called at all — the point is that ai.session.* gauges specifically
+      // never appear, not that some other metric was flushed.
+      const sentMetrics = ((mockSendMetrics.mock.calls[0] as unknown[])?.[0] ?? []) as Array<
+        Record<string, unknown>
+      >;
+      const metricNames = sentMetrics.map((m) => m.name);
+
+      expect(metricNames).not.toContain('ai.session.duration_ms');
+      expect(metricNames).not.toContain('ai.session.unique_files_read');
+      expect(metricNames).not.toContain('ai.session.unique_files_written');
     });
 
     it('emits ai.feedback.count on stop when a feedbackCollector is provided', async () => {
@@ -1372,8 +1428,18 @@ describe('session trace ID propagation', () => {
     expect(isProxyToolCall(record)).toBe(false);
   });
 
-  it('proxyToolCallToNrEvent: uses sessionTraceId when provided', () => {
-    const record = makeProxyRecord({ sessionId: 'old-session-id' });
+  it('proxyToolCallToNrEvent: prefers record.sessionId (the real per-connection id) over sessionTraceId', () => {
+    const record = makeProxyRecord({ sessionId: 'proxy-conn-abc' });
+    const event = proxyToolCallToNrEvent(record, {
+      developer: 'dev',
+      appName: 'app',
+      sessionTraceId: TRACE_ID,
+    });
+    expect(event.session_id).toBe('proxy-conn-abc');
+  });
+
+  it('proxyToolCallToNrEvent: falls back to sessionTraceId when record.sessionId is null', () => {
+    const record = makeProxyRecord({ sessionId: null });
     const event = proxyToolCallToNrEvent(record, {
       developer: 'dev',
       appName: 'app',

--- a/src/transport/nr-ingest.ts
+++ b/src/transport/nr-ingest.ts
@@ -112,6 +112,15 @@ export interface NrIngestOptions {
   transport?: 'nr-events-api' | 'otlp' | 'both';
   /** Turn cost attributor for enriching AiToolCall events with cost data. */
   turnCostAttributor?: TurnCostAttributor;
+  /**
+   * Whether `emitSessionGauges()` should emit the `ai.session.duration_ms` /
+   * `unique_files_read` / `unique_files_written` gauges. Default true.
+   * Proxy mode multiplexes many concurrent clients through one process, so
+   * `sessionTracker` reflects no single coherent session — set false there
+   * to avoid emitting a misleading aggregate (e.g. a week-long proxy process
+   * reporting `duration_ms≈604800000` with file-activity counts stuck at 0).
+   */
+  trackSessionGauges?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -259,7 +268,12 @@ export function proxyToolCallToNrEvent(
   if (attrs.projectId) event.project_id = attrs.projectId;
   if (attrs.orgId) event.org_id = attrs.orgId;
 
-  if (attrs.sessionTraceId != null) event.session_id = attrs.sessionTraceId;
+  // Prefer the record's own per-connection sessionId (the real per-client
+  // identity — see ProxyManager.resolveSessionId) over the process-wide
+  // sessionTraceId, which is a shared fallback that would otherwise collapse
+  // every concurrent proxy client into one fake session.
+  const sessionId = record.sessionId ?? attrs.sessionTraceId;
+  if (sessionId != null) event.session_id = sessionId;
   if (record.proxyOverheadMs != null) event.proxy_overhead_ms = record.proxyOverheadMs;
   if (record.errorType != null) event.error_type = record.errorType;
   if (record.inputSizeBytes != null) event.request_size_bytes = record.inputSizeBytes;
@@ -791,6 +805,7 @@ export class NrIngestManager {
   private readonly turnCostAttributor?: TurnCostAttributor;
   private readonly otlpTransport: OtlpTransport | null;
   private readonly otlpEventBridge: OtlpEventBridge | null;
+  private readonly trackSessionGauges: boolean;
   private sessionGaugeIntervalId: ReturnType<typeof setInterval> | null = null;
   private running = false;
 
@@ -815,6 +830,7 @@ export class NrIngestManager {
         localStore: options.localStore,
       });
     this.metricHarvestIntervalMs = options.metricHarvestIntervalMs ?? 60_000;
+    this.trackSessionGauges = options.trackSessionGauges ?? true;
 
     let otlpTransport: OtlpTransport | null = null;
     let otlpEventBridge: OtlpEventBridge | null = null;
@@ -936,9 +952,15 @@ export class NrIngestManager {
 
     this.scheduler.addEvent(event);
 
-    // Record per-call metrics for NR Metric API
+    // Record per-call metrics for NR Metric API. Proxy calls carry their own
+    // per-connection sessionId (see ProxyManager.resolveSessionId) — prefer
+    // it over the process-wide sessionTraceId so metrics from concurrent
+    // proxy clients don't all collapse onto one fake session. Non-proxy
+    // records keep using sessionTraceId unchanged.
     const tool = record.toolName;
-    const sessionId = this.sessionTraceId;
+    const sessionId = isProxyToolCall(record)
+      ? (record.sessionId ?? this.sessionTraceId)
+      : this.sessionTraceId;
     const teamDims: Record<string, string> = {};
     if (this.teamId) teamDims.team_id = this.teamId;
     if (this.projectId) teamDims.project_id = this.projectId;
@@ -1224,10 +1246,12 @@ export class NrIngestManager {
       );
     };
 
-    const metrics = this.sessionTracker.getMetrics();
-    record('ai.session.duration_ms', metrics.sessionDurationMs, { ...teamAttrs });
-    record('ai.session.unique_files_read', metrics.uniqueFilesRead, { ...teamAttrs });
-    record('ai.session.unique_files_written', metrics.uniqueFilesWritten, { ...teamAttrs });
+    if (this.trackSessionGauges) {
+      const metrics = this.sessionTracker.getMetrics();
+      record('ai.session.duration_ms', metrics.sessionDurationMs, { ...teamAttrs });
+      record('ai.session.unique_files_read', metrics.uniqueFilesRead, { ...teamAttrs });
+      record('ai.session.unique_files_written', metrics.uniqueFilesWritten, { ...teamAttrs });
+    }
 
     // Emit cost and efficiency metrics with developer dimension so Team View
     // FACET developer queries return per-developer breakdowns.


### PR DESCRIPTION
## Summary

- Proxy mode multiplexes many concurrent developers' MCP clients through one process, but collapsed all of them into a single fake session — every `ProxyToolCallRecord` hardcoded `sessionId: null`, and `AiMcpToolCall` events / per-tool metrics were tagged with one process-level `sessionTraceId` instead.
- `ProxyManager` now resolves a real per-client session id (the MCP `Mcp-Session-Id` request header when present, otherwise one generated per TCP connection via a `WeakMap<Socket, string>`) and threads it through `AiMcpToolCall` events and per-tool metrics.
- The `ai.session.*` gauges (previously reporting a never-populated, single-session `SessionTracker` in proxy mode — e.g. a week-long process reporting a multi-day "session duration" with zero file activity) are now gated off via a new `trackSessionGauges` option.
- Proxy mode now constructs an unscoped `LocalStore` (mirroring `--local` mode) so the on-disk security audit log is actually persisted for proxied traffic, instead of silently no-op'ing.
- `StdioUpstream`'s shared-connection-across-all-clients limitation is documented (class-level comment), not fixed with pooling — a larger design change explicitly descoped for this PR.
- Deliberately left the generic `AiToolCall` event's `session_id` unchanged (still `sessionTraceId`) — two pre-existing tests lock in that field as a cross-mode "single source of truth"; the proxy-specific `AiMcpToolCall` event and metrics carry the real per-connection id instead.

Closes #244

## Test plan

- [x] New tests in `proxy-manager.test.ts`: `mcp-session-id` header passthrough, per-connection fallback id generation, distinct ids across distinct connections.
- [x] New/updated tests in `nr-ingest.test.ts`: `proxyToolCallToNrEvent` prefers `record.sessionId`; `ingestToolCall` scopes the metric-dimension fix to proxy records only (regression guard confirms stdio/local unaffected); `trackSessionGauges: false` suppresses the three `ai.session.*` gauges.
- [x] `npm run build && npm test` — full suite green (4638 passed, 3 pre-existing skips).
- [x] `npm run lint` — no new lint issues (1 error/5 warnings, all pre-existing in unrelated `scripts/*.ts` files).