### PR TITLE
Fix: Decouple maintenance GC from dashboard-bind, add retention defaults and file-tracker caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.12] - 2026-07-20
+
+### Added
+
+- `retainSessionsDays` now defaults to 90 days instead of retention being off by default; set it to `null` explicitly in config.json to disable retention.
+- Retention now also sweeps `weekly_summaries/`, not just `sessions/`, and re-runs every 6 hours instead of once at startup.
+- `ContextWindowTracker.fileReadCounts` and `SessionTracker.filesRead`/`filesWritten` are now capped at 10,000 unique file paths per session, evicting the oldest-touched file first — previously unbounded, unlike every sibling capped structure in the same files.
+
+### Fixed
+
+- Orphan-buffer/breadcrumb/dead-instance GC only ran when the `--local` dashboard won its port bind, but the default `mode` is `cloud` (the documented stdio-MCP setup) — a crashed session in the default configuration leaked `buffer-<id>.jsonl` and heartbeat files forever. GC now runs unconditionally in every mode, independent of dashboard-bind status.
+
 ## [1.6.11] - 2026-07-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.11",
+      "version": "1.6.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -48,6 +48,7 @@ beforeEach(() => {
   delete process.env.NR_AI_DASHBOARD_PORT;
   delete process.env.NR_AI_DASHBOARD_HOST;
   delete process.env.NR_AI_DASHBOARD_OPEN;
+  delete process.env.NEW_RELIC_AI_RETAIN_SESSIONS_DAYS;
 });
 
 afterEach(() => {
@@ -976,6 +977,41 @@ describe('budget fields', () => {
     expect(config.sessionBudgetUsd).toBeNull();
     expect(config.dailyBudgetUsd).toBeNull();
     expect(config.weeklyBudgetUsd).toBeNull();
+  });
+});
+
+describe('retainSessionsDays', () => {
+  it('defaults to 90 when neither env var nor config file key is set', () => {
+    process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    const configPath = writeConfigFile({});
+    const config = loadMcpConfig({ config: configPath });
+    expect(config.retainSessionsDays).toBe(90);
+  });
+
+  it('stays disabled (null) when the config file explicitly sets it to null', () => {
+    process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    const configPath = writeConfigFile({ retainSessionsDays: null });
+    const config = loadMcpConfig({ config: configPath });
+    expect(config.retainSessionsDays).toBeNull();
+  });
+
+  it('loads a numeric value from the config file', () => {
+    process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    const configPath = writeConfigFile({ retainSessionsDays: 30 });
+    const config = loadMcpConfig({ config: configPath });
+    expect(config.retainSessionsDays).toBe(30);
+  });
+
+  it('env var overrides the config file value', () => {
+    process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    process.env.NEW_RELIC_AI_RETAIN_SESSIONS_DAYS = '14';
+    const configPath = writeConfigFile({ retainSessionsDays: 30 });
+    const config = loadMcpConfig({ config: configPath });
+    expect(config.retainSessionsDays).toBe(14);
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ export interface McpServerConfig {
   readonly nrApiKey: string | null;
   readonly digestWebhookUrl: string | null;
   readonly digestSchedule: string; // cron expression, default: "0 9 * * 1" (Monday 9am)
+  /** Default: 90. `null` disables retention (only reachable via an explicit `null` in config.json). */
   readonly retainSessionsDays: number | null;
   readonly personalAlertThresholds: PersonalAlertThresholds;
   readonly otlpEndpoint: string | null;
@@ -85,6 +86,11 @@ export interface McpServerConfig {
 }
 
 export const DEFAULT_STORAGE_PATH = resolve(homedir(), '.newrelic-preflight');
+
+// Applied only when neither the env var nor the config file specify
+// retainSessionsDays at all — an explicit `null` in config.json still means
+// "retention disabled" (see the resolution logic below).
+const DEFAULT_RETAIN_SESSIONS_DAYS = 90;
 
 export type PlatformTarget = 'native' | 'wsl-windows-cc' | 'wsl-linux-cc';
 
@@ -694,7 +700,11 @@ export function loadMcpConfig(cliOptions?: Partial<CliOptions>): Readonly<McpSer
         const v = parseInt(raw, 10);
         if (Number.isFinite(v) && v > 0) return v;
       }
-      return typeof file.retainSessionsDays === 'number' ? file.retainSessionsDays : null;
+      if (typeof file.retainSessionsDays === 'number') return file.retainSessionsDays;
+      // Explicit `null` in the config file is a deliberate opt-out — distinct
+      // from the key being absent entirely, which falls through to the default.
+      if (file.retainSessionsDays === null) return null;
+      return DEFAULT_RETAIN_SESSIONS_DAYS;
     })(),
 
     otlpEndpoint:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve, join } from 'node:path';
 import {
@@ -11,6 +11,8 @@ import {
   setupDashboardPostBind,
   getDashboardRepollIntervalMs,
   DEFAULT_DASHBOARD_REPOLL_MS,
+  startRetentionSweep,
+  startMaintenanceGc,
 } from './index.js';
 import type { DashboardServer } from './dashboard/dashboard-server.js';
 import type { LocalStore } from './storage/index.js';
@@ -392,6 +394,45 @@ describe('getDashboardRepollIntervalMs()', () => {
 });
 
 describe('setupDashboardPostBind()', () => {
+  function makeLocalStore(): {
+    store: LocalStore;
+    writeLocalDashboardPid: ReturnType<typeof jest.fn>;
+  } {
+    const writeLocalDashboardPid = jest.fn();
+    const store = { writeLocalDashboardPid } as unknown as LocalStore;
+    return { store, writeLocalDashboardPid };
+  }
+
+  it('writes the local-dashboard pid file when isLocalMode is true', () => {
+    const { store, writeLocalDashboardPid } = makeLocalStore();
+    setupDashboardPostBind(
+      { address: '127.0.0.1', port: 7777 },
+      { localStore: store, openOnStart: false, isLocalMode: true },
+    );
+    expect(writeLocalDashboardPid).toHaveBeenCalledWith(process.argv.slice(1), process.cwd());
+  });
+
+  it('does not write the local-dashboard pid file when isLocalMode is false (--stdio)', () => {
+    const { store, writeLocalDashboardPid } = makeLocalStore();
+    setupDashboardPostBind(
+      { address: '127.0.0.1', port: 7777 },
+      { localStore: store, openOnStart: false, isLocalMode: false },
+    );
+    expect(writeLocalDashboardPid).not.toHaveBeenCalled();
+  });
+
+  it('warns that openOnStart is not implemented when set', () => {
+    const { store } = makeLocalStore();
+    setupDashboardPostBind(
+      { address: '127.0.0.1', port: 7777 },
+      { localStore: store, openOnStart: true, isLocalMode: false },
+    );
+    const logged = stderrSpy.mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(logged.some((l: string) => l.includes('openOnStart is not implemented'))).toBe(true);
+  });
+});
+
+describe('startMaintenanceGc()', () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -404,19 +445,16 @@ describe('setupDashboardPostBind()', () => {
     gcStaleBreadcrumbs: ReturnType<typeof jest.fn>;
     gcOrphanBuffers: ReturnType<typeof jest.fn>;
     getActiveSessionIdsFromHeartbeats: ReturnType<typeof jest.fn>;
-    writeLocalDashboardPid: ReturnType<typeof jest.fn>;
     gcDeadLocalInstances: ReturnType<typeof jest.fn>;
   } {
     const gcStaleBreadcrumbs = jest.fn();
     const gcOrphanBuffers = jest.fn();
     const getActiveSessionIdsFromHeartbeats = jest.fn(() => new Set<string>());
-    const writeLocalDashboardPid = jest.fn();
     const gcDeadLocalInstances = jest.fn(() => 0);
     const store = {
       gcStaleBreadcrumbs,
       gcOrphanBuffers,
       getActiveSessionIdsFromHeartbeats,
-      writeLocalDashboardPid,
       gcDeadLocalInstances,
     } as unknown as LocalStore;
     return {
@@ -424,29 +462,22 @@ describe('setupDashboardPostBind()', () => {
       gcStaleBreadcrumbs,
       gcOrphanBuffers,
       getActiveSessionIdsFromHeartbeats,
-      writeLocalDashboardPid,
       gcDeadLocalInstances,
     };
   }
 
-  it('runs a GC pass immediately on bind and returns an unref-able interval', () => {
+  it('runs a GC pass immediately and returns an unref-able interval', () => {
     const { store, gcStaleBreadcrumbs, gcOrphanBuffers } = makeLocalStore();
-    const handle = setupDashboardPostBind(
-      { address: '127.0.0.1', port: 7777 },
-      { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: false },
-    );
+    const handle = startMaintenanceGc({ localStore: store, liveSessionRegistry: undefined });
     expect(gcStaleBreadcrumbs).toHaveBeenCalledTimes(1);
     expect(gcOrphanBuffers).toHaveBeenCalledTimes(1);
-    expect(typeof (handle as NodeJS.Timeout).unref).toBe('function');
+    expect(typeof handle.unref).toBe('function');
     clearInterval(handle);
   });
 
   it('schedules subsequent GC passes on the 5-minute interval', () => {
     const { store, gcStaleBreadcrumbs } = makeLocalStore();
-    const handle = setupDashboardPostBind(
-      { address: '127.0.0.1', port: 7777 },
-      { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: false },
-    );
+    const handle = startMaintenanceGc({ localStore: store, liveSessionRegistry: undefined });
     expect(gcStaleBreadcrumbs).toHaveBeenCalledTimes(1);
     jest.advanceTimersByTime(5 * 60 * 1000);
     expect(gcStaleBreadcrumbs).toHaveBeenCalledTimes(2);
@@ -460,11 +491,8 @@ describe('setupDashboardPostBind()', () => {
     getActiveSessionIdsFromHeartbeats.mockReturnValue(new Set(['heartbeat-only']));
     const liveSessionRegistry = {
       getLiveSessions: jest.fn(() => new Set(['registry-only'])),
-    } as unknown as Parameters<typeof setupDashboardPostBind>[1]['liveSessionRegistry'];
-    const handle = setupDashboardPostBind(
-      { address: '127.0.0.1', port: 7777 },
-      { localStore: store, liveSessionRegistry, openOnStart: false, isLocalMode: false },
-    );
+    } as unknown as Parameters<typeof startMaintenanceGc>[0]['liveSessionRegistry'];
+    const handle = startMaintenanceGc({ localStore: store, liveSessionRegistry });
     const liveArg = gcOrphanBuffers.mock.calls[0]?.[0] as Set<string>;
     expect(liveArg.has('heartbeat-only')).toBe(true);
     expect(liveArg.has('registry-only')).toBe(true);
@@ -482,47 +510,72 @@ describe('setupDashboardPostBind()', () => {
     );
     const liveSessionRegistry = {
       getLiveSessions,
-    } as unknown as Parameters<typeof setupDashboardPostBind>[1]['liveSessionRegistry'];
-    const handle = setupDashboardPostBind(
-      { address: '127.0.0.1', port: 7777 },
-      { localStore: store, liveSessionRegistry, openOnStart: false, isLocalMode: false },
-    );
+    } as unknown as Parameters<typeof startMaintenanceGc>[0]['liveSessionRegistry'];
+    const handle = startMaintenanceGc({ localStore: store, liveSessionRegistry });
     expect(getLiveSessions).toHaveBeenCalledWith({ includeSynthetic: true });
     const liveArg = gcOrphanBuffers.mock.calls[0]?.[0] as Set<string>;
     expect(liveArg.has('proxy-1234567890')).toBe(true);
     clearInterval(handle);
   });
 
-  it('writes the local-dashboard pid file when isLocalMode is true', () => {
-    const { store, writeLocalDashboardPid } = makeLocalStore();
-    const handle = setupDashboardPostBind(
-      { address: '127.0.0.1', port: 7777 },
-      { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: true },
-    );
-    expect(writeLocalDashboardPid).toHaveBeenCalledWith(process.argv.slice(1), process.cwd());
-    clearInterval(handle);
-  });
-
-  it('does not write the local-dashboard pid file when isLocalMode is false (--stdio)', () => {
-    const { store, writeLocalDashboardPid } = makeLocalStore();
-    const handle = setupDashboardPostBind(
-      { address: '127.0.0.1', port: 7777 },
-      { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: false },
-    );
-    expect(writeLocalDashboardPid).not.toHaveBeenCalled();
-    clearInterval(handle);
-  });
-
   it('runs gcDeadLocalInstances as part of the GC pass', () => {
     const { store, gcDeadLocalInstances } = makeLocalStore();
-    const handle = setupDashboardPostBind(
-      { address: '127.0.0.1', port: 7777 },
-      { localStore: store, liveSessionRegistry: undefined, openOnStart: false, isLocalMode: false },
-    );
+    const handle = startMaintenanceGc({ localStore: store, liveSessionRegistry: undefined });
     expect(gcDeadLocalInstances).toHaveBeenCalledTimes(1);
     jest.advanceTimersByTime(5 * 60 * 1000);
     expect(gcDeadLocalInstances).toHaveBeenCalledTimes(2);
     clearInterval(handle);
+  });
+});
+
+describe('startRetentionSweep()', () => {
+  let storagePath: string;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    storagePath = mkdtempSync(join(tmpdir(), 'nr-retention-sweep-'));
+    mkdirSync(resolve(storagePath, 'sessions'), { recursive: true });
+    mkdirSync(resolve(storagePath, 'weekly_summaries'), { recursive: true });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    rmSync(storagePath, { recursive: true, force: true });
+  });
+
+  function writeOldFile(subdir: string, name: string): string {
+    const path = resolve(storagePath, subdir, name);
+    writeFileSync(path, '{}', { mode: 0o600 });
+    const oldDate = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000);
+    utimesSync(path, oldDate, oldDate);
+    return path;
+  }
+
+  it('returns null and schedules nothing when retainSessionsDays is null', () => {
+    const handle = startRetentionSweep({ storagePath, retainSessionsDays: null });
+    expect(handle).toBeNull();
+  });
+
+  it('purges old session and weekly-summary files immediately on start', () => {
+    const oldSession = writeOldFile('sessions', '2026-01-01_old.json');
+    const oldSummary = writeOldFile('weekly_summaries', '2026-W01.json');
+
+    const handle = startRetentionSweep({ storagePath, retainSessionsDays: 90 });
+
+    expect(existsSync(oldSession)).toBe(false);
+    expect(existsSync(oldSummary)).toBe(false);
+    expect(typeof (handle as NodeJS.Timeout).unref).toBe('function');
+    clearInterval(handle as NodeJS.Timeout);
+  });
+
+  it('re-runs the sweep every 6 hours', () => {
+    const handle = startRetentionSweep({ storagePath, retainSessionsDays: 90 });
+
+    const secondOldSession = writeOldFile('sessions', '2026-01-02_old2.json');
+    jest.advanceTimersByTime(6 * 60 * 60 * 1000);
+    expect(existsSync(secondOldSession)).toBe(false);
+
+    clearInterval(handle as NodeJS.Timeout);
   });
 });
 
@@ -561,13 +614,10 @@ describe('startDashboardRepoll()', () => {
     clearInterval(handle);
   });
 
-  it('on takeover success: clears the interval, runs postBind, calls onTakeover', async () => {
+  it('on takeover success: clears the interval, runs postBind', async () => {
     const start = jest.fn(() => Promise.resolve({ address: '127.0.0.1', port: 7777 }));
     const server = makeServer(start);
-    const postBindHandle = setInterval(() => undefined, 10_000);
-    postBindHandle.unref?.();
-    const postBind = jest.fn((_addr: { address: string; port: number }) => postBindHandle);
-    const onTakeover = jest.fn((_handle: NodeJS.Timeout) => undefined);
+    const postBind = jest.fn((_addr: { address: string; port: number }) => undefined);
     const log = silentLogger();
 
     const handle = startDashboardRepoll({
@@ -576,7 +626,6 @@ describe('startDashboardRepoll()', () => {
       port: 7777,
       intervalMs: 50,
       postBind: postBind as Parameters<typeof startDashboardRepoll>[0]['postBind'],
-      onTakeover: onTakeover as Parameters<typeof startDashboardRepoll>[0]['onTakeover'],
       logger: log,
     });
 
@@ -587,7 +636,6 @@ describe('startDashboardRepoll()', () => {
 
     expect(start).toHaveBeenCalledTimes(1);
     expect(postBind).toHaveBeenCalledWith({ address: '127.0.0.1', port: 7777 });
-    expect(onTakeover).toHaveBeenCalledWith(postBindHandle);
     expect(log.info).toHaveBeenCalledWith(expect.stringContaining('taken over'));
 
     // After takeover the interval should be cleared — advance time and
@@ -597,7 +645,6 @@ describe('startDashboardRepoll()', () => {
     expect(start).toHaveBeenCalledTimes(1);
 
     clearInterval(handle);
-    clearInterval(postBindHandle);
   });
 
   it('keeps polling silently when the port is still EADDRINUSE', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   sessionSummaryToDriftRecord,
 } from './storage/session-store.js';
 import { WeeklySummaryGenerator } from './storage/weekly-summary.js';
+import { purgeOldSessions, purgeOldWeeklySummaries } from './storage/retention.js';
 import { HookEventProcessor } from './hooks/index.js';
 import { SessionTracker } from './metrics/session-tracker.js';
 import { CostTracker } from './metrics/cost-tracker.js';
@@ -244,17 +245,93 @@ export function getDashboardRepollIntervalMs(): number {
   return parsed;
 }
 
+const RETENTION_SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+export interface RetentionSweepDeps {
+  readonly storagePath: string;
+  readonly retainSessionsDays: number | null;
+}
+
+/** Purge old session and weekly-summary files. No-op when retention is disabled. */
+export function runRetentionSweep(deps: RetentionSweepDeps): void {
+  if (deps.retainSessionsDays === null || deps.retainSessionsDays <= 0) return;
+  const deletedSessionFiles = purgeOldSessions(deps.storagePath, deps.retainSessionsDays);
+  const deletedWeeklySummaryFiles = purgeOldWeeklySummaries(
+    deps.storagePath,
+    deps.retainSessionsDays,
+  );
+  if (deletedSessionFiles > 0 || deletedWeeklySummaryFiles > 0) {
+    logger.info('Retention purge complete', { deletedSessionFiles, deletedWeeklySummaryFiles });
+  }
+}
+
+/**
+ * Run the retention sweep once immediately, then every 6 hours. Runs in
+ * every mode (cloud/local/both) — retention isn't gated on the dashboard
+ * binding a port. Returns null (and schedules nothing) when
+ * `retainSessionsDays` is disabled.
+ */
+export function startRetentionSweep(deps: RetentionSweepDeps): NodeJS.Timeout | null {
+  if (deps.retainSessionsDays === null || deps.retainSessionsDays <= 0) return null;
+  runRetentionSweep(deps);
+  const interval = setInterval(() => runRetentionSweep(deps), RETENTION_SWEEP_INTERVAL_MS);
+  interval.unref?.();
+  return interval;
+}
+
+export interface MaintenanceGcDeps {
+  readonly localStore: LocalStore;
+  readonly liveSessionRegistry: LiveSessionRegistry | undefined;
+}
+
+/**
+ * One orphan-buffer/breadcrumb/dead-instance GC pass. `gcOrphanBuffers()` is
+ * rename-based, so concurrent processes each running this independently just
+ * means an occasional benign "already moved" warning — no leader election
+ * needed to call this from every process.
+ */
+export function runMaintenanceGcPass(deps: MaintenanceGcDeps): void {
+  const log = createLogger('mcp-cli');
+  const { localStore, liveSessionRegistry } = deps;
+  try {
+    localStore.gcStaleBreadcrumbs();
+    localStore.gcDeadLocalInstances();
+    const live = localStore.getActiveSessionIdsFromHeartbeats();
+    if (liveSessionRegistry) {
+      for (const id of liveSessionRegistry.getLiveSessions({ includeSynthetic: true })) {
+        live.add(id);
+      }
+    }
+    localStore.gcOrphanBuffers(live);
+  } catch (err) {
+    log.warn('GC pass failed', { error: String(err) });
+  }
+}
+
+/**
+ * Run the maintenance GC pass immediately, then every 5 minutes. Called
+ * unconditionally in every mode (cloud/local/both) — decoupled from whether
+ * the `--local` dashboard wins its port bind.
+ */
+export function startMaintenanceGc(deps: MaintenanceGcDeps): NodeJS.Timeout {
+  runMaintenanceGcPass(deps);
+  const interval = setInterval(() => runMaintenanceGcPass(deps), 5 * 60 * 1000);
+  interval.unref?.();
+  return interval;
+}
+
 /**
  * Side-effects wired up once the dashboard HTTP server has bound the port.
  * Runs on the initial-bind success path and on the re-poll takeover path so
  * a headless MCP that later seizes the dashboard performs the same setup
  * (orphan GC, openOnStart warning) as one that bound on first try.
  *
- * Returns the orphan-GC interval handle so the shutdown path can clear it.
+ * Maintenance GC now runs independently of dashboard-bind status (see
+ * `startMaintenanceGc()`), so this only handles the PID file and the
+ * openOnStart warning.
  */
 export interface DashboardPostBindDeps {
   readonly localStore: LocalStore;
-  readonly liveSessionRegistry: LiveSessionRegistry | undefined;
   readonly openOnStart: boolean;
   /** True for `--local` mode — writes the local-dashboard PID file so `preflight update` can find and restart this process. Never true for `--stdio`. */
   readonly isLocalMode: boolean;
@@ -263,37 +340,13 @@ export interface DashboardPostBindDeps {
 export function setupDashboardPostBind(
   addr: { address: string; port: number },
   deps: DashboardPostBindDeps,
-): NodeJS.Timeout {
+): void {
   const log = createLogger('mcp-cli');
   log.info(`Dashboard ready at http://${addr.address}:${addr.port}`);
 
   if (deps.isLocalMode) {
     deps.localStore.writeLocalDashboardPid(process.argv.slice(1), process.cwd());
   }
-
-  // Only the dashboard owner runs orphan-buffer/breadcrumb GC — running it
-  // from every MCP would race with itself and re-archive files repeatedly.
-  // Run once at startup, then every 5 minutes. The interval is unref'd so
-  // it doesn't keep the event loop alive.
-  const { localStore, liveSessionRegistry } = deps;
-  const runGc = (): void => {
-    try {
-      localStore.gcStaleBreadcrumbs();
-      localStore.gcDeadLocalInstances();
-      const live = localStore.getActiveSessionIdsFromHeartbeats();
-      if (liveSessionRegistry) {
-        for (const id of liveSessionRegistry.getLiveSessions({ includeSynthetic: true })) {
-          live.add(id);
-        }
-      }
-      localStore.gcOrphanBuffers(live);
-    } catch (err) {
-      log.warn('GC pass failed', { error: String(err) });
-    }
-  };
-  runGc();
-  const interval = setInterval(runGc, 5 * 60 * 1000);
-  interval.unref?.();
 
   // openOnStart is declared in config but auto-open isn't implemented
   // in v1 — log a warning so a user who set it doesn't assume the feature
@@ -304,8 +357,6 @@ export function setupDashboardPostBind(
         'Open it manually in your browser.',
     );
   }
-
-  return interval;
 }
 
 /**
@@ -327,8 +378,7 @@ export interface DashboardRepollOptions {
   readonly host: string;
   readonly port: number;
   readonly intervalMs?: number;
-  readonly postBind: (addr: { address: string; port: number }) => NodeJS.Timeout;
-  readonly onTakeover?: (gcInterval: NodeJS.Timeout) => void;
+  readonly postBind: (addr: { address: string; port: number }) => void;
   readonly logger?: {
     info: (msg: string, meta?: Record<string, unknown>) => void;
     warn: (msg: string, meta?: Record<string, unknown>) => void;
@@ -349,8 +399,7 @@ export function startDashboardRepoll(opts: DashboardRepollOptions): NodeJS.Timeo
         log.info(
           `Dashboard ownership taken over at http://${addr.address}:${addr.port}; previous owner exited.`,
         );
-        const gcInterval = opts.postBind({ address: addr.address, port: addr.port });
-        opts.onTakeover?.(gcInterval);
+        opts.postBind({ address: addr.address, port: addr.port });
       } catch (err) {
         const decision = classifyDashboardStartError(err, opts.host, opts.port);
         if (decision.kind === 'rethrow') {
@@ -597,7 +646,11 @@ async function main(): Promise<void> {
   let alertRulesWatcher: import('node:fs').FSWatcher | undefined;
   let alertRulesWatchTimer: NodeJS.Timeout | undefined;
   let localStoreForShutdown: LocalStore | undefined;
-  let gcInterval: NodeJS.Timeout | undefined;
+  // Maintenance GC (orphan buffers/breadcrumbs/dead instances) and the
+  // retention sweep (sessions/ + weekly_summaries/) both run in every mode,
+  // independent of dashboard-bind status. Cleared in the shutdown handler.
+  let maintenanceGcInterval: NodeJS.Timeout | undefined;
+  let retentionInterval: NodeJS.Timeout | undefined;
   // Periodic local session-JSON flush so a non-clean exit (crash/SIGKILL)
   // loses at most one interval of session data — persistSession otherwise runs
   // only on clean shutdown. Cleared in the shutdown handler. Synthetic /
@@ -632,7 +685,8 @@ async function main(): Promise<void> {
         sessionSpan.end(stats.toolCallCount, taskMetrics.totalTasksCompleted);
       }
       if (alertEvaluationInterval) clearInterval(alertEvaluationInterval);
-      if (gcInterval) clearInterval(gcInterval);
+      if (maintenanceGcInterval) clearInterval(maintenanceGcInterval);
+      if (retentionInterval) clearInterval(retentionInterval);
       if (dashboardRepollInterval) clearInterval(dashboardRepollInterval);
       if (sessionPersistInterval) clearInterval(sessionPersistInterval);
       // Remove this MCP's heartbeat so the next dashboard-owner GC pass
@@ -795,13 +849,11 @@ async function main(): Promise<void> {
       logger.warn('Legacy buffer migration failed (continuing)', { error: String(err) });
     }
 
-    if (config.retainSessionsDays !== null && config.retainSessionsDays > 0) {
-      const { purgeOldSessions } = await import('./storage/retention.js');
-      const purged = purgeOldSessions(config.storagePath, config.retainSessionsDays);
-      if (purged > 0) {
-        logger.info('Retention purge complete', { deletedSessionFiles: purged });
-      }
-    }
+    retentionInterval =
+      startRetentionSweep({
+        storagePath: config.storagePath,
+        retainSessionsDays: config.retainSessionsDays,
+      }) ?? undefined;
 
     sessionTracker = new SessionTracker(sessionTraceId);
     const costTracker = new CostTracker(sessionTracker);
@@ -838,6 +890,9 @@ async function main(): Promise<void> {
     const apiFailureTracker = new ApiFailureTracker();
     liveSessionRegistry = new LiveSessionRegistry();
     liveSessionRegistry.startSampling();
+    // Unconditional in every mode — decoupled from whether the `--local`
+    // dashboard wins its port bind (see startMaintenanceGc()'s doc comment).
+    maintenanceGcInterval = startMaintenanceGc({ localStore, liveSessionRegistry });
     const turnCostAttributor = new TurnCostAttributor();
     const turnTracker = new TurnTracker();
     const gitEfficiencyTracker = new GitEfficiencyTracker();
@@ -1285,19 +1340,19 @@ async function main(): Promise<void> {
 
       // Capture deps for the post-bind helper. Both the initial-bind path
       // and the re-poll takeover path call this; keeping the closure small
-      // ensures the two paths produce identical side effects (GC interval,
-      // openOnStart warning, etc.).
+      // ensures the two paths produce identical side effects (PID file,
+      // openOnStart warning, etc.). Maintenance GC is unconditional and
+      // already running by this point — not part of this helper.
       const postBindDeps: DashboardPostBindDeps = {
         localStore,
-        liveSessionRegistry,
         openOnStart: config.dashboard.openOnStart,
         isLocalMode: options.local,
       };
-      const runPostBind = (boundAddr: { address: string; port: number }): NodeJS.Timeout =>
+      const runPostBind = (boundAddr: { address: string; port: number }): void =>
         setupDashboardPostBind(boundAddr, postBindDeps);
 
       if (addr) {
-        gcInterval = runPostBind(addr);
+        runPostBind(addr);
       } else {
         // This MCP is headless. Schedule periodic re-bind attempts so it can
         // take over if the current dashboard owner exits. The interval is
@@ -1307,9 +1362,6 @@ async function main(): Promise<void> {
           host: config.dashboard.host,
           port: config.dashboard.port,
           postBind: runPostBind,
-          onTakeover: (handle) => {
-            gcInterval = handle;
-          },
           logger,
         });
         // In --local mode the dashboard IS the process — the HTTP listener is

--- a/src/metrics/context-window-tracker.test.ts
+++ b/src/metrics/context-window-tracker.test.ts
@@ -92,4 +92,21 @@ describe('ContextWindowTracker', () => {
     // file-d has no repeats so it must not appear
     expect(top.find((e) => e.file === '/file-d.ts')).toBeUndefined();
   });
+
+  it('caps fileReadCounts at MAX_UNIQUE_FILES, evicting the earliest-read file first', () => {
+    const t = new ContextWindowTracker();
+    for (let i = 0; i < 10_001; i++) {
+      t.recordToolCall(makeRecord({ filePath: `/file-${i}.ts` }));
+    }
+    expect(t.getMetrics().uniqueFilesRead).toBe(10_000);
+
+    // The very first file read should have been evicted to make room...
+    t.recordToolCall(makeRecord({ filePath: '/file-0.ts' }));
+    expect(t.getMetrics().uniqueFilesRead).toBe(10_000);
+
+    // ...while the most recently read file is still tracked.
+    t.recordToolCall(makeRecord({ filePath: '/file-10000.ts' }));
+    t.recordToolCall(makeRecord({ filePath: '/file-10000.ts' }));
+    expect(t.getMetrics().topRepeatedFiles.some((e) => e.file === '/file-10000.ts')).toBe(true);
+  });
 });

--- a/src/metrics/context-window-tracker.ts
+++ b/src/metrics/context-window-tracker.ts
@@ -8,6 +8,11 @@ export interface ContextWindowMetrics {
   readonly topRepeatedFiles: ReadonlyArray<{ file: string; readCount: number }>;
 }
 
+// Bounds memory on sessions that touch an unusually large number of distinct
+// files (e.g. a repo-wide codemod or search) — head-drop the oldest-read
+// file once the cap is hit, matching EventBuffer's eviction policy.
+const MAX_UNIQUE_FILES = 10_000;
+
 export class ContextWindowTracker {
   private fileReadCounts = new Map<string, number>();
 
@@ -16,6 +21,10 @@ export class ContextWindowTracker {
     const filePath = record.filePath as string | undefined;
     if (!filePath) return;
     const count = this.fileReadCounts.get(filePath) ?? 0;
+    if (count === 0 && this.fileReadCounts.size >= MAX_UNIQUE_FILES) {
+      const oldest = this.fileReadCounts.keys().next().value;
+      if (oldest !== undefined) this.fileReadCounts.delete(oldest);
+    }
     this.fileReadCounts.set(filePath, count + 1);
   }
 

--- a/src/metrics/session-tracker.test.ts
+++ b/src/metrics/session-tracker.test.ts
@@ -176,6 +176,32 @@ describe('SessionTracker', () => {
       expect(metrics.uniqueFilesRead).toBe(0);
       expect(metrics.uniqueFilesWritten).toBe(0);
     });
+
+    it('caps uniqueFilesRead at MAX_UNIQUE_FILES, evicting the earliest-read file first', () => {
+      const tracker = new SessionTracker('test-session');
+
+      for (let i = 0; i < 10_001; i++) {
+        tracker.recordToolCall(makeRecord({ toolName: 'Read', filePath: `/file-${i}.ts` }));
+      }
+      expect(tracker.getMetrics().uniqueFilesRead).toBe(10_000);
+
+      // Re-reading the evicted first file should count as a new entry and
+      // stay within the cap (proves head-drop, not a silent no-op past cap).
+      tracker.recordToolCall(makeRecord({ toolName: 'Read', filePath: '/file-0.ts' }));
+      expect(tracker.getMetrics().uniqueFilesRead).toBe(10_000);
+    });
+
+    it('caps uniqueFilesWritten at MAX_UNIQUE_FILES, evicting the earliest-written file first', () => {
+      const tracker = new SessionTracker('test-session');
+
+      for (let i = 0; i < 10_001; i++) {
+        tracker.recordToolCall(makeRecord({ toolName: 'Write', filePath: `/file-${i}.ts` }));
+      }
+      expect(tracker.getMetrics().uniqueFilesWritten).toBe(10_000);
+
+      tracker.recordToolCall(makeRecord({ toolName: 'Write', filePath: '/file-0.ts' }));
+      expect(tracker.getMetrics().uniqueFilesWritten).toBe(10_000);
+    });
   });
 
   describe('bash tracking', () => {

--- a/src/metrics/session-tracker.ts
+++ b/src/metrics/session-tracker.ts
@@ -63,6 +63,20 @@ export interface SessionMetrics {
 
 const MAX_TIMELINE_ENTRIES = 10_000;
 
+// Bounds memory on sessions that touch an unusually large number of distinct
+// files (e.g. a repo-wide codemod or search) — head-drop the oldest-added
+// file once the cap is hit, matching EventBuffer's eviction policy.
+const MAX_UNIQUE_FILES = 10_000;
+
+/** Add to a bounded Set, evicting the oldest entry (insertion order) once `MAX_UNIQUE_FILES` is hit. */
+function addBoundedFile(set: Set<string>, filePath: string): void {
+  if (!set.has(filePath) && set.size >= MAX_UNIQUE_FILES) {
+    const oldest = set.values().next().value;
+    if (oldest !== undefined) set.delete(oldest);
+  }
+  set.add(filePath);
+}
+
 export function computeP95(values: number[]): number {
   if (values.length === 0) return 0;
   const sorted = [...values].sort((a, b) => a - b);
@@ -178,9 +192,9 @@ export class SessionTracker implements Resettable {
     const filePath = record.filePath as string | undefined;
     if (filePath) {
       if (tool === 'Read') {
-        this.filesRead.add(filePath);
+        addBoundedFile(this.filesRead, filePath);
       } else if (tool === 'Write' || tool === 'Edit') {
-        this.filesWritten.add(filePath);
+        addBoundedFile(this.filesWritten, filePath);
       }
     }
 

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -274,8 +274,9 @@ export class LocalStore {
 
   /**
    * Write a heartbeat file `active-<sessionId>.pid` containing this process's
-   * PID. Used by the dashboard owner's GC pass to determine which buffer
-   * files still have a live owner. The MCP should call this once after
+   * PID. Used by the maintenance GC pass (see `startMaintenanceGc()` in
+   * index.ts, run by every MCP process) to determine which buffer files
+   * still have a live owner. The MCP should call this once after
    * resolving its session_id, and remove it on graceful shutdown via
    * `removeHeartbeat()`.
    *
@@ -297,7 +298,7 @@ export class LocalStore {
 
   /**
    * Remove this MCP's heartbeat file. Called from the shutdown handler so the
-   * dashboard owner's next GC pass knows the buffer is up for adoption.
+   * next maintenance GC pass knows the buffer is up for adoption.
    *
    * No-op if no heartbeat was ever written or if the file is already gone.
    */
@@ -476,9 +477,9 @@ export class LocalStore {
   /**
    * Garbage-collect instance-registry entries whose PID is no longer alive —
    * mirrors `gcStaleBreadcrumbs()`. Called opportunistically from the
-   * dashboard owner's periodic GC pass (see `setupDashboardPostBind()` in
-   * index.ts), so entries left behind by a process that didn't shut down
-   * cleanly don't accumulate indefinitely.
+   * maintenance GC pass (see `startMaintenanceGc()` in index.ts, run by
+   * every MCP process), so entries left behind by a process that didn't shut
+   * down cleanly don't accumulate indefinitely.
    *
    * @returns the number of entries deleted
    */

--- a/src/storage/retention.test.ts
+++ b/src/storage/retention.test.ts
@@ -12,7 +12,7 @@ import {
 import { resolve, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
-import { purgeOldSessions } from './retention.js';
+import { purgeOldSessions, purgeOldWeeklySummaries } from './retention.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 
@@ -97,6 +97,70 @@ describe('purgeOldSessions', () => {
     utimesSync(filePath, recentDate, recentDate);
 
     const deleted = purgeOldSessions(dir, 30);
+    expect(deleted).toBe(0);
+    expect(existsSync(filePath)).toBe(true);
+  });
+});
+
+describe('purgeOldWeeklySummaries', () => {
+  function makeWeeklySummariesDir(dir: string): void {
+    mkdirSync(resolve(dir, 'weekly_summaries'), { recursive: true });
+  }
+
+  function writeWeeklySummaryFile(storagePath: string, name: string): void {
+    const path = resolve(storagePath, 'weekly_summaries', name);
+    writeFileSync(path, JSON.stringify({ week: name }), { mode: 0o600 });
+  }
+
+  it('returns 0 when weekly_summaries directory does not exist', () => {
+    const dir = resolve(tmpdir(), randomUUID()); // never created
+    expect(purgeOldWeeklySummaries(dir, 90)).toBe(0);
+  });
+
+  it('returns 0 for empty weekly_summaries directory', () => {
+    const dir = makeTempDir();
+    makeWeeklySummariesDir(dir);
+    expect(purgeOldWeeklySummaries(dir, 90)).toBe(0);
+  });
+
+  it('does not delete recently-created files', () => {
+    const dir = makeTempDir();
+    makeWeeklySummariesDir(dir);
+    writeWeeklySummaryFile(dir, '2026-W16.json');
+    const deleted = purgeOldWeeklySummaries(dir, 90);
+    expect(deleted).toBe(0);
+    expect(existsSync(resolve(dir, 'weekly_summaries', '2026-W16.json'))).toBe(true);
+  });
+
+  it('ignores non-JSON files', () => {
+    const dir = makeTempDir();
+    makeWeeklySummariesDir(dir);
+    writeFileSync(resolve(dir, 'weekly_summaries', 'readme.txt'), 'ignore me');
+    expect(purgeOldWeeklySummaries(dir, 0)).toBe(0); // 0 day retention: only .json deleted
+  });
+
+  it('deletes JSON files older than retainDays', () => {
+    const dir = makeTempDir();
+    makeWeeklySummariesDir(dir);
+    const filePath = resolve(dir, 'weekly_summaries', '2026-W01.json');
+    writeFileSync(filePath, JSON.stringify({ week: '2026-W01' }), { mode: 0o600 });
+    const oldDate = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000);
+    utimesSync(filePath, oldDate, oldDate);
+
+    const deleted = purgeOldWeeklySummaries(dir, 90);
+    expect(deleted).toBe(1);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  it('keeps files younger than retainDays', () => {
+    const dir = makeTempDir();
+    makeWeeklySummariesDir(dir);
+    const filePath = resolve(dir, 'weekly_summaries', '2026-W10.json');
+    writeFileSync(filePath, JSON.stringify({ week: '2026-W10' }), { mode: 0o600 });
+    const recentDate = new Date(Date.now() - 89 * 24 * 60 * 60 * 1000);
+    utimesSync(filePath, recentDate, recentDate);
+
+    const deleted = purgeOldWeeklySummaries(dir, 90);
     expect(deleted).toBe(0);
     expect(existsSync(filePath)).toBe(true);
   });

--- a/src/storage/retention.ts
+++ b/src/storage/retention.ts
@@ -4,29 +4,39 @@ import { createLogger } from '../shared/index.js';
 
 const logger = createLogger('retention');
 
-export function purgeOldSessions(storagePath: string, retainDays: number): number {
-  const sessionsDir = resolve(storagePath, 'sessions');
-  // Sessions are deleted if mtime < cutoff. Sessions exactly at the cutoff (rare in practice) are retained.
+/**
+ * Delete every `.json` file in `<storagePath>/<subdir>` whose mtime is older
+ * than `retainDays`. Shared by `purgeOldSessions` and
+ * `purgeOldWeeklySummaries` — only the subdirectory and log label differ.
+ */
+function purgeOldJsonFiles(
+  storagePath: string,
+  subdir: string,
+  retainDays: number,
+  fileKind: string,
+): number {
+  const dir = resolve(storagePath, subdir);
+  // Files are deleted if mtime < cutoff. Files exactly at the cutoff (rare in practice) are retained.
   const cutoffMs = Date.now() - retainDays * 24 * 60 * 60 * 1000;
   let deletedCount = 0;
 
   let files: string[];
   try {
-    files = readdirSync(sessionsDir);
+    files = readdirSync(dir);
   } catch {
-    return 0; // sessions directory doesn't exist yet
+    return 0; // directory doesn't exist yet
   }
 
   for (const file of files) {
     if (!file.endsWith('.json')) continue;
-    const fullPath = resolve(sessionsDir, file);
+    const fullPath = resolve(dir, file);
     try {
       const stat = statSync(fullPath);
       if (stat.mtimeMs < cutoffMs) {
         try {
           unlinkSync(fullPath);
           deletedCount++;
-          logger.debug('Purged old session file', {
+          logger.debug(`Purged old ${fileKind} file`, {
             file,
             ageDays: Math.floor((Date.now() - stat.mtimeMs) / 86_400_000),
           });
@@ -36,18 +46,26 @@ export function purgeOldSessions(storagePath: string, retainDays: number): numbe
             // Already deleted by another process — still count it
             deletedCount++;
           } else {
-            logger.warn('Failed to delete session file', { file, error: String(unlinkErr) });
+            logger.warn(`Failed to delete ${fileKind} file`, { file, error: String(unlinkErr) });
           }
         }
       }
     } catch (err) {
-      logger.warn('Failed to check/delete session file', { file, error: String(err) });
+      logger.warn(`Failed to check/delete ${fileKind} file`, { file, error: String(err) });
     }
   }
 
   if (deletedCount > 0) {
-    logger.info('Purged old session files', { count: deletedCount, retainDays });
+    logger.info(`Purged old ${fileKind} files`, { count: deletedCount, retainDays });
   }
 
   return deletedCount;
+}
+
+export function purgeOldSessions(storagePath: string, retainDays: number): number {
+  return purgeOldJsonFiles(storagePath, 'sessions', retainDays, 'session');
+}
+
+export function purgeOldWeeklySummaries(storagePath: string, retainDays: number): number {
+  return purgeOldJsonFiles(storagePath, 'weekly_summaries', retainDays, 'weekly summary');
 }


### PR DESCRIPTION
## Summary

- Retention (`retainSessionsDays`) now defaults to 90 days instead of being off by default (an explicit `null` in config.json still disables it — a deliberate opt-out, distinct from the key being absent). The purge now also sweeps `weekly_summaries/`, not just `sessions/`, and re-runs every 6 hours instead of once at startup.
- Orphan-buffer/breadcrumb/dead-instance GC previously only ran when the `--local` dashboard won its port bind, but the default `mode` is `cloud` (the documented stdio-MCP setup) — a crashed session in the default configuration leaked `buffer-<id>.jsonl` and heartbeat files forever. GC now runs unconditionally in every mode. `gcOrphanBuffers()` is rename-based and already tolerates concurrent execution across processes (a second attempt on an already-moved file just logs a benign warning), so no new leader-election primitive was needed.
- `ContextWindowTracker.fileReadCounts` and `SessionTracker.filesRead`/`filesWritten` were uncapped, unlike every sibling capped structure in the same files. Both now cap at 10,000 unique file paths per session with insertion-order head-drop eviction.

As a consequence of decoupling GC from the dashboard-bind lifecycle, `setupDashboardPostBind()` shrank to just PID-file-writing + the `openOnStart` warning, and `startDashboardRepoll()`'s now-unnecessary `onTakeover` callback was removed.

Closes #247

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — full suite green (4666 passed, pre-existing unrelated skips)
- [x] `npm run lint` — 0 new errors/warnings (1 pre-existing error + 5 warnings, both in `scripts/`, confirmed present on `main` before this branch)
- [x] `npm run format:check` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>