### PR TITLE
Fix: SubagentWatcher UTF-8 boundary decode + dashboard-health test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.14] - 2026-07-21
+
+### Fixed
+
+- `SubagentWatcher` decoded each 64KB poll read with a one-shot `toString('utf-8')`; a multi-byte character (emoji, non-ASCII) whose bytes straddled the read boundary was silently replaced with the Unicode replacement character and permanently lost, since the byte cursor had already advanced past those bytes. Decoding now goes through a per-file `StringDecoder`, which buffers an incomplete trailing byte sequence and reconstructs the character correctly on the next poll.
+
+### Added
+
+- Test coverage for `dashboard-health.ts` (`waitForHealthyDashboard()` and `getDashboardAddress()`), which had none despite gating the pass/fail signal shown by `preflight update` and the setup wizard's daemon-install flow.
+
 ## [1.6.13] - 2026-07-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.13",
+      "version": "1.6.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/subagent-watcher.test.ts
+++ b/src/hooks/subagent-watcher.test.ts
@@ -623,6 +623,66 @@ describe('SubagentWatcher', () => {
   });
 
   // -------------------------------------------------------------------------
+  // UTF-8 multi-byte character straddling the 64 KiB poll-boundary read
+  // -------------------------------------------------------------------------
+
+  function makeAssistantLineWithId(messageId: string): string {
+    return JSON.stringify({
+      type: 'assistant',
+      agentId: AGENT_ID,
+      uuid: 'turn-uuid-1',
+      timestamp: '2026-06-15T12:00:00.000Z',
+      sessionId: PARENT_SESSION,
+      message: {
+        id: messageId,
+        role: 'assistant',
+        model: 'claude-opus-4-7',
+        stop_reason: 'end_turn',
+        content: [{ type: 'text' }],
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_input_tokens: 1000,
+          cache_creation_input_tokens: 200,
+        },
+      },
+    });
+  }
+
+  it('decodes a multi-byte character whose UTF-8 bytes straddle the 64 KiB poll boundary', () => {
+    // Everything in the template up to messageId's value is plain ASCII, so
+    // the marker's string index equals its UTF-8 byte offset.
+    const MARKER = 'MARKERMARKERMARKER';
+    const markerOffset = makeAssistantLineWithId(MARKER).indexOf(MARKER);
+
+    // 💥 (U+1F4A5) is 4 bytes in UTF-8. Pad with ASCII ('a' is 1 byte each) so
+    // the emoji's bytes land at [65534, 65538) — 2 bytes inside the first poll
+    // read ([0, 65536), MAX_BYTES_PER_POLL), 2 bytes in the next.
+    const padLen = 65536 - 2 - markerOffset;
+    const expectedMessageId = 'a'.repeat(padLen) + '💥' + '_tail';
+    const line = makeAssistantLineWithId(expectedMessageId);
+    expect(Buffer.byteLength(line)).toBeGreaterThan(65536);
+    writeFileSync(agentJsonl, line + '\n');
+
+    const watcher = new SubagentWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+
+    // First poll reads exactly [0, 65536) — the emoji is split mid-character
+    // and the line has no newline within that window, so nothing emits yet.
+    watcher.poll();
+    expect(countTokens()).toHaveLength(0);
+
+    // Second poll reads the remainder, completing the emoji and the line.
+    watcher.poll();
+    const tokens = countTokens();
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]!.messageId).toBe(expectedMessageId);
+  });
+
+  // -------------------------------------------------------------------------
   // Schema-drift + cost self-check observability health events
   // -------------------------------------------------------------------------
 

--- a/src/hooks/subagent-watcher.ts
+++ b/src/hooks/subagent-watcher.ts
@@ -40,6 +40,7 @@ import {
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
+import { StringDecoder } from 'node:string_decoder';
 
 import { createLogger } from '../shared/index.js';
 import type { LocalStore } from '../storage/local-store.js';
@@ -227,6 +228,19 @@ export class SubagentWatcher {
   // cursor file. Bounded per-entry by MAX_PARTIAL_LINE_BYTES (see processFile)
   // and per-key by the number of files discovered this poll (see poll()).
   private readonly partialByPath = new Map<string, string>();
+
+  // Per-file UTF-8 decoder state. A 64 KiB poll read can end mid-multi-byte
+  // character; StringDecoder buffers an incomplete trailing sequence
+  // internally and transparently prepends it on the next write() call on the
+  // same instance, so a split character reconstructs correctly across polls
+  // without us tracking raw tail bytes ourselves. This state is in-memory
+  // only, not persisted to the byte cursor: a process restart landing
+  // exactly between the splitting poll and the completing poll still
+  // corrupts that one character, same as before this fix — narrower than
+  // the bug being fixed (a restart is rare; every poll boundary is not).
+  // Evicted alongside
+  // partialByPath in evictStalePartials() — see that method's comment.
+  private readonly decoderByPath = new Map<string, StringDecoder>();
 
   // Health counters
   private filesWatched = 0;
@@ -537,7 +551,12 @@ export class SubagentWatcher {
     }
     if (actuallyRead === 0) return;
 
-    const chunk = buf.subarray(0, actuallyRead).toString('utf-8');
+    let decoder = this.decoderByPath.get(file.path);
+    if (decoder === undefined) {
+      decoder = new StringDecoder('utf-8');
+      this.decoderByPath.set(file.path, decoder);
+    }
+    const chunk = decoder.write(buf.subarray(0, actuallyRead));
     this.bytesRead += actuallyRead;
 
     // Carry over any partial-line content from the previous poll. The in-memory
@@ -646,11 +665,14 @@ export class SubagentWatcher {
    * file reappears, we resume from it.
    */
   private evictStalePartials(files: DiscoveredFile[]): void {
-    if (this.partialByPath.size === 0) return;
+    if (this.partialByPath.size === 0 && this.decoderByPath.size === 0) return;
     const live = new Set<string>();
     for (const f of files) live.add(f.path);
     for (const path of this.partialByPath.keys()) {
       if (!live.has(path)) this.partialByPath.delete(path);
+    }
+    for (const path of this.decoderByPath.keys()) {
+      if (!live.has(path)) this.decoderByPath.delete(path);
     }
   }
 

--- a/src/install/dashboard-health.test.ts
+++ b/src/install/dashboard-health.test.ts
@@ -1,0 +1,91 @@
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
+
+import * as configMod from '../config.js';
+import type { McpServerConfig } from '../config.js';
+import { getDashboardAddress, waitForHealthyDashboard } from './dashboard-health.js';
+
+jest.mock('../config.js', () => ({ loadMcpConfig: jest.fn() }));
+
+const mockedLoadMcpConfig = configMod.loadMcpConfig as jest.MockedFunction<
+  typeof configMod.loadMcpConfig
+>;
+
+describe('getDashboardAddress()', () => {
+  afterEach(() => {
+    mockedLoadMcpConfig.mockReset();
+  });
+
+  it('returns the configured host/port when loadMcpConfig() succeeds', () => {
+    mockedLoadMcpConfig.mockReturnValue({
+      dashboard: { host: '127.0.0.1', port: 7777, openOnStart: false },
+    } as unknown as McpServerConfig);
+    expect(getDashboardAddress()).toEqual({ host: '127.0.0.1', port: 7777 });
+  });
+
+  it('returns null when loadMcpConfig() throws (e.g. cloud mode missing credentials)', () => {
+    mockedLoadMcpConfig.mockImplementation(() => {
+      throw new Error('missing credentials');
+    });
+    expect(getDashboardAddress()).toBeNull();
+  });
+});
+
+describe('waitForHealthyDashboard()', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('resolves true immediately on a healthy, version-matching response', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: true, version: '1.6.14' }),
+    })) as unknown as typeof fetch;
+
+    const healthy = await waitForHealthyDashboard('127.0.0.1', 7777, '1.6.14', 50, 5);
+    expect(healthy).toBe(true);
+  });
+
+  it('resolves false once timeoutMs elapses on a persistent version mismatch', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: true, version: '1.6.13' }),
+    })) as unknown as typeof fetch;
+
+    const healthy = await waitForHealthyDashboard('127.0.0.1', 7777, '1.6.14', 50, 5);
+    expect(healthy).toBe(false);
+  });
+
+  it('treats thrown connection errors as "not yet" and recovers once the server comes up', async () => {
+    let calls = 0;
+    global.fetch = jest.fn(async () => {
+      calls += 1;
+      if (calls < 3) throw new Error('ECONNREFUSED');
+      return { ok: true, json: async () => ({ ok: true, version: '1.6.14' }) };
+    }) as unknown as typeof fetch;
+
+    const healthy = await waitForHealthyDashboard('127.0.0.1', 7777, '1.6.14', 500, 5);
+    expect(healthy).toBe(true);
+    expect(calls).toBeGreaterThanOrEqual(3);
+  });
+
+  it('resolves false once timeoutMs elapses when every call throws (connection refused, never recovers)', async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+
+    const healthy = await waitForHealthyDashboard('127.0.0.1', 7777, '1.6.14', 50, 5);
+    expect(healthy).toBe(false);
+  });
+
+  it('short-circuits the version check when expectedVersion is null', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: true, version: '9.9.9' }),
+    })) as unknown as typeof fetch;
+
+    const healthy = await waitForHealthyDashboard('127.0.0.1', 7777, null, 50, 5);
+    expect(healthy).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- `SubagentWatcher.processFile()` decoded each 64KB poll read with a one-shot `toString('utf-8')`. A multi-byte character (emoji, non-ASCII) whose bytes straddled the read boundary got silently replaced with U+FFFD and permanently lost, since the byte cursor had already advanced past those bytes — a real risk to subagent cost/token attribution. Decoding now goes through a per-file `StringDecoder` (`node:string_decoder`), which buffers an incomplete trailing sequence and reconstructs it on the next poll.
- `dashboard-health.ts` had zero test coverage despite gating the pass/fail signal `preflight update` and the setup wizard's daemon-install flow show the user. Added `dashboard-health.test.ts` covering `waitForHealthyDashboard()` (healthy match, version-mismatch timeout, connection-refused-then-recovers, always-fails timeout, `expectedVersion=null` short-circuit) and `getDashboardAddress()` (success and config-load-throws branches).

Version bumped 1.6.13 → 1.6.14 (the decode fix changes shipped runtime behavior).

Closes #249

## Test plan

- [x] New regression test in `subagent-watcher.test.ts` computes the exact byte offset needed to split a 4-byte emoji across the 64KB poll boundary and asserts the reconstructed `messageId` is byte-for-byte correct
- [x] New `dashboard-health.test.ts` (7 cases) — all pass
- [x] Full suite: `npm run build && npm test && npm run lint && npm run format:check` — 4690 tests pass, lint/format clean (pre-existing `scripts/` lint baseline unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)