### PR TITLE
Fix: instruction-file tracking generalized beyond CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.15] - 2026-07-21
+
+### Added
+
+- Every platform adapter now declares which file(s) it treats as persistent agent instructions — Cursor's `.cursorrules`, Windsurf's `.windsurfrules` — in addition to the `CLAUDE.md`/`.claude/` convention already watched on every platform.
+
+### Fixed
+
+- `nr_observe_get_claudemd_impact` and `nr_observe_get_instruction_drift` only ever detected changes to a file literally named `CLAUDE.md`, so a Cursor or Windsurf project's real instruction file was invisible to both tools even though both platforms have the same tool-call visibility Claude Code does. Both tools now also watch each detected platform's actual instruction-file convention.
+- `nr_observe_get_instruction_drift` previously matched any file path merely containing the substring `CLAUDE.md` (e.g. `NOT_CLAUDE.md`, `CLAUDE.md.bak`), not just the real instruction file. It now matches only the actual file.
+
 ## [1.6.14] - 2026-07-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.14",
+      "version": "1.6.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -1070,6 +1070,7 @@ describe('HookEventProcessor', () => {
       const fakeAdapter = {
         platformName: 'fake',
         visibilityLevel: 'full-hooks' as const,
+        capabilities: { instructionFilePaths: [] },
         initialize: async () => {},
         normalizeToolCall: () => {
           throw new Error('not used by this test');
@@ -1107,6 +1108,7 @@ describe('HookEventProcessor', () => {
       const fakeAdapter = {
         platformName: 'fake',
         visibilityLevel: 'full-hooks' as const,
+        capabilities: { instructionFilePaths: [] },
         initialize: async () => {},
         normalizeToolCall: () => {
           throw new Error('not used by this test');
@@ -1135,6 +1137,7 @@ describe('HookEventProcessor', () => {
       const fakeAdapter = {
         platformName: 'fake',
         visibilityLevel: 'full-hooks' as const,
+        capabilities: { instructionFilePaths: [] },
         initialize: async () => {},
         normalizeToolCall: () => {
           throw new Error('not used by this test');
@@ -1167,6 +1170,7 @@ describe('HookEventProcessor', () => {
       const fakeAdapter = {
         platformName: 'fake',
         visibilityLevel: 'full-hooks' as const,
+        capabilities: { instructionFilePaths: [] },
         initialize: async () => {},
         normalizeToolCall: () => {
           throw new Error('not used by this test');
@@ -1191,6 +1195,7 @@ describe('HookEventProcessor', () => {
       const fakeAdapter = {
         platformName: 'fake',
         visibilityLevel: 'full-hooks' as const,
+        capabilities: { instructionFilePaths: [] },
         initialize: async () => {},
         normalizeToolCall: () => {
           throw new Error('not used by this test');

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { EfficiencyScorer } from './metrics/efficiency-score.js';
 import { TrendAnalyzer } from './metrics/trend-analyzer.js';
 import { CollaborationProfiler } from './metrics/collaboration-profile.js';
 import { ClaudeMdTracker } from './metrics/claudemd-tracker.js';
+import { createDefaultRegistry } from './platforms/index.js';
 import { CostPerOutcomeAnalyzer } from './metrics/cost-per-outcome.js';
 import { PersonalCoach } from './metrics/personal-coach.js';
 import { PromptFeedbackEngine } from './metrics/prompt-feedback.js';
@@ -884,7 +885,9 @@ async function main(): Promise<void> {
     const latencyDecompositionTracker: LatencyDecompositionTracker | undefined = undefined;
     const decisionTracker = new DecisionTracker({ recordContent: config.recordContent });
     const transcriptMessageTracker = new TranscriptMessageTracker();
-    const instructionDriftTracker = new InstructionDriftTracker();
+    const instructionDriftTracker = new InstructionDriftTracker({
+      instructionFilePaths: createDefaultRegistry().getActive().capabilities.instructionFilePaths,
+    });
     const toolSelectionScorer = new ToolSelectionScorer();
     const qualityProxyTracker = new QualityProxyTracker();
     // ApiFailureTracker is instantiated but never fed: recordRequest()/recordFailure()
@@ -1077,7 +1080,12 @@ async function main(): Promise<void> {
 
     const trendAnalyzer = new TrendAnalyzer({ sessionStore });
     const collaborationProfiler = new CollaborationProfiler({ sessionStore });
-    const claudeMdTracker = new ClaudeMdTracker({ sessionStore });
+    const activeInstructionFilePaths =
+      createDefaultRegistry().getActive().capabilities.instructionFilePaths;
+    const claudeMdTracker = new ClaudeMdTracker({
+      sessionStore,
+      instructionFilePaths: activeInstructionFilePaths,
+    });
     const costPerOutcomeAnalyzer = new CostPerOutcomeAnalyzer();
     const personalCoach = new PersonalCoach(weeklySummaryGenerator, config.developer);
     const promptFeedbackEngine = new PromptFeedbackEngine({

--- a/src/metrics/claudemd-tracker.test.ts
+++ b/src/metrics/claudemd-tracker.test.ts
@@ -6,7 +6,7 @@ import type { MetricAggregator } from '../shared/index.js';
 import { SessionStore } from '../storage/session-store.js';
 import type { FullSessionSummary } from '../storage/session-store.js';
 import type { ToolCallRecord } from '../storage/types.js';
-import { ClaudeMdTracker } from './claudemd-tracker.js';
+import { ClaudeMdTracker, matchesInstructionFile } from './claudemd-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -728,5 +728,73 @@ describe('ClaudeMdTracker', () => {
     } as unknown as MetricAggregator;
     tracker.emitMetrics(agg);
     expect(recorded.filter((n) => n === 'ai.claudemd.change')).toHaveLength(0);
+  });
+});
+
+describe('matchesInstructionFile', () => {
+  it('matches CLAUDE.md at the root', () => {
+    expect(matchesInstructionFile('CLAUDE.md', ['CLAUDE.md', '.claude/'])).toBe(true);
+  });
+
+  it('matches CLAUDE.md nested in a subdirectory', () => {
+    expect(matchesInstructionFile('/repo/src/CLAUDE.md', ['CLAUDE.md', '.claude/'])).toBe(true);
+  });
+
+  it('matches files inside .claude/', () => {
+    expect(matchesInstructionFile('/repo/.claude/settings.json', ['CLAUDE.md', '.claude/'])).toBe(
+      true,
+    );
+  });
+
+  it('does not match an unrelated file', () => {
+    expect(matchesInstructionFile('/repo/src/index.ts', ['CLAUDE.md', '.claude/'])).toBe(false);
+  });
+
+  it('matches a plain-filename pattern like .cursorrules', () => {
+    expect(matchesInstructionFile('/repo/.cursorrules', ['.cursorrules'])).toBe(true);
+  });
+
+  it('does not match a filename that merely contains the pattern as a substring', () => {
+    expect(matchesInstructionFile('/repo/NOT_CLAUDE.md', ['CLAUDE.md'])).toBe(false);
+  });
+
+  it('does not match a bare directory-pattern name with no trailing slash or path prefix', () => {
+    expect(matchesInstructionFile('.claude', ['CLAUDE.md', '.claude/'])).toBe(false);
+  });
+});
+
+describe('ClaudeMdTracker — configurable instruction file paths', () => {
+  it('detects changes to a platform-specific instruction file when configured', () => {
+    const tracker = new ClaudeMdTracker({
+      sessionStore: store,
+      instructionFilePaths: ['.cursorrules'],
+    });
+
+    const change = tracker.detectChange(
+      makeToolCall({
+        toolName: 'Write',
+        filePath: '/repo/.cursorrules',
+        lineCount: 5,
+      } as Partial<ToolCallRecord>),
+    );
+
+    expect(change).not.toBeNull();
+  });
+
+  it('still detects CLAUDE.md changes even when a platform-specific path is configured', () => {
+    const tracker = new ClaudeMdTracker({
+      sessionStore: store,
+      instructionFilePaths: ['.cursorrules'],
+    });
+
+    const change = tracker.detectChange(
+      makeToolCall({
+        toolName: 'Write',
+        filePath: '/project/CLAUDE.md',
+        lineCount: 5,
+      } as Partial<ToolCallRecord>),
+    );
+
+    expect(change).not.toBeNull();
   });
 });

--- a/src/metrics/claudemd-tracker.ts
+++ b/src/metrics/claudemd-tracker.ts
@@ -91,8 +91,24 @@ const DEFAULT_INPUT_COST_PER_MTOK = 3;
 /** Average turns per session — used for per-session cost estimation. */
 const AVG_TURNS_PER_SESSION = 10;
 
-/** Regex matching CLAUDE.md files and .claude/ directory contents. */
-const CLAUDEMD_PATTERN = /(?:^|\/)CLAUDE\.md$|(?:^|\/)\.claude\//;
+/** Always watched regardless of platform — the common-denominator convention. */
+const DEFAULT_INSTRUCTION_FILE_PATHS: readonly string[] = ['CLAUDE.md', '.claude/'];
+
+/**
+ * True if `filePath` matches one of `patterns`. A pattern ending in `/` is
+ * treated as a directory prefix (matches anywhere in the path); otherwise
+ * it's treated as an exact filename (matches at the start of the path or
+ * immediately after a `/`). Mirrors the semantics of the regex this
+ * replaces: `/(?:^|\/)CLAUDE\.md$|(?:^|\/)\.claude\//`.
+ */
+export function matchesInstructionFile(filePath: string, patterns: readonly string[]): boolean {
+  return patterns.some((pattern) => {
+    if (pattern.endsWith('/')) {
+      return filePath.includes(`/${pattern}`) || filePath.startsWith(pattern);
+    }
+    return filePath === pattern || filePath.endsWith(`/${pattern}`);
+  });
+}
 
 const MAX_CHANGES = 1_000;
 
@@ -102,17 +118,28 @@ const MAX_CHANGES = 1_000;
 
 export class ClaudeMdTracker {
   private readonly sessionStore: SessionStore;
+  private readonly instructionFilePaths: readonly string[];
   private readonly changes: ClaudeMdChange[] = [];
   private lastEmittedIndex = 0;
   private cachedImpact: { timestamp: number; report: ClaudeMdImpactReport } | null = null;
 
-  constructor(options: { sessionStore: SessionStore }) {
+  constructor(options: { sessionStore: SessionStore; instructionFilePaths?: readonly string[] }) {
     this.sessionStore = options.sessionStore;
+    this.instructionFilePaths = [
+      ...new Set([...DEFAULT_INSTRUCTION_FILE_PATHS, ...(options.instructionFilePaths ?? [])]),
+    ];
+  }
+
+  /** The file path(s)/patterns this instance watches for instruction-file changes. */
+  getTrackedPaths(): readonly string[] {
+    return this.instructionFilePaths;
   }
 
   /**
-   * Examine a tool call record and detect if it modifies a CLAUDE.md or
-   * `.claude/` file. Returns the change event if detected, null otherwise.
+   * Examine a tool call record and detect if it modifies a tracked
+   * instruction file (CLAUDE.md/.claude/ always; plus whatever
+   * platform-specific paths this instance was configured with). Returns the
+   * change event if detected, null otherwise.
    */
   detectChange(toolCall: ToolCallRecord): ClaudeMdChange | null {
     if (toolCall.toolName !== 'Write' && toolCall.toolName !== 'Edit') {
@@ -120,7 +147,7 @@ export class ClaudeMdTracker {
     }
 
     const filePath = typeof toolCall.filePath === 'string' ? toolCall.filePath : null;
-    if (!filePath || !CLAUDEMD_PATTERN.test(filePath)) {
+    if (!filePath || !matchesInstructionFile(filePath, this.instructionFilePaths)) {
       return null;
     }
 

--- a/src/metrics/instruction-drift-tracker.test.ts
+++ b/src/metrics/instruction-drift-tracker.test.ts
@@ -355,3 +355,25 @@ describe('InstructionDriftTracker.recordToolCall (content-based hashing)', () =>
     expect(tracker.promptHash).toBeNull();
   });
 });
+
+describe('InstructionDriftTracker — configurable instruction file paths', () => {
+  it('hashes a platform-specific instruction file when configured', () => {
+    const cursorRulesPath = join(tmpDir, '.cursorrules');
+    writeFileSync(cursorRulesPath, 'be terse');
+    const tracker = new InstructionDriftTracker({ instructionFilePaths: ['.cursorrules'] });
+
+    tracker.recordToolCall(makeReadRecord({ filePath: cursorRulesPath }));
+
+    expect(tracker.promptHash).not.toBeNull();
+  });
+
+  it('still hashes CLAUDE.md even when a platform-specific path is configured', () => {
+    const claudeMdPath = join(tmpDir, 'CLAUDE.md');
+    writeFileSync(claudeMdPath, 'be terse');
+    const tracker = new InstructionDriftTracker({ instructionFilePaths: ['.cursorrules'] });
+
+    tracker.recordToolCall(makeReadRecord({ filePath: claudeMdPath }));
+
+    expect(tracker.promptHash).not.toBeNull();
+  });
+});

--- a/src/metrics/instruction-drift-tracker.ts
+++ b/src/metrics/instruction-drift-tracker.ts
@@ -10,7 +10,7 @@
 
 import { createHash } from 'node:crypto';
 import { createLogger } from '../shared/index.js';
-import { ClaudeMdTracker } from './claudemd-tracker.js';
+import { ClaudeMdTracker, matchesInstructionFile } from './claudemd-tracker.js';
 import type { ToolCallRecord } from '../storage/types.js';
 
 const logger = createLogger('instruction-drift');
@@ -62,6 +62,7 @@ export interface InstructionDriftMetrics {
 export interface InstructionDriftOptions {
   readonly maxRecords?: number;
   readonly minSessionsForComparison?: number;
+  readonly instructionFilePaths?: readonly string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -78,6 +79,7 @@ const DEFAULT_MIN_SESSIONS = 3;
 export class InstructionDriftTracker {
   private readonly maxRecords: number;
   private readonly minSessionsForComparison: number;
+  private readonly instructionFilePaths: readonly string[];
 
   private currentPromptHash: string | null = null;
   private readonly records: SessionOutcomeRecord[] = [];
@@ -86,6 +88,9 @@ export class InstructionDriftTracker {
   constructor(options?: InstructionDriftOptions) {
     this.maxRecords = options?.maxRecords ?? DEFAULT_MAX_RECORDS;
     this.minSessionsForComparison = options?.minSessionsForComparison ?? DEFAULT_MIN_SESSIONS;
+    this.instructionFilePaths = [
+      ...new Set(['CLAUDE.md', '.claude/', ...(options?.instructionFilePaths ?? [])]),
+    ];
   }
 
   get promptHash(): string | null {
@@ -99,7 +104,7 @@ export class InstructionDriftTracker {
     if (!filePath) return;
 
     // Only track reads of instruction files
-    if (!filePath.includes('CLAUDE.md') && !filePath.includes('.claude/')) return;
+    if (!matchesInstructionFile(filePath, this.instructionFilePaths)) return;
 
     let hash: string;
     try {

--- a/src/platforms/amazon-q-adapter.ts
+++ b/src/platforms/amazon-q-adapter.ts
@@ -47,6 +47,7 @@ function isAmazonQToolCallEvent(x: unknown): x is AmazonQToolCallEvent {
 export class AmazonQAdapter implements PlatformAdapter {
   readonly platformName = 'amazon-q';
   readonly visibilityLevel = 'full-hooks' as const;
+  readonly capabilities = { instructionFilePaths: [] as const };
 
   async initialize(_config: PlatformConfig): Promise<void> {
     // Amazon Q Developer CLI supports MCP as a client (preflight can be

--- a/src/platforms/claude-code-adapter.ts
+++ b/src/platforms/claude-code-adapter.ts
@@ -9,6 +9,7 @@ import type {
 export class ClaudeCodeAdapter implements PlatformAdapter {
   readonly platformName = 'claude-code';
   readonly visibilityLevel = 'full-hooks' as const;
+  readonly capabilities = { instructionFilePaths: ['CLAUDE.md', '.claude/'] as const };
 
   async initialize(_config: PlatformConfig): Promise<void> {
     // No-op — Claude Code hooks are configured externally

--- a/src/platforms/continue-adapter.ts
+++ b/src/platforms/continue-adapter.ts
@@ -46,6 +46,7 @@ function isContinueToolCallEvent(x: unknown): x is ContinueToolCallEvent {
 export class ContinueAdapter implements PlatformAdapter {
   readonly platformName = 'continue';
   readonly visibilityLevel = 'mcp-tools-only' as const;
+  readonly capabilities = { instructionFilePaths: [] as const };
 
   async initialize(_config: PlatformConfig): Promise<void> {
     // Continue's native agent (VS Code/JetBrains extension and CLI) has no

--- a/src/platforms/copilot-adapter.ts
+++ b/src/platforms/copilot-adapter.ts
@@ -71,6 +71,7 @@ export function parseCopilotUsageResponse(raw: unknown): CopilotUsageRecord[] {
 export class CopilotAdapter implements PlatformAdapter {
   readonly platformName = 'copilot';
   readonly visibilityLevel = 'self-reported' as const;
+  readonly capabilities = { instructionFilePaths: [] as const };
 
   async initialize(_config: PlatformConfig): Promise<void> {
     // Copilot does not use MCP natively. Data arrives from

--- a/src/platforms/cursor-adapter.ts
+++ b/src/platforms/cursor-adapter.ts
@@ -63,6 +63,9 @@ function isCursorToolCallEvent(x: unknown): x is CursorToolCallEvent {
 export class CursorAdapter implements PlatformAdapter {
   readonly platformName = 'cursor';
   readonly visibilityLevel = 'full-hooks' as const;
+  // https://docs.cursor.com/context/rules — project rules live in `.cursorrules`
+  // (legacy, still supported) or `.cursor/rules/*.mdc`.
+  readonly capabilities = { instructionFilePaths: ['.cursorrules', '.cursor/rules/'] as const };
 
   async initialize(_config: PlatformConfig): Promise<void> {
     // Cursor's built-in tool activity (shell commands, file reads/edits) is

--- a/src/platforms/generic-mcp-adapter.ts
+++ b/src/platforms/generic-mcp-adapter.ts
@@ -124,6 +124,7 @@ export function validateReportToolCallInput(raw: unknown): ReportToolCallInput {
 export class GenericMcpAdapter implements PlatformAdapter {
   readonly platformName = 'generic-mcp';
   readonly visibilityLevel = 'self-reported' as const;
+  readonly capabilities = { instructionFilePaths: [] as const };
 
   private sessionMetadata: PlatformSessionMetadata = { platform: 'generic-mcp' };
 

--- a/src/platforms/kiro-adapter.ts
+++ b/src/platforms/kiro-adapter.ts
@@ -72,6 +72,7 @@ function isKiroToolCallEvent(x: unknown): x is KiroToolCallEvent {
 export class KiroAdapter implements PlatformAdapter {
   readonly platformName = 'kiro';
   readonly visibilityLevel = 'full-hooks' as const;
+  readonly capabilities = { instructionFilePaths: [] as const };
 
   async initialize(_config: PlatformConfig): Promise<void> {
     // Amazon Kiro connects via the MCP stdio protocol.

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -58,6 +58,7 @@ afterEach(() => {
 class FakeAdapter implements PlatformAdapter {
   readonly platformName: string;
   readonly visibilityLevel = 'full-hooks' as const;
+  readonly capabilities = { instructionFilePaths: [] };
   private readonly supported: boolean;
 
   constructor(name: string, supported: boolean) {
@@ -137,6 +138,7 @@ describe('PlatformRegistry', () => {
       const mutableAdapter: PlatformAdapter = {
         platformName: 'mutable',
         visibilityLevel: 'full-hooks',
+        capabilities: { instructionFilePaths: [] },
         async initialize() {},
         normalizeToolCall() {
           return {
@@ -352,6 +354,34 @@ describe('visibility level', () => {
     for (const adapter of registry.getRegistered()) {
       expect(VALID_LEVELS.has(adapter.visibilityLevel)).toBe(true);
     }
+  });
+});
+
+describe('capabilities', () => {
+  it('every registered adapter declares a capabilities object with an array of instructionFilePaths', () => {
+    const registry = createDefaultRegistry();
+    for (const adapter of registry.getRegistered()) {
+      expect(adapter.capabilities).toBeDefined();
+      expect(Array.isArray(adapter.capabilities.instructionFilePaths)).toBe(true);
+    }
+  });
+
+  it('claude-code declares CLAUDE.md and .claude/ as instruction file paths', () => {
+    const registry = createDefaultRegistry();
+    const claudeCode = registry.getRegistered().find((a) => a.platformName === 'claude-code')!;
+    expect(claudeCode.capabilities.instructionFilePaths).toEqual(['CLAUDE.md', '.claude/']);
+  });
+
+  it('cursor declares .cursorrules as an instruction file path', () => {
+    const registry = createDefaultRegistry();
+    const cursor = registry.getRegistered().find((a) => a.platformName === 'cursor')!;
+    expect(cursor.capabilities.instructionFilePaths).toContain('.cursorrules');
+  });
+
+  it('windsurf declares .windsurfrules as an instruction file path', () => {
+    const registry = createDefaultRegistry();
+    const windsurf = registry.getRegistered().find((a) => a.platformName === 'windsurf')!;
+    expect(windsurf.capabilities.instructionFilePaths).toContain('.windsurfrules');
   });
 });
 

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -45,9 +45,30 @@ export interface PlatformSessionMetadata {
  */
 export type PlatformVisibilityLevel = 'full-hooks' | 'self-reported' | 'mcp-tools-only';
 
+/**
+ * Per-platform feature capabilities that go beyond the coarse
+ * `visibilityLevel` — features that assume a specific platform construct
+ * (rather than "hooks vs. no hooks") check these instead of hardcoding
+ * Claude Code's own vocabulary. See docs/PLATFORM_ABSTRACTION_AUDIT.md.
+ */
+export interface PlatformCapabilities {
+  /**
+   * File path(s) or path-fragments this platform's own tooling treats as
+   * persistent agent instructions (Preflight calls this "the instruction
+   * file" regardless of platform) — e.g. Cursor's `.cursorrules`. Every
+   * entry must trace to that platform's own documentation, cited in a
+   * comment on the adapter. Leave empty (`[]`) when unconfirmed — do not
+   * guess. `ClaudeMdTracker`/`InstructionDriftTracker` always additionally
+   * watch `CLAUDE.md`/`.claude/` regardless of this list, so an empty
+   * array here does not lose any detection Preflight already has today.
+   */
+  readonly instructionFilePaths: readonly string[];
+}
+
 export interface PlatformAdapter {
   readonly platformName: string;
   readonly visibilityLevel: PlatformVisibilityLevel;
+  readonly capabilities: PlatformCapabilities;
   initialize(config: PlatformConfig): Promise<void>;
   normalizeToolCall(raw: unknown): NormalizedToolCall;
   /**

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -49,7 +49,7 @@ export type PlatformVisibilityLevel = 'full-hooks' | 'self-reported' | 'mcp-tool
  * Per-platform feature capabilities that go beyond the coarse
  * `visibilityLevel` — features that assume a specific platform construct
  * (rather than "hooks vs. no hooks") check these instead of hardcoding
- * Claude Code's own vocabulary. See docs/PLATFORM_ABSTRACTION_AUDIT.md.
+ * Claude Code's own vocabulary.
  */
 export interface PlatformCapabilities {
   /**

--- a/src/platforms/windsurf-adapter.ts
+++ b/src/platforms/windsurf-adapter.ts
@@ -41,6 +41,9 @@ function isWindsurfToolCallEvent(x: unknown): x is WindsurfToolCallEvent {
 export class WindsurfAdapter implements PlatformAdapter {
   readonly platformName = 'windsurf';
   readonly visibilityLevel = 'full-hooks' as const;
+  // https://docs.windsurf.com/windsurf/cascade/memories#rules — project rules
+  // live in `.windsurfrules`.
+  readonly capabilities = { instructionFilePaths: ['.windsurfrules'] as const };
 
   async initialize(_config: PlatformConfig): Promise<void> {
     // Windsurf supports MCP natively via its own mcp_config.json. Built-in

--- a/src/platforms/zed-adapter.ts
+++ b/src/platforms/zed-adapter.ts
@@ -49,6 +49,7 @@ function isZedToolCallEvent(x: unknown): x is ZedToolCallEvent {
 export class ZedAdapter implements PlatformAdapter {
   readonly platformName = 'zed';
   readonly visibilityLevel = 'mcp-tools-only' as const;
+  readonly capabilities = { instructionFilePaths: [] as const };
 
   async initialize(_config: PlatformConfig): Promise<void> {
     // Zed's native agent has no hook/callback mechanism for tool-call

--- a/src/tools/cross-session-tools.ts
+++ b/src/tools/cross-session-tools.ts
@@ -128,7 +128,9 @@ export const COLLABORATION_PROFILE_TOOL = {
 export const CLAUDEMD_IMPACT_TOOL = {
   name: 'nr_observe_get_claudemd_impact',
   description:
-    'Get the impact report for the most recent CLAUDE.md change: before/after comparison with deltas and verdict.',
+    "Get the impact report for the most recent change to the project's instruction file " +
+    "(CLAUDE.md, or the active platform's equivalent — e.g. .cursorrules on Cursor): " +
+    'before/after comparison with deltas and verdict.',
   inputSchema: {
     type: 'object' as const,
     properties: {},
@@ -473,7 +475,14 @@ export function handleGetClaudeMdImpact(claudeMdTracker: ClaudeMdTracker) {
       content: [
         {
           type: 'text' as const,
-          text: JSON.stringify({ message: 'No CLAUDE.md changes detected' }, null, 2),
+          text: JSON.stringify(
+            {
+              message: 'No instruction-file changes detected',
+              tracked_paths: claudeMdTracker.getTrackedPaths(),
+            },
+            null,
+            2,
+          ),
         },
       ],
     };

--- a/src/tools/extended-analytics-tools.ts
+++ b/src/tools/extended-analytics-tools.ts
@@ -76,7 +76,9 @@ export const DECISION_TREE_TOOL = {
 export const INSTRUCTION_DRIFT_TOOL = {
   name: 'nr_observe_get_instruction_drift',
   description:
-    'Get instruction/prompt drift analysis: tracks how CLAUDE.md or system prompt changes correlate with session outcomes (success rate, token usage, thrashing).',
+    "Get instruction/prompt drift analysis: tracks how the project's instruction file (CLAUDE.md, " +
+    "or the active platform's equivalent) or system prompt changes correlate with session outcomes " +
+    '(success rate, token usage, thrashing).',
   inputSchema: { type: 'object' as const, properties: {} },
   annotations: { readOnlyHint: true },
 };


### PR DESCRIPTION
Fixes #259

## Summary

Every platform adapter now declares which file(s) it treats as persistent agent instructions — Cursor's `.cursorrules`, Windsurf's `.windsurfrules` — in addition to the `CLAUDE.md`/`.claude/` convention already watched on every platform.

- `nr_observe_get_claudemd_impact` and `nr_observe_get_instruction_drift` previously only detected changes to a file literally named `CLAUDE.md`. Both tools now also watch each detected platform's actual instruction-file convention.
- `nr_observe_get_instruction_drift` previously matched any file path merely containing the substring `CLAUDE.md` (e.g. `NOT_CLAUDE.md`, `CLAUDE.md.bak`), not just the real instruction file. It now matches only the actual file.

See `CHANGELOG.md` for full details.

## Test plan

- [x] `npm run build && npm test` — 4708/4708 passing (3 skipped)
- [x] `npm run lint` && `npm run format:check` — clean