### PR TITLE
Feat: add nr_observe_mark_task_boundary MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.16] - 2026-07-21
+
+### Added
+
+- New MCP tool `nr_observe_mark_task_boundary` lets any AI coding assistant explicitly signal the end of a task. Claude Code already gets this boundary for free from its own `AskUserQuestion`/`TaskUpdate` tool calls, but platforms without an equivalent tool had no way to mark task boundaries, which reduced the accuracy of anti-pattern, efficiency-score, and cost-per-outcome metrics that segment activity by task.
+
 ## [1.6.15] - 2026-07-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,7 @@ Tools are conditionally registered based on available dependencies (e.g., cross-
 - `nr_observe_get_anti_patterns` — detected thrashing, re-reads, blind edits, stuck loops
 - `nr_observe_get_workflow_trace` — ordered sequence of recent tool calls
 - `nr_observe_report_feedback` — record user quality feedback (`good`/`bad`/`neutral`) for a task
+- `nr_observe_mark_task_boundary` — explicitly close the current task; the universal (and, outside Claude Code, the only) task-boundary signal
 
 **Analytics Tools:**
 

--- a/docs/COMMANDS_TABLE.md
+++ b/docs/COMMANDS_TABLE.md
@@ -444,6 +444,33 @@ Source: `src/tools/workflow-tools.ts`
 
 ---
 
+### `nr_observe_mark_task_boundary`
+
+Explicitly mark the end of the current task. This is the universal task-boundary signal — call it on any platform, but it's the only boundary signal on platforms other than Claude Code, which also infers boundaries from its own `AskUserQuestion`/`TaskUpdate` tool calls.
+
+**Parameters:** None
+
+**Returns:**
+
+```json
+{
+  "recorded": true,
+  "closed_task_id": "task-001"
+}
+```
+
+`closed_task_id` is `null` if no task was active.
+
+**Data source:** `TaskDetector`
+
+**How it works:** Calls `TaskDetector.markBoundary()`, which closes the active task (if any) the same way the `AskUserQuestion`/`TaskUpdate` boundary signals do — computing the cost/token delta since task start, appending the completed task to history, and clearing the active task. Improves the accuracy of anti-pattern, efficiency-score, and cost-per-outcome metrics, which all segment activity by task.
+
+**Requires:** `TaskDetector`
+
+Source: `src/tools/workflow-tools.ts`, `src/metrics/task-detector.ts`
+
+---
+
 ## Cross-Session Tools
 
 These tools query persisted session data from disk (`~/.newrelic-preflight/sessions/`). They are only registered when `SessionStore` and related analyzers are available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.15",
+  "version": "1.6.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.15",
+      "version": "1.6.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.15",
+  "version": "1.6.16",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/metrics/task-detector.test.ts
+++ b/src/metrics/task-detector.test.ts
@@ -785,3 +785,33 @@ describe('drainNewlyCompletedTasks()', () => {
     expect(detector.getCompletedTasks()).toHaveLength(0);
   });
 });
+
+describe('markBoundary', () => {
+  it('closes the active task and returns it', () => {
+    const detector = new TaskDetector();
+    detector.recordToolCall(makeRecord({ toolName: 'Read', filePath: '/a.ts' }));
+
+    const closed = detector.markBoundary(Date.now());
+
+    expect(closed).not.toBeNull();
+    expect(closed!.toolCallCount).toBe(1);
+    expect(detector.getMetrics().currentTaskActive).toBe(false);
+    expect(detector.getMetrics().totalTasksCompleted).toBe(1);
+  });
+
+  it('returns null when no task is active', () => {
+    const detector = new TaskDetector();
+    expect(detector.markBoundary(Date.now())).toBeNull();
+  });
+
+  it('is equivalent to the existing AskUserQuestion boundary signal', () => {
+    const detector = new TaskDetector();
+    detector.recordToolCall(makeRecord({ toolName: 'Read', filePath: '/a.ts' }));
+    detector.recordToolCall(makeRecord({ toolName: 'Read', filePath: '/b.ts' }));
+
+    const closed = detector.markBoundary(Date.now());
+
+    expect(closed!.filesRead).toEqual(['/a.ts', '/b.ts']);
+    expect(detector.getCurrentTask()).toBeNull();
+  });
+});

--- a/src/metrics/task-detector.ts
+++ b/src/metrics/task-detector.ts
@@ -272,6 +272,17 @@ export class TaskDetector implements Resettable {
     return this.activeTask?.taskId ?? null;
   }
 
+  /**
+   * Explicitly close the current task, if one is active. This is the
+   * universal task-boundary signal any platform's calling agent can invoke
+   * via `nr_observe_mark_task_boundary` — the only boundary signal available
+   * on platforms that have no equivalent to Claude Code's
+   * `AskUserQuestion`/`TaskUpdate` tools.
+   */
+  markBoundary(timestamp: number): AiCodingTask | null {
+    return this.closeCurrentTask(timestamp);
+  }
+
   getMetrics(): TaskMetrics {
     const completed = this.completedTasks;
 
@@ -338,8 +349,8 @@ export class TaskDetector implements Resettable {
     this.snapshotCostState();
   }
 
-  private closeCurrentTask(endTime: number): void {
-    if (this.activeTask === null) return;
+  private closeCurrentTask(endTime: number): AiCodingTask | null {
+    if (this.activeTask === null) return null;
 
     const { costUsd, tokens } = this.computeCostDelta();
 
@@ -360,6 +371,7 @@ export class TaskDetector implements Resettable {
 
     this.activeTask = null;
     this.clearIdleTimer();
+    return completed;
   }
 
   private snapshotCostState(): void {

--- a/src/tools/workflow-tools.test.ts
+++ b/src/tools/workflow-tools.test.ts
@@ -12,6 +12,7 @@ import {
   handleGetAntiPatterns,
   handleGetEfficiencyScore,
   handleReportFeedback,
+  handleMarkTaskBoundary,
   registerWorkflowTools,
 } from './workflow-tools.js';
 import { handleGetCostBreakdown } from './cost-tools.js';
@@ -776,6 +777,7 @@ describe('registerWorkflowTools()', () => {
       'nr_observe_get_anti_patterns',
       'nr_observe_get_efficiency_score',
       'nr_observe_get_workflow_trace',
+      'nr_observe_mark_task_boundary',
       'nr_observe_report_feedback',
     ]);
     const result = await handlers.nr_observe_get_workflow_trace!(undefined);
@@ -811,6 +813,7 @@ describe('registerWorkflowTools()', () => {
       'nr_observe_get_anti_patterns',
       'nr_observe_get_efficiency_score',
       'nr_observe_get_workflow_trace',
+      'nr_observe_mark_task_boundary',
       'nr_observe_report_feedback',
     ]);
   });
@@ -822,5 +825,47 @@ describe('registerWorkflowTools()', () => {
     expect(result.isError).toBe(true);
     const body = JSON.parse(result.content[0]!.text);
     expect(body.error).toContain('Invalid feedback');
+  });
+});
+
+describe('handleMarkTaskBoundary()', () => {
+  it('closes the active task and reports its id', () => {
+    const taskDetector = new TaskDetector();
+    taskDetector.recordToolCall(makeRecord({ toolName: 'Read', filePath: '/a.ts' }));
+
+    const result = handleMarkTaskBoundary(taskDetector);
+    const body = JSON.parse(result.content[0]!.text) as {
+      recorded: boolean;
+      closed_task_id: string | null;
+    };
+
+    expect(body.recorded).toBe(true);
+    expect(body.closed_task_id).not.toBeNull();
+  });
+
+  it('reports a null closed_task_id when no task was active', () => {
+    const taskDetector = new TaskDetector();
+
+    const result = handleMarkTaskBoundary(taskDetector);
+    const body = JSON.parse(result.content[0]!.text) as {
+      recorded: boolean;
+      closed_task_id: string | null;
+    };
+
+    expect(body.recorded).toBe(true);
+    expect(body.closed_task_id).toBeNull();
+  });
+});
+
+describe('registerWorkflowTools — mark_task_boundary', () => {
+  it('is available whenever taskDetector is provided', () => {
+    const taskDetector = new TaskDetector();
+    const { tools } = registerWorkflowTools({ taskDetector });
+    expect(tools.some((t) => t.name === 'nr_observe_mark_task_boundary')).toBe(true);
+  });
+
+  it('is not listed when taskDetector is absent', () => {
+    const { tools } = registerWorkflowTools({});
+    expect(tools.some((t) => t.name === 'nr_observe_mark_task_boundary')).toBe(false);
   });
 });

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -145,6 +145,22 @@ export const REPORT_FEEDBACK_TOOL = {
   annotations: { readOnlyHint: false },
 };
 
+export const MARK_TASK_BOUNDARY_TOOL = {
+  name: 'nr_observe_mark_task_boundary',
+  description:
+    'Explicitly mark the end of the current task (a discrete unit of work between user ' +
+    'instructions). Call this once you finish responding to a user request. This is the ' +
+    "universal task-boundary signal — call it on any platform, but it's the *only* boundary " +
+    'signal on platforms other than Claude Code (which also infers boundaries from its own ' +
+    'AskUserQuestion/TaskUpdate tool calls). Improves the accuracy of anti-pattern, ' +
+    'efficiency-score, and cost-per-outcome metrics, which all segment activity by task.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {},
+  },
+  annotations: { readOnlyHint: false },
+};
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -375,6 +391,26 @@ export function handleReportFeedback(
   };
 }
 
+export function handleMarkTaskBoundary(taskDetector: TaskDetector) {
+  const closed = taskDetector.markBoundary(Date.now());
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          {
+            recorded: true,
+            closed_task_id: closed?.taskId ?? null,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
@@ -446,6 +482,15 @@ export function registerWorkflowTools(deps: WorkflowToolsDeps): RegisteredToolSe
               : String(err);
           return errorResult(`Invalid feedback: ${message}`);
         }
+      },
+    },
+    {
+      definition: MARK_TASK_BOUNDARY_TOOL,
+      available: !!deps.taskDetector,
+      handle: () => {
+        const check = requireTracker(deps.taskDetector, 'TaskDetector');
+        if (!check.ok) return check.result;
+        return handleMarkTaskBoundary(check.value);
       },
     },
   ]);


### PR DESCRIPTION
## Summary

Adds a new MCP tool, `nr_observe_mark_task_boundary`, that lets any AI coding assistant explicitly signal the end of a task. Claude Code already gets this boundary for free from its own `AskUserQuestion`/`TaskUpdate` tool calls, but platforms without an equivalent tool had no way to mark task boundaries, which reduced the accuracy of anti-pattern, efficiency-score, and cost-per-outcome metrics that segment activity by task.

Fixes #261

- `TaskDetector.markBoundary(timestamp)` closes the active task the same way the existing boundary signals do, returning the closed task (or `null` if none was active).
- The new tool is documented in `CLAUDE.md` and `docs/COMMANDS_TABLE.md`.

## Test plan

- [x] `npm test` — full suite passes
- [x] `npm run build` — clean
- [x] `npm run lint` / `npm run format:check` — clean