### PR TITLE
Fix: Thread validateSsrfUrl into key-validator.ts and cross-session-tools.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.18] - 2026-07-21
+
+### Fixed
+
+- License-key/API-key validation (`install/key-validator.ts`) and the team-summary NerdGraph query (`tools/cross-session-tools.ts`) now run their outbound URL through the same SSRF validation (`validateSsrfUrl`) already applied to the proxy's outbound HTTP dispatch. Both build their URL from a fixed map of real NR hostnames, so this closes a consistency gap rather than a currently exploitable path.
+
 ## [1.6.17] - 2026-07-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.17",
+  "version": "1.6.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.17",
+      "version": "1.6.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.17",
+  "version": "1.6.18",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/install/key-validator.test.ts
+++ b/src/install/key-validator.test.ts
@@ -1,10 +1,21 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+// As in src/security/ssrf.test.ts and src/proxy/upstream-http.test.ts, the module
+// must be replaced wholesale via jest.mock() before anything else imports it —
+// this ESM/ts-jest setup can't jest.spyOn() a named export directly.
+jest.mock('../security/index.js', () => ({ validateSsrfUrl: jest.fn() }));
+
+import { validateSsrfUrl } from '../security/index.js';
 import {
   validateLicenseKey,
   validateApiKey,
   getEventsApiUrl,
   getNerdgraphUrl,
 } from './key-validator.js';
+
+afterEach(() => {
+  jest.mocked(validateSsrfUrl).mockReset();
+});
 
 // ---------------------------------------------------------------------------
 // URL helper tests
@@ -159,6 +170,20 @@ describe('validateLicenseKey', () => {
     const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
     expect((options.headers as Record<string, string>)['X-Insert-Key']).toBe('MY-KEY');
   });
+
+  it('rejects without calling fetch when SSRF validation fails', async () => {
+    jest.mocked(validateSsrfUrl).mockImplementation(() => {
+      throw new Error('blocked host');
+    });
+    const result = await validateLicenseKey({
+      licenseKey: 'TEST-KEY',
+      accountId: '12345',
+      collectorHost: null,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.valid).toBe(false);
+    expect(result.detail).toContain('blocked host');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -271,5 +296,15 @@ describe('validateApiKey', () => {
     await validateApiKey({ nrApiKey: 'NRAK-MY-KEY', collectorHost: null });
     const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
     expect((options.headers as Record<string, string>)['Api-Key']).toBe('NRAK-MY-KEY');
+  });
+
+  it('rejects without calling fetch when SSRF validation fails', async () => {
+    jest.mocked(validateSsrfUrl).mockImplementation(() => {
+      throw new Error('blocked host');
+    });
+    const result = await validateApiKey({ nrApiKey: 'NRAK-TEST', collectorHost: null });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.valid).toBe(false);
+    expect(result.detail).toContain('blocked host');
   });
 });

--- a/src/install/key-validator.ts
+++ b/src/install/key-validator.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '../shared/index.js';
+import { validateSsrfUrl } from '../security/index.js';
 
 const logger = createLogger('key-validator');
 
@@ -42,6 +43,7 @@ export async function validateLicenseKey(params: {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
+    validateSsrfUrl('validateLicenseKey', new URL(url));
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'X-Insert-Key': licenseKey, 'Content-Type': 'application/json' },
@@ -88,6 +90,7 @@ export async function validateApiKey(params: {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
+    validateSsrfUrl('validateApiKey', new URL(url));
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'Api-Key': nrApiKey, 'Content-Type': 'application/json' },

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -1,4 +1,11 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+// As in src/security/ssrf.test.ts and src/proxy/upstream-http.test.ts, the module
+// must be replaced wholesale via jest.mock() before anything else imports it —
+// this ESM/ts-jest setup can't jest.spyOn() a named export directly.
+jest.mock('../security/index.js', () => ({ validateSsrfUrl: jest.fn() }));
+
+import { validateSsrfUrl } from '../security/index.js';
 import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -45,6 +52,7 @@ beforeEach(() => {
 
 afterEach(() => {
   stderrSpy.mockRestore();
+  jest.mocked(validateSsrfUrl).mockReset();
   if (existsSync(tmpDir)) {
     rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -973,6 +981,26 @@ describe('Cross-session tool handlers', () => {
   // -------------------------------------------------------------------------
 
   describe('handleGetTeamSummary success path', () => {
+    it('rejects without calling fetch when SSRF validation fails', async () => {
+      jest.mocked(validateSsrfUrl).mockImplementation(() => {
+        throw new Error('blocked host');
+      });
+      const fetchSpy = jest.spyOn(global, 'fetch');
+      try {
+        const result = await handleGetTeamSummary({
+          teamId: 'my-team',
+          accountId: '12345',
+          nrApiKey: 'test-key',
+        });
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0]!.text);
+        expect(parsed.error).toContain('blocked host');
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
     it('merges rows from all 3 NRQL queries into developers/totals', async () => {
       const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
         const body = typeof init?.body === 'string' ? init.body : '';

--- a/src/tools/cross-session-tools.ts
+++ b/src/tools/cross-session-tools.ts
@@ -15,6 +15,7 @@
 
 import { readFileSync, writeFileSync } from 'node:fs';
 
+import { validateSsrfUrl } from '../security/index.js';
 import type { SessionStore } from '../storage/session-store.js';
 import { formatSlackDigest } from '../digest/digest-formatter.js';
 import { sendSlackDigest } from '../digest/digest-sender.js';
@@ -791,6 +792,7 @@ export async function handleGetTeamSummary(options: {
   }
 
   async function runNrql<T = Record<string, unknown>>(nrql: string): Promise<T[]> {
+    validateSsrfUrl('handleGetTeamSummary', new URL(nerdgraphUrl));
     const resp = await fetch(nerdgraphUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'API-Key': options.nrApiKey! },


### PR DESCRIPTION
Fixes #265

## Summary

- License-key/API-key validation and the team-summary NerdGraph query now run their outbound URL through the same SSRF validation (`validateSsrfUrl`) already applied to the proxy's outbound HTTP dispatch.
- Both call sites build their URL from a fixed map of real NR hostnames with a safe fallback, so this closes a defense-in-depth/consistency gap rather than a currently exploitable path — no behavior change for legitimate calls.

## Test plan

- [x] Added tests asserting `fetch` is never called when SSRF validation rejects the target URL, for both `key-validator.ts` and `cross-session-tools.ts`.
- [x] `npm run build && npm test` — full suite passes.
- [x] `npm run lint` — no new lint issues introduced.
- [x] Version bumped to 1.6.18 and CHANGELOG updated.