### PR TITLE
Fix: Drop dead sessionId field from client-side AlertEvent type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.20] - 2026-07-21
+
+### Fixed
+
+- The client-side `AlertEvent` type in `src/web/api/client.ts` declared an optional `sessionId` field mirroring the server-side `AlertEvent` shape, but `AlertLog`'s runtime schema (`src/alerts/alert-log.ts`) never included `sessionId`, so `/api/alerts/recent` never actually returned it. Removed the dead field; `src/web/store/liveStore.ts` already had its own `AlertEvent` correctly omitting it, with a comment explaining why.
+
 ## [1.6.19] - 2026-07-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.19",
+  "version": "1.6.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.19",
+      "version": "1.6.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.19",
+  "version": "1.6.20",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -612,9 +612,11 @@ export interface CacheHealthResponse {
   readonly week_over_week_delta_pts: number | null;
 }
 
+// Mirrors the shape AlertLog.readRecent actually returns — its
+// AlertEventSchema (src/alerts/alert-log.ts) has no sessionId field, so the
+// live server-side AlertEvent's optional sessionId never reaches this API.
 export interface AlertEvent {
   readonly id: string;
-  readonly sessionId?: string;
   readonly state: 'firing' | 'cleared';
   readonly severity: 'info' | 'warning' | 'critical';
   readonly title: string;


### PR DESCRIPTION
## Summary
- `src/web/api/client.ts`'s `AlertEvent` type declared an optional `sessionId` field mirroring the server-side `AlertEvent` shape (`src/dashboard/live-event-bus.ts`), but `AlertLog`'s runtime schema (`src/alerts/alert-log.ts`, `AlertEventSchema`) never included `sessionId` — Zod's default object parsing strips unknown keys, so `/api/alerts/recent` never actually returns it.
- Verified the only consumer of this type (`RecentAlertsPanel` in `src/web/views/Today.tsx`) never reads `.sessionId`, so no behavior changes.
- `src/web/store/liveStore.ts` already has its own local `AlertEvent` (used for the SSE-driven live-alert store) correctly omitting `sessionId`, with a comment explaining why. Added an analogous comment to `client.ts`'s copy.

Fixes #232

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.web.json` — clean
- [x] `npm test` — 4709 passed