### PR TITLE
Feat: Add Factory Droid platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-07-22
+
+### Added
+
+- **Factory Droid platform adapter** — Preflight now detects and normalizes tool calls from [Factory Droid](https://factory.ai), Factory.ai's agentic CLI and IDE integrations. Droid sessions are detected via `MCP_CLIENT=droid` or `NEW_RELIC_AI_PLATFORM=droid` (Factory's documentation doesn't expose an ambient environment variable for automatic detection, unlike several other platforms). Droid's `PreToolUse`/`PostToolUse` hook events use the same shape Claude Code, Kiro, and Amazon Q already send, so its built-in tool calls (`Task`, `Execute`, `Glob`, `Grep`, `Read`, `Edit`, `Create`, `FetchUrl`, `WebSearch`) are captured and mapped to Preflight's standard vocabulary automatically once hooks are configured. Setup instructions are included in `docs/ADAPTERS.md`.
+
 ## [1.6.20] - 2026-07-21
 
 ### Fixed

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,6 +1,6 @@
 # Platform Adapters
 
-Preflight supports 8 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
+Preflight supports 9 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
 
 This doc is the canonical reference for what each adapter can and can't observe, how detection and setup actually work, and where the gaps are. It mirrors `src/platforms/*.ts` and the hook-event handling in `src/hooks/collector-script.ts` — if you change either, update this doc in the same PR.
 
@@ -8,17 +8,17 @@ This doc is the canonical reference for what each adapter can and can't observe,
 
 ## Integration mechanisms
 
-| Mechanism                                                                                                      | Platforms                   | What's captured                                                                        | `visibilityLevel` |
-| -------------------------------------------------------------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
-| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q | All built-in tool calls                                                                | `full-hooks`      |
-| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf            | All built-in tool calls                                                                | `full-hooks`      |
-| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev           | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
-| **HTTP push from an extension**                                                                                | GitHub Copilot              | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
-| **Self-report via MCP tools**                                                                                  | Generic MCP fallback        | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
+| Mechanism                                                                                                      | Platforms                          | What's captured                                                                        | `visibilityLevel` |
+| -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
+| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid | All built-in tool calls                                                                | `full-hooks`      |
+| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                   | All built-in tool calls                                                                | `full-hooks`      |
+| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev                  | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
+| **HTTP push from an extension**                                                                                | GitHub Copilot                     | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
+| **Self-report via MCP tools**                                                                                  | Generic MCP fallback               | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
 
 Every `PlatformAdapter` (`src/platforms/types.ts`) declares a `visibilityLevel` field encoding this table in code, not just prose — `full-hooks` (automatic, deterministic capture), `self-reported` (built-in-tool-shaped events are observable, but only if an external party — a third-party extension, or the calling MCP client itself — actually reports them), or `mcp-tools-only` (structurally cannot see built-in tool calls at all). Consumers that blend metrics across platforms (`nr_observe_get_platform_comparison`, the weekly digest's per-platform breakdown) use `getPlatformVisibilityMap()` (`src/platforms/platform-registry.ts`) to tag results and caveat comparisons that span more than one level.
 
-Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
+Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
 
 ---
 
@@ -218,6 +218,43 @@ Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-regi
    }
    ```
 2. Restart Kiro (or reconnect MCP servers from the Kiro MCP panel).
+
+---
+
+## Factory Droid (`droid`)
+
+**Mechanism:** Native `hooks.json` hook system (`~/.factory/hooks.json` user scope, `.factory/hooks.json` project scope, or an org-managed policy) — [docs.factory.ai/reference/hooks-reference](https://docs.factory.ai/reference/hooks-reference). Droid's `PreToolUse`/`PostToolUse` events send `hook_event_name`, `tool_name`, `tool_input`/`tool_response` in the same shape Claude Code, Kiro, and Amazon Q use, so they're handled by the same generic branches in `collector-script.ts` — no platform-specific parsing was needed. Also supports MCP as a client independently of the hooks system.
+
+**Detection (`isSupported()`):** `MCP_CLIENT === 'droid'`, or `NEW_RELIC_AI_PLATFORM === 'droid'`. Unlike Cursor/Windsurf/Kiro, Factory's documentation names no ambient environment variable for a Droid-spawned MCP server process (`FACTORY_PROJECT_DIR` is scoped to hook _command_ subprocesses only) — detection is explicit-opt-in only; don't invent one.
+
+**Tool-map:** Droid's documented `PreToolUse`/`PostToolUse` matchers are `Task`, `Execute`, `Glob`, `Grep`, `Read`, `Edit`, `Create`, `FetchUrl`, `WebSearch`. `Read`, `Glob`, `Grep`, `Edit` already match Preflight's canonical vocabulary and are listed as explicit identity entries in `DROID_TOOL_MAP` (there is no pass-through fallback). `Task`→Agent, `Execute`→Bash, `Create`→Write, `FetchUrl`→WebFetch, `WebSearch`→WebSearch.
+
+**Known gap:** `collector-script.ts`'s per-tool metadata extractors (`extractInputMeta`/`extractOutputMeta`) switch on the raw, unmapped tool name written into the buffer — so Droid's `Create`/`Execute`/`Task` calls don't get the extra structured fields (content length, command classification, etc.) that `Write`/`Bash`/`Agent` get for Claude Code. This is the same situation Kiro's `fsWrite`/`fsCreate`/etc. are already in; `Read`/`Glob`/`Grep`/`Edit` (matching exactly) are unaffected.
+
+**Setup:**
+
+1. Add a `PreToolUse`/`PostToolUse` hook pair matching all tools to `hooks.json` (`~/.factory/hooks.json` or `.factory/hooks.json`):
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [
+         { "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }
+       ],
+       "PostToolUse": [
+         { "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }
+       ]
+     }
+   }
+   ```
+2. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`)
+3. Register the Preflight MCP server:
+   ```
+   droid mcp add preflight "npx preflight --stdio" \
+     --env MCP_CLIENT=droid \
+     --env NEW_RELIC_LICENSE_KEY=<your-key> \
+     --env NEW_RELIC_ACCOUNT_ID=<your-account-id>
+   ```
+4. Restart Droid
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.20",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.6.20",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.6.20",
+  "version": "1.7.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/platforms/droid-adapter.test.ts
+++ b/src/platforms/droid-adapter.test.ts
@@ -1,0 +1,234 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { DroidAdapter } from './droid-adapter.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  for (const key of ['MCP_CLIENT', 'NEW_RELIC_AI_PLATFORM']) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('DroidAdapter', () => {
+  const adapter = new DroidAdapter();
+
+  it('has platformName "droid"', () => {
+    expect(adapter.platformName).toBe('droid');
+  });
+
+  it('declares visibilityLevel "full-hooks"', () => {
+    expect(adapter.visibilityLevel).toBe('full-hooks');
+  });
+
+  it('declares AGENTS.md as an instruction file path', () => {
+    expect(adapter.capabilities.instructionFilePaths).toEqual(['AGENTS.md']);
+  });
+
+  describe('normalizeToolCall', () => {
+    it('maps "Task" to "Agent"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'Task', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Agent');
+      expect(normalized.platformToolName).toBe('Task');
+      expect(normalized.platform).toBe('droid');
+    });
+
+    it('maps "Execute" to "Bash"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'Execute',
+        timestamp: 2000,
+        command: 'npm test',
+      });
+      expect(normalized.toolName).toBe('Bash');
+      expect(normalized.command).toBe('npm test');
+    });
+
+    it('maps "Create" to "Write"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'Create', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Write');
+    });
+
+    it('maps "FetchUrl" to "WebFetch"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'FetchUrl', timestamp: 2000 });
+      expect(normalized.toolName).toBe('WebFetch');
+    });
+
+    it('maps "WebSearch" to "WebSearch" (identity)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'WebSearch', timestamp: 2000 });
+      expect(normalized.toolName).toBe('WebSearch');
+    });
+
+    it('maps "Read" to "Read" (identity)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'Read', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Read');
+    });
+
+    it('maps "Glob" to "Glob" (identity)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'Glob', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Glob');
+    });
+
+    it('maps "Grep" to "Grep" (identity)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'Grep', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Grep');
+    });
+
+    it('maps "Edit" to "Edit" (identity)', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'Edit',
+        timestamp: 2000,
+        filePath: '/src/app.ts',
+      });
+      expect(normalized.toolName).toBe('Edit');
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('accepts "toolName" field as an alternative to "tool"', () => {
+      const normalized = adapter.normalizeToolCall({ toolName: 'Read', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Read');
+      expect(normalized.platformToolName).toBe('Read');
+    });
+
+    it('normalizes path to filePath', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'Read', path: '/src/app.ts' });
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('maps unknown tool to "Unknown" with platformToolName preserved', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'mcp__github__search',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('mcp__github__search');
+    });
+
+    it('defaults missing tool name to "unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ timestamp: 2000 });
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.toolName).toBe('Unknown');
+    });
+
+    it('falls back to safe defaults when raw is not an object (e.g. null)', () => {
+      const normalized = adapter.normalizeToolCall(null);
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.platform).toBe('droid');
+      expect(normalized.success).toBe(true);
+      expect(normalized.durationMs).toBeNull();
+    });
+
+    it('defaults success to true when not provided', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'Read', timestamp: 2000 });
+      expect(normalized.success).toBe(true);
+    });
+
+    it('preserves error field', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'Edit',
+        timestamp: 2000,
+        success: false,
+        error: 'permission denied',
+      });
+      expect(normalized.success).toBe(false);
+      expect(normalized.error).toBe('permission denied');
+    });
+
+    it('uses current time when timestamp is missing', () => {
+      const before = Date.now();
+      const normalized = adapter.normalizeToolCall({ tool: 'Read' });
+      const after = Date.now();
+      expect(normalized.timestamp).toBeGreaterThanOrEqual(before);
+      expect(normalized.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('includes inputSizeBytes and outputSizeBytes when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'Read',
+        timestamp: 2000,
+        inputSizeBytes: 50,
+        outputSizeBytes: 1000,
+      });
+      expect(normalized.inputSizeBytes).toBe(50);
+      expect(normalized.outputSizeBytes).toBe(1000);
+    });
+
+    it('includes sessionId when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'Read',
+        timestamp: 2000,
+        sessionId: 'droid-sess-001',
+      });
+      expect(normalized.sessionId).toBe('droid-sess-001');
+    });
+  });
+
+  describe('getSessionMetadata', () => {
+    it('returns platform "droid"', () => {
+      const meta = adapter.getSessionMetadata();
+      expect(meta.platform).toBe('droid');
+    });
+  });
+
+  describe('isSupported', () => {
+    it('returns true when MCP_CLIENT is "droid"', () => {
+      process.env.MCP_CLIENT = 'droid';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns true when NEW_RELIC_AI_PLATFORM is "droid"', () => {
+      process.env.NEW_RELIC_AI_PLATFORM = 'droid';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns false in a non-Droid environment', () => {
+      expect(adapter.isSupported()).toBe(false);
+    });
+  });
+
+  describe('getHookInstallInstructions', () => {
+    it('returns non-empty Droid-specific instructions', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions.length).toBeGreaterThan(0);
+      expect(instructions).toContain('Droid');
+    });
+
+    it('references hooks.json', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('hooks.json');
+    });
+
+    it('mentions NEW_RELIC_LICENSE_KEY', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_LICENSE_KEY');
+    });
+
+    it('mentions NEW_RELIC_ACCOUNT_ID', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
+    });
+  });
+
+  describe('initialize', () => {
+    it('completes without error', async () => {
+      await expect(adapter.initialize({})).resolves.toBeUndefined();
+    });
+  });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('Task')).toBe('Agent');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
+});

--- a/src/platforms/droid-adapter.ts
+++ b/src/platforms/droid-adapter.ts
@@ -1,0 +1,114 @@
+import type {
+  NormalizedToolCall,
+  PlatformAdapter,
+  PlatformConfig,
+  PlatformSessionMetadata,
+} from './types.js';
+
+/**
+ * Maps Factory Droid's built-in tool names to the normalized Claude Code
+ * tool vocabulary. Source: Droid's documented PreToolUse/PostToolUse
+ * matchers (https://docs.factory.ai/reference/hooks-reference) — Task,
+ * Execute, Glob, Grep, Read, Edit, Create, FetchUrl, WebSearch. Read, Glob,
+ * Grep, and Edit already match Preflight's canonical vocabulary exactly and
+ * are listed here as explicit identity entries — mapToolName has no
+ * pass-through fallback, so an omitted key would incorrectly fall through
+ * to 'Unknown'.
+ */
+const DROID_TOOL_MAP: Record<string, string> = {
+  Task: 'Agent',
+  Execute: 'Bash',
+  Create: 'Write',
+  FetchUrl: 'WebFetch',
+  WebSearch: 'WebSearch',
+  Read: 'Read',
+  Glob: 'Glob',
+  Grep: 'Grep',
+  Edit: 'Edit',
+};
+
+interface DroidToolCallEvent {
+  tool?: string;
+  toolName?: string;
+  timestamp?: number;
+  durationMs?: number;
+  success?: boolean;
+  error?: string;
+  filePath?: string;
+  path?: string;
+  command?: string;
+  inputSizeBytes?: number;
+  outputSizeBytes?: number;
+  sessionId?: string;
+}
+
+function isDroidToolCallEvent(x: unknown): x is DroidToolCallEvent {
+  return typeof x === 'object' && x !== null;
+}
+
+export class DroidAdapter implements PlatformAdapter {
+  readonly platformName = 'droid';
+  readonly visibilityLevel = 'full-hooks' as const;
+  readonly capabilities = { instructionFilePaths: ['AGENTS.md'] as const };
+
+  async initialize(_config: PlatformConfig): Promise<void> {
+    // Droid hooks are configured externally (hooks.json).
+  }
+
+  normalizeToolCall(raw: unknown): NormalizedToolCall {
+    const event = isDroidToolCallEvent(raw) ? raw : {};
+    const platformToolName = event.tool ?? event.toolName ?? 'unknown';
+    const toolName = DROID_TOOL_MAP[platformToolName] ?? 'Unknown';
+    const filePath = event.filePath ?? event.path;
+
+    return {
+      toolName,
+      platformToolName,
+      platform: this.platformName,
+      timestamp: event.timestamp ?? Date.now(),
+      durationMs: event.durationMs ?? null,
+      success: event.success ?? true,
+      ...(event.error !== undefined && { error: event.error }),
+      ...(event.inputSizeBytes !== undefined && { inputSizeBytes: event.inputSizeBytes }),
+      ...(event.outputSizeBytes !== undefined && { outputSizeBytes: event.outputSizeBytes }),
+      ...(filePath !== undefined && { filePath }),
+      ...(event.command !== undefined && { command: event.command }),
+      ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+    };
+  }
+
+  mapToolName(platformToolName: string): string {
+    return DROID_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
+  getSessionMetadata(): PlatformSessionMetadata {
+    return {
+      platform: this.platformName,
+    };
+  }
+
+  getHookInstallInstructions(): string {
+    return [
+      'Factory Droid Setup:',
+      '1. Add a PreToolUse/PostToolUse hook pair to hooks.json',
+      '   (~/.factory/hooks.json user scope, or .factory/hooks.json project scope):',
+      '   {',
+      '     "hooks": {',
+      '       "PreToolUse": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }],',
+      '       "PostToolUse": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }]',
+      '     }',
+      '   }',
+      '2. Ensure preflight-collector is on PATH (npm link, or npm install -g @newrelic/preflight)',
+      '3. Register the Preflight MCP server:',
+      '   droid mcp add preflight "npx preflight --stdio" \\',
+      '     --env MCP_CLIENT=droid \\',
+      '     --env NEW_RELIC_LICENSE_KEY=<your-key> \\',
+      '     --env NEW_RELIC_ACCOUNT_ID=<your-account-id>',
+      '4. Restart Droid',
+    ].join('\n');
+  }
+
+  isSupported(): boolean {
+    return process.env.MCP_CLIENT === 'droid' || process.env.NEW_RELIC_AI_PLATFORM === 'droid';
+  }
+}

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -14,6 +14,7 @@ export { ZedAdapter } from './zed-adapter.js';
 export { ContinueAdapter } from './continue-adapter.js';
 export { AmazonQAdapter } from './amazon-q-adapter.js';
 export { KiroAdapter } from './kiro-adapter.js';
+export { DroidAdapter } from './droid-adapter.js';
 export { GenericMcpAdapter, validateReportToolCallInput } from './generic-mcp-adapter.js';
 export type {
   ReportToolCallInput,

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -9,6 +9,7 @@ import { ZedAdapter } from './zed-adapter.js';
 import { ContinueAdapter } from './continue-adapter.js';
 import { AmazonQAdapter } from './amazon-q-adapter.js';
 import { KiroAdapter } from './kiro-adapter.js';
+import { DroidAdapter } from './droid-adapter.js';
 import type { PlatformAdapter, PlatformSessionMetadata, NormalizedToolCall } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -260,6 +261,15 @@ describe('PlatformRegistry', () => {
       expect(detected!.platformName).toBe('kiro');
     });
 
+    it('selects Droid adapter when MCP_CLIENT is "droid"', () => {
+      process.env.MCP_CLIENT = 'droid';
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('droid');
+    });
+
     it('falls back to generic-mcp when no specific platform detected', () => {
       const registry = createDefaultRegistry();
 
@@ -318,7 +328,7 @@ describe('createDefaultRegistry', () => {
     const registry = createDefaultRegistry();
     const registered = registry.getRegistered();
 
-    expect(registered).toHaveLength(9);
+    expect(registered).toHaveLength(10);
     expect(registered[0]).toBeInstanceOf(ClaudeCodeAdapter);
     expect(registered[1]).toBeInstanceOf(CursorAdapter);
     expect(registered[2]).toBeInstanceOf(WindsurfAdapter);
@@ -327,16 +337,18 @@ describe('createDefaultRegistry', () => {
     expect(registered[5]).toBeInstanceOf(ContinueAdapter);
     expect(registered[6]).toBeInstanceOf(AmazonQAdapter);
     expect(registered[7]).toBeInstanceOf(KiroAdapter);
-    expect(registered[8]).toBeInstanceOf(GenericMcpAdapter);
+    expect(registered[8]).toBeInstanceOf(DroidAdapter);
+    expect(registered[9]).toBeInstanceOf(GenericMcpAdapter);
   });
 
-  it('includes zed, continue, amazon-q, and kiro adapters', () => {
+  it('includes zed, continue, amazon-q, kiro, and droid adapters', () => {
     const registry = createDefaultRegistry();
     const names = registry.getRegistered().map((a) => a.platformName);
     expect(names).toContain('zed');
     expect(names).toContain('continue');
     expect(names).toContain('amazon-q');
     expect(names).toContain('kiro');
+    expect(names).toContain('droid');
   });
 
   it('ends with generic-mcp as fallback', () => {
@@ -383,6 +395,12 @@ describe('capabilities', () => {
     const windsurf = registry.getRegistered().find((a) => a.platformName === 'windsurf')!;
     expect(windsurf.capabilities.instructionFilePaths).toContain('.windsurfrules');
   });
+
+  it('droid declares AGENTS.md as an instruction file path', () => {
+    const registry = createDefaultRegistry();
+    const droid = registry.getRegistered().find((a) => a.platformName === 'droid')!;
+    expect(droid.capabilities.instructionFilePaths).toContain('AGENTS.md');
+  });
 });
 
 describe('all adapters implement PlatformAdapter interface', () => {
@@ -395,6 +413,7 @@ describe('all adapters implement PlatformAdapter interface', () => {
     new ContinueAdapter(),
     new AmazonQAdapter(),
     new KiroAdapter(),
+    new DroidAdapter(),
     new GenericMcpAdapter(),
   ];
 

--- a/src/platforms/platform-registry.ts
+++ b/src/platforms/platform-registry.ts
@@ -8,6 +8,7 @@ import { ZedAdapter } from './zed-adapter.js';
 import { ContinueAdapter } from './continue-adapter.js';
 import { AmazonQAdapter } from './amazon-q-adapter.js';
 import { KiroAdapter } from './kiro-adapter.js';
+import { DroidAdapter } from './droid-adapter.js';
 import { GenericMcpAdapter } from './generic-mcp-adapter.js';
 
 const logger = createLogger('platform-registry');
@@ -61,6 +62,7 @@ export function createDefaultRegistry(): PlatformRegistry {
   registry.register(new ContinueAdapter());
   registry.register(new AmazonQAdapter());
   registry.register(new KiroAdapter());
+  registry.register(new DroidAdapter());
   registry.register(new GenericMcpAdapter()); // always last
   return registry;
 }


### PR DESCRIPTION
Fixes #197

## Summary
- Add `DroidAdapter`, the 10th `PlatformAdapter`, for Factory.ai's Droid CLI/IDE
- Register it in `createDefaultRegistry()` between Kiro and the generic-mcp fallback
- Document it in `docs/ADAPTERS.md`, following the existing per-platform section format
- Version bump to 1.7.0 with a matching CHANGELOG entry

Droid's hooks system (`hooks.json`) sends `hook_event_name`/`tool_name`/`tool_input`/`tool_response` in the same shape Claude Code, Kiro, and Amazon Q already use, so this required no changes to the hook collector — verified against Droid's own documentation (docs.factory.ai/reference/hooks-reference) before writing any code.

`isSupported()` detection is explicit-opt-in only (`MCP_CLIENT`/`NEW_RELIC_AI_PLATFORM` env vars) — Factory's docs name no ambient environment variable for a Droid-spawned MCP server process, so none was invented, per this repo's sourcing convention.

## Test plan
- [x] `npx jest -- src/platforms/` — full platform suite (11 suites / 456 tests) passing
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run build` — succeeds