### PR TITLE
Feat: Add Google Gemini CLI platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-07-22
+
+### Added
+
+- **Google Gemini CLI platform adapter** — Preflight now detects and normalizes tool calls from [Gemini CLI](https://github.com/google-gemini/gemini-cli), Google's agentic command-line coding assistant. Gemini CLI sessions are detected via `MCP_CLIENT=gemini-cli` or `NEW_RELIC_AI_PLATFORM=gemini-cli` (Gemini CLI's documentation doesn't expose an ambient environment variable for the MCP server process itself, unlike several other platforms). Gemini CLI's hooks use their own event names (`BeforeTool`/`AfterTool` rather than `PreToolUse`/`PostToolUse`) but the same field shapes Claude Code already sends, so its built-in tool calls (`read_file`, `write_file`, `replace`, `run_shell_command`, `glob`, `grep_search`, `google_web_search`, `web_fetch`) are captured and mapped to Preflight's standard vocabulary automatically once hooks are configured. Gemini CLI also requires hook output to be valid JSON, so the collector now writes an empty JSON object to stdout for Gemini CLI invocations specifically, leaving every other platform's behavior unchanged. Setup instructions are included in `docs/ADAPTERS.md`.
+
 ## [1.7.0] - 2026-07-22
 
 ### Added

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,6 +1,6 @@
 # Platform Adapters
 
-Preflight supports 9 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
+Preflight supports 10 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
 
 This doc is the canonical reference for what each adapter can and can't observe, how detection and setup actually work, and where the gaps are. It mirrors `src/platforms/*.ts` and the hook-event handling in `src/hooks/collector-script.ts` — if you change either, update this doc in the same PR.
 
@@ -11,14 +11,17 @@ This doc is the canonical reference for what each adapter can and can't observe,
 | Mechanism                                                                                                      | Platforms                          | What's captured                                                                        | `visibilityLevel` |
 | -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
 | **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid | All built-in tool calls                                                                | `full-hooks`      |
+| **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                         | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
 | **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                   | All built-in tool calls                                                                | `full-hooks`      |
 | **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev                  | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
 | **HTTP push from an extension**                                                                                | GitHub Copilot                     | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
 | **Self-report via MCP tools**                                                                                  | Generic MCP fallback               | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
 
+[^gemini-hybrid]: Gemini CLI's hook _event names_ (`BeforeTool`/`AfterTool`) don't match `PreToolUse`/`PostToolUse`, so it needs its own branches in `collector-script.ts` — but the _fields_ inside those events (`tool_name`, `tool_input`, `tool_response`) are shaped exactly like Claude Code's, so those branches reuse the existing field-extraction helpers rather than needing new ones.
+
 Every `PlatformAdapter` (`src/platforms/types.ts`) declares a `visibilityLevel` field encoding this table in code, not just prose — `full-hooks` (automatic, deterministic capture), `self-reported` (built-in-tool-shaped events are observable, but only if an external party — a third-party extension, or the calling MCP client itself — actually reports them), or `mcp-tools-only` (structurally cannot see built-in tool calls at all). Consumers that blend metrics across platforms (`nr_observe_get_platform_comparison`, the weekly digest's per-platform breakdown) use `getPlatformVisibilityMap()` (`src/platforms/platform-registry.ts`) to tag results and caveat comparisons that span more than one level.
 
-Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
+Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
 
 ---
 
@@ -255,6 +258,47 @@ Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-regi
      --env NEW_RELIC_ACCOUNT_ID=<your-account-id>
    ```
 4. Restart Droid
+
+---
+
+## Google Gemini CLI (`gemini-cli`)
+
+**Mechanism:** Native `BeforeTool`/`AfterTool` hooks configured in `settings.json` (`.gemini/settings.json` project scope, `~/.gemini/settings.json` user scope, or `/etc/gemini-cli/settings.json` system scope) — [github.com/google-gemini/gemini-cli/blob/main/docs/hooks/reference.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/reference.md). Gemini CLI's event _names_ don't match Claude Code's (`BeforeTool`/`AfterTool`, not `PreToolUse`/`PostToolUse`), so `collector-script.ts` has dedicated branches for them — but the _fields_ inside those events (`tool_name`, `tool_input`, `tool_response`, `session_id`, `transcript_path`, `cwd`) match Claude Code's shape exactly, so those branches reuse the same field-extraction helpers. Also supports MCP as a client independently of the hooks system.
+
+**Detection (`isSupported()`):** `MCP_CLIENT === 'gemini-cli'`, or `NEW_RELIC_AI_PLATFORM === 'gemini-cli'`. Like Droid, Gemini CLI's documentation names real environment variables for hook _command_ subprocesses (`GEMINI_PROJECT_DIR`, `GEMINI_SESSION_ID`, `GEMINI_CWD`, `GEMINI_PLANS_DIR` — [docs/hooks/index.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/index.md)) but none confirmed for the MCP-server subprocess itself ([docs/tools/mcp-server.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)'s environment-sanitization section documents only explicit `env` overrides) — detection is explicit-opt-in only.
+
+**Success/failure signal:** Unlike Kiro/Amazon Q's `tool_response.success` boolean, Gemini CLI's `AfterTool` event has no `success` field at all — failure is signaled by the presence of `tool_response.error`. `collector-script.ts`'s `aftertool` branch derives `success` from that field's presence rather than reusing the `posttooluse` branch's boolean lookup.
+
+**Stdout contract:** Gemini CLI requires hook stdout to be either empty (treated as a parse failure that falls back to "Allow" with a warning) or valid JSON — every one of its own example hooks prints `{}` before exiting 0, even for pure side-effect hooks ([docs/hooks/index.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/index.md)'s "Strict JSON requirements"). `collector-script.ts` writes `{}\n` to stdout after processing a hook, gated to Gemini CLI only (`isSupported()`'s same env check) — no other platform's collector behavior changes.
+
+**Tool-map:** Gemini CLI's documented built-in tools ([docs/tools/file-system.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/file-system.md), [docs/tools/shell.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/shell.md), [docs/tools/web-search.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/web-search.md), [docs/tools/web-fetch.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/web-fetch.md)): `read_file`→Read, `write_file`→Write, `replace`→Edit (Gemini CLI's edit tool is named `replace`, not `edit`), `run_shell_command`→Bash, `glob`→Glob, `grep_search`→Grep, `google_web_search`→WebSearch, `web_fetch`→WebFetch. `list_directory` has no Claude Code equivalent and is deliberately left unmapped, falling through to `'Unknown'` with the original name preserved. There is no Task/Agent-equivalent subagent-dispatch tool anywhere in Gemini CLI's built-in tool set.
+
+**Known gaps:** `collector-script.ts`'s per-tool metadata extractors (`extractInputMeta`/`extractOutputMeta`) switch on the raw, unmapped tool name — so Gemini CLI's `replace`/`run_shell_command`/`read_file` calls don't get the extra structured fields (old/new string lengths, exit codes, etc.) that Edit/Bash/Read get for Claude Code, the same situation Droid and Kiro are already in. In particular, `run_shell_command`'s exit code and output live inside `tool_response.llmContent`, whose internal structure isn't part of Gemini CLI's documented public contract, so no attempt is made to parse it.
+
+**Setup:**
+
+1. Add a `BeforeTool`/`AfterTool` hook pair matching all tools to `settings.json` (`~/.gemini/settings.json` user scope or `.gemini/settings.json` project scope):
+   ```json
+   {
+     "hooks": {
+       "BeforeTool": [
+         { "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }
+       ],
+       "AfterTool": [
+         { "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }
+       ]
+     }
+   }
+   ```
+2. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`)
+3. Register the Preflight MCP server:
+   ```
+   gemini mcp add preflight "npx preflight --stdio" \
+     -e MCP_CLIENT=gemini-cli \
+     -e NEW_RELIC_LICENSE_KEY=<your-key> \
+     -e NEW_RELIC_ACCOUNT_ID=<your-account-id>
+   ```
+4. Restart Gemini CLI
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -23,12 +23,14 @@ import {
 } from './collector-script.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
+let stdoutSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
 let bufferPath: string;
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
   stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
   tmpDir = resolve(tmpdir(), `nr-hook-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(tmpDir, { recursive: true });
   bufferPath = resolve(tmpDir, 'buffer.jsonl');
@@ -39,6 +41,7 @@ beforeEach(() => {
 
 afterEach(() => {
   stderrSpy.mockRestore();
+  stdoutSpy.mockRestore();
   if (existsSync(tmpDir)) {
     rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -83,6 +86,33 @@ function makePostToolUseFailure(overrides?: Record<string, unknown>): string {
     is_interrupt: false,
     cwd: '/projects/test',
     permission_mode: 'default',
+    ...overrides,
+  });
+}
+
+function makeGeminiBeforeTool(overrides?: Record<string, unknown>): string {
+  return JSON.stringify({
+    hook_event_name: 'BeforeTool',
+    session_id: 'gemini-sess-001',
+    transcript_path: '/tmp/gemini-transcript.json',
+    cwd: '/projects/test',
+    timestamp: '2026-07-22T00:00:00.000Z',
+    tool_name: 'read_file',
+    tool_input: { file_path: '/tmp/test.ts', limit: 100 },
+    ...overrides,
+  });
+}
+
+function makeGeminiAfterTool(overrides?: Record<string, unknown>): string {
+  return JSON.stringify({
+    hook_event_name: 'AfterTool',
+    session_id: 'gemini-sess-001',
+    transcript_path: '/tmp/gemini-transcript.json',
+    cwd: '/projects/test',
+    timestamp: '2026-07-22T00:00:00.000Z',
+    tool_name: 'write_file',
+    tool_input: { file_path: '/tmp/out.ts', content: 'hello' },
+    tool_response: { llmContent: 'Wrote file.', returnDisplay: 'Wrote file.' },
     ...overrides,
   });
 }
@@ -1695,6 +1725,75 @@ describe('collector-script', () => {
       };
       expect(() => readStdinSync()).toThrow('ENOENT');
       expect(calls).toEqual(['/dev/stdin']);
+    });
+  });
+
+  describe('collector-script — Gemini CLI hook event names (https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/reference.md)', () => {
+    it('writes a pre event when hook_event_name is "BeforeTool"', () => {
+      processHook(makeGeminiBeforeTool());
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].mode).toBe('pre');
+      expect(events[0].tool).toBe('read_file');
+    });
+
+    it('writes a successful post event when tool_response has no error field', () => {
+      processHook(makeGeminiAfterTool());
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].mode).toBe('post');
+      expect(events[0].success).toBe(true);
+    });
+
+    it('writes a failed post event when tool_response.error is present', () => {
+      processHook(
+        makeGeminiAfterTool({
+          tool_response: { llmContent: 'boom', returnDisplay: 'boom', error: 'file not found' },
+        }),
+      );
+      const events = readBufferEvents();
+      expect(events[0].success).toBe(false);
+    });
+
+    it('captures session_id the same way Claude Code does', () => {
+      processHook(makeGeminiBeforeTool());
+      const events = readBufferEvents();
+      expect(events[0].sessionId).toBe('gemini-sess-001');
+    });
+
+    it('captures transcript_path as transcriptPath', () => {
+      processHook(makeGeminiBeforeTool());
+      const events = readBufferEvents();
+      expect(events[0].transcriptPath).toBe('/tmp/gemini-transcript.json');
+    });
+
+    it('still ignores a genuinely unknown hook_event_name', () => {
+      processHook(makeGeminiBeforeTool({ hook_event_name: 'SessionStart' }));
+      expect(readBufferEvents()).toHaveLength(0);
+    });
+  });
+
+  describe('collector-script — Gemini CLI stdout contract (https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/index.md)', () => {
+    it('writes "{}" to stdout when MCP_CLIENT is "gemini-cli"', () => {
+      process.env.MCP_CLIENT = 'gemini-cli';
+      processHook(makeGeminiAfterTool());
+      expect(stdoutSpy).toHaveBeenCalledWith('{}\n');
+    });
+
+    it('writes "{}" to stdout when NEW_RELIC_AI_PLATFORM is "gemini-cli"', () => {
+      process.env.NEW_RELIC_AI_PLATFORM = 'gemini-cli';
+      processHook(makeGeminiBeforeTool());
+      expect(stdoutSpy).toHaveBeenCalledWith('{}\n');
+    });
+
+    it('does not write to stdout for a Claude Code event', () => {
+      processHook(makePreToolUse());
+      expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not write to stdout for a Gemini CLI-shaped event when neither env var is set', () => {
+      processHook(makeGeminiBeforeTool());
+      expect(stdoutSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -694,6 +694,15 @@ function processHook(raw: string): void {
   const recordContent = getRecordContent();
   const maxContentLen = getMaxContentLength();
 
+  // Gemini CLI (https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/index.md,
+  // "Strict JSON requirements") requires hook stdout to be either empty
+  // (treated as a parse failure that falls back to a warning + "Allow") or
+  // valid JSON — every one of its own example hooks prints "{}" even for
+  // pure side-effect hooks. No other platform reads this collector's
+  // stdout, so this check is scoped to Gemini CLI only.
+  const isGeminiCli =
+    process.env.MCP_CLIENT === 'gemini-cli' || process.env.NEW_RELIC_AI_PLATFORM === 'gemini-cli';
+
   let event: Record<string, unknown>;
 
   if (eventName === 'pretooluse') {
@@ -769,6 +778,61 @@ function processHook(raw: string): void {
       error: redact(data.error ?? 'unknown error'),
       isInterrupt: data.is_interrupt ?? false,
     };
+  } else if (eventName === 'beforetool') {
+    // Gemini CLI (https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/reference.md)
+    // sends BeforeTool/AfterTool instead of PreToolUse/PostToolUse, but the
+    // fields inside those events (tool_name, tool_input, tool_response) match
+    // Claude Code's shape exactly — reuse the same field extraction as the
+    // pretooluse branch above.
+    event = {
+      mode: 'pre' as const,
+      tool: toolName,
+      timestamp,
+      inputSize: sizeOf(data.tool_input),
+      inputHash: hashInput(data.tool_input),
+    };
+
+    const inputMeta = extractInputMeta(toolName, data.tool_input);
+    if (inputMeta !== undefined) event.toolInput = inputMeta;
+
+    if (recordContent && data.tool_input !== undefined) {
+      const content =
+        typeof data.tool_input === 'string' ? data.tool_input : JSON.stringify(data.tool_input);
+      event.inputContent = redact(truncate(content, maxContentLen));
+    }
+  } else if (eventName === 'aftertool') {
+    // Gemini CLI has no tool_response.success boolean (unlike Kiro/Amazon Q) —
+    // failure is signaled by the presence of tool_response.error instead
+    // (https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/reference.md,
+    // AfterTool's documented output fields: "tool_response... containing
+    // llmContent, returnDisplay, and optional error").
+    const toolResponse = data.tool_response;
+    const hasError =
+      toolResponse !== null &&
+      typeof toolResponse === 'object' &&
+      !Array.isArray(toolResponse) &&
+      (toolResponse as Record<string, unknown>).error !== undefined;
+    event = {
+      mode: 'post' as const,
+      tool: toolName,
+      timestamp,
+      outputSize: sizeOf(data.tool_response),
+      success: !hasError,
+    };
+
+    const postInputMeta = extractInputMeta(toolName, data.tool_input);
+    if (postInputMeta !== undefined) event.toolInput = postInputMeta;
+
+    const outputMeta = extractOutputMeta(toolName, data.tool_response);
+    if (outputMeta !== undefined) event.toolOutput = outputMeta;
+
+    if (recordContent && data.tool_response !== undefined) {
+      const content =
+        typeof data.tool_response === 'string'
+          ? data.tool_response
+          : JSON.stringify(data.tool_response);
+      event.outputContent = redact(truncate(content, maxContentLen));
+    }
   } else if (eventName === 'beforeshellexecution') {
     // Cursor's shell hooks carry no tool_name field — the event name itself
     // identifies the tool. Confirmed payload shape:
@@ -971,9 +1035,23 @@ function processHook(raw: string): void {
     // Silent failure — never block Claude Code
   }
 
+  // Gemini CLI's own hook examples always print "{}" before exiting 0, even
+  // for pure side-effect hooks — see the isGeminiCli comment above. Gated to
+  // Gemini CLI only; no other platform's collector behavior changes.
+  if (isGeminiCli) {
+    try {
+      process.stdout.write('{}\n');
+    } catch {
+      // Silent failure — never block Gemini CLI
+    }
+  }
+
   // After writing the tool event, collect token usage from the transcript.
-  // Only on PostToolUse — each assistant turn produces exactly one usage object.
-  if (eventName === 'posttooluse') {
+  // Only on PostToolUse/AfterTool — each assistant turn produces exactly one
+  // usage object. This is a no-op for Gemini CLI's transcript format (not
+  // Claude Code's Anthropic-shaped JSONL) — same accepted behavior as
+  // Droid/Kiro/Amazon Q, whose transcripts aren't in this format either.
+  if (eventName === 'posttooluse' || eventName === 'aftertool') {
     try {
       collectTranscriptTokens(data);
     } catch {

--- a/src/platforms/gemini-cli-adapter.test.ts
+++ b/src/platforms/gemini-cli-adapter.test.ts
@@ -1,0 +1,235 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { GeminiCliAdapter } from './gemini-cli-adapter.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  for (const key of ['MCP_CLIENT', 'NEW_RELIC_AI_PLATFORM']) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('GeminiCliAdapter', () => {
+  const adapter = new GeminiCliAdapter();
+
+  it('has platformName "gemini-cli"', () => {
+    expect(adapter.platformName).toBe('gemini-cli');
+  });
+
+  it('declares visibilityLevel "full-hooks"', () => {
+    expect(adapter.visibilityLevel).toBe('full-hooks');
+  });
+
+  it('declares GEMINI.md as an instruction file path', () => {
+    expect(adapter.capabilities.instructionFilePaths).toEqual(['GEMINI.md']);
+  });
+
+  describe('normalizeToolCall', () => {
+    it('maps "read_file" to "Read"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Read');
+      expect(normalized.platformToolName).toBe('read_file');
+      expect(normalized.platform).toBe('gemini-cli');
+    });
+
+    it('maps "write_file" to "Write"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'write_file', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Write');
+    });
+
+    it('maps "replace" to "Edit"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'replace',
+        timestamp: 2000,
+        filePath: '/src/app.ts',
+      });
+      expect(normalized.toolName).toBe('Edit');
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('maps "run_shell_command" to "Bash"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'run_shell_command',
+        timestamp: 2000,
+        command: 'npm test',
+      });
+      expect(normalized.toolName).toBe('Bash');
+      expect(normalized.command).toBe('npm test');
+    });
+
+    it('maps "glob" to "Glob"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'glob', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Glob');
+    });
+
+    it('maps "grep_search" to "Grep"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'grep_search', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Grep');
+    });
+
+    it('maps "google_web_search" to "WebSearch"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'google_web_search', timestamp: 2000 });
+      expect(normalized.toolName).toBe('WebSearch');
+    });
+
+    it('maps "web_fetch" to "WebFetch"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'web_fetch', timestamp: 2000 });
+      expect(normalized.toolName).toBe('WebFetch');
+    });
+
+    it('maps "list_directory" to "Unknown" with platformToolName preserved (no Claude Code equivalent)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'list_directory', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('list_directory');
+    });
+
+    it('accepts "toolName" field as an alternative to "tool"', () => {
+      const normalized = adapter.normalizeToolCall({ toolName: 'read_file', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Read');
+      expect(normalized.platformToolName).toBe('read_file');
+    });
+
+    it('normalizes path to filePath', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file', path: '/src/app.ts' });
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('maps unknown tool to "Unknown" with platformToolName preserved', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'mcp_github_search',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('mcp_github_search');
+    });
+
+    it('defaults missing tool name to "unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ timestamp: 2000 });
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.toolName).toBe('Unknown');
+    });
+
+    it('falls back to safe defaults when raw is not an object (e.g. null)', () => {
+      const normalized = adapter.normalizeToolCall(null);
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.platform).toBe('gemini-cli');
+      expect(normalized.success).toBe(true);
+      expect(normalized.durationMs).toBeNull();
+    });
+
+    it('defaults success to true when not provided', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file', timestamp: 2000 });
+      expect(normalized.success).toBe(true);
+    });
+
+    it('preserves error field', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'replace',
+        timestamp: 2000,
+        success: false,
+        error: 'file not found',
+      });
+      expect(normalized.success).toBe(false);
+      expect(normalized.error).toBe('file not found');
+    });
+
+    it('uses current time when timestamp is missing', () => {
+      const before = Date.now();
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file' });
+      const after = Date.now();
+      expect(normalized.timestamp).toBeGreaterThanOrEqual(before);
+      expect(normalized.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('includes inputSizeBytes and outputSizeBytes when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'read_file',
+        timestamp: 2000,
+        inputSizeBytes: 50,
+        outputSizeBytes: 1000,
+      });
+      expect(normalized.inputSizeBytes).toBe(50);
+      expect(normalized.outputSizeBytes).toBe(1000);
+    });
+
+    it('includes sessionId when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'read_file',
+        timestamp: 2000,
+        sessionId: 'gemini-sess-001',
+      });
+      expect(normalized.sessionId).toBe('gemini-sess-001');
+    });
+  });
+
+  describe('getSessionMetadata', () => {
+    it('returns platform "gemini-cli"', () => {
+      const meta = adapter.getSessionMetadata();
+      expect(meta.platform).toBe('gemini-cli');
+    });
+  });
+
+  describe('isSupported', () => {
+    it('returns true when MCP_CLIENT is "gemini-cli"', () => {
+      process.env.MCP_CLIENT = 'gemini-cli';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns true when NEW_RELIC_AI_PLATFORM is "gemini-cli"', () => {
+      process.env.NEW_RELIC_AI_PLATFORM = 'gemini-cli';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns false in a non-Gemini-CLI environment', () => {
+      expect(adapter.isSupported()).toBe(false);
+    });
+  });
+
+  describe('getHookInstallInstructions', () => {
+    it('returns non-empty Gemini CLI-specific instructions', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions.length).toBeGreaterThan(0);
+      expect(instructions).toContain('Gemini CLI');
+    });
+
+    it('references settings.json', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('settings.json');
+    });
+
+    it('mentions NEW_RELIC_LICENSE_KEY', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_LICENSE_KEY');
+    });
+
+    it('mentions NEW_RELIC_ACCOUNT_ID', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
+    });
+  });
+
+  describe('initialize', () => {
+    it('completes without error', async () => {
+      await expect(adapter.initialize({})).resolves.toBeUndefined();
+    });
+  });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('read_file')).toBe('Read');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
+});

--- a/src/platforms/gemini-cli-adapter.ts
+++ b/src/platforms/gemini-cli-adapter.ts
@@ -1,0 +1,116 @@
+import type {
+  NormalizedToolCall,
+  PlatformAdapter,
+  PlatformConfig,
+  PlatformSessionMetadata,
+} from './types.js';
+
+/**
+ * Maps Gemini CLI's built-in tool names to the normalized Claude Code tool
+ * vocabulary. Source: Gemini CLI's own tool reference docs
+ * (github.com/google-gemini/gemini-cli — docs/tools/file-system.md,
+ * docs/tools/shell.md, docs/tools/web-search.md, docs/tools/web-fetch.md).
+ * `list_directory` has no Claude Code equivalent and is deliberately left
+ * unmapped — mapToolName has no pass-through fallback, so an omitted key
+ * falls through to 'Unknown' with the original name preserved. There is
+ * also no Task/Agent-equivalent subagent-dispatch tool anywhere in Gemini
+ * CLI's built-in tool set.
+ */
+const GEMINI_CLI_TOOL_MAP: Record<string, string> = {
+  read_file: 'Read',
+  write_file: 'Write',
+  replace: 'Edit',
+  run_shell_command: 'Bash',
+  glob: 'Glob',
+  grep_search: 'Grep',
+  google_web_search: 'WebSearch',
+  web_fetch: 'WebFetch',
+};
+
+interface GeminiCliToolCallEvent {
+  tool?: string;
+  toolName?: string;
+  timestamp?: number;
+  durationMs?: number;
+  success?: boolean;
+  error?: string;
+  filePath?: string;
+  path?: string;
+  command?: string;
+  inputSizeBytes?: number;
+  outputSizeBytes?: number;
+  sessionId?: string;
+}
+
+function isGeminiCliToolCallEvent(x: unknown): x is GeminiCliToolCallEvent {
+  return typeof x === 'object' && x !== null;
+}
+
+export class GeminiCliAdapter implements PlatformAdapter {
+  readonly platformName = 'gemini-cli';
+  readonly visibilityLevel = 'full-hooks' as const;
+  readonly capabilities = { instructionFilePaths: ['GEMINI.md'] as const };
+
+  async initialize(_config: PlatformConfig): Promise<void> {
+    // Gemini CLI hooks are configured externally (settings.json).
+  }
+
+  normalizeToolCall(raw: unknown): NormalizedToolCall {
+    const event = isGeminiCliToolCallEvent(raw) ? raw : {};
+    const platformToolName = event.tool ?? event.toolName ?? 'unknown';
+    const toolName = GEMINI_CLI_TOOL_MAP[platformToolName] ?? 'Unknown';
+    const filePath = event.filePath ?? event.path;
+
+    return {
+      toolName,
+      platformToolName,
+      platform: this.platformName,
+      timestamp: event.timestamp ?? Date.now(),
+      durationMs: event.durationMs ?? null,
+      success: event.success ?? true,
+      ...(event.error !== undefined && { error: event.error }),
+      ...(event.inputSizeBytes !== undefined && { inputSizeBytes: event.inputSizeBytes }),
+      ...(event.outputSizeBytes !== undefined && { outputSizeBytes: event.outputSizeBytes }),
+      ...(filePath !== undefined && { filePath }),
+      ...(event.command !== undefined && { command: event.command }),
+      ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+    };
+  }
+
+  mapToolName(platformToolName: string): string {
+    return GEMINI_CLI_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
+  getSessionMetadata(): PlatformSessionMetadata {
+    return {
+      platform: this.platformName,
+    };
+  }
+
+  getHookInstallInstructions(): string {
+    return [
+      'Gemini CLI Setup:',
+      '1. Add BeforeTool/AfterTool hooks to settings.json',
+      '   (~/.gemini/settings.json user scope, or .gemini/settings.json project scope):',
+      '   {',
+      '     "hooks": {',
+      '       "BeforeTool": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }],',
+      '       "AfterTool": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }]',
+      '     }',
+      '   }',
+      '2. Ensure preflight-collector is on PATH (npm link, or npm install -g @newrelic/preflight)',
+      '3. Register the Preflight MCP server:',
+      '   gemini mcp add preflight "npx preflight --stdio" \\',
+      '     -e MCP_CLIENT=gemini-cli \\',
+      '     -e NEW_RELIC_LICENSE_KEY=<your-key> \\',
+      '     -e NEW_RELIC_ACCOUNT_ID=<your-account-id>',
+      '4. Restart Gemini CLI',
+    ].join('\n');
+  }
+
+  isSupported(): boolean {
+    return (
+      process.env.MCP_CLIENT === 'gemini-cli' || process.env.NEW_RELIC_AI_PLATFORM === 'gemini-cli'
+    );
+  }
+}

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -15,6 +15,7 @@ export { ContinueAdapter } from './continue-adapter.js';
 export { AmazonQAdapter } from './amazon-q-adapter.js';
 export { KiroAdapter } from './kiro-adapter.js';
 export { DroidAdapter } from './droid-adapter.js';
+export { GeminiCliAdapter } from './gemini-cli-adapter.js';
 export { GenericMcpAdapter, validateReportToolCallInput } from './generic-mcp-adapter.js';
 export type {
   ReportToolCallInput,

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -10,6 +10,7 @@ import { ContinueAdapter } from './continue-adapter.js';
 import { AmazonQAdapter } from './amazon-q-adapter.js';
 import { KiroAdapter } from './kiro-adapter.js';
 import { DroidAdapter } from './droid-adapter.js';
+import { GeminiCliAdapter } from './gemini-cli-adapter.js';
 import type { PlatformAdapter, PlatformSessionMetadata, NormalizedToolCall } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -270,6 +271,15 @@ describe('PlatformRegistry', () => {
       expect(detected!.platformName).toBe('droid');
     });
 
+    it('selects Gemini CLI adapter when MCP_CLIENT is "gemini-cli"', () => {
+      process.env.MCP_CLIENT = 'gemini-cli';
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('gemini-cli');
+    });
+
     it('falls back to generic-mcp when no specific platform detected', () => {
       const registry = createDefaultRegistry();
 
@@ -328,7 +338,7 @@ describe('createDefaultRegistry', () => {
     const registry = createDefaultRegistry();
     const registered = registry.getRegistered();
 
-    expect(registered).toHaveLength(10);
+    expect(registered).toHaveLength(11);
     expect(registered[0]).toBeInstanceOf(ClaudeCodeAdapter);
     expect(registered[1]).toBeInstanceOf(CursorAdapter);
     expect(registered[2]).toBeInstanceOf(WindsurfAdapter);
@@ -338,10 +348,11 @@ describe('createDefaultRegistry', () => {
     expect(registered[6]).toBeInstanceOf(AmazonQAdapter);
     expect(registered[7]).toBeInstanceOf(KiroAdapter);
     expect(registered[8]).toBeInstanceOf(DroidAdapter);
-    expect(registered[9]).toBeInstanceOf(GenericMcpAdapter);
+    expect(registered[9]).toBeInstanceOf(GeminiCliAdapter);
+    expect(registered[10]).toBeInstanceOf(GenericMcpAdapter);
   });
 
-  it('includes zed, continue, amazon-q, kiro, and droid adapters', () => {
+  it('includes zed, continue, amazon-q, kiro, droid, and gemini-cli adapters', () => {
     const registry = createDefaultRegistry();
     const names = registry.getRegistered().map((a) => a.platformName);
     expect(names).toContain('zed');
@@ -349,6 +360,7 @@ describe('createDefaultRegistry', () => {
     expect(names).toContain('amazon-q');
     expect(names).toContain('kiro');
     expect(names).toContain('droid');
+    expect(names).toContain('gemini-cli');
   });
 
   it('ends with generic-mcp as fallback', () => {
@@ -401,6 +413,12 @@ describe('capabilities', () => {
     const droid = registry.getRegistered().find((a) => a.platformName === 'droid')!;
     expect(droid.capabilities.instructionFilePaths).toContain('AGENTS.md');
   });
+
+  it('gemini-cli declares GEMINI.md as an instruction file path', () => {
+    const registry = createDefaultRegistry();
+    const geminiCli = registry.getRegistered().find((a) => a.platformName === 'gemini-cli')!;
+    expect(geminiCli.capabilities.instructionFilePaths).toContain('GEMINI.md');
+  });
 });
 
 describe('all adapters implement PlatformAdapter interface', () => {
@@ -414,6 +432,7 @@ describe('all adapters implement PlatformAdapter interface', () => {
     new AmazonQAdapter(),
     new KiroAdapter(),
     new DroidAdapter(),
+    new GeminiCliAdapter(),
     new GenericMcpAdapter(),
   ];
 

--- a/src/platforms/platform-registry.ts
+++ b/src/platforms/platform-registry.ts
@@ -9,6 +9,7 @@ import { ContinueAdapter } from './continue-adapter.js';
 import { AmazonQAdapter } from './amazon-q-adapter.js';
 import { KiroAdapter } from './kiro-adapter.js';
 import { DroidAdapter } from './droid-adapter.js';
+import { GeminiCliAdapter } from './gemini-cli-adapter.js';
 import { GenericMcpAdapter } from './generic-mcp-adapter.js';
 
 const logger = createLogger('platform-registry');
@@ -63,6 +64,7 @@ export function createDefaultRegistry(): PlatformRegistry {
   registry.register(new AmazonQAdapter());
   registry.register(new KiroAdapter());
   registry.register(new DroidAdapter());
+  registry.register(new GeminiCliAdapter());
   registry.register(new GenericMcpAdapter()); // always last
   return registry;
 }


### PR DESCRIPTION
Fixes #196

## Summary
- Add `GeminiCliAdapter`, the 11th `PlatformAdapter`, for Google's Gemini CLI
- Register it in `createDefaultRegistry()` between the Droid adapter and the generic-mcp fallback
- Add two new hook branches (`BeforeTool`/`AfterTool`) to the hook collector, plus a Gemini-CLI-only fix so the collector's stdout satisfies Gemini CLI's strict JSON hook contract
- Document it in `docs/ADAPTERS.md`, following the existing per-platform section format
- Version bump to 1.8.0 with a matching CHANGELOG entry

Gemini CLI's hook event names (`BeforeTool`/`AfterTool`) don't match Claude Code's (`PreToolUse`/`PostToolUse`), so this needed two new branches in the hook collector — but the fields inside those events (`tool_name`, `tool_input`, `tool_response`) match Claude Code's shape exactly, verified against Gemini CLI's own documentation (`google-gemini/gemini-cli`'s `docs/hooks/reference.md`, `docs/hooks/index.md`, `docs/tools/*.md`) before writing any code, so the new branches reuse the existing field-extraction helpers rather than duplicating logic. Failure is derived from `tool_response.error`'s presence, since Gemini CLI has no `success` boolean.

`isSupported()` detection is explicit-opt-in only (`MCP_CLIENT`/`NEW_RELIC_AI_PLATFORM` env vars) — Gemini CLI's docs name real environment variables for hook *command* subprocesses but none confirmed for the MCP-server process itself, so none was invented, per this repo's sourcing convention.

## Test plan
- [x] `npx jest -- src/platforms/gemini-cli-adapter.test.ts src/platforms/platform-registry.test.ts src/hooks/collector-script.test.ts` — 265/265 passing
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run build` — succeeds