### PR TITLE
Feat: Add Cline platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-07-22
+
+### Added
+
+- **Cline platform adapter** — Preflight now detects [Cline](https://cline.bot) (VS Code and JetBrains extension, formerly "Claude Dev"). Cline sessions are detected via `MCP_CLIENT=cline` or `NEW_RELIC_AI_PLATFORM=cline` (Cline doesn't forward ambient environment variables into an MCP server's own subprocess, unlike several other platforms, so there's no ambient variable to detect automatically). Cline's VS Code/JetBrains extension has no hook or callback mechanism for its built-in tool calls — confirmed against Cline's own documentation — so Preflight observes only calls Cline routes to Preflight's own MCP tools, the same visibility level as the existing Zed and Continue.dev adapters. Setup instructions are included in `docs/ADAPTERS.md`.
+
 ## [1.8.0] - 2026-07-22
 
 ### Added

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,6 +1,6 @@
 # Platform Adapters
 
-Preflight supports 10 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
+Preflight supports 11 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
 
 This doc is the canonical reference for what each adapter can and can't observe, how detection and setup actually work, and where the gaps are. It mirrors `src/platforms/*.ts` and the hook-event handling in `src/hooks/collector-script.ts` — if you change either, update this doc in the same PR.
 
@@ -13,7 +13,7 @@ This doc is the canonical reference for what each adapter can and can't observe,
 | **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid | All built-in tool calls                                                                | `full-hooks`      |
 | **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                         | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
 | **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                   | All built-in tool calls                                                                | `full-hooks`      |
-| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev                  | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
+| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev, Cline           | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
 | **HTTP push from an extension**                                                                                | GitHub Copilot                     | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
 | **Self-report via MCP tools**                                                                                  | Generic MCP fallback               | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
 
@@ -155,6 +155,38 @@ Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-regi
 3. Reload Continue.
 
 **Note:** the `continuedev/continue` repository is no longer actively maintained and is read-only as of its final 2.0.0 release, so a deeper hook integration is unlikely to land upstream.
+
+---
+
+## Cline (`cline`)
+
+**Mechanism:** None for built-in tools on Cline's VS Code/JetBrains extension — its own docs state Plugins/Hooks and Custom Tools are "not applicable on VSCode and JetBrains Extension for now" ([docs.cline.bot/customization/plugins](https://docs.cline.bot/customization/plugins), [docs.cline.bot/tools-reference/all-cline-tools](https://docs.cline.bot/tools-reference/all-cline-tools)) — only the Cline SDK, CLI, and Kanban support the `beforeTool`/`afterTool` lifecycle hooks documented at [docs.cline.bot/sdk/plugins](https://docs.cline.bot/sdk/plugins). Cline also does not forward ambient environment variables into an MCP server's subprocess automatically — only vars explicitly listed in that server's own `env` config block reach it. As a Cline MCP server, Preflight can only receive calls Cline's agent makes to Preflight's own exposed tools.
+
+**Detection (`isSupported()`):** `MCP_CLIENT === 'cline'` or `NEW_RELIC_AI_PLATFORM === 'cline'` — explicit opt-in only, since no ambient env var is set on the MCP server process.
+
+**Tool-map status:** `CLINE_TOOL_MAP` covers only `execute_command`, `read_file`, and `replace_in_file` — the three tool names [docs.cline.bot/tools-reference/all-cline-tools](https://docs.cline.bot/tools-reference/all-cline-tools) literally names in its "Legacy Tool Names vs Current Runtime Tools" section. It exists for correctness and any future hook capability — it is currently **unreachable**, since no Cline event reaches it. Other real or reported Cline tool names (`write_to_file`, `search_files`, `list_files`, `browser_action`, `use_mcp_tool`, `ask_followup_question`, `attempt_completion`, `new_task`, `plan_mode_respond`, etc.) are left unmapped rather than guessed at without a documented source.
+
+**Setup:**
+
+1. There is no hook mechanism for tool-call capture in Cline's VS Code/JetBrains extension — Preflight only sees calls made to its own MCP tools.
+2. Extension: open the Cline panel → MCP Servers icon → Configure tab → "Configure MCP Servers", and add to `mcpServers`:
+   ```json
+   {
+     "mcpServers": {
+       "preflight": {
+         "command": "npx",
+         "args": ["preflight", "--stdio"],
+         "env": {
+           "MCP_CLIENT": "cline",
+           "NEW_RELIC_LICENSE_KEY": "<your-key>",
+           "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"
+         }
+       }
+     }
+   }
+   ```
+3. CLI: edit `~/.cline/mcp.json` with the same shape, or run `cline mcp`.
+4. Restart Cline / reload the extension.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/platforms/cline-adapter.test.ts
+++ b/src/platforms/cline-adapter.test.ts
@@ -1,0 +1,268 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { ClineAdapter } from './cline-adapter.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  for (const key of ['MCP_CLIENT', 'NEW_RELIC_AI_PLATFORM']) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('ClineAdapter', () => {
+  const adapter = new ClineAdapter();
+
+  it('has platformName "cline"', () => {
+    expect(adapter.platformName).toBe('cline');
+  });
+
+  it('declares visibilityLevel "mcp-tools-only"', () => {
+    expect(adapter.visibilityLevel).toBe('mcp-tools-only');
+  });
+
+  it('declares .clinerules/ as an instruction file path', () => {
+    expect(adapter.capabilities.instructionFilePaths).toEqual(['.clinerules/']);
+  });
+
+  describe('normalizeToolCall', () => {
+    it('maps "execute_command" to "Bash"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'execute_command',
+        timestamp: 2000,
+        command: 'npm test',
+      });
+      expect(normalized.toolName).toBe('Bash');
+      expect(normalized.platformToolName).toBe('execute_command');
+      expect(normalized.platform).toBe('cline');
+      expect(normalized.command).toBe('npm test');
+    });
+
+    it('maps "read_file" to "Read"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'read_file',
+        timestamp: 2000,
+        filePath: '/src/app.ts',
+      });
+      expect(normalized.toolName).toBe('Read');
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('maps "replace_in_file" to "Edit"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'replace_in_file', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Edit');
+    });
+
+    it('leaves "write_to_file" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'write_to_file', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('write_to_file');
+    });
+
+    it('leaves "search_files" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'search_files', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('search_files');
+    });
+
+    it('leaves "list_files" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'list_files', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('list_files');
+    });
+
+    it('leaves "browser_action" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'browser_action', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('browser_action');
+    });
+
+    it('leaves "use_mcp_tool" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'use_mcp_tool', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('use_mcp_tool');
+    });
+
+    it('leaves "ask_followup_question" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'ask_followup_question',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('ask_followup_question');
+    });
+
+    it('leaves "attempt_completion" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'attempt_completion', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('attempt_completion');
+    });
+
+    it('leaves "new_task" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'new_task', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('new_task');
+    });
+
+    it('leaves "plan_mode_respond" unmapped (falls through to "Unknown")', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'plan_mode_respond', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('plan_mode_respond');
+    });
+
+    it('maps unknown tool to "Unknown" with platformToolName preserved', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'custom_cline_tool', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('custom_cline_tool');
+    });
+
+    it('defaults missing tool name to "unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ timestamp: 2000 });
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.toolName).toBe('Unknown');
+    });
+
+    it('defaults success to true when not provided', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file', timestamp: 2000 });
+      expect(normalized.success).toBe(true);
+    });
+
+    it('preserves error field', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'replace_in_file',
+        timestamp: 2000,
+        success: false,
+        error: 'permission denied',
+      });
+      expect(normalized.success).toBe(false);
+      expect(normalized.error).toBe('permission denied');
+    });
+
+    it('uses current time when timestamp is missing', () => {
+      const before = Date.now();
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file' });
+      const after = Date.now();
+      expect(normalized.timestamp).toBeGreaterThanOrEqual(before);
+      expect(normalized.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('includes inputSizeBytes and outputSizeBytes when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'read_file',
+        timestamp: 2000,
+        inputSizeBytes: 50,
+        outputSizeBytes: 1000,
+      });
+      expect(normalized.inputSizeBytes).toBe(50);
+      expect(normalized.outputSizeBytes).toBe(1000);
+    });
+
+    it('includes sessionId when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'read_file',
+        timestamp: 2000,
+        sessionId: 'cline-sess-001',
+      });
+      expect(normalized.sessionId).toBe('cline-sess-001');
+    });
+
+    it('falls back to safe defaults when raw is not an object (e.g. null)', () => {
+      const normalized = adapter.normalizeToolCall(null);
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.platform).toBe('cline');
+      expect(normalized.success).toBe(true);
+      expect(normalized.durationMs).toBeNull();
+    });
+
+    it('does not validate field types — a numeric "sessionId" leaks through unchanged', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'read_file', sessionId: 42 });
+      expect(normalized.sessionId).toBe(42);
+    });
+  });
+
+  describe('getSessionMetadata', () => {
+    it('returns platform "cline" with no extra fields', () => {
+      const meta = adapter.getSessionMetadata();
+      expect(meta).toEqual({ platform: 'cline' });
+    });
+  });
+
+  describe('isSupported', () => {
+    it('returns true when MCP_CLIENT is "cline"', () => {
+      process.env.MCP_CLIENT = 'cline';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns true when NEW_RELIC_AI_PLATFORM is "cline"', () => {
+      process.env.NEW_RELIC_AI_PLATFORM = 'cline';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns false in a non-Cline environment', () => {
+      expect(adapter.isSupported()).toBe(false);
+    });
+  });
+
+  describe('getHookInstallInstructions', () => {
+    it('returns non-empty Cline-specific instructions', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions.length).toBeGreaterThan(0);
+      expect(instructions).toContain('Cline');
+    });
+
+    it('mentions NEW_RELIC_LICENSE_KEY', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_LICENSE_KEY');
+    });
+
+    it('mentions NEW_RELIC_ACCOUNT_ID', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
+    });
+
+    it('states Cline has no hook mechanism instead of claiming automatic capture', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('no hook mechanism');
+    });
+
+    it('documents the real mcpServers settings key', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('mcpServers');
+    });
+
+    it('documents the MCP_CLIENT=cline opt-in env var', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('MCP_CLIENT');
+    });
+  });
+
+  describe('initialize', () => {
+    it('completes without error', async () => {
+      await expect(adapter.initialize({})).resolves.toBeUndefined();
+    });
+  });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('read_file')).toBe('Read');
+    });
+
+    it('maps "execute_command" to "Bash"', () => {
+      expect(adapter.mapToolName('execute_command')).toBe('Bash');
+    });
+
+    it('returns "Unknown" for a real Cline tool with no canonical equivalent', () => {
+      expect(adapter.mapToolName('browser_action')).toBe('Unknown');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
+});

--- a/src/platforms/cline-adapter.ts
+++ b/src/platforms/cline-adapter.ts
@@ -1,0 +1,135 @@
+import type {
+  NormalizedToolCall,
+  PlatformAdapter,
+  PlatformConfig,
+  PlatformSessionMetadata,
+} from './types.js';
+
+/**
+ * Maps Cline's built-in tool names to the normalized Claude Code tool
+ * vocabulary. Source: docs.cline.bot/tools-reference/all-cline-tools,
+ * whose "Legacy Tool Names vs Current Runtime Tools" section names
+ * execute_command, read_file, and replace_in_file directly as tool names
+ * that appear in "older docs/examples" — contrasted with the newer
+ * "ClineCore" SDK runtime's read_files/apply_patch/bash/etc. That page does
+ * not state which surface (VS Code/JetBrains extension vs. SDK/CLI) emits
+ * which name set, and does not enumerate a complete historical tool list —
+ * so it's unconfirmed whether the current extension still emits these
+ * exact names today. Since visibilityLevel is 'mcp-tools-only' (see
+ * initialize() below), this map is currently unreachable from any real
+ * hook pipeline regardless. It exists for correctness and any future hook
+ * capability, same as Zed's and Continue's tool maps. Other real or
+ * reported Cline tool names (write_to_file, search_files, list_files,
+ * browser_action, use_mcp_tool, ask_followup_question, attempt_completion,
+ * new_task, plan_mode_respond, etc.) are left unmapped rather than guessed
+ * at without a documented source — mapToolName has no pass-through
+ * fallback, so an omitted key falls through to 'Unknown' with the original
+ * name preserved.
+ */
+const CLINE_TOOL_MAP: Record<string, string> = {
+  execute_command: 'Bash',
+  read_file: 'Read',
+  replace_in_file: 'Edit',
+};
+
+interface ClineToolCallEvent {
+  tool?: string;
+  toolName?: string;
+  timestamp?: number;
+  durationMs?: number;
+  success?: boolean;
+  error?: string;
+  filePath?: string;
+  path?: string;
+  command?: string;
+  inputSizeBytes?: number;
+  outputSizeBytes?: number;
+  sessionId?: string;
+}
+
+function isClineToolCallEvent(x: unknown): x is ClineToolCallEvent {
+  return typeof x === 'object' && x !== null;
+}
+
+export class ClineAdapter implements PlatformAdapter {
+  readonly platformName = 'cline';
+  readonly visibilityLevel = 'mcp-tools-only' as const;
+  readonly capabilities = { instructionFilePaths: ['.clinerules/'] as const };
+
+  async initialize(_config: PlatformConfig): Promise<void> {
+    // Cline's VS Code/JetBrains extension has no hook/callback mechanism for
+    // built-in tool-call interception (confirmed: docs.cline.bot/customization/plugins
+    // and docs.cline.bot/tools-reference/all-cline-tools both state Plugins/Custom
+    // Tools are "not applicable on VSCode and JetBrains Extension for now" — only
+    // Cline SDK, CLI, and Kanban support the beforeTool/afterTool lifecycle hooks
+    // documented at docs.cline.bot/sdk/plugins). As a Cline MCP server, Preflight
+    // can only receive calls Cline's agent makes to Preflight's own exposed tools —
+    // it cannot observe Cline's built-in execute_command/read_file/write_to_file/
+    // etc. calls.
+  }
+
+  normalizeToolCall(raw: unknown): NormalizedToolCall {
+    const event = isClineToolCallEvent(raw) ? raw : {};
+    const platformToolName = event.tool ?? event.toolName ?? 'unknown';
+    const toolName = CLINE_TOOL_MAP[platformToolName] ?? 'Unknown';
+    const filePath = event.filePath ?? event.path;
+
+    return {
+      toolName,
+      platformToolName,
+      platform: this.platformName,
+      timestamp: event.timestamp ?? Date.now(),
+      durationMs: event.durationMs ?? null,
+      success: event.success ?? true,
+      ...(event.error !== undefined && { error: event.error }),
+      ...(event.inputSizeBytes !== undefined && { inputSizeBytes: event.inputSizeBytes }),
+      ...(event.outputSizeBytes !== undefined && { outputSizeBytes: event.outputSizeBytes }),
+      ...(filePath !== undefined && { filePath }),
+      ...(event.command !== undefined && { command: event.command }),
+      ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+    };
+  }
+
+  mapToolName(platformToolName: string): string {
+    return CLINE_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
+  getSessionMetadata(): PlatformSessionMetadata {
+    return {
+      platform: this.platformName,
+    };
+  }
+
+  getHookInstallInstructions(): string {
+    return [
+      'Cline Setup:',
+      '',
+      "Cline's VS Code/JetBrains extension has no hook mechanism for tool-call",
+      'capture — Preflight configured as a Cline MCP server only sees calls made',
+      "to its own tools, not Cline's built-in execute_command/read_file/",
+      'write_to_file/etc. calls.',
+      '',
+      '1. Extension: open the Cline panel, click the MCP Servers icon, open the',
+      '   Configure tab, click "Configure MCP Servers", and add to mcpServers:',
+      '   {',
+      '     "mcpServers": {',
+      '       "preflight": {',
+      '         "command": "npx",',
+      '         "args": ["preflight", "--stdio"],',
+      '         "env": {',
+      '           "MCP_CLIENT": "cline",',
+      '           "NEW_RELIC_LICENSE_KEY": "<your-key>",',
+      '           "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"',
+      '         }',
+      '       }',
+      '     }',
+      '   }',
+      '2. CLI: edit ~/.cline/mcp.json with the same shape, or run `cline mcp`.',
+      '3. Restart Cline / reload the extension.',
+    ].join('\n');
+  }
+
+  isSupported(): boolean {
+    return process.env.MCP_CLIENT === 'cline' || process.env.NEW_RELIC_AI_PLATFORM === 'cline';
+  }
+}

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -16,6 +16,7 @@ export { AmazonQAdapter } from './amazon-q-adapter.js';
 export { KiroAdapter } from './kiro-adapter.js';
 export { DroidAdapter } from './droid-adapter.js';
 export { GeminiCliAdapter } from './gemini-cli-adapter.js';
+export { ClineAdapter } from './cline-adapter.js';
 export { GenericMcpAdapter, validateReportToolCallInput } from './generic-mcp-adapter.js';
 export type {
   ReportToolCallInput,

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -11,6 +11,7 @@ import { AmazonQAdapter } from './amazon-q-adapter.js';
 import { KiroAdapter } from './kiro-adapter.js';
 import { DroidAdapter } from './droid-adapter.js';
 import { GeminiCliAdapter } from './gemini-cli-adapter.js';
+import { ClineAdapter } from './cline-adapter.js';
 import type { PlatformAdapter, PlatformSessionMetadata, NormalizedToolCall } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -280,6 +281,15 @@ describe('PlatformRegistry', () => {
       expect(detected!.platformName).toBe('gemini-cli');
     });
 
+    it('selects Cline adapter when MCP_CLIENT is "cline"', () => {
+      process.env.MCP_CLIENT = 'cline';
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('cline');
+    });
+
     it('falls back to generic-mcp when no specific platform detected', () => {
       const registry = createDefaultRegistry();
 
@@ -338,7 +348,7 @@ describe('createDefaultRegistry', () => {
     const registry = createDefaultRegistry();
     const registered = registry.getRegistered();
 
-    expect(registered).toHaveLength(11);
+    expect(registered).toHaveLength(12);
     expect(registered[0]).toBeInstanceOf(ClaudeCodeAdapter);
     expect(registered[1]).toBeInstanceOf(CursorAdapter);
     expect(registered[2]).toBeInstanceOf(WindsurfAdapter);
@@ -349,10 +359,11 @@ describe('createDefaultRegistry', () => {
     expect(registered[7]).toBeInstanceOf(KiroAdapter);
     expect(registered[8]).toBeInstanceOf(DroidAdapter);
     expect(registered[9]).toBeInstanceOf(GeminiCliAdapter);
-    expect(registered[10]).toBeInstanceOf(GenericMcpAdapter);
+    expect(registered[10]).toBeInstanceOf(ClineAdapter);
+    expect(registered[11]).toBeInstanceOf(GenericMcpAdapter);
   });
 
-  it('includes zed, continue, amazon-q, kiro, droid, and gemini-cli adapters', () => {
+  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, and cline adapters', () => {
     const registry = createDefaultRegistry();
     const names = registry.getRegistered().map((a) => a.platformName);
     expect(names).toContain('zed');
@@ -361,6 +372,7 @@ describe('createDefaultRegistry', () => {
     expect(names).toContain('kiro');
     expect(names).toContain('droid');
     expect(names).toContain('gemini-cli');
+    expect(names).toContain('cline');
   });
 
   it('ends with generic-mcp as fallback', () => {
@@ -419,6 +431,12 @@ describe('capabilities', () => {
     const geminiCli = registry.getRegistered().find((a) => a.platformName === 'gemini-cli')!;
     expect(geminiCli.capabilities.instructionFilePaths).toContain('GEMINI.md');
   });
+
+  it('cline declares .clinerules/ as an instruction file path', () => {
+    const registry = createDefaultRegistry();
+    const cline = registry.getRegistered().find((a) => a.platformName === 'cline')!;
+    expect(cline.capabilities.instructionFilePaths).toContain('.clinerules/');
+  });
 });
 
 describe('all adapters implement PlatformAdapter interface', () => {
@@ -433,6 +451,7 @@ describe('all adapters implement PlatformAdapter interface', () => {
     new KiroAdapter(),
     new DroidAdapter(),
     new GeminiCliAdapter(),
+    new ClineAdapter(),
     new GenericMcpAdapter(),
   ];
 

--- a/src/platforms/platform-registry.ts
+++ b/src/platforms/platform-registry.ts
@@ -10,6 +10,7 @@ import { AmazonQAdapter } from './amazon-q-adapter.js';
 import { KiroAdapter } from './kiro-adapter.js';
 import { DroidAdapter } from './droid-adapter.js';
 import { GeminiCliAdapter } from './gemini-cli-adapter.js';
+import { ClineAdapter } from './cline-adapter.js';
 import { GenericMcpAdapter } from './generic-mcp-adapter.js';
 
 const logger = createLogger('platform-registry');
@@ -65,6 +66,7 @@ export function createDefaultRegistry(): PlatformRegistry {
   registry.register(new KiroAdapter());
   registry.register(new DroidAdapter());
   registry.register(new GeminiCliAdapter());
+  registry.register(new ClineAdapter());
   registry.register(new GenericMcpAdapter()); // always last
   return registry;
 }


### PR DESCRIPTION
## Summary

- Adds `ClineAdapter` for [Cline](https://cline.bot) (VS Code/JetBrains extension, formerly "Claude Dev"), closing #198.
- Scoped `visibilityLevel: 'mcp-tools-only'` — the same tier as `ZedAdapter`/`ContinueAdapter` — because Cline's own docs confirm its VS Code/JetBrains extension (the dominant, highest-adoption surface) has no hook/callback mechanism for built-in tool calls; that capability exists only on Cline's separate SDK/CLI/Kanban surfaces.
- `CLINE_TOOL_MAP` intentionally covers only `execute_command`, `read_file`, and `replace_in_file` — the three tool names Cline's own docs (`docs.cline.bot/tools-reference/all-cline-tools`) literally name. Other real/reported Cline tool names are left unmapped rather than guessed at, per this repo's "never invent a tool map, cite real docs" convention.
- Registers the adapter in `createDefaultRegistry()` and documents it in `docs/ADAPTERS.md`, following the existing Zed/Continue.dev section structure.
- Version bump to 1.9.0 with a matching CHANGELOG entry.

Fixes #198

## Test plan

- [x] `npm run build && npm test` — full suite passing
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run format:check` — clean
- [x] New `cline-adapter.test.ts` (39 cases): tool-name mapping, unmapped-tool fallback to `Unknown`, `isSupported()` detection, session metadata, hook-install instructions
- [x] `platform-registry.test.ts` updated: registration count/order, detection, `.clinerules/` capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)