### PR TITLE
Feat: Add Codex (OpenAI) platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2026-07-22
+
+### Added
+
+- **OpenAI Codex platform adapter** — Preflight now detects and normalizes tool calls from [OpenAI Codex](https://developers.openai.com/codex) (CLI, IDE extension, and desktop app). Codex sessions are detected via `MCP_CLIENT=codex` or `NEW_RELIC_AI_PLATFORM=codex` (Codex's documentation lists no ambient environment variable for the MCP server process itself, unlike several other platforms). Codex's native `PreToolUse`/`PostToolUse` hooks use the same event vocabulary and field shapes Claude Code already sends, so built-in tool calls (shell commands, unified exec, `apply_patch` file edits, MCP tool calls, and subagent spawns) are captured and mapped to Preflight's standard vocabulary automatically once hooks are configured. Hosted tools such as `WebSearch` are not observable — Codex's own documentation confirms these never reach the local function-tool hook path. Setup instructions are included in `docs/ADAPTERS.md`.
+
 ## [1.9.0] - 2026-07-22
 
 ### Added

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,6 +1,6 @@
 # Platform Adapters
 
-Preflight supports 11 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
+Preflight supports 12 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
 
 This doc is the canonical reference for what each adapter can and can't observe, how detection and setup actually work, and where the gaps are. It mirrors `src/platforms/*.ts` and the hook-event handling in `src/hooks/collector-script.ts` — if you change either, update this doc in the same PR.
 
@@ -8,20 +8,20 @@ This doc is the canonical reference for what each adapter can and can't observe,
 
 ## Integration mechanisms
 
-| Mechanism                                                                                                      | Platforms                          | What's captured                                                                        | `visibilityLevel` |
-| -------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
-| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid | All built-in tool calls                                                                | `full-hooks`      |
-| **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                         | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
-| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                   | All built-in tool calls                                                                | `full-hooks`      |
-| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev, Cline           | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
-| **HTTP push from an extension**                                                                                | GitHub Copilot                     | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
-| **Self-report via MCP tools**                                                                                  | Generic MCP fallback               | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
+| Mechanism                                                                                                      | Platforms                                 | What's captured                                                                        | `visibilityLevel` |
+| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
+| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid, Codex | All built-in tool calls                                                                | `full-hooks`      |
+| **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                                | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
+| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                          | All built-in tool calls                                                                | `full-hooks`      |
+| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev, Cline                  | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
+| **HTTP push from an extension**                                                                                | GitHub Copilot                            | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
+| **Self-report via MCP tools**                                                                                  | Generic MCP fallback                      | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
 
 [^gemini-hybrid]: Gemini CLI's hook _event names_ (`BeforeTool`/`AfterTool`) don't match `PreToolUse`/`PostToolUse`, so it needs its own branches in `collector-script.ts` — but the _fields_ inside those events (`tool_name`, `tool_input`, `tool_response`) are shaped exactly like Claude Code's, so those branches reuse the existing field-extraction helpers rather than needing new ones.
 
 Every `PlatformAdapter` (`src/platforms/types.ts`) declares a `visibilityLevel` field encoding this table in code, not just prose — `full-hooks` (automatic, deterministic capture), `self-reported` (built-in-tool-shaped events are observable, but only if an external party — a third-party extension, or the calling MCP client itself — actually reports them), or `mcp-tools-only` (structurally cannot see built-in tool calls at all). Consumers that blend metrics across platforms (`nr_observe_get_platform_comparison`, the weekly digest's per-platform breakdown) use `getPlatformVisibilityMap()` (`src/platforms/platform-registry.ts`) to tag results and caveat comparisons that span more than one level.
 
-Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
+Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, Cline, Codex, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
 
 ---
 
@@ -331,6 +331,48 @@ Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-regi
      -e NEW_RELIC_ACCOUNT_ID=<your-account-id>
    ```
 4. Restart Gemini CLI
+
+---
+
+## OpenAI Codex (`codex`)
+
+**Mechanism:** Native `hooks.json` lifecycle-hooks system (`~/.codex/hooks.json` user scope, `<repo>/.codex/hooks.json` project scope, or inline `[hooks]` tables in `config.toml`) — [developers.openai.com/codex/hooks](https://developers.openai.com/codex/hooks). Codex's `PreToolUse`/`PostToolUse` events send `hook_event_name`, `tool_name`, `tool_input`/`tool_response`, `session_id`, `cwd`, `transcript_path`, `tool_use_id`, `permission_mode` in the same shape Claude Code, Kiro, Amazon Q, and Droid use, so they're handled by the same generic branches in `collector-script.ts` — no platform-specific parsing was needed. Also supports MCP as a client independently of the hooks system ([developers.openai.com/codex/extend/mcp](https://developers.openai.com/codex/extend/mcp)). Non-managed hooks (anything outside a system/MDM/`requirements.toml`-managed source) require one-time review and trust via `/hooks` in the Codex CLI before they run.
+
+**Detection (`isSupported()`):** `MCP_CLIENT === 'codex'`, or `NEW_RELIC_AI_PLATFORM === 'codex'`. Checked Codex's full documented environment-variable list ([developers.openai.com/codex/config-file/environment-variables](https://developers.openai.com/codex/config-file/environment-variables)) — `CODEX_HOME`, `CODEX_SQLITE_HOME`, `CODEX_NON_INTERACTIVE`, `CODEX_INSTALL_DIR`, `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, `CODEX_CA_CERTIFICATE`, `RUST_LOG` — none are documented as injected into an MCP server subprocess's environment as an ambient "running under Codex" signal. `CLAUDE_PLUGIN_ROOT`/`CLAUDE_PLUGIN_DATA` are real but scoped to plugin-bundled hook _command_ subprocesses specifically, not to an MCP server started via `codex mcp add` — detection is explicit-opt-in only, same as Droid/Gemini CLI/Cline.
+
+**Tool coverage, confirmed via Codex's own tool-coverage table:** shell commands and unified exec (`exec_command`) are both fully covered (Yes/Yes for `PreToolUse`/`PostToolUse`), reported with the canonical literal `tool_name` `"Bash"` — no translation needed. `apply_patch` is also fully covered but always reports `tool_name` literally as `"apply_patch"` (never split into `Edit`/`Write`, even though Codex's own hook _matcher_ config lets a user alias-match it as either); `CODEX_TOOL_MAP` collapses it to `'Edit'`, a single value, the same treatment Windsurf gives `pre_write_code`. MCP tool calls and other local function tools (e.g. `spawn_agent`, matched by the coverage table as also aliasable to `Agent`) are fully covered too. `update_plan` has no confirmed Preflight canonical equivalent and is left unmapped.
+
+**Known gaps:**
+
+- **Hosted tools are entirely unobservable.** Codex's own tool-coverage table marks hosted tools such as `WebSearch` as No/No for both `PreToolUse` and `PostToolUse` — "these don't use the local function-tool hook path." Preflight cannot see these calls at all, regardless of hook configuration.
+- **`apply_patch` calls don't get Edit's structured metadata.** `collector-script.ts`'s `extractInputMeta`/`extractOutputMeta` switch on the _raw_ tool name (`"apply_patch"`, not `"Edit"`) before `mapToolName()` ever runs, so Codex's `apply_patch` calls don't get the `oldStringLength`/`newStringLength`/etc. fields Claude Code's `Edit` calls get — the same pre-existing situation Gemini CLI's `replace` and Droid's `Create`/`Execute`/`Task` are already in.
+- **A `write_stdin` poll against an already-open unified-exec session doesn't re-trigger `PreToolUse`.** This is narrower than it may sound: `exec_command` itself is fully covered (Yes/Yes) — only a _follow-up_ poll of a session that already passed `PreToolUse` is exempt from running it again.
+
+**Setup:**
+
+1. Add a `PreToolUse`/`PostToolUse` hook pair matching all tools to `hooks.json` (`~/.codex/hooks.json` user scope or `<repo>/.codex/hooks.json` project scope):
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [
+         { "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }
+       ],
+       "PostToolUse": [
+         { "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }
+       ]
+     }
+   }
+   ```
+2. Run `/hooks` in the Codex CLI to review and trust this hook definition — non-managed hooks are skipped until reviewed.
+3. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`)
+4. Register the Preflight MCP server:
+   ```
+   codex mcp add preflight --env MCP_CLIENT=codex \
+     --env NEW_RELIC_LICENSE_KEY=<your-key> \
+     --env NEW_RELIC_ACCOUNT_ID=<your-account-id> \
+     -- npx preflight --stdio
+   ```
+5. Restart Codex
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/platforms/codex-adapter.test.ts
+++ b/src/platforms/codex-adapter.test.ts
@@ -1,0 +1,224 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { CodexAdapter } from './codex-adapter.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  for (const key of ['MCP_CLIENT', 'NEW_RELIC_AI_PLATFORM']) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('CodexAdapter', () => {
+  const adapter = new CodexAdapter();
+
+  it('has platformName "codex"', () => {
+    expect(adapter.platformName).toBe('codex');
+  });
+
+  it('declares visibilityLevel "full-hooks"', () => {
+    expect(adapter.visibilityLevel).toBe('full-hooks');
+  });
+
+  it('declares AGENTS.md as an instruction file path', () => {
+    expect(adapter.capabilities.instructionFilePaths).toEqual(['AGENTS.md']);
+  });
+
+  describe('normalizeToolCall', () => {
+    it('maps "Bash" to "Bash" (identity)', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'Bash',
+        timestamp: 2000,
+        command: 'npm test',
+      });
+      expect(normalized.toolName).toBe('Bash');
+      expect(normalized.command).toBe('npm test');
+    });
+
+    it('maps "apply_patch" to "Edit"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'apply_patch',
+        timestamp: 2000,
+        filePath: '/src/app.ts',
+      });
+      expect(normalized.toolName).toBe('Edit');
+      expect(normalized.platformToolName).toBe('apply_patch');
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('maps "spawn_agent" to "Agent"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'spawn_agent', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Agent');
+    });
+
+    it('leaves "update_plan" unmapped, falling through to "Unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'update_plan', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('update_plan');
+    });
+
+    it('leaves an arbitrary MCP tool name unmapped, falling through to "Unknown"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'mcp__filesystem__read_file',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('mcp__filesystem__read_file');
+    });
+
+    it('never fabricates a mapping for a hosted tool Codex cannot hook (e.g. WebSearch)', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'WebSearch', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('WebSearch');
+    });
+
+    it('accepts "toolName" field as an alternative to "tool"', () => {
+      const normalized = adapter.normalizeToolCall({ toolName: 'Bash', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Bash');
+      expect(normalized.platformToolName).toBe('Bash');
+    });
+
+    it('normalizes path to filePath', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'apply_patch', path: '/src/app.ts' });
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('maps unknown tool to "Unknown" with platformToolName preserved', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'totally_unmapped_tool',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('totally_unmapped_tool');
+    });
+
+    it('defaults missing tool name to "unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ timestamp: 2000 });
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.toolName).toBe('Unknown');
+    });
+
+    it('falls back to safe defaults when raw is not an object (e.g. null)', () => {
+      const normalized = adapter.normalizeToolCall(null);
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.platform).toBe('codex');
+      expect(normalized.success).toBe(true);
+      expect(normalized.durationMs).toBeNull();
+    });
+
+    it('defaults success to true when not provided', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'Bash', timestamp: 2000 });
+      expect(normalized.success).toBe(true);
+    });
+
+    it('preserves error field', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'apply_patch',
+        timestamp: 2000,
+        success: false,
+        error: 'patch failed to apply',
+      });
+      expect(normalized.success).toBe(false);
+      expect(normalized.error).toBe('patch failed to apply');
+    });
+
+    it('uses current time when timestamp is missing', () => {
+      const before = Date.now();
+      const normalized = adapter.normalizeToolCall({ tool: 'Bash' });
+      const after = Date.now();
+      expect(normalized.timestamp).toBeGreaterThanOrEqual(before);
+      expect(normalized.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('includes inputSizeBytes and outputSizeBytes when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'Bash',
+        timestamp: 2000,
+        inputSizeBytes: 50,
+        outputSizeBytes: 1000,
+      });
+      expect(normalized.inputSizeBytes).toBe(50);
+      expect(normalized.outputSizeBytes).toBe(1000);
+    });
+
+    it('includes sessionId when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'Bash',
+        timestamp: 2000,
+        sessionId: 'codex-sess-001',
+      });
+      expect(normalized.sessionId).toBe('codex-sess-001');
+    });
+  });
+
+  describe('getSessionMetadata', () => {
+    it('returns platform "codex"', () => {
+      const meta = adapter.getSessionMetadata();
+      expect(meta.platform).toBe('codex');
+    });
+  });
+
+  describe('isSupported', () => {
+    it('returns true when MCP_CLIENT is "codex"', () => {
+      process.env.MCP_CLIENT = 'codex';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns true when NEW_RELIC_AI_PLATFORM is "codex"', () => {
+      process.env.NEW_RELIC_AI_PLATFORM = 'codex';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns false in a non-Codex environment', () => {
+      expect(adapter.isSupported()).toBe(false);
+    });
+  });
+
+  describe('getHookInstallInstructions', () => {
+    it('returns non-empty Codex-specific instructions', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions.length).toBeGreaterThan(0);
+      expect(instructions).toContain('Codex');
+    });
+
+    it('references hooks.json', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('hooks.json');
+    });
+
+    it('mentions NEW_RELIC_LICENSE_KEY', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_LICENSE_KEY');
+    });
+
+    it('mentions NEW_RELIC_ACCOUNT_ID', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
+    });
+  });
+
+  describe('initialize', () => {
+    it('completes without error', async () => {
+      await expect(adapter.initialize({})).resolves.toBeUndefined();
+    });
+  });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('apply_patch')).toBe('Edit');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
+});

--- a/src/platforms/codex-adapter.ts
+++ b/src/platforms/codex-adapter.ts
@@ -1,0 +1,137 @@
+import type {
+  NormalizedToolCall,
+  PlatformAdapter,
+  PlatformConfig,
+  PlatformSessionMetadata,
+} from './types.js';
+
+/**
+ * Maps OpenAI Codex's built-in tool names to the normalized Claude Code tool
+ * vocabulary. Source: developers.openai.com/codex/hooks's "Tool coverage"
+ * table and PreToolUse/PostToolUse field reference. Codex's own hook
+ * payload already reports shell commands and unified-exec (exec_command)
+ * calls alike with the canonical literal tool_name "Bash", so no
+ * translation is needed there. apply_patch always reports tool_name
+ * literally as "apply_patch" (never "Edit" or "Write", even though Codex's
+ * own hook *matcher* config lets a user alias-match it as either) — mapped
+ * here to 'Edit' as a single collapsed value, since a patch body can touch
+ * multiple files with mixed add/update/delete actions and there's no clean
+ * 1:1 mapping to Preflight's Read/Write/Edit vocabulary regardless of
+ * approach (same precedent as Windsurf's pre_write_code -> 'Edit'). This
+ * means Codex's apply_patch calls don't get collector-script.ts's Edit-
+ * specific metadata extraction (oldStringLength/newStringLength/etc.),
+ * since that switches on the raw tool_name ("apply_patch", not "Edit")
+ * before mapToolName() ever runs — the same pre-existing gap Gemini CLI's
+ * replace and Droid's Create/Execute/Task calls are already in.
+ * spawn_agent's tool_name is confirmed literal (the coverage table's note
+ * "spawn_agent also matches Agent" documents Agent as a matcher *alias*,
+ * not the payload's actual tool_name value) -> mapped to 'Agent'.
+ * update_plan has no confirmed Preflight canonical equivalent and is left
+ * unmapped -> falls through to 'Unknown' with the original name preserved.
+ * Hosted tools (e.g. WebSearch) are confirmed unobservable by Codex's own
+ * hooks and are never reported through this path at all — see Known gaps
+ * in docs/ADAPTERS.md.
+ */
+const CODEX_TOOL_MAP: Record<string, string> = {
+  Bash: 'Bash',
+  apply_patch: 'Edit',
+  spawn_agent: 'Agent',
+};
+
+interface CodexToolCallEvent {
+  tool?: string;
+  toolName?: string;
+  timestamp?: number;
+  durationMs?: number;
+  success?: boolean;
+  error?: string;
+  filePath?: string;
+  path?: string;
+  command?: string;
+  inputSizeBytes?: number;
+  outputSizeBytes?: number;
+  sessionId?: string;
+}
+
+function isCodexToolCallEvent(x: unknown): x is CodexToolCallEvent {
+  return typeof x === 'object' && x !== null;
+}
+
+export class CodexAdapter implements PlatformAdapter {
+  readonly platformName = 'codex';
+  readonly visibilityLevel = 'full-hooks' as const;
+  // developers.openai.com/codex/config-file/config-reference's
+  // model_instructions_file field: "Replacement for built-in instructions
+  // instead of AGENTS.md." Same convention Droid, Cursor, and Gemini CLI
+  // also read.
+  readonly capabilities = { instructionFilePaths: ['AGENTS.md'] as const };
+
+  async initialize(_config: PlatformConfig): Promise<void> {
+    // Codex hooks are configured externally (hooks.json or inline [hooks]
+    // tables in config.toml).
+  }
+
+  normalizeToolCall(raw: unknown): NormalizedToolCall {
+    const event = isCodexToolCallEvent(raw) ? raw : {};
+    const platformToolName = event.tool ?? event.toolName ?? 'unknown';
+    const toolName = CODEX_TOOL_MAP[platformToolName] ?? 'Unknown';
+    const filePath = event.filePath ?? event.path;
+
+    return {
+      toolName,
+      platformToolName,
+      platform: this.platformName,
+      timestamp: event.timestamp ?? Date.now(),
+      durationMs: event.durationMs ?? null,
+      success: event.success ?? true,
+      ...(event.error !== undefined && { error: event.error }),
+      ...(event.inputSizeBytes !== undefined && { inputSizeBytes: event.inputSizeBytes }),
+      ...(event.outputSizeBytes !== undefined && { outputSizeBytes: event.outputSizeBytes }),
+      ...(filePath !== undefined && { filePath }),
+      ...(event.command !== undefined && { command: event.command }),
+      ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+    };
+  }
+
+  mapToolName(platformToolName: string): string {
+    return CODEX_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
+  getSessionMetadata(): PlatformSessionMetadata {
+    return {
+      platform: this.platformName,
+    };
+  }
+
+  getHookInstallInstructions(): string {
+    return [
+      'OpenAI Codex Setup:',
+      '',
+      '1. Add a PreToolUse/PostToolUse hook pair matching all tools to hooks.json',
+      '   (~/.codex/hooks.json user scope, or <repo>/.codex/hooks.json project scope):',
+      '   {',
+      '     "hooks": {',
+      '       "PreToolUse": [',
+      '         { "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }',
+      '       ],',
+      '       "PostToolUse": [',
+      '         { "matcher": "*", "hooks": [{ "type": "command", "command": "preflight-collector" }] }',
+      '       ]',
+      '     }',
+      '   }',
+      '2. Non-managed hooks require one-time review and trust before they run —',
+      '   run `/hooks` in the Codex CLI to review and trust this hook definition.',
+      '3. Ensure preflight-collector is on your PATH (npm link, or npm install -g @newrelic/preflight)',
+      '4. Register the Preflight MCP server:',
+      '   codex mcp add preflight --env MCP_CLIENT=codex \\',
+      '     --env NEW_RELIC_LICENSE_KEY=<your-key> \\',
+      '     --env NEW_RELIC_ACCOUNT_ID=<your-account-id> \\',
+      '     -- npx preflight --stdio',
+      '5. Restart Codex',
+    ].join('\n');
+  }
+
+  isSupported(): boolean {
+    return process.env.MCP_CLIENT === 'codex' || process.env.NEW_RELIC_AI_PLATFORM === 'codex';
+  }
+}

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -17,6 +17,7 @@ export { KiroAdapter } from './kiro-adapter.js';
 export { DroidAdapter } from './droid-adapter.js';
 export { GeminiCliAdapter } from './gemini-cli-adapter.js';
 export { ClineAdapter } from './cline-adapter.js';
+export { CodexAdapter } from './codex-adapter.js';
 export { GenericMcpAdapter, validateReportToolCallInput } from './generic-mcp-adapter.js';
 export type {
   ReportToolCallInput,

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -12,6 +12,7 @@ import { KiroAdapter } from './kiro-adapter.js';
 import { DroidAdapter } from './droid-adapter.js';
 import { GeminiCliAdapter } from './gemini-cli-adapter.js';
 import { ClineAdapter } from './cline-adapter.js';
+import { CodexAdapter } from './codex-adapter.js';
 import type { PlatformAdapter, PlatformSessionMetadata, NormalizedToolCall } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -290,6 +291,15 @@ describe('PlatformRegistry', () => {
       expect(detected!.platformName).toBe('cline');
     });
 
+    it('selects Codex adapter when MCP_CLIENT is "codex"', () => {
+      process.env.MCP_CLIENT = 'codex';
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('codex');
+    });
+
     it('falls back to generic-mcp when no specific platform detected', () => {
       const registry = createDefaultRegistry();
 
@@ -348,7 +358,7 @@ describe('createDefaultRegistry', () => {
     const registry = createDefaultRegistry();
     const registered = registry.getRegistered();
 
-    expect(registered).toHaveLength(12);
+    expect(registered).toHaveLength(13);
     expect(registered[0]).toBeInstanceOf(ClaudeCodeAdapter);
     expect(registered[1]).toBeInstanceOf(CursorAdapter);
     expect(registered[2]).toBeInstanceOf(WindsurfAdapter);
@@ -360,10 +370,11 @@ describe('createDefaultRegistry', () => {
     expect(registered[8]).toBeInstanceOf(DroidAdapter);
     expect(registered[9]).toBeInstanceOf(GeminiCliAdapter);
     expect(registered[10]).toBeInstanceOf(ClineAdapter);
-    expect(registered[11]).toBeInstanceOf(GenericMcpAdapter);
+    expect(registered[11]).toBeInstanceOf(CodexAdapter);
+    expect(registered[12]).toBeInstanceOf(GenericMcpAdapter);
   });
 
-  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, and cline adapters', () => {
+  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, cline, and codex adapters', () => {
     const registry = createDefaultRegistry();
     const names = registry.getRegistered().map((a) => a.platformName);
     expect(names).toContain('zed');
@@ -373,6 +384,7 @@ describe('createDefaultRegistry', () => {
     expect(names).toContain('droid');
     expect(names).toContain('gemini-cli');
     expect(names).toContain('cline');
+    expect(names).toContain('codex');
   });
 
   it('ends with generic-mcp as fallback', () => {
@@ -452,6 +464,7 @@ describe('all adapters implement PlatformAdapter interface', () => {
     new DroidAdapter(),
     new GeminiCliAdapter(),
     new ClineAdapter(),
+    new CodexAdapter(),
     new GenericMcpAdapter(),
   ];
 

--- a/src/platforms/platform-registry.ts
+++ b/src/platforms/platform-registry.ts
@@ -11,6 +11,7 @@ import { KiroAdapter } from './kiro-adapter.js';
 import { DroidAdapter } from './droid-adapter.js';
 import { GeminiCliAdapter } from './gemini-cli-adapter.js';
 import { ClineAdapter } from './cline-adapter.js';
+import { CodexAdapter } from './codex-adapter.js';
 import { GenericMcpAdapter } from './generic-mcp-adapter.js';
 
 const logger = createLogger('platform-registry');
@@ -67,6 +68,7 @@ export function createDefaultRegistry(): PlatformRegistry {
   registry.register(new DroidAdapter());
   registry.register(new GeminiCliAdapter());
   registry.register(new ClineAdapter());
+  registry.register(new CodexAdapter());
   registry.register(new GenericMcpAdapter()); // always last
   return registry;
 }


### PR DESCRIPTION
## Summary

- Adds `CodexAdapter` for OpenAI Codex CLI/IDE extension/desktop app, the 12th named `PlatformAdapter` (`src/platforms/codex-adapter.ts`).
- Full-hooks tier: Codex's native `hooks.json` `PreToolUse`/`PostToolUse` events already match Claude Code's payload shape, so `src/hooks/collector-script.ts` needs no changes.
- Tool map: `Bash`→`Bash` (identity, Codex's own canonical name), `apply_patch`→`Edit` (single collapsed value — Codex's own hook payload always reports `apply_patch` literally, never `Edit`/`Write`), `spawn_agent`→`Agent`. `update_plan` and arbitrary MCP tool names are deliberately left unmapped.
- Detection is explicit opt-in only (`MCP_CLIENT=codex` or `NEW_RELIC_AI_PLATFORM=codex`) — confirmed no ambient env var exists across Codex's full documented environment-variable list.
- `docs/ADAPTERS.md` gets a new Codex section (mechanism/detection/tool coverage/known gaps/setup) plus 3 small fixes to existing text (platform count, table row, and a drive-by fix restoring a missing "Cline" from a prior PR's detection-order sentence).
- Known gaps documented: hosted tools (`WebSearch` etc.) are entirely unobservable (confirmed via Codex's own tool-coverage table); `apply_patch` calls don't get `Edit`'s structured metadata extraction (same pre-existing situation as Gemini CLI/Droid); a `write_stdin` poll against an already-open unified-exec session doesn't re-trigger `PreToolUse` — narrower than originally suspected, since `exec_command` itself is fully covered.
- Version bump 1.9.0 → 1.10.0 + CHANGELOG entry.

Every mechanism claim was verified directly against `developers.openai.com/codex/hooks`, `/codex/config-file/environment-variables`, `/codex/extend/mcp`, and `/codex/config-file/config-reference` — not assumed from the linked issue's paraphrase.

Fixes #202

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — passes, no regressions
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] New `src/platforms/codex-adapter.test.ts` covers tool-name mapping, unmapped/hosted-tool non-fabrication, both detection env vars, and interface parity
- [x] `src/platforms/platform-registry.test.ts` updated for the 13th registered adapter (12 named + generic-mcp fallback) and new detection case

🤖 Generated with [Claude Code](https://claude.com/claude-code)