### PR TITLE
Feat: Add opencode platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2026-07-23
+
+### Added
+
+- **opencode platform adapter** — Preflight now detects and normalizes tool calls from [opencode](https://opencode.ai). opencode sessions are detected via `MCP_CLIENT=opencode` or `NEW_RELIC_AI_PLATFORM=opencode` (opencode's documentation lists no ambient environment variable for the MCP server process itself, unlike several other platforms). Unlike Claude Code, Kiro, Amazon Q, Droid, and Codex, which all send `PreToolUse`/`PostToolUse` hooks from an external hooks configuration, opencode has no external hooks file — its only interception point is an in-process plugin. Preflight ships a documented plugin snippet (see `docs/ADAPTERS.md`) that translates opencode's own `tool.execute.before`/`tool.execute.after` plugin events into the same shape Claude Code already sends, so built-in tool calls (`bash`, `read`, `write`, `edit`, `apply_patch`, `grep`, `glob`, `webfetch`, `websearch`, `skill`, `todowrite`, `question`) are captured and mapped to Preflight's standard vocabulary automatically once the plugin is installed. opencode's hook payload carries no success/failure signal, so every captured tool call is currently reported as successful, and only `bash`/`read`/`edit`/`write` receive structured input metadata. Setup instructions are included in `docs/ADAPTERS.md`.
+
 ## [1.10.0] - 2026-07-22
 
 ### Added

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,6 +1,6 @@
 # Platform Adapters
 
-Preflight supports 12 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
+Preflight supports 13 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
 
 This doc is the canonical reference for what each adapter can and can't observe, how detection and setup actually work, and where the gaps are. It mirrors `src/platforms/*.ts` and the hook-event handling in `src/hooks/collector-script.ts` — if you change either, update this doc in the same PR.
 
@@ -8,20 +8,20 @@ This doc is the canonical reference for what each adapter can and can't observe,
 
 ## Integration mechanisms
 
-| Mechanism                                                                                                      | Platforms                                 | What's captured                                                                        | `visibilityLevel` |
-| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
-| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid, Codex | All built-in tool calls                                                                | `full-hooks`      |
-| **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                                | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
-| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                          | All built-in tool calls                                                                | `full-hooks`      |
-| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev, Cline                  | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
-| **HTTP push from an extension**                                                                                | GitHub Copilot                            | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
-| **Self-report via MCP tools**                                                                                  | Generic MCP fallback                      | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
+| Mechanism                                                                                                      | Platforms                                           | What's captured                                                                        | `visibilityLevel` |
+| -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
+| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid, Codex, opencode | All built-in tool calls                                                                | `full-hooks`      |
+| **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                                          | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
+| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                                    | All built-in tool calls                                                                | `full-hooks`      |
+| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev, Cline                            | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
+| **HTTP push from an extension**                                                                                | GitHub Copilot                                      | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
+| **Self-report via MCP tools**                                                                                  | Generic MCP fallback                                | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
 
 [^gemini-hybrid]: Gemini CLI's hook _event names_ (`BeforeTool`/`AfterTool`) don't match `PreToolUse`/`PostToolUse`, so it needs its own branches in `collector-script.ts` — but the _fields_ inside those events (`tool_name`, `tool_input`, `tool_response`) are shaped exactly like Claude Code's, so those branches reuse the existing field-extraction helpers rather than needing new ones.
 
 Every `PlatformAdapter` (`src/platforms/types.ts`) declares a `visibilityLevel` field encoding this table in code, not just prose — `full-hooks` (automatic, deterministic capture), `self-reported` (built-in-tool-shaped events are observable, but only if an external party — a third-party extension, or the calling MCP client itself — actually reports them), or `mcp-tools-only` (structurally cannot see built-in tool calls at all). Consumers that blend metrics across platforms (`nr_observe_get_platform_comparison`, the weekly digest's per-platform breakdown) use `getPlatformVisibilityMap()` (`src/platforms/platform-registry.ts`) to tag results and caveat comparisons that span more than one level.
 
-Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, Cline, Codex, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
+Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, Cline, Codex, opencode, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
 
 ---
 
@@ -373,6 +373,45 @@ Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-regi
      -- npx preflight --stdio
    ```
 5. Restart Codex
+
+---
+
+## opencode (`opencode`)
+
+**Mechanism:** Unlike every other `full-hooks` platform above, opencode has no external hooks.json — its only interception point is an in-process JS/TS plugin loaded from `.opencode/plugins/` (project) or `~/.config/opencode/plugins/` (global), or via an npm package listed in `opencode.json`'s `plugin` array ([opencode.ai/docs/plugins/](https://opencode.ai/docs/plugins/)). Preflight ships a documented plugin snippet (see Setup below) that translates opencode's real `tool.execute.before`/`tool.execute.after` hook payloads — confirmed from the published `@opencode-ai/plugin` npm package's own type definitions: `input: {tool, sessionID, callID}` / `output: {args}` for `before`, `input: {tool, sessionID, callID, args}` / `output: {title, output, metadata}` for `after` — into Claude Code's `PreToolUse`/`PostToolUse` JSON shape before piping to `preflight-collector`. `collector-script.ts`'s existing generic branches handle it as a result — **no changes to that file were needed.**
+
+**Detection (`isSupported()`):** `MCP_CLIENT === 'opencode'`, or `NEW_RELIC_AI_PLATFORM === 'opencode'`. Checked opencode's full documented local-MCP-server option set ([opencode.ai/docs/mcp-servers/](https://opencode.ai/docs/mcp-servers/)) — `type`, `command`, `cwd`, `environment`, `enabled`, `timeout` — nothing is documented as an ambient "running under opencode" signal injected into a spawned local MCP server's environment. Detection is explicit-opt-in only, same as Droid/Gemini CLI/Cline/Codex.
+
+**Tool coverage, confirmed via opencode's own tools doc ([opencode.ai/docs/tools/](https://opencode.ai/docs/tools/)):** `bash`, `read`, `write`, `edit`, `grep`, `glob`, `webfetch`, `websearch` (gated behind `OPENCODE_ENABLE_EXA` or the OpenCode-hosted provider) map directly. `apply_patch` collapses to `'Edit'` — same "no clean 1:1, multi-file patch" reasoning as `CodexAdapter`. `skill` maps to `'Skill'` (same precedent as `ContinueAdapter`'s `read_skill`). `todowrite` maps to `'TaskCreate'` (same precedent as `AmazonQAdapter`'s `todo_list`). `question` maps to `'AskUserQuestion'` (opencode's own docs describe a header + question text + options list, matching that tool's shape). `lsp` (experimental, gated behind `OPENCODE_EXPERIMENTAL_LSP_TOOL`) has no confirmed Preflight canonical equivalent and is left unmapped.
+
+**Known gaps:**
+
+- **No success/error signal exists in opencode's hook payload at all.** Every opencode tool call reports `success: true` unconditionally — same convention as Cursor's `afterShellExecution`/Windsurf's `post_read_code`. A genuinely failed tool call (e.g. non-zero bash exit) is indistinguishable from a successful one through this hook.
+- **Only `bash`/`read`/`edit`/`write` get structured input metadata.** The plugin snippet's `toClaudeShape()` function special-cases these four, remapping their `args` fields: `bash` → `{ command: args.command }`, and `read`/`edit`/`write` → `{ file_path: args.filePath }`. `apply_patch`/`grep`/`glob`/`webfetch`/`websearch`/`todowrite`/`skill`/`question`'s `args` are forwarded as-is — for `apply_patch` specifically, this means its `patchText` field never reaches `collector-script.ts`'s `Edit`-case extractors (which expect `old_string`/`new_string`), so despite being mapped to the `Edit` tool name, it gets no structured metadata.
+- **No output-side metadata at all** (`exitCode`, `editSuccess`, `grepMatchCount`, etc.). opencode's `output.output`/`output.metadata` are opaque and tool-specific with no documented convention — the plugin snippet's `PostToolUse` payload intentionally omits `tool_response` rather than guessing a mapping.
+- **Requires a user-installed plugin file, not a JSON hooks config** — a genuinely different, code-based setup step from every other platform's instructions.
+
+**Setup:**
+
+1. Register the Preflight MCP server in `opencode.json`:
+   ```json
+   {
+     "mcp": {
+       "preflight": {
+         "type": "local",
+         "command": ["npx", "preflight", "--stdio"],
+         "environment": {
+           "MCP_CLIENT": "opencode",
+           "NEW_RELIC_LICENSE_KEY": "<your-key>",
+           "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"
+         }
+       }
+     }
+   }
+   ```
+2. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`)
+3. Create `.opencode/plugins/preflight.js` (project) or `~/.config/opencode/plugins/preflight.js` (global) with the snippet in `OpencodeAdapter.getHookInstallInstructions()` (`src/platforms/opencode-adapter.ts`) — reproduced there in full.
+4. Restart opencode.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -18,6 +18,7 @@ export { DroidAdapter } from './droid-adapter.js';
 export { GeminiCliAdapter } from './gemini-cli-adapter.js';
 export { ClineAdapter } from './cline-adapter.js';
 export { CodexAdapter } from './codex-adapter.js';
+export { OpencodeAdapter } from './opencode-adapter.js';
 export { GenericMcpAdapter, validateReportToolCallInput } from './generic-mcp-adapter.js';
 export type {
   ReportToolCallInput,

--- a/src/platforms/opencode-adapter.test.ts
+++ b/src/platforms/opencode-adapter.test.ts
@@ -1,0 +1,229 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { OpencodeAdapter } from './opencode-adapter.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  for (const key of ['MCP_CLIENT', 'NEW_RELIC_AI_PLATFORM']) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('OpencodeAdapter', () => {
+  const adapter = new OpencodeAdapter();
+
+  it('has platformName "opencode"', () => {
+    expect(adapter.platformName).toBe('opencode');
+  });
+
+  it('declares visibilityLevel "full-hooks"', () => {
+    expect(adapter.visibilityLevel).toBe('full-hooks');
+  });
+
+  it('declares AGENTS.md as an instruction file path', () => {
+    expect(adapter.capabilities.instructionFilePaths).toEqual(['AGENTS.md']);
+  });
+
+  describe('normalizeToolCall', () => {
+    const cases: Array<[string, string]> = [
+      ['bash', 'Bash'],
+      ['read', 'Read'],
+      ['write', 'Write'],
+      ['edit', 'Edit'],
+      ['apply_patch', 'Edit'],
+      ['grep', 'Grep'],
+      ['glob', 'Glob'],
+      ['webfetch', 'WebFetch'],
+      ['websearch', 'WebSearch'],
+      ['skill', 'Skill'],
+      ['todowrite', 'TaskCreate'],
+      ['question', 'AskUserQuestion'],
+    ];
+
+    for (const [platformToolName, expected] of cases) {
+      it(`maps "${platformToolName}" to "${expected}"`, () => {
+        const normalized = adapter.normalizeToolCall({ tool: platformToolName, timestamp: 2000 });
+        expect(normalized.toolName).toBe(expected);
+        expect(normalized.platformToolName).toBe(platformToolName);
+      });
+    }
+
+    it('leaves "lsp" unmapped, falling through to "Unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'lsp', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('lsp');
+    });
+
+    it('leaves an arbitrary unrecognized tool name unmapped, falling through to "Unknown"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'totally_unmapped_tool',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('totally_unmapped_tool');
+    });
+
+    it('accepts "toolName" field as an alternative to "tool"', () => {
+      const normalized = adapter.normalizeToolCall({ toolName: 'bash', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Bash');
+      expect(normalized.platformToolName).toBe('bash');
+    });
+
+    it('defaults missing tool name to "unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ timestamp: 2000 });
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.toolName).toBe('Unknown');
+    });
+
+    it('falls back to safe defaults when raw is not an object (e.g. null)', () => {
+      const normalized = adapter.normalizeToolCall(null);
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.platform).toBe('opencode');
+      expect(normalized.success).toBe(true);
+      expect(normalized.durationMs).toBeNull();
+    });
+
+    it('defaults success to true when not provided', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'bash', timestamp: 2000 });
+      expect(normalized.success).toBe(true);
+    });
+
+    it('preserves error field', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        success: false,
+        error: 'command failed',
+      });
+      expect(normalized.success).toBe(false);
+      expect(normalized.error).toBe('command failed');
+    });
+
+    it('uses current time when timestamp is missing', () => {
+      const before = Date.now();
+      const normalized = adapter.normalizeToolCall({ tool: 'bash' });
+      const after = Date.now();
+      expect(normalized.timestamp).toBeGreaterThanOrEqual(before);
+      expect(normalized.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('includes inputSizeBytes and outputSizeBytes when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        inputSizeBytes: 50,
+        outputSizeBytes: 1000,
+      });
+      expect(normalized.inputSizeBytes).toBe(50);
+      expect(normalized.outputSizeBytes).toBe(1000);
+    });
+
+    it('includes sessionId when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        sessionId: 'opencode-sess-001',
+      });
+      expect(normalized.sessionId).toBe('opencode-sess-001');
+    });
+
+    it('includes filePath when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'read',
+        timestamp: 2000,
+        filePath: '/src/app.ts',
+      });
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('includes command when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        command: 'npm test',
+      });
+      expect(normalized.command).toBe('npm test');
+    });
+  });
+
+  describe('getSessionMetadata', () => {
+    it('returns platform "opencode"', () => {
+      const meta = adapter.getSessionMetadata();
+      expect(meta.platform).toBe('opencode');
+    });
+  });
+
+  describe('isSupported', () => {
+    it('returns true when MCP_CLIENT is "opencode"', () => {
+      process.env.MCP_CLIENT = 'opencode';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns true when NEW_RELIC_AI_PLATFORM is "opencode"', () => {
+      process.env.NEW_RELIC_AI_PLATFORM = 'opencode';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns false in a non-opencode environment', () => {
+      expect(adapter.isSupported()).toBe(false);
+    });
+  });
+
+  describe('getHookInstallInstructions', () => {
+    it('returns non-empty opencode-specific instructions', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions.length).toBeGreaterThan(0);
+      expect(instructions).toContain('opencode');
+    });
+
+    it('documents the plugin directory', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('.opencode/plugins/');
+    });
+
+    it('documents the tool.execute.before/after hooks', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions).toContain('tool.execute.before');
+      expect(instructions).toContain('tool.execute.after');
+    });
+
+    it('mentions preflight-collector', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('preflight-collector');
+    });
+
+    it('mentions NEW_RELIC_LICENSE_KEY', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_LICENSE_KEY');
+    });
+
+    it('mentions NEW_RELIC_ACCOUNT_ID', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
+    });
+  });
+
+  describe('initialize', () => {
+    it('completes without error', async () => {
+      await expect(adapter.initialize({})).resolves.toBeUndefined();
+    });
+  });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('apply_patch')).toBe('Edit');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
+});

--- a/src/platforms/opencode-adapter.ts
+++ b/src/platforms/opencode-adapter.ts
@@ -1,0 +1,183 @@
+import type {
+  NormalizedToolCall,
+  PlatformAdapter,
+  PlatformConfig,
+  PlatformSessionMetadata,
+} from './types.js';
+
+/**
+ * Maps opencode's built-in tool names (opencode.ai/docs/tools/) to the
+ * normalized Claude Code tool vocabulary. `bash`/`read`/`write`/`edit`/
+ * `grep`/`glob`/`webfetch`/`websearch` map directly. `apply_patch` collapses
+ * to 'Edit' — a single patch can touch multiple files with mixed
+ * add/update/delete actions, so there's no clean 1:1 mapping, same
+ * precedent as CodexAdapter's apply_patch -> 'Edit'. `skill` maps to 'Skill'
+ * (same precedent as ContinueAdapter's read_skill -> 'Skill'). `todowrite`
+ * maps to 'TaskCreate' (same precedent as AmazonQAdapter's todo_list ->
+ * 'TaskCreate'). `question` maps to 'AskUserQuestion' — opencode's own docs
+ * describe it as "Each question includes a header, the question text, and a
+ * list of options," matching AskUserQuestion's shape. `lsp` is experimental
+ * (gated behind OPENCODE_EXPERIMENTAL_LSP_TOOL) with no confirmed Preflight
+ * canonical equivalent and is left unmapped -> falls through to 'Unknown',
+ * same treatment as Codex's update_plan.
+ */
+const OPENCODE_TOOL_MAP: Record<string, string> = {
+  bash: 'Bash',
+  read: 'Read',
+  write: 'Write',
+  edit: 'Edit',
+  apply_patch: 'Edit',
+  grep: 'Grep',
+  glob: 'Glob',
+  webfetch: 'WebFetch',
+  websearch: 'WebSearch',
+  skill: 'Skill',
+  todowrite: 'TaskCreate',
+  question: 'AskUserQuestion',
+};
+
+interface OpencodeToolCallEvent {
+  tool?: string;
+  toolName?: string;
+  timestamp?: number;
+  durationMs?: number;
+  success?: boolean;
+  error?: string;
+  filePath?: string;
+  path?: string;
+  command?: string;
+  inputSizeBytes?: number;
+  outputSizeBytes?: number;
+  sessionId?: string;
+}
+
+function isOpencodeToolCallEvent(x: unknown): x is OpencodeToolCallEvent {
+  return typeof x === 'object' && x !== null;
+}
+
+export class OpencodeAdapter implements PlatformAdapter {
+  readonly platformName = 'opencode';
+  readonly visibilityLevel = 'full-hooks' as const;
+  // opencode.ai/docs/rules/: project-level AGENTS.md, with CLAUDE.md as a
+  // documented fallback (opencode's own "Claude Code Compatibility" mode).
+  readonly capabilities = { instructionFilePaths: ['AGENTS.md'] as const };
+
+  async initialize(_config: PlatformConfig): Promise<void> {
+    // opencode's tool-call capture is delivered via a user-installed plugin
+    // file (see getHookInstallInstructions()), not configured by this
+    // process — same no-op shape as every other full-hooks adapter.
+  }
+
+  normalizeToolCall(raw: unknown): NormalizedToolCall {
+    const event = isOpencodeToolCallEvent(raw) ? raw : {};
+    const platformToolName = event.tool ?? event.toolName ?? 'unknown';
+    const toolName = OPENCODE_TOOL_MAP[platformToolName] ?? 'Unknown';
+    const filePath = event.filePath ?? event.path;
+
+    return {
+      toolName,
+      platformToolName,
+      platform: this.platformName,
+      timestamp: event.timestamp ?? Date.now(),
+      durationMs: event.durationMs ?? null,
+      success: event.success ?? true,
+      ...(event.error !== undefined && { error: event.error }),
+      ...(event.inputSizeBytes !== undefined && { inputSizeBytes: event.inputSizeBytes }),
+      ...(event.outputSizeBytes !== undefined && { outputSizeBytes: event.outputSizeBytes }),
+      ...(filePath !== undefined && { filePath }),
+      ...(event.command !== undefined && { command: event.command }),
+      ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+    };
+  }
+
+  mapToolName(platformToolName: string): string {
+    return OPENCODE_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
+  getSessionMetadata(): PlatformSessionMetadata {
+    return {
+      platform: this.platformName,
+    };
+  }
+
+  getHookInstallInstructions(): string {
+    return [
+      'opencode Setup:',
+      '',
+      '1. Register the Preflight MCP server in opencode.json:',
+      '   {',
+      '     "mcp": {',
+      '       "preflight": {',
+      '         "type": "local",',
+      '         "command": ["npx", "preflight", "--stdio"],',
+      '         "environment": {',
+      '           "MCP_CLIENT": "opencode",',
+      '           "NEW_RELIC_LICENSE_KEY": "<your-key>",',
+      '           "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"',
+      '         }',
+      '       }',
+      '     }',
+      '   }',
+      '2. Ensure preflight-collector is on your PATH (npm link, or npm install -g @newrelic/preflight)',
+      '3. Built-in tool calls (bash, read, write, edit, etc.) require a plugin file, since',
+      '   opencode has no external hooks.json — it only supports in-process JS/TS plugins.',
+      '   Create .opencode/plugins/preflight.js (project) or',
+      '   ~/.config/opencode/plugins/preflight.js (global) with:',
+      '',
+      '   import { spawn } from "node:child_process"',
+      '',
+      '   const TOOL_MAP = {',
+      '     bash: "Bash", read: "Read", write: "Write", edit: "Edit",',
+      '     apply_patch: "Edit", grep: "Grep", glob: "Glob",',
+      '     webfetch: "WebFetch", websearch: "WebSearch", skill: "Skill",',
+      '     todowrite: "TaskCreate", question: "AskUserQuestion",',
+      '   }',
+      '',
+      '   function report(payload) {',
+      '     const child = spawn("preflight-collector", [], { stdio: ["pipe", "ignore", "ignore"] })',
+      '     child.stdin.write(JSON.stringify(payload))',
+      '     child.stdin.end()',
+      '   }',
+      '',
+      '   function toClaudeShape(tool, args) {',
+      '     if (tool === "bash") return { command: args.command }',
+      '     if (tool === "read" || tool === "edit" || tool === "write") return { file_path: args.filePath }',
+      '     return args',
+      '   }',
+      '',
+      '   export const PreflightPlugin = async () => ({',
+      '     "tool.execute.before": async (input, output) => {',
+      '       report({',
+      '         hook_event_name: "PreToolUse",',
+      '         tool_name: TOOL_MAP[input.tool] ?? "Unknown",',
+      '         tool_input: toClaudeShape(input.tool, output.args),',
+      '         tool_use_id: input.callID,',
+      '         session_id: input.sessionID,',
+      '       })',
+      '     },',
+      '     "tool.execute.after": async (input, output) => {',
+      '       report({',
+      '         hook_event_name: "PostToolUse",',
+      '         tool_name: TOOL_MAP[input.tool] ?? "Unknown",',
+      '         tool_use_id: input.callID,',
+      '         session_id: input.sessionID,',
+      '       })',
+      '     },',
+      '   })',
+      '',
+      '4. Restart opencode.',
+      '',
+      "Known gaps: opencode's hook payload has no success/error field, so every",
+      'tool call reports success unconditionally. Only bash/read/edit/write',
+      "get structured input metadata; other tools' arg shapes (including apply_patch)",
+      'are undocumented and forwarded as-is. No output-side metadata (exit codes,',
+      'match counts, etc.) is captured — see docs/ADAPTERS.md for details.',
+    ].join('\n');
+  }
+
+  isSupported(): boolean {
+    return (
+      process.env.MCP_CLIENT === 'opencode' || process.env.NEW_RELIC_AI_PLATFORM === 'opencode'
+    );
+  }
+}

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -13,6 +13,7 @@ import { DroidAdapter } from './droid-adapter.js';
 import { GeminiCliAdapter } from './gemini-cli-adapter.js';
 import { ClineAdapter } from './cline-adapter.js';
 import { CodexAdapter } from './codex-adapter.js';
+import { OpencodeAdapter } from './opencode-adapter.js';
 import type { PlatformAdapter, PlatformSessionMetadata, NormalizedToolCall } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -300,6 +301,15 @@ describe('PlatformRegistry', () => {
       expect(detected!.platformName).toBe('codex');
     });
 
+    it('selects opencode adapter when MCP_CLIENT is "opencode"', () => {
+      process.env.MCP_CLIENT = 'opencode';
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('opencode');
+    });
+
     it('falls back to generic-mcp when no specific platform detected', () => {
       const registry = createDefaultRegistry();
 
@@ -358,7 +368,7 @@ describe('createDefaultRegistry', () => {
     const registry = createDefaultRegistry();
     const registered = registry.getRegistered();
 
-    expect(registered).toHaveLength(13);
+    expect(registered).toHaveLength(14);
     expect(registered[0]).toBeInstanceOf(ClaudeCodeAdapter);
     expect(registered[1]).toBeInstanceOf(CursorAdapter);
     expect(registered[2]).toBeInstanceOf(WindsurfAdapter);
@@ -371,10 +381,11 @@ describe('createDefaultRegistry', () => {
     expect(registered[9]).toBeInstanceOf(GeminiCliAdapter);
     expect(registered[10]).toBeInstanceOf(ClineAdapter);
     expect(registered[11]).toBeInstanceOf(CodexAdapter);
-    expect(registered[12]).toBeInstanceOf(GenericMcpAdapter);
+    expect(registered[12]).toBeInstanceOf(OpencodeAdapter);
+    expect(registered[13]).toBeInstanceOf(GenericMcpAdapter);
   });
 
-  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, cline, and codex adapters', () => {
+  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, cline, codex, and opencode adapters', () => {
     const registry = createDefaultRegistry();
     const names = registry.getRegistered().map((a) => a.platformName);
     expect(names).toContain('zed');
@@ -385,6 +396,7 @@ describe('createDefaultRegistry', () => {
     expect(names).toContain('gemini-cli');
     expect(names).toContain('cline');
     expect(names).toContain('codex');
+    expect(names).toContain('opencode');
   });
 
   it('ends with generic-mcp as fallback', () => {
@@ -465,6 +477,7 @@ describe('all adapters implement PlatformAdapter interface', () => {
     new GeminiCliAdapter(),
     new ClineAdapter(),
     new CodexAdapter(),
+    new OpencodeAdapter(),
     new GenericMcpAdapter(),
   ];
 

--- a/src/platforms/platform-registry.ts
+++ b/src/platforms/platform-registry.ts
@@ -12,6 +12,7 @@ import { DroidAdapter } from './droid-adapter.js';
 import { GeminiCliAdapter } from './gemini-cli-adapter.js';
 import { ClineAdapter } from './cline-adapter.js';
 import { CodexAdapter } from './codex-adapter.js';
+import { OpencodeAdapter } from './opencode-adapter.js';
 import { GenericMcpAdapter } from './generic-mcp-adapter.js';
 
 const logger = createLogger('platform-registry');
@@ -69,6 +70,7 @@ export function createDefaultRegistry(): PlatformRegistry {
   registry.register(new GeminiCliAdapter());
   registry.register(new ClineAdapter());
   registry.register(new CodexAdapter());
+  registry.register(new OpencodeAdapter());
   registry.register(new GenericMcpAdapter()); // always last
   return registry;
 }


### PR DESCRIPTION
## Summary

- Adds `OpencodeAdapter`, the 13th named platform adapter, for [opencode](https://opencode.ai)
- opencode has no external hooks.json like every prior `full-hooks` adapter — its only interception point is an in-process JS/TS plugin. Ships a documented copy-paste plugin snippet (`getHookInstallInstructions()`) that translates opencode's real `tool.execute.before`/`tool.execute.after` hook payloads into Claude Code's `PreToolUse`/`PostToolUse` JSON shape, so the existing hook collector needed **zero changes** — its generic branches already handle the translated shape
- 12-entry tool-name map, each non-obvious mapping sourced to a real sibling-adapter precedent or opencode's own docs; `lsp` deliberately left unmapped (experimental, gated, no confirmed equivalent)
- Explicit-opt-in detection (`MCP_CLIENT`/`NEW_RELIC_AI_PLATFORM === 'opencode'`) — no ambient env var exists to auto-detect opencode
- New `docs/ADAPTERS.md` section (Mechanism / Detection / Tool coverage / Known gaps / Setup), following the existing per-platform format
- Bumps to v1.11.0 with a CHANGELOG entry

Fixes #201

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — passing, 0 failures
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run format:check` — clean