### PR TITLE
Feat: Add Kilo Code platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2026-07-23
+
+### Added
+
+- **Kilo Code platform adapter** — Preflight now detects and normalizes tool calls from [Kilo Code](https://kilocode.ai) (`@kilocode/cli`). Kilo Code sessions are detected via `MCP_CLIENT=kilocode` or `NEW_RELIC_AI_PLATFORM=kilocode` (Kilo's documentation lists no ambient environment variable for the MCP server process itself, unlike several other platforms). Kilo CLI is a confirmed fork of opencode and shares its exact plugin-based interception mechanism — no external hooks.json, only an in-process plugin. Preflight ships a documented plugin snippet (see `docs/ADAPTERS.md`) that translates Kilo's own `tool.execute.before`/`tool.execute.after` plugin events into the same shape Claude Code already sends, so built-in tool calls (`read`, `glob`, `grep`, `edit`, `write`, `apply_patch`, `bash`, `webfetch`, `websearch`, `question`, `todowrite`, `todoread`, `plan`, `task`, `skill`) are captured and mapped to Preflight's standard vocabulary automatically once the plugin is installed. Kilo's hook payload carries no success/failure signal, so every captured tool call is currently reported as successful, and only `bash`/`read`/`edit`/`write` receive structured input metadata. Setup instructions are included in `docs/ADAPTERS.md`.
+
 ## [1.11.0] - 2026-07-23
 
 ### Added

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,6 +1,6 @@
 # Platform Adapters
 
-Preflight supports 13 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
+Preflight supports 14 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
 
 This doc is the canonical reference for what each adapter can and can't observe, how detection and setup actually work, and where the gaps are. It mirrors `src/platforms/*.ts` and the hook-event handling in `src/hooks/collector-script.ts` — if you change either, update this doc in the same PR.
 
@@ -8,20 +8,20 @@ This doc is the canonical reference for what each adapter can and can't observe,
 
 ## Integration mechanisms
 
-| Mechanism                                                                                                      | Platforms                                           | What's captured                                                                        | `visibilityLevel` |
-| -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
-| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid, Codex, opencode | All built-in tool calls                                                                | `full-hooks`      |
-| **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                                          | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
-| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                                    | All built-in tool calls                                                                | `full-hooks`      |
-| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev, Cline                            | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
-| **HTTP push from an extension**                                                                                | GitHub Copilot                                      | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
-| **Self-report via MCP tools**                                                                                  | Generic MCP fallback                                | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
+| Mechanism                                                                                                      | Platforms                                                      | What's captured                                                                        | `visibilityLevel` |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
+| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid, Codex, opencode, Kilo Code | All built-in tool calls                                                                | `full-hooks`      |
+| **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                                                     | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
+| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                                               | All built-in tool calls                                                                | `full-hooks`      |
+| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev, Cline                                       | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
+| **HTTP push from an extension**                                                                                | GitHub Copilot                                                 | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
+| **Self-report via MCP tools**                                                                                  | Generic MCP fallback                                           | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
 
 [^gemini-hybrid]: Gemini CLI's hook _event names_ (`BeforeTool`/`AfterTool`) don't match `PreToolUse`/`PostToolUse`, so it needs its own branches in `collector-script.ts` — but the _fields_ inside those events (`tool_name`, `tool_input`, `tool_response`) are shaped exactly like Claude Code's, so those branches reuse the existing field-extraction helpers rather than needing new ones.
 
 Every `PlatformAdapter` (`src/platforms/types.ts`) declares a `visibilityLevel` field encoding this table in code, not just prose — `full-hooks` (automatic, deterministic capture), `self-reported` (built-in-tool-shaped events are observable, but only if an external party — a third-party extension, or the calling MCP client itself — actually reports them), or `mcp-tools-only` (structurally cannot see built-in tool calls at all). Consumers that blend metrics across platforms (`nr_observe_get_platform_comparison`, the weekly digest's per-platform breakdown) use `getPlatformVisibilityMap()` (`src/platforms/platform-registry.ts`) to tag results and caveat comparisons that span more than one level.
 
-Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, Cline, Codex, opencode, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
+Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, Cline, Codex, opencode, Kilo Code, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
 
 ---
 
@@ -412,6 +412,46 @@ Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-regi
 2. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`)
 3. Create `.opencode/plugins/preflight.js` (project) or `~/.config/opencode/plugins/preflight.js` (global) with the snippet in `OpencodeAdapter.getHookInstallInstructions()` (`src/platforms/opencode-adapter.ts`) — reproduced there in full.
 4. Restart opencode.
+
+---
+
+## Kilo Code (`kilocode`)
+
+**Mechanism:** Kilo CLI (`@kilocode/cli`) is a confirmed literal fork of opencode — Kilo's own docs state directly: "The Kilo CLI is a fork of OpenCode." It shares opencode's exact interception mechanism: no external hooks.json, only an in-process JS/TS plugin loaded from `.kilo/plugin/` (project) or `~/.config/kilo/plugin/` (global) — **not** `.opencode/`, since Kilo CLI 1.0 no longer reads legacy `.opencode`/`.kilocode` directories ([kilocode.ai/docs/automate/extending/plugins](https://kilocode.ai/docs/automate/extending/plugins)). Preflight ships a documented plugin snippet (see Setup below) that translates Kilo's real `tool.execute.before`/`tool.execute.after` hook payloads — confirmed from `packages/plugin/src/index.ts` in [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode), the actual source backing the published `@kilocode/plugin` npm package: `input: {tool, sessionID, callID}` / `output: {args}` for `before`, `input: {tool, sessionID, callID, args}` / `output: {title, output, metadata}` for `after` — byte-identical field names to opencode's confirmed shapes. `collector-script.ts`'s existing generic branches handle it as a result — **no changes to that file were needed.**
+
+**Detection (`isSupported()`):** `MCP_CLIENT === 'kilocode'`, or `NEW_RELIC_AI_PLATFORM === 'kilocode'`. Checked Kilo's full documented "Environment Variable Overrides" set ([kilocode.ai/docs/code-with-ai/platforms/cli](https://kilocode.ai/docs/code-with-ai/platforms/cli)) — `KILO_PROVIDER`, `KILOCODE_<FIELD>`/`KILO_<FIELD_NAME>`, `KILO_ORG_ID`, `KILO_CONFIG`/`KILO_CONFIG_CONTENT`, `KILO_PURE` — every one is an optional user-set config override or a plugin-disable switch, none is an ambient "running under Kilo" marker a spawned MCP server process could rely on. Detection is explicit-opt-in only, same as opencode/Droid/Gemini CLI/Cline/Codex.
+
+**Tool coverage, confirmed via Kilo's own tools docs ([kilocode.ai/docs/automate/tools](https://kilocode.ai/docs/automate/tools), [/docs/automate/how-tools-work](https://kilocode.ai/docs/automate/how-tools-work)):** `read`, `glob`, `grep`, `edit`, `write`, `bash`, `webfetch`, `websearch` map directly. `apply_patch` collapses to `'Edit'` — same precedent as `CodexAdapter`/`OpencodeAdapter`. `skill` maps to `'Skill'`, `question` maps to `'AskUserQuestion'`, and `todowrite` maps to `'TaskCreate'` — all reusing `OpencodeAdapter`'s precedents directly. `task` (spawns a sub-agent/child session) maps to `'Agent'` — same precedent as Zed/Codex's `spawn_agent` and Cursor/Droid's `Task`. `todoread` maps to `'TaskList'` and `plan` maps to `'EnterPlanMode'` — both real, pre-existing entries in Preflight's canonical tool vocabulary with no adapter-map precedent before this one. `agent_manager` (a VS-Code-specific UI action starting Agent Manager local/worktree sessions) has no clean canonical equivalent and is left unmapped, same treatment as opencode's `lsp` and Codex's `update_plan`. Kilo's built-in Playwright MCP server tools (namespaced `kilo-playwright_*`) are not fixed map keys and fall through to `'Unknown'`, same as any other platform's MCP-server tool calls.
+
+**Known gaps:**
+
+- **No success/error signal exists in Kilo's hook payload at all**, same gap as opencode — every Kilo tool call reports `success: true` unconditionally.
+- **Only `bash`/`read`/`edit`/`write` get structured input metadata.** The plugin snippet's `toClaudeShape()` function special-cases these four. `apply_patch`/`glob`/`grep`/`webfetch`/`websearch`/`todowrite`/`todoread`/`plan`/`task`/`skill`/`question`/`agent_manager`'s `args` are forwarded as-is — for `apply_patch` specifically, its (unconfirmed but presumed opencode-identical) `patchText` field never reaches `collector-script.ts`'s `Edit`-case extractors, so despite being mapped to the `Edit` tool name it gets no structured metadata.
+- **No output-side metadata at all** (`exitCode`, `editSuccess`, etc.) — `output.output`/`output.metadata` are opaque, so the `PostToolUse` payload intentionally omits `tool_response`.
+- **`kilo-playwright_*` tool calls report as `'Unknown'`** with the dynamic name preserved as `platformToolName` — they're observable through this same plugin mechanism but aren't translated by the snippet's static tool map.
+- **Requires a user-installed plugin file, not a JSON hooks config** — same setup burden as opencode.
+
+**Setup:**
+
+1. Register the Preflight MCP server in `kilo.json`:
+   ```json
+   {
+     "mcp": {
+       "preflight": {
+         "type": "local",
+         "command": ["npx", "preflight", "--stdio"],
+         "environment": {
+           "MCP_CLIENT": "kilocode",
+           "NEW_RELIC_LICENSE_KEY": "<your-key>",
+           "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"
+         }
+       }
+     }
+   }
+   ```
+2. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`)
+3. Create `.kilo/plugin/preflight.ts` (project) or `~/.config/kilo/plugin/preflight.ts` (global) with the snippet in `KiloCodeAdapter.getHookInstallInstructions()` (`src/platforms/kilo-code-adapter.ts`) — reproduced there in full, using Kilo's current plugin module descriptor shape (`export default { id, server }`).
+4. Restart Kilo Code.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -19,6 +19,7 @@ export { GeminiCliAdapter } from './gemini-cli-adapter.js';
 export { ClineAdapter } from './cline-adapter.js';
 export { CodexAdapter } from './codex-adapter.js';
 export { OpencodeAdapter } from './opencode-adapter.js';
+export { KiloCodeAdapter } from './kilo-code-adapter.js';
 export { GenericMcpAdapter, validateReportToolCallInput } from './generic-mcp-adapter.js';
 export type {
   ReportToolCallInput,

--- a/src/platforms/kilo-code-adapter.test.ts
+++ b/src/platforms/kilo-code-adapter.test.ts
@@ -1,0 +1,249 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { KiloCodeAdapter } from './kilo-code-adapter.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  for (const key of ['MCP_CLIENT', 'NEW_RELIC_AI_PLATFORM']) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('KiloCodeAdapter', () => {
+  const adapter = new KiloCodeAdapter();
+
+  it('has platformName "kilocode"', () => {
+    expect(adapter.platformName).toBe('kilocode');
+  });
+
+  it('declares visibilityLevel "full-hooks"', () => {
+    expect(adapter.visibilityLevel).toBe('full-hooks');
+  });
+
+  it('declares AGENTS.md as an instruction file path', () => {
+    expect(adapter.capabilities.instructionFilePaths).toEqual(['AGENTS.md']);
+  });
+
+  describe('normalizeToolCall', () => {
+    const cases: Array<[string, string]> = [
+      ['read', 'Read'],
+      ['glob', 'Glob'],
+      ['grep', 'Grep'],
+      ['edit', 'Edit'],
+      ['write', 'Write'],
+      ['apply_patch', 'Edit'],
+      ['bash', 'Bash'],
+      ['webfetch', 'WebFetch'],
+      ['websearch', 'WebSearch'],
+      ['question', 'AskUserQuestion'],
+      ['todowrite', 'TaskCreate'],
+      ['todoread', 'TaskList'],
+      ['plan', 'EnterPlanMode'],
+      ['task', 'Agent'],
+      ['skill', 'Skill'],
+    ];
+
+    for (const [platformToolName, expected] of cases) {
+      it(`maps "${platformToolName}" to "${expected}"`, () => {
+        const normalized = adapter.normalizeToolCall({ tool: platformToolName, timestamp: 2000 });
+        expect(normalized.toolName).toBe(expected);
+        expect(normalized.platformToolName).toBe(platformToolName);
+      });
+    }
+
+    it('leaves "agent_manager" unmapped, falling through to "Unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'agent_manager', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('agent_manager');
+    });
+
+    it('leaves a namespaced kilo-playwright MCP tool call unmapped, falling through to "Unknown"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'kilo-playwright_browser_click',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('kilo-playwright_browser_click');
+    });
+
+    it('leaves an arbitrary unrecognized tool name unmapped, falling through to "Unknown"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'totally_unmapped_tool',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('totally_unmapped_tool');
+    });
+
+    it('accepts "toolName" field as an alternative to "tool"', () => {
+      const normalized = adapter.normalizeToolCall({ toolName: 'bash', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Bash');
+      expect(normalized.platformToolName).toBe('bash');
+    });
+
+    it('defaults missing tool name to "unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ timestamp: 2000 });
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.toolName).toBe('Unknown');
+    });
+
+    it('falls back to safe defaults when raw is not an object (e.g. null)', () => {
+      const normalized = adapter.normalizeToolCall(null);
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.platform).toBe('kilocode');
+      expect(normalized.success).toBe(true);
+      expect(normalized.durationMs).toBeNull();
+    });
+
+    it('defaults success to true when not provided', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'bash', timestamp: 2000 });
+      expect(normalized.success).toBe(true);
+    });
+
+    it('preserves error field', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        success: false,
+        error: 'command failed',
+      });
+      expect(normalized.success).toBe(false);
+      expect(normalized.error).toBe('command failed');
+    });
+
+    it('uses current time when timestamp is missing', () => {
+      const before = Date.now();
+      const normalized = adapter.normalizeToolCall({ tool: 'bash' });
+      const after = Date.now();
+      expect(normalized.timestamp).toBeGreaterThanOrEqual(before);
+      expect(normalized.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('includes inputSizeBytes and outputSizeBytes when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        inputSizeBytes: 50,
+        outputSizeBytes: 1000,
+      });
+      expect(normalized.inputSizeBytes).toBe(50);
+      expect(normalized.outputSizeBytes).toBe(1000);
+    });
+
+    it('includes sessionId when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        sessionId: 'kilocode-sess-001',
+      });
+      expect(normalized.sessionId).toBe('kilocode-sess-001');
+    });
+
+    it('includes filePath when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'read',
+        timestamp: 2000,
+        filePath: '/src/app.ts',
+      });
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('includes command when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        command: 'npm test',
+      });
+      expect(normalized.command).toBe('npm test');
+    });
+  });
+
+  describe('getSessionMetadata', () => {
+    it('returns platform "kilocode"', () => {
+      const meta = adapter.getSessionMetadata();
+      expect(meta.platform).toBe('kilocode');
+    });
+  });
+
+  describe('isSupported', () => {
+    it('returns true when MCP_CLIENT is "kilocode"', () => {
+      process.env.MCP_CLIENT = 'kilocode';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns true when NEW_RELIC_AI_PLATFORM is "kilocode"', () => {
+      process.env.NEW_RELIC_AI_PLATFORM = 'kilocode';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns false in a non-kilocode environment', () => {
+      expect(adapter.isSupported()).toBe(false);
+    });
+  });
+
+  describe('getHookInstallInstructions', () => {
+    it('returns non-empty Kilo Code-specific instructions', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions.length).toBeGreaterThan(0);
+      expect(instructions).toContain('Kilo');
+    });
+
+    it('documents the plugin directory', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('.kilo/plugin/');
+    });
+
+    it('does not reference opencode plugin paths', () => {
+      expect(adapter.getHookInstallInstructions()).not.toContain('.opencode/plugins/');
+    });
+
+    it('documents the tool.execute.before/after hooks', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions).toContain('tool.execute.before');
+      expect(instructions).toContain('tool.execute.after');
+    });
+
+    it('documents the current (non-legacy) plugin module descriptor shape', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('export default { id:');
+    });
+
+    it('mentions preflight-collector', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('preflight-collector');
+    });
+
+    it('mentions NEW_RELIC_LICENSE_KEY', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_LICENSE_KEY');
+    });
+
+    it('mentions NEW_RELIC_ACCOUNT_ID', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
+    });
+  });
+
+  describe('initialize', () => {
+    it('completes without error', async () => {
+      await expect(adapter.initialize({})).resolves.toBeUndefined();
+    });
+  });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('apply_patch')).toBe('Edit');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
+});

--- a/src/platforms/kilo-code-adapter.ts
+++ b/src/platforms/kilo-code-adapter.ts
@@ -1,0 +1,205 @@
+import type {
+  NormalizedToolCall,
+  PlatformAdapter,
+  PlatformConfig,
+  PlatformSessionMetadata,
+} from './types.js';
+
+/**
+ * Maps Kilo Code's built-in tool names (kilocode.ai/docs/automate/tools,
+ * /docs/automate/how-tools-work) to the normalized Claude Code tool
+ * vocabulary. Kilo CLI is a confirmed literal fork of opencode ("The Kilo
+ * CLI is a fork of OpenCode" — kilocode.ai/docs/code-with-ai/platforms/cli),
+ * so its base tool set and mapping precedents mirror OpencodeAdapter's:
+ * `read`/`glob`/`grep`/`edit`/`write`/`bash`/`webfetch`/`websearch` map
+ * directly. `apply_patch` collapses to 'Edit' (same precedent as
+ * CodexAdapter and OpencodeAdapter — a single patch can touch multiple
+ * files with mixed add/update/delete actions, no clean 1:1 mapping).
+ * `skill` maps to 'Skill' (same precedent as OpencodeAdapter/
+ * ContinueAdapter). `question` maps to 'AskUserQuestion' (same precedent as
+ * OpencodeAdapter). `todowrite` maps to 'TaskCreate' (same precedent as
+ * AmazonQAdapter/OpencodeAdapter). `task` (spawns a sub-agent/child session)
+ * maps to 'Agent' — same precedent as Zed/Codex's spawn_agent and
+ * Cursor/Droid's Task. `todoread` maps to 'TaskList' and `plan` maps to
+ * 'EnterPlanMode' — both are real, pre-existing entries in Preflight's
+ * canonical tool vocabulary (see TERMINAL_OUTPUT_TOOLS in
+ * src/metrics/tool-selection-scorer.ts) with no adapter-map precedent
+ * before this one; chosen by user decision during brainstorming, not
+ * invented. `agent_manager` (starts VS-Code-specific Agent Manager
+ * local/worktree sessions) has no clean canonical equivalent and is left
+ * unmapped -> falls through to 'Unknown', same treatment as opencode's
+ * `lsp` and Codex's `update_plan`. Kilo's built-in Playwright MCP server
+ * tools (namespaced `kilo-playwright_*`) are not fixed map keys and are not
+ * special-cased -> they also fall through to 'Unknown' with the original
+ * name preserved, same as any other platform's MCP-server tool calls.
+ */
+const KILO_CODE_TOOL_MAP: Record<string, string> = {
+  read: 'Read',
+  glob: 'Glob',
+  grep: 'Grep',
+  edit: 'Edit',
+  write: 'Write',
+  apply_patch: 'Edit',
+  bash: 'Bash',
+  webfetch: 'WebFetch',
+  websearch: 'WebSearch',
+  question: 'AskUserQuestion',
+  todowrite: 'TaskCreate',
+  todoread: 'TaskList',
+  plan: 'EnterPlanMode',
+  task: 'Agent',
+  skill: 'Skill',
+};
+
+interface KiloCodeToolCallEvent {
+  tool?: string;
+  toolName?: string;
+  timestamp?: number;
+  durationMs?: number;
+  success?: boolean;
+  error?: string;
+  filePath?: string;
+  path?: string;
+  command?: string;
+  inputSizeBytes?: number;
+  outputSizeBytes?: number;
+  sessionId?: string;
+}
+
+function isKiloCodeToolCallEvent(x: unknown): x is KiloCodeToolCallEvent {
+  return typeof x === 'object' && x !== null;
+}
+
+export class KiloCodeAdapter implements PlatformAdapter {
+  readonly platformName = 'kilocode';
+  readonly visibilityLevel = 'full-hooks' as const;
+  // kilocode.ai/docs/code-with-ai/platforms/cli's Built-in Commands table:
+  // `/init` — "Create/update AGENTS.md file for the project." Same
+  // convention opencode, Codex, Droid, Cursor, and Gemini CLI already read.
+  readonly capabilities = { instructionFilePaths: ['AGENTS.md'] as const };
+
+  async initialize(_config: PlatformConfig): Promise<void> {
+    // Kilo Code's tool-call capture is delivered via a user-installed
+    // plugin file (see getHookInstallInstructions()), not configured by
+    // this process — same no-op shape as every other full-hooks adapter.
+  }
+
+  normalizeToolCall(raw: unknown): NormalizedToolCall {
+    const event = isKiloCodeToolCallEvent(raw) ? raw : {};
+    const platformToolName = event.tool ?? event.toolName ?? 'unknown';
+    const toolName = KILO_CODE_TOOL_MAP[platformToolName] ?? 'Unknown';
+    const filePath = event.filePath ?? event.path;
+
+    return {
+      toolName,
+      platformToolName,
+      platform: this.platformName,
+      timestamp: event.timestamp ?? Date.now(),
+      durationMs: event.durationMs ?? null,
+      success: event.success ?? true,
+      ...(event.error !== undefined && { error: event.error }),
+      ...(event.inputSizeBytes !== undefined && { inputSizeBytes: event.inputSizeBytes }),
+      ...(event.outputSizeBytes !== undefined && { outputSizeBytes: event.outputSizeBytes }),
+      ...(filePath !== undefined && { filePath }),
+      ...(event.command !== undefined && { command: event.command }),
+      ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+    };
+  }
+
+  mapToolName(platformToolName: string): string {
+    return KILO_CODE_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
+  getSessionMetadata(): PlatformSessionMetadata {
+    return {
+      platform: this.platformName,
+    };
+  }
+
+  getHookInstallInstructions(): string {
+    return [
+      'Kilo Code Setup:',
+      '',
+      '1. Register the Preflight MCP server in kilo.json:',
+      '   {',
+      '     "mcp": {',
+      '       "preflight": {',
+      '         "type": "local",',
+      '         "command": ["npx", "preflight", "--stdio"],',
+      '         "environment": {',
+      '           "MCP_CLIENT": "kilocode",',
+      '           "NEW_RELIC_LICENSE_KEY": "<your-key>",',
+      '           "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"',
+      '         }',
+      '       }',
+      '     }',
+      '   }',
+      '2. Ensure preflight-collector is on your PATH (npm link, or npm install -g @newrelic/preflight)',
+      '3. Built-in tool calls (read, edit, write, bash, etc.) require a plugin file, since',
+      '   Kilo Code has no external hooks.json — it only supports in-process JS/TS plugins',
+      '   (Kilo CLI is a fork of opencode and shares this mechanism exactly). Create',
+      '   .kilo/plugin/preflight.ts (project) or ~/.config/kilo/plugin/preflight.ts (global) with:',
+      '',
+      '   import { spawn } from "node:child_process"',
+      '   import type { Plugin } from "@kilocode/plugin"',
+      '',
+      '   const TOOL_MAP: Record<string, string> = {',
+      '     read: "Read", glob: "Glob", grep: "Grep", edit: "Edit", write: "Write",',
+      '     apply_patch: "Edit", bash: "Bash", webfetch: "WebFetch", websearch: "WebSearch",',
+      '     question: "AskUserQuestion", todowrite: "TaskCreate", todoread: "TaskList",',
+      '     plan: "EnterPlanMode", task: "Agent", skill: "Skill",',
+      '   }',
+      '',
+      '   function report(payload: unknown) {',
+      '     const child = spawn("preflight-collector", [], { stdio: ["pipe", "ignore", "ignore"] })',
+      '     child.stdin.write(JSON.stringify(payload))',
+      '     child.stdin.end()',
+      '   }',
+      '',
+      '   function toClaudeShape(tool: string, args: any) {',
+      '     if (tool === "bash") return { command: args.command }',
+      '     if (tool === "read" || tool === "edit" || tool === "write") return { file_path: args.filePath }',
+      '     return args',
+      '   }',
+      '',
+      '   const PreflightPlugin: Plugin = async () => ({',
+      '     "tool.execute.before": async (input, output) => {',
+      '       report({',
+      '         hook_event_name: "PreToolUse",',
+      '         tool_name: TOOL_MAP[input.tool] ?? "Unknown",',
+      '         tool_input: toClaudeShape(input.tool, output.args),',
+      '         tool_use_id: input.callID,',
+      '         session_id: input.sessionID,',
+      '       })',
+      '     },',
+      '     "tool.execute.after": async (input, output) => {',
+      '       report({',
+      '         hook_event_name: "PostToolUse",',
+      '         tool_name: TOOL_MAP[input.tool] ?? "Unknown",',
+      '         tool_use_id: input.callID,',
+      '         session_id: input.sessionID,',
+      '       })',
+      '     },',
+      '   })',
+      '',
+      '   export default { id: "preflight", server: PreflightPlugin }',
+      '',
+      '4. Restart Kilo Code.',
+      '',
+      "Known gaps: Kilo's hook payload has no success/error field, so every",
+      'tool call reports success unconditionally. Only bash/read/edit/write',
+      "get structured input metadata; other tools' arg shapes (including",
+      'apply_patch) are undocumented and forwarded as-is. No output-side',
+      'metadata (exit codes, match counts, etc.) is captured. kilo-playwright_*',
+      "(Kilo's built-in Playwright MCP) tool calls are observable through this",
+      'same plugin mechanism but report as Unknown, same as any unrecognized',
+      'MCP tool call — see docs/ADAPTERS.md for details.',
+    ].join('\n');
+  }
+
+  isSupported(): boolean {
+    return (
+      process.env.MCP_CLIENT === 'kilocode' || process.env.NEW_RELIC_AI_PLATFORM === 'kilocode'
+    );
+  }
+}

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -14,6 +14,7 @@ import { GeminiCliAdapter } from './gemini-cli-adapter.js';
 import { ClineAdapter } from './cline-adapter.js';
 import { CodexAdapter } from './codex-adapter.js';
 import { OpencodeAdapter } from './opencode-adapter.js';
+import { KiloCodeAdapter } from './kilo-code-adapter.js';
 import type { PlatformAdapter, PlatformSessionMetadata, NormalizedToolCall } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -310,6 +311,15 @@ describe('PlatformRegistry', () => {
       expect(detected!.platformName).toBe('opencode');
     });
 
+    it('selects Kilo Code adapter when MCP_CLIENT is "kilocode"', () => {
+      process.env.MCP_CLIENT = 'kilocode';
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('kilocode');
+    });
+
     it('falls back to generic-mcp when no specific platform detected', () => {
       const registry = createDefaultRegistry();
 
@@ -368,7 +378,7 @@ describe('createDefaultRegistry', () => {
     const registry = createDefaultRegistry();
     const registered = registry.getRegistered();
 
-    expect(registered).toHaveLength(14);
+    expect(registered).toHaveLength(15);
     expect(registered[0]).toBeInstanceOf(ClaudeCodeAdapter);
     expect(registered[1]).toBeInstanceOf(CursorAdapter);
     expect(registered[2]).toBeInstanceOf(WindsurfAdapter);
@@ -382,10 +392,11 @@ describe('createDefaultRegistry', () => {
     expect(registered[10]).toBeInstanceOf(ClineAdapter);
     expect(registered[11]).toBeInstanceOf(CodexAdapter);
     expect(registered[12]).toBeInstanceOf(OpencodeAdapter);
-    expect(registered[13]).toBeInstanceOf(GenericMcpAdapter);
+    expect(registered[13]).toBeInstanceOf(KiloCodeAdapter);
+    expect(registered[14]).toBeInstanceOf(GenericMcpAdapter);
   });
 
-  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, cline, codex, and opencode adapters', () => {
+  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, cline, codex, opencode, and kilocode adapters', () => {
     const registry = createDefaultRegistry();
     const names = registry.getRegistered().map((a) => a.platformName);
     expect(names).toContain('zed');
@@ -397,6 +408,7 @@ describe('createDefaultRegistry', () => {
     expect(names).toContain('cline');
     expect(names).toContain('codex');
     expect(names).toContain('opencode');
+    expect(names).toContain('kilocode');
   });
 
   it('ends with generic-mcp as fallback', () => {
@@ -478,6 +490,7 @@ describe('all adapters implement PlatformAdapter interface', () => {
     new ClineAdapter(),
     new CodexAdapter(),
     new OpencodeAdapter(),
+    new KiloCodeAdapter(),
     new GenericMcpAdapter(),
   ];
 

--- a/src/platforms/platform-registry.ts
+++ b/src/platforms/platform-registry.ts
@@ -13,6 +13,7 @@ import { GeminiCliAdapter } from './gemini-cli-adapter.js';
 import { ClineAdapter } from './cline-adapter.js';
 import { CodexAdapter } from './codex-adapter.js';
 import { OpencodeAdapter } from './opencode-adapter.js';
+import { KiloCodeAdapter } from './kilo-code-adapter.js';
 import { GenericMcpAdapter } from './generic-mcp-adapter.js';
 
 const logger = createLogger('platform-registry');
@@ -71,6 +72,7 @@ export function createDefaultRegistry(): PlatformRegistry {
   registry.register(new ClineAdapter());
   registry.register(new CodexAdapter());
   registry.register(new OpencodeAdapter());
+  registry.register(new KiloCodeAdapter());
   registry.register(new GenericMcpAdapter()); // always last
   return registry;
 }


### PR DESCRIPTION
## Summary
- Adds `KiloCodeAdapter` — the 14th named `PlatformAdapter` — for [Kilo Code](https://kilocode.ai) (`@kilocode/cli`), a confirmed literal fork of opencode that shares its exact plugin hook payload shapes (`tool.execute.before`/`tool.execute.after`)
- Registers the adapter in `createDefaultRegistry()` and the platforms barrel export
- Documents the platform in `docs/ADAPTERS.md` (Mechanism/Detection/Tool coverage/Known gaps/Setup)
- Bumps version to 1.12.0 with a CHANGELOG entry

Closes #199

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (4985 passed, 0 failures)
- [x] `npm run lint` and `npm run format:check` pass
- [x] Registry sanity check: 15 adapters registered, ending in `[..., 'opencode', 'kilocode', 'generic-mcp']`

🤖 Generated with subagent-driven development (Claude Code)