### PR TITLE
Feat: Add Pi platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2026-07-23
+
+### Added
+
+- **Pi platform adapter** — Preflight now detects and normalizes tool calls from [Pi](https://pi.dev) (`@earendil-works/pi-coding-agent`). Pi sessions are detected via `PI_CODING_AGENT=true`, a real ambient environment variable Pi itself sets for exactly this purpose. Pi has zero MCP client support by deliberate design, so unlike every other `full-hooks` platform this adapter does not register an MCP server — setup instead uses `--local` mode (optionally backed by the existing background dashboard daemon on macOS) since nothing else keeps a Preflight process running for Pi sessions. Preflight ships a documented extension snippet (see `docs/ADAPTERS.md`) that translates Pi's own `tool_call`/`tool_result` extension events into the same shape Claude Code already sends, so built-in tool calls (`bash`, `read`, `write`, `edit`, `grep`, `find`) are captured and mapped to Preflight's standard vocabulary automatically once the extension is installed. Unlike opencode/Kilo Code, Pi's hook payload does carry a real success/failure signal (`event.isError`), so captured tool calls report their actual outcome rather than always reporting success. `ls` and any tool disabled by default have no structured coverage yet. Setup instructions are included in `docs/ADAPTERS.md`.
+
 ## [1.12.0] - 2026-07-23
 
 ### Added

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,6 +1,6 @@
 # Platform Adapters
 
-Preflight supports 14 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
+Preflight supports 15 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
 
 This doc is the canonical reference for what each adapter can and can't observe, how detection and setup actually work, and where the gaps are. It mirrors `src/platforms/*.ts` and the hook-event handling in `src/hooks/collector-script.ts` — if you change either, update this doc in the same PR.
 
@@ -8,20 +8,22 @@ This doc is the canonical reference for what each adapter can and can't observe,
 
 ## Integration mechanisms
 
-| Mechanism                                                                                                      | Platforms                                                      | What's captured                                                                        | `visibilityLevel` |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
-| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid, Codex, opencode, Kilo Code | All built-in tool calls                                                                | `full-hooks`      |
-| **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                                                     | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
-| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                                               | All built-in tool calls                                                                | `full-hooks`      |
-| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev, Cline                                       | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
-| **HTTP push from an extension**                                                                                | GitHub Copilot                                                 | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
-| **Self-report via MCP tools**                                                                                  | Generic MCP fallback                                           | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
+| Mechanism                                                                                                      | Platforms                                                                      | What's captured                                                                        | `visibilityLevel` |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ----------------- |
+| **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid, Codex, opencode, Kilo Code, Pi[^pi-no-mcp] | All built-in tool calls                                                                | `full-hooks`      |
+| **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                                                                     | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
+| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                                                               | All built-in tool calls                                                                | `full-hooks`      |
+| **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev, Cline                                                       | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
+| **HTTP push from an extension**                                                                                | GitHub Copilot                                                                 | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
+| **Self-report via MCP tools**                                                                                  | Generic MCP fallback                                                           | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
 
 [^gemini-hybrid]: Gemini CLI's hook _event names_ (`BeforeTool`/`AfterTool`) don't match `PreToolUse`/`PostToolUse`, so it needs its own branches in `collector-script.ts` — but the _fields_ inside those events (`tool_name`, `tool_input`, `tool_response`) are shaped exactly like Claude Code's, so those branches reuse the existing field-extraction helpers rather than needing new ones.
 
+[^pi-no-mcp]: Pi has no MCP client support at all, by its own explicit design choice — unlike every other `full-hooks` platform in this row, its setup does not register an MCP server. See the Pi section below for its `--local`-mode-only setup path.
+
 Every `PlatformAdapter` (`src/platforms/types.ts`) declares a `visibilityLevel` field encoding this table in code, not just prose — `full-hooks` (automatic, deterministic capture), `self-reported` (built-in-tool-shaped events are observable, but only if an external party — a third-party extension, or the calling MCP client itself — actually reports them), or `mcp-tools-only` (structurally cannot see built-in tool calls at all). Consumers that blend metrics across platforms (`nr_observe_get_platform_comparison`, the weekly digest's per-platform breakdown) use `getPlatformVisibilityMap()` (`src/platforms/platform-registry.ts`) to tag results and caveat comparisons that span more than one level.
 
-Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, Cline, Codex, opencode, Kilo Code, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
+Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, Cline, Codex, opencode, Kilo Code, Pi, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
 
 ---
 
@@ -452,6 +454,34 @@ Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-regi
 2. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`)
 3. Create `.kilo/plugin/preflight.ts` (project) or `~/.config/kilo/plugin/preflight.ts` (global) with the snippet in `KiloCodeAdapter.getHookInstallInstructions()` (`src/platforms/kilo-code-adapter.ts`) — reproduced there in full, using Kilo's current plugin module descriptor shape (`export default { id, server }`).
 4. Restart Kilo Code.
+
+---
+
+## Pi (`pi`)
+
+**Mechanism:** [Pi](https://pi.dev) (`@earendil-works/pi-coding-agent`) ships a native Extension API — TypeScript modules in `~/.pi/agent/extensions/` (global) or `.pi/extensions/` (project-local), auto-discovered and hot-reloadable via `/reload`. Confirmed from `docs/extensions.md`'s "Tool Events" section (`github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md`): `pi.on("tool_call", (event, ctx) => {...})` fires before every built-in or custom tool executes, exposing `event.toolName`/`event.toolCallId`/mutable `event.input`, and can block via `return { block: true, reason? }`. `pi.on("tool_result", (event, ctx) => {...})` fires after, exposing `event.content`/`event.details`/**`event.isError`**/`event.usage`, and can modify the result. Preflight ships a documented extension snippet (see Setup below) that translates these into Claude Code's exact `PreToolUse`/`PostToolUse` hook JSON shape before piping to `preflight-collector` — `collector-script.ts`'s existing generic branches handle it as a result, **no changes to that file were needed.**
+
+Pi has **no MCP client support at all**, confirmed as deliberate, stated philosophy on `pi.dev` and in the README's "Philosophy" section: _"No MCP. Build CLI tools with READMEs (see Skills), or build an extension that adds MCP support."_ This makes Pi's setup path structurally different from every other `full-hooks` adapter: there is no MCP server registration step, and `--stdio` mode (the mode every other `full-hooks` adapter pairs with) is categorically unusable. Setup instead uses Preflight's `--local` mode (`ARCHITECTURE.md`: "Collection plane + Processing pipeline + Dashboard HTTP server. No MCP connection") plus the existing macOS dashboard daemon (`installDashboardDaemon()` in `src/install/schedule.ts`) to keep a `--local` process running persistently, since nothing else spawns or owns one for Pi sessions.
+
+**Detection (`isSupported()`):** `PI_CODING_AGENT === 'true'` — confirmed from the README's Environment Variables table: _"Set to `true` by the CLI and RPC entry points so child processes can detect that they run inside Pi."_ A real, documented, first-party ambient signal — not an invented one, and no explicit-opt-in fallback is needed.
+
+**Tool coverage, confirmed from the README's CLI Reference (`Available built-in tools: read, bash, edit, write, grep, find, ls`):** `bash`/`read`/`write`/`edit`/`grep` map directly. `find` maps to `'Glob'` — same precedent as Gemini CLI's `glob` → `'Glob'`. `ls` has no confirmed canonical Preflight tool-name equivalent and is left unmapped → falls through to `'Unknown'`, same treatment as `ZedAdapter`'s `create_directory`/`move_path`. Only `read`/`write`/`edit`/`bash` are enabled **by default** — `grep`/`find`/`ls` are real built-ins but require explicit `--tools` enabling to produce any events.
+
+**Known gaps:**
+
+- **No MCP client support exists in Pi at all**, by the platform's own explicit design choice — this adapter's setup path (`--local` mode + the macOS dashboard daemon) is structurally different from every other adapter's "register the MCP server + install a hook" two-step.
+- **The persistent-process daemon is macOS-only.** `installDashboardDaemon()` installs a `launchd` LaunchAgent; no systemd unit or Windows Task Scheduler equivalent exists in this codebase today. Linux/Windows users must keep `preflight --local` running manually.
+- **`ls` has no confirmed canonical Preflight tool-name equivalent** and reports as `'Unknown'`.
+- **`grep`/`find`/`ls` are disabled by default** — they only produce events in sessions that explicitly enable them via `--tools`.
+- **`event.input`'s exact per-tool field shapes are confirmed only for `bash` and `read`** in `docs/extensions.md`'s own example. The extension snippet forwards `event.input` as-is for every tool rather than remapping field names, so `collector-script.ts`'s tool-specific input extractors (which expect Claude Code's own field names, e.g. `file_path`) won't populate for Pi's calls — an honest gap, not a broken mapping.
+
+**Setup:**
+
+1. Run `preflight setup` once to configure `NEW_RELIC_LICENSE_KEY`/`NEW_RELIC_ACCOUNT_ID` and, on macOS, install the background dashboard daemon that keeps a `--local` process running persistently.
+2. On Linux/Windows (no daemon support yet): run `preflight --local &` yourself in a persistent terminal/tmux session and keep it running.
+3. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`).
+4. Create `~/.pi/agent/extensions/preflight.ts` (global) or `.pi/extensions/preflight.ts` (project) with the snippet in `PiAdapter.getHookInstallInstructions()` (`src/platforms/pi-adapter.ts`) — reproduced there in full.
+5. Restart Pi (or run `/reload` in an active session).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -20,6 +20,7 @@ export { ClineAdapter } from './cline-adapter.js';
 export { CodexAdapter } from './codex-adapter.js';
 export { OpencodeAdapter } from './opencode-adapter.js';
 export { KiloCodeAdapter } from './kilo-code-adapter.js';
+export { PiAdapter } from './pi-adapter.js';
 export { GenericMcpAdapter, validateReportToolCallInput } from './generic-mcp-adapter.js';
 export type {
   ReportToolCallInput,

--- a/src/platforms/pi-adapter.test.ts
+++ b/src/platforms/pi-adapter.test.ts
@@ -1,0 +1,229 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { PiAdapter } from './pi-adapter.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  for (const key of ['PI_CODING_AGENT']) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('PiAdapter', () => {
+  const adapter = new PiAdapter();
+
+  it('has platformName "pi"', () => {
+    expect(adapter.platformName).toBe('pi');
+  });
+
+  it('declares visibilityLevel "full-hooks"', () => {
+    expect(adapter.visibilityLevel).toBe('full-hooks');
+  });
+
+  it('declares AGENTS.md as an instruction file path', () => {
+    expect(adapter.capabilities.instructionFilePaths).toEqual(['AGENTS.md']);
+  });
+
+  describe('normalizeToolCall', () => {
+    const cases: Array<[string, string]> = [
+      ['bash', 'Bash'],
+      ['read', 'Read'],
+      ['write', 'Write'],
+      ['edit', 'Edit'],
+      ['grep', 'Grep'],
+      ['find', 'Glob'],
+    ];
+
+    for (const [platformToolName, expected] of cases) {
+      it(`maps "${platformToolName}" to "${expected}"`, () => {
+        const normalized = adapter.normalizeToolCall({ tool: platformToolName, timestamp: 2000 });
+        expect(normalized.toolName).toBe(expected);
+        expect(normalized.platformToolName).toBe(platformToolName);
+      });
+    }
+
+    it('leaves "ls" unmapped, falling through to "Unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'ls', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('ls');
+    });
+
+    it('leaves an arbitrary unrecognized tool name unmapped, falling through to "Unknown"', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'totally_unmapped_tool',
+        timestamp: 2000,
+      });
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('totally_unmapped_tool');
+    });
+
+    it('accepts "toolName" field as an alternative to "tool"', () => {
+      const normalized = adapter.normalizeToolCall({ toolName: 'bash', timestamp: 2000 });
+      expect(normalized.toolName).toBe('Bash');
+      expect(normalized.platformToolName).toBe('bash');
+    });
+
+    it('defaults missing tool name to "unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ timestamp: 2000 });
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.toolName).toBe('Unknown');
+    });
+
+    it('falls back to safe defaults when raw is not an object (e.g. null)', () => {
+      const normalized = adapter.normalizeToolCall(null);
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.platform).toBe('pi');
+      expect(normalized.success).toBe(true);
+      expect(normalized.durationMs).toBeNull();
+    });
+
+    it('defaults success to true when not provided', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'bash', timestamp: 2000 });
+      expect(normalized.success).toBe(true);
+    });
+
+    it('preserves error field', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        success: false,
+        error: 'command failed',
+      });
+      expect(normalized.success).toBe(false);
+      expect(normalized.error).toBe('command failed');
+    });
+
+    it('uses current time when timestamp is missing', () => {
+      const before = Date.now();
+      const normalized = adapter.normalizeToolCall({ tool: 'bash' });
+      const after = Date.now();
+      expect(normalized.timestamp).toBeGreaterThanOrEqual(before);
+      expect(normalized.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('includes inputSizeBytes and outputSizeBytes when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        inputSizeBytes: 50,
+        outputSizeBytes: 1000,
+      });
+      expect(normalized.inputSizeBytes).toBe(50);
+      expect(normalized.outputSizeBytes).toBe(1000);
+    });
+
+    it('includes sessionId when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        sessionId: 'pi-sess-001',
+      });
+      expect(normalized.sessionId).toBe('pi-sess-001');
+    });
+
+    it('includes filePath when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'read',
+        timestamp: 2000,
+        filePath: '/src/app.ts',
+      });
+      expect(normalized.filePath).toBe('/src/app.ts');
+    });
+
+    it('includes command when present', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'bash',
+        timestamp: 2000,
+        command: 'npm test',
+      });
+      expect(normalized.command).toBe('npm test');
+    });
+  });
+
+  describe('getSessionMetadata', () => {
+    it('returns platform "pi"', () => {
+      const meta = adapter.getSessionMetadata();
+      expect(meta.platform).toBe('pi');
+    });
+  });
+
+  describe('isSupported', () => {
+    it('returns true when PI_CODING_AGENT is "true"', () => {
+      process.env.PI_CODING_AGENT = 'true';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns false when PI_CODING_AGENT is unset', () => {
+      expect(adapter.isSupported()).toBe(false);
+    });
+
+    it('returns false when PI_CODING_AGENT is set to a non-"true" value', () => {
+      process.env.PI_CODING_AGENT = '1';
+      expect(adapter.isSupported()).toBe(false);
+    });
+  });
+
+  describe('getHookInstallInstructions', () => {
+    it('returns non-empty Pi-specific instructions', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions.length).toBeGreaterThan(0);
+      expect(instructions).toContain('Pi');
+    });
+
+    it('documents the extension directory', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('.pi/extensions/');
+    });
+
+    it('documents the tool_call/tool_result events', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions).toContain('tool_call');
+      expect(instructions).toContain('tool_result');
+    });
+
+    it('documents --local mode instead of MCP server registration', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions).toContain('--local');
+      expect(instructions).not.toContain('--stdio');
+    });
+
+    it('mentions preflight-collector', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('preflight-collector');
+    });
+
+    it('mentions NEW_RELIC_LICENSE_KEY', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_LICENSE_KEY');
+    });
+
+    it('mentions NEW_RELIC_ACCOUNT_ID', () => {
+      expect(adapter.getHookInstallInstructions()).toContain('NEW_RELIC_ACCOUNT_ID');
+    });
+  });
+
+  describe('initialize', () => {
+    it('completes without error', async () => {
+      await expect(adapter.initialize({})).resolves.toBeUndefined();
+    });
+  });
+
+  describe('mapToolName', () => {
+    it('maps a known tool name', () => {
+      expect(adapter.mapToolName('bash')).toBe('Bash');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
+});

--- a/src/platforms/pi-adapter.ts
+++ b/src/platforms/pi-adapter.ts
@@ -1,0 +1,163 @@
+import type {
+  NormalizedToolCall,
+  PlatformAdapter,
+  PlatformConfig,
+  PlatformSessionMetadata,
+} from './types.js';
+
+/**
+ * Maps Pi's built-in tool names (confirmed from the README's CLI Reference —
+ * github.com/earendil-works/pi/blob/main/packages/coding-agent/README.md —
+ * "Available built-in tools: read, bash, edit, write, grep, find, ls") to the
+ * normalized Claude Code tool vocabulary. `bash`/`read`/`write`/`edit`/`grep`
+ * map directly. `find` maps to 'Glob' — same precedent as Gemini CLI's
+ * `glob` -> 'Glob' (a file-finding tool, even though Pi's own docs don't
+ * detail `find`'s exact argument shape). `ls` has no confirmed canonical
+ * Preflight tool-name equivalent — listing a directory's contents isn't
+ * reading a file's contents — and is deliberately left unmapped -> falls
+ * through to 'Unknown', same "leave genuinely uncovered names unmapped"
+ * precedent as ZedAdapter's `create_directory`/`move_path`. Only
+ * `read`/`write`/`edit`/`bash` are enabled by default; `grep`/`find`/`ls`
+ * are real Pi built-ins but require explicit `--tools` enabling to produce
+ * any events at all.
+ */
+const PI_TOOL_MAP: Record<string, string> = {
+  bash: 'Bash',
+  read: 'Read',
+  write: 'Write',
+  edit: 'Edit',
+  grep: 'Grep',
+  find: 'Glob',
+};
+
+interface PiToolCallEvent {
+  tool?: string;
+  toolName?: string;
+  timestamp?: number;
+  durationMs?: number;
+  success?: boolean;
+  error?: string;
+  filePath?: string;
+  path?: string;
+  command?: string;
+  inputSizeBytes?: number;
+  outputSizeBytes?: number;
+  sessionId?: string;
+}
+
+function isPiToolCallEvent(x: unknown): x is PiToolCallEvent {
+  return typeof x === 'object' && x !== null;
+}
+
+export class PiAdapter implements PlatformAdapter {
+  readonly platformName = 'pi';
+  readonly visibilityLevel = 'full-hooks' as const;
+  // Confirmed via the README's Context Files section: "Pi loads AGENTS.md
+  // (or CLAUDE.md) at startup" from global, parent-directory-walk, and cwd
+  // locations. Same convention opencode, Codex, Droid, Cursor, and Gemini
+  // CLI already read.
+  readonly capabilities = { instructionFilePaths: ['AGENTS.md'] as const };
+
+  async initialize(_config: PlatformConfig): Promise<void> {
+    // Pi's tool-call capture is delivered via a user-installed extension
+    // file (see getHookInstallInstructions()), not configured by this
+    // process — same no-op shape as every other full-hooks adapter.
+  }
+
+  normalizeToolCall(raw: unknown): NormalizedToolCall {
+    const event = isPiToolCallEvent(raw) ? raw : {};
+    const platformToolName = event.tool ?? event.toolName ?? 'unknown';
+    const toolName = PI_TOOL_MAP[platformToolName] ?? 'Unknown';
+    const filePath = event.filePath ?? event.path;
+
+    return {
+      toolName,
+      platformToolName,
+      platform: this.platformName,
+      timestamp: event.timestamp ?? Date.now(),
+      durationMs: event.durationMs ?? null,
+      success: event.success ?? true,
+      ...(event.error !== undefined && { error: event.error }),
+      ...(event.inputSizeBytes !== undefined && { inputSizeBytes: event.inputSizeBytes }),
+      ...(event.outputSizeBytes !== undefined && { outputSizeBytes: event.outputSizeBytes }),
+      ...(filePath !== undefined && { filePath }),
+      ...(event.command !== undefined && { command: event.command }),
+      ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+    };
+  }
+
+  mapToolName(platformToolName: string): string {
+    return PI_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
+  getSessionMetadata(): PlatformSessionMetadata {
+    return {
+      platform: this.platformName,
+    };
+  }
+
+  getHookInstallInstructions(): string {
+    return [
+      'Pi Setup:',
+      '',
+      'Pi has no MCP client support by design — there is no MCP server',
+      'registration step. Preflight instead runs in --local mode, which needs',
+      'a persistently running process since nothing spawns one per Pi session.',
+      '',
+      '1. Run `preflight setup` once to configure NEW_RELIC_LICENSE_KEY and',
+      '   NEW_RELIC_ACCOUNT_ID and (on macOS) install the background dashboard',
+      '   daemon that keeps a --local process running persistently.',
+      '2. On Linux/Windows (no daemon support yet): run `preflight --local &`',
+      '   yourself in a persistent terminal/tmux session and keep it running.',
+      '3. Ensure preflight-collector is on your PATH (npm link, or npm install -g @newrelic/preflight)',
+      '4. Create ~/.pi/agent/extensions/preflight.ts (global) or',
+      '   .pi/extensions/preflight.ts (project) with:',
+      '',
+      '   import { spawn } from "node:child_process"',
+      '',
+      '   const TOOL_MAP = {',
+      '     bash: "Bash", read: "Read", write: "Write", edit: "Edit",',
+      '     grep: "Grep", find: "Glob",',
+      '   }',
+      '',
+      '   function report(payload) {',
+      '     const child = spawn("preflight-collector", [], { stdio: ["pipe", "ignore", "ignore"] })',
+      '     child.stdin.write(JSON.stringify(payload))',
+      '     child.stdin.end()',
+      '   }',
+      '',
+      '   export default function (pi) {',
+      '     pi.on("tool_call", (event) => {',
+      '       report({',
+      '         hook_event_name: "PreToolUse",',
+      '         tool_name: TOOL_MAP[event.toolName] ?? "Unknown",',
+      '         tool_input: event.input,',
+      '         tool_use_id: event.toolCallId,',
+      '       })',
+      '     })',
+      '     pi.on("tool_result", (event) => {',
+      '       report({',
+      '         hook_event_name: "PostToolUse",',
+      '         tool_name: TOOL_MAP[event.toolName] ?? "Unknown",',
+      '         tool_use_id: event.toolCallId,',
+      '         tool_response: { success: !event.isError },',
+      '       })',
+      '     })',
+      '   }',
+      '',
+      '5. Restart Pi (or run /reload in an active session).',
+      '',
+      'Known gaps: ls has no confirmed canonical Preflight tool-name',
+      'equivalent and reports as Unknown. grep/find/ls are Pi built-ins but',
+      'disabled by default — they only produce events in sessions that',
+      'explicitly enable them via --tools. event.input is forwarded as-is for',
+      "every tool rather than remapped to Claude Code's own field names, so",
+      "collector-script.ts's tool-specific input extractors (file_path, etc.)",
+      'will not populate for Pi calls. See docs/ADAPTERS.md for details.',
+    ].join('\n');
+  }
+
+  isSupported(): boolean {
+    return process.env.PI_CODING_AGENT === 'true';
+  }
+}

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -15,6 +15,7 @@ import { ClineAdapter } from './cline-adapter.js';
 import { CodexAdapter } from './codex-adapter.js';
 import { OpencodeAdapter } from './opencode-adapter.js';
 import { KiloCodeAdapter } from './kilo-code-adapter.js';
+import { PiAdapter } from './pi-adapter.js';
 import type { PlatformAdapter, PlatformSessionMetadata, NormalizedToolCall } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -43,6 +44,7 @@ const ENV_KEYS = [
   'KIRO_SESSION_ID',
   'KIRO_IDE',
   'KIRO_VERSION',
+  'PI_CODING_AGENT',
 ];
 
 beforeEach(() => {
@@ -320,6 +322,15 @@ describe('PlatformRegistry', () => {
       expect(detected!.platformName).toBe('kilocode');
     });
 
+    it('selects Pi adapter when PI_CODING_AGENT is "true"', () => {
+      process.env.PI_CODING_AGENT = 'true';
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('pi');
+    });
+
     it('falls back to generic-mcp when no specific platform detected', () => {
       const registry = createDefaultRegistry();
 
@@ -378,7 +389,7 @@ describe('createDefaultRegistry', () => {
     const registry = createDefaultRegistry();
     const registered = registry.getRegistered();
 
-    expect(registered).toHaveLength(15);
+    expect(registered).toHaveLength(16);
     expect(registered[0]).toBeInstanceOf(ClaudeCodeAdapter);
     expect(registered[1]).toBeInstanceOf(CursorAdapter);
     expect(registered[2]).toBeInstanceOf(WindsurfAdapter);
@@ -393,10 +404,11 @@ describe('createDefaultRegistry', () => {
     expect(registered[11]).toBeInstanceOf(CodexAdapter);
     expect(registered[12]).toBeInstanceOf(OpencodeAdapter);
     expect(registered[13]).toBeInstanceOf(KiloCodeAdapter);
-    expect(registered[14]).toBeInstanceOf(GenericMcpAdapter);
+    expect(registered[14]).toBeInstanceOf(PiAdapter);
+    expect(registered[15]).toBeInstanceOf(GenericMcpAdapter);
   });
 
-  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, cline, codex, opencode, and kilocode adapters', () => {
+  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, cline, codex, opencode, kilocode, and pi adapters', () => {
     const registry = createDefaultRegistry();
     const names = registry.getRegistered().map((a) => a.platformName);
     expect(names).toContain('zed');
@@ -409,6 +421,7 @@ describe('createDefaultRegistry', () => {
     expect(names).toContain('codex');
     expect(names).toContain('opencode');
     expect(names).toContain('kilocode');
+    expect(names).toContain('pi');
   });
 
   it('ends with generic-mcp as fallback', () => {
@@ -491,6 +504,7 @@ describe('all adapters implement PlatformAdapter interface', () => {
     new CodexAdapter(),
     new OpencodeAdapter(),
     new KiloCodeAdapter(),
+    new PiAdapter(),
     new GenericMcpAdapter(),
   ];
 

--- a/src/platforms/platform-registry.ts
+++ b/src/platforms/platform-registry.ts
@@ -14,6 +14,7 @@ import { ClineAdapter } from './cline-adapter.js';
 import { CodexAdapter } from './codex-adapter.js';
 import { OpencodeAdapter } from './opencode-adapter.js';
 import { KiloCodeAdapter } from './kilo-code-adapter.js';
+import { PiAdapter } from './pi-adapter.js';
 import { GenericMcpAdapter } from './generic-mcp-adapter.js';
 
 const logger = createLogger('platform-registry');
@@ -73,6 +74,7 @@ export function createDefaultRegistry(): PlatformRegistry {
   registry.register(new CodexAdapter());
   registry.register(new OpencodeAdapter());
   registry.register(new KiloCodeAdapter());
+  registry.register(new PiAdapter());
   registry.register(new GenericMcpAdapter()); // always last
   return registry;
 }


### PR DESCRIPTION
## Summary

Incremental sync of the Pi platform adapter from the private repo (v1.13.0).

- Adds `PiAdapter` — the 15th named `PlatformAdapter` — for [Pi](https://pi.dev) (`@earendil-works/pi-coding-agent`), using its native Extension API (`tool_call`/`tool_result` events) for full built-in tool-call capture.
- Pi has zero MCP client support by deliberate platform design, so unlike every other `full-hooks` adapter, setup uses Preflight's existing `--local` mode (optionally backed by the existing macOS-only background dashboard daemon) instead of MCP server registration.
- Detection via `PI_CODING_AGENT=true`, a real ambient environment variable Pi itself documents for this purpose.
- Ships a documented extension snippet translating Pi's `tool_call`/`tool_result` events into Claude Code's `PreToolUse`/`PostToolUse` hook shape — no changes to the hook collector needed. Pi's hook payload carries a real success/failure signal (`event.isError`), unlike opencode/Kilo Code which always report success.
- `docs/ADAPTERS.md` updated; `CHANGELOG.md` entry added; version bumped to 1.13.0.

Closes #200.

## Test plan

- [x] `npm run build && npm test` — 5027/5030 tests passing (3 pre-existing skips), 0 failures