### PR TITLE
Feat: Add Google Antigravity platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2026-07-23
+
+### Added
+
+- **Google Antigravity platform adapter** — Preflight now detects and normalizes tool calls from Google Antigravity (2.0 / IDE / CLI) as a full `full-hooks` platform. Antigravity ships a real, first-party, documented `hooks.json` mechanism (`PreToolUse`/`PostToolUse`) covering every built-in tool call (`run_command`, `view_file`, `write_to_file`, `grep_search`, and more — see `docs/ADAPTERS.md` for the full map). Antigravity's hook payloads carry no field naming which event fired at all, so Preflight dispatches on payload shape instead (presence of a `toolCall` key means `PreToolUse`); because `PostToolUse` carries no tool name either, pairing is done by a `stepIdx`-derived ID rather than by tool name. Detection is explicit opt-in (`MCP_CLIENT=antigravity`) — no ambient environment variable is exposed for this purpose. Setup instructions (both MCP registration and the `hooks.json` entries) are in `docs/ADAPTERS.md`.
+
 ## [1.13.0] - 2026-07-23
 
 ### Added

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,6 +1,6 @@
 # Platform Adapters
 
-Preflight supports 15 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
+Preflight supports 16 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).
 
 This doc is the canonical reference for what each adapter can and can't observe, how detection and setup actually work, and where the gaps are. It mirrors `src/platforms/*.ts` and the hook-event handling in `src/hooks/collector-script.ts` — if you change either, update this doc in the same PR.
 
@@ -12,7 +12,7 @@ This doc is the canonical reference for what each adapter can and can't observe,
 | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ----------------- |
 | **Uniform hook events** (`tool_name`/`tool_input`, PreToolUse/PostToolUse-shaped, case-insensitive event name) | Claude Code, Kiro, Amazon Q, Droid, Codex, opencode, Kilo Code, Pi[^pi-no-mcp] | All built-in tool calls                                                                | `full-hooks`      |
 | **Own event names, Claude-Code-shaped fields**[^gemini-hybrid]                                                 | Gemini CLI                                                                     | All built-in tool calls (and third-party MCP tool calls)                               | `full-hooks`      |
-| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf                                                               | All built-in tool calls                                                                | `full-hooks`      |
+| **Platform-specific hook events** (own field vocabulary, own branches in `collector-script.ts`)                | Cursor, Windsurf, Antigravity[^agy-shape-only]                                 | All built-in tool calls                                                                | `full-hooks`      |
 | **MCP-client-only** (no hook/callback mechanism exists)                                                        | Zed, Continue.dev, Cline                                                       | Only calls routed to Preflight's own MCP tools — **not** the platform's built-in tools | `mcp-tools-only`  |
 | **HTTP push from an extension**                                                                                | GitHub Copilot                                                                 | Whatever the (user-supplied) extension forwards                                        | `self-reported`   |
 | **Self-report via MCP tools**                                                                                  | Generic MCP fallback                                                           | Whatever the caller reports via `nr_observe_report_tool_call`                          | `self-reported`   |
@@ -21,9 +21,11 @@ This doc is the canonical reference for what each adapter can and can't observe,
 
 [^pi-no-mcp]: Pi has no MCP client support at all, by its own explicit design choice — unlike every other `full-hooks` platform in this row, its setup does not register an MCP server. See the Pi section below for its `--local`-mode-only setup path.
 
+[^agy-shape-only]: Antigravity's hook payloads have no field whose _value_ names the event (unlike every other row in this table) — `collector-script.ts` dispatches on payload _shape_ instead (presence of a `toolCall` key means `PreToolUse`). See the Antigravity section below.
+
 Every `PlatformAdapter` (`src/platforms/types.ts`) declares a `visibilityLevel` field encoding this table in code, not just prose — `full-hooks` (automatic, deterministic capture), `self-reported` (built-in-tool-shaped events are observable, but only if an external party — a third-party extension, or the calling MCP client itself — actually reports them), or `mcp-tools-only` (structurally cannot see built-in tool calls at all). Consumers that blend metrics across platforms (`nr_observe_get_platform_comparison`, the weekly digest's per-platform breakdown) use `getPlatformVisibilityMap()` (`src/platforms/platform-registry.ts`) to tag results and caveat comparisons that span more than one level.
 
-Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, Cline, Codex, opencode, Kilo Code, Pi, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
+Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-registry.ts`) registers adapters in a fixed order — Claude Code, Cursor, Windsurf, Copilot, Zed, Continue, Amazon Q, Kiro, Droid, Gemini CLI, Cline, Codex, opencode, Kilo Code, Pi, Antigravity, then the generic MCP fallback (always last, `isSupported()` always `true`). `PlatformRegistry.detect()` returns the **first** adapter whose `isSupported()` returns `true`; there is no `NEW_RELIC_AI_PLATFORM`-driven override for most platforms (see per-platform detection below).
 
 ---
 
@@ -482,6 +484,55 @@ Pi has **no MCP client support at all**, confirmed as deliberate, stated philoso
 3. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`).
 4. Create `~/.pi/agent/extensions/preflight.ts` (global) or `.pi/extensions/preflight.ts` (project) with the snippet in `PiAdapter.getHookInstallInstructions()` (`src/platforms/pi-adapter.ts`) — reproduced there in full.
 5. Restart Pi (or run `/reload` in an active session).
+
+---
+
+## Google Antigravity (`antigravity`)
+
+**Mechanism:** Google Antigravity (2.0 / IDE / CLI — the Python SDK is out of scope, see Known gaps) ships a real, first-party, documented `hooks.json` mechanism: [antigravity.google/docs/hooks](https://antigravity.google/docs/hooks) (identical content on [/docs/ide/hooks](https://antigravity.google/docs/ide/hooks)). `PreToolUse`/`PostToolUse` fire around every built-in tool call, matched by regex against tool name; handlers receive JSON on stdin and must reply with JSON on stdout. This is a `full-hooks` mechanism, not the `mcp-tools-only` tier a platform lacking any hook mechanism would get — Antigravity's `hooks.json` is real, first-party, and documented, confirmed by fetching Google's own docs directly. Antigravity also supports MCP separately and natively — [/docs/mcp](https://antigravity.google/docs/mcp) — via `mcp_config.json`.
+
+Antigravity's hook payloads have **no field naming the event type at all** — `PreToolUse`'s payload is `{ toolCall: { name, args }, stepIdx, conversationId, ... }`; `PostToolUse`'s is `{ stepIdx, error, conversationId, ... }`, with no tool-name field whatsoever. `collector-script.ts` dispatches on the presence of `toolCall` instead. Because `PostToolUse` never carries a tool name, both events set `toolUseId` from `stepIdx` so `HookEventProcessor` pairs them by ID rather than its tool-name-FIFO fallback — the merged record's `toolName` comes from the matched pre-event (confirmed by reading `HookEventProcessor.handlePostEvent()` directly), so the post-event's placeholder `'unknown'` tool name is never surfaced for a successfully-paired call.
+
+**Detection (`isSupported()`):** `MCP_CLIENT === 'antigravity'`. No ambient environment variable is confirmed to exist for Antigravity (checked `/docs/cli/reference`, `/docs/cli/settings`, `/docs/ide/settings`, `/docs/cli/sandbox`, `/docs/sidecars`) — explicit opt-in only, same as opencode/Kilo Code/Codex.
+
+**Tool coverage, confirmed from the Hooks page's "Supported Tools" section:** `view_file`→`Read`, `write_to_file`→`Write`, `replace_file_content`→`Edit`, `multi_replace_file_content`→`MultiEdit`, `list_dir`/`find_by_name`→`Glob`, `grep_search`→`Grep`, `search_web`→`WebSearch`, `read_url_content`→`WebFetch`, `run_command`→`Bash`, `invoke_subagent`→`Agent`. `manage_task`, `schedule`, `list_permissions`, `ask_permission`, `define_subagent`, `send_message`, `manage_subagents`, `ask_question`, and `generate_image` are real Antigravity built-ins with no canonical Preflight equivalent, deliberately left unmapped.
+
+**Known gaps:**
+
+- **`PreToolUse`'s `toolCall.args` field names** (`CommandLine`, `TargetFile`, `ReplacementChunks`, etc.) **are not remapped through `extractInputMeta()`'s tool-specific extractors** — `toolInput` metadata is absent for Antigravity calls until that mapping is added; an honest gap, not a guess.
+- **`PostToolUse` carries no output content/exit-code field at all** (only `stepIdx`/`error`) — `toolOutput` metadata (e.g. Bash exit codes) can never be populated for Antigravity, a platform limitation, not an implementation gap.
+- **The Antigravity SDK (Python, for building custom agents on Antigravity's own runtime) is out of scope** — it documents MCP support but no interactive hooks surface of its own.
+- **No confirmed ambient env var** — detection is explicit-opt-in only (`MCP_CLIENT=antigravity`).
+
+**Setup:**
+
+1. Register Preflight as an MCP server for its own `nr_observe_*` tools — add to `mcp_config.json` (global `~/.gemini/config/mcp_config.json`, or per-workspace `.agents/mcp_config.json`):
+   ```json
+   {
+     "mcpServers": {
+       "preflight": {
+         "command": "npx",
+         "args": ["preflight", "--stdio"],
+         "env": {
+           "MCP_CLIENT": "antigravity",
+           "NEW_RELIC_LICENSE_KEY": "<your-key>",
+           "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"
+         }
+       }
+     }
+   }
+   ```
+2. Capture built-in tool calls via `hooks.json` (same global/workspace locations):
+   ```json
+   {
+     "preflight": {
+       "PreToolUse": [{ "matcher": "*", "hooks": [{ "command": "preflight-collector" }] }],
+       "PostToolUse": [{ "matcher": "*", "hooks": [{ "command": "preflight-collector" }] }]
+     }
+   }
+   ```
+3. Ensure `preflight-collector` is on `PATH` (`npm link`, or `npm install -g @newrelic/preflight`).
+4. Restart Antigravity (or reload the workspace).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -117,6 +117,30 @@ function makeGeminiAfterTool(overrides?: Record<string, unknown>): string {
   });
 }
 
+function makeAntigravityPreToolUse(overrides?: Record<string, unknown>): string {
+  return JSON.stringify({
+    toolCall: { name: 'run_command', args: { CommandLine: 'npm test', Cwd: '/workspace/project' } },
+    stepIdx: 19,
+    conversationId: 'agy-conv-001',
+    workspacePaths: ['/workspace/project'],
+    transcriptPath: '/tmp/agy-transcript.jsonl',
+    artifactDirectoryPath: '/tmp/agy-artifacts',
+    ...overrides,
+  });
+}
+
+function makeAntigravityPostToolUse(overrides?: Record<string, unknown>): string {
+  return JSON.stringify({
+    stepIdx: 19,
+    error: '',
+    conversationId: 'agy-conv-001',
+    workspacePaths: ['/workspace/project'],
+    transcriptPath: '/tmp/agy-transcript.jsonl',
+    artifactDirectoryPath: '/tmp/agy-artifacts',
+    ...overrides,
+  });
+}
+
 function readBufferEvents(): Record<string, unknown>[] {
   if (!existsSync(bufferPath)) return [];
   const raw = readFileSync(bufferPath, 'utf-8').trim();
@@ -1794,6 +1818,66 @@ describe('collector-script', () => {
     it('does not write to stdout for a Gemini CLI-shaped event when neither env var is set', () => {
       processHook(makeGeminiBeforeTool());
       expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('collector-script — Antigravity hook events (https://antigravity.google/docs/hooks)', () => {
+    it('writes a pre event with tool from toolCall.name and toolUseId from stepIdx', () => {
+      delete process.env.NEW_RELIC_AI_MCP_BUFFER_PATH;
+      process.env.NEW_RELIC_AI_MCP_STORAGE_PATH = tmpDir;
+      processHook(makeAntigravityPreToolUse());
+
+      const events = readBufferLines('agy-conv-001');
+      expect(events).toHaveLength(1);
+      const event = events[0]!;
+      expect(event.mode).toBe('pre');
+      expect(event.tool).toBe('run_command');
+      expect(event.toolUseId).toBe('19');
+      expect(event.sessionId).toBe('agy-conv-001');
+    });
+
+    it('replies with {"decision":"allow"} on stdout for PreToolUse', () => {
+      processHook(makeAntigravityPreToolUse());
+      expect(stdoutSpy).toHaveBeenCalledWith('{"decision":"allow"}\n');
+    });
+
+    it('writes a post event with tool "unknown" and toolUseId from stepIdx', () => {
+      delete process.env.NEW_RELIC_AI_MCP_BUFFER_PATH;
+      process.env.NEW_RELIC_AI_MCP_STORAGE_PATH = tmpDir;
+      processHook(makeAntigravityPostToolUse());
+
+      const events = readBufferLines('agy-conv-001');
+      expect(events).toHaveLength(1);
+      const event = events[0]!;
+      expect(event.mode).toBe('post');
+      expect(event.tool).toBe('unknown');
+      expect(event.toolUseId).toBe('19');
+      expect(event.success).toBe(true);
+    });
+
+    it('reports success: false when PostToolUse carries a non-empty error', () => {
+      delete process.env.NEW_RELIC_AI_MCP_BUFFER_PATH;
+      process.env.NEW_RELIC_AI_MCP_STORAGE_PATH = tmpDir;
+      processHook(makeAntigravityPostToolUse({ error: 'exit status 1' }));
+
+      const events = readBufferLines('agy-conv-001');
+      const event = events[0]!;
+      expect(event.success).toBe(false);
+      expect(event.error).toBe('exit status 1');
+    });
+
+    it('replies with {} on stdout for PostToolUse', () => {
+      processHook(makeAntigravityPostToolUse());
+      expect(stdoutSpy).toHaveBeenCalledWith('{}\n');
+    });
+
+    it('does not misfire on a Claude Code PreToolUse payload (no toolCall key)', () => {
+      processHook(makePreToolUse());
+      // Claude Code's own pretooluse branch should still handle this, not the
+      // Antigravity one — same buffer file (no conversationId), tool preserved.
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]!.tool).toBe('Read');
     });
   });
 });

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -494,6 +494,15 @@ interface HookInput {
   agent_action_name?: string;
   trajectory_id?: string;
   tool_info?: Record<string, unknown>;
+  // Antigravity (https://antigravity.google/docs/hooks, identical on
+  // /docs/ide/hooks) sends no field naming which event fired at all —
+  // PreToolUse payloads carry `toolCall`/`stepIdx`; PostToolUse payloads
+  // carry only `stepIdx`/`error`. `conversationId` is Antigravity's closest
+  // analog to session_id (never sends session_id, same situation as
+  // Cursor's conversation_id and Windsurf's trajectory_id).
+  toolCall?: { name?: string; args?: Record<string, unknown> };
+  stepIdx?: number;
+  conversationId?: string;
   [key: string]: unknown;
 }
 
@@ -665,7 +674,11 @@ function processHook(raw: string): void {
   // Windsurf (https://docs.windsurf.com/windsurf/cascade/hooks) never sends
   // session_id either — trajectory_id is its closest analog, the same role
   // conversation_id plays for Cursor.
-  const sessionId = data.session_id ?? data.conversation_id ?? data.trajectory_id;
+  // Antigravity (https://antigravity.google/docs/hooks) never sends
+  // session_id either — conversationId (camelCase, Antigravity's own field
+  // name) is its closest analog, same role trajectory_id plays for Windsurf.
+  const sessionId =
+    data.session_id ?? data.conversation_id ?? data.trajectory_id ?? data.conversationId;
 
   // Drop a PPID breadcrumb at the very top so the MCP server can resolve its
   // Claude Code session_id without an env-var or initialize-payload extension.
@@ -702,6 +715,18 @@ function processHook(raw: string): void {
   // stdout, so this check is scoped to Gemini CLI only.
   const isGeminiCli =
     process.env.MCP_CLIENT === 'gemini-cli' || process.env.NEW_RELIC_AI_PLATFORM === 'gemini-cli';
+
+  // Antigravity (https://antigravity.google/docs/hooks) sends no field
+  // naming which event fired — payload shape is the only signal. Hoisted
+  // once so the dispatch branch below and the required-stdout-reply block
+  // further down can never diverge on which event they think this is, same
+  // precedent as isGeminiCli above.
+  const isAntigravityPre = data.toolCall !== undefined;
+  const isAntigravityPost =
+    !isAntigravityPre &&
+    typeof data.stepIdx === 'number' &&
+    data.hook_event_name === undefined &&
+    data.agent_action_name === undefined;
 
   let event: Record<string, unknown>;
 
@@ -999,6 +1024,47 @@ function processHook(raw: string): void {
       timestamp,
       success: true,
     };
+  } else if (isAntigravityPre) {
+    // Antigravity PreToolUse — no self-describing event-name field exists
+    // (see HookInput's comment above); presence of `toolCall` is
+    // Antigravity's own signal that this is PreToolUse, since PostToolUse
+    // never carries that key.
+    const agyToolName = data.toolCall?.name ?? 'unknown';
+    event = {
+      mode: 'pre' as const,
+      tool: agyToolName,
+      timestamp,
+      inputSize: sizeOf(data.toolCall?.args),
+      inputHash: hashInput(data.toolCall?.args),
+      ...(typeof data.stepIdx === 'number' && { toolUseId: String(data.stepIdx) }),
+    };
+
+    // Raw Antigravity argument names (CommandLine, TargetFile, etc.) don't
+    // match any canonical-name case in extractInputMeta()'s switch, so this
+    // currently always returns undefined — a known, documented gap (see
+    // docs/ADAPTERS.md's Antigravity section), not a guess at field names.
+    const inputMeta = extractInputMeta(agyToolName, data.toolCall?.args);
+    if (inputMeta !== undefined) event.toolInput = inputMeta;
+
+    if (recordContent && data.toolCall?.args !== undefined) {
+      event.inputContent = redact(truncate(JSON.stringify(data.toolCall.args), maxContentLen));
+    }
+  } else if (isAntigravityPost) {
+    // Antigravity PostToolUse — carries no tool-name field at all, only
+    // stepIdx/error. toolUseId-based pairing in event-processor.ts recovers
+    // the real tool name from the matched pre-event (confirmed by reading
+    // HookEventProcessor.handlePostEvent(): the merged record's toolName
+    // always comes from the pre-event, never the post-event's own tool
+    // field) — 'unknown' here is a safe placeholder, not a broken mapping.
+    const hasError = typeof data.error === 'string' && data.error !== '';
+    event = {
+      mode: 'post' as const,
+      tool: 'unknown',
+      timestamp,
+      success: !hasError,
+      toolUseId: String(data.stepIdx),
+      ...(typeof data.error === 'string' && data.error !== '' && { error: redact(data.error) }),
+    };
   } else {
     // Unknown hook event — ignore silently
     return;
@@ -1043,6 +1109,24 @@ function processHook(raw: string): void {
       process.stdout.write('{}\n');
     } catch {
       // Silent failure — never block Gemini CLI
+    }
+  }
+
+  // Antigravity requires a stdout reply on every PreToolUse/PostToolUse hook
+  // invocation (https://antigravity.google/docs/hooks) — a required
+  // `decision` field for PreToolUse, an empty object for PostToolUse.
+  // Preflight is observation-only, so this always allows.
+  if (isAntigravityPre) {
+    try {
+      process.stdout.write('{"decision":"allow"}\n');
+    } catch {
+      // Silent failure — never block Antigravity
+    }
+  } else if (isAntigravityPost) {
+    try {
+      process.stdout.write('{}\n');
+    } catch {
+      // Silent failure — never block Antigravity
     }
   }
 

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { LocalStore } from '../storage/local-store.js';
 import { HookEventProcessor } from './event-processor.js';
+import { AntigravityAdapter } from '../platforms/antigravity-adapter.js';
 import type { HookEvent, PreHookEvent, PostHookEvent, ToolCallRecord } from '../storage/types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -187,6 +188,28 @@ describe('HookEventProcessor', () => {
       expect(record.durationMs).toBeNull();
       expect(record.success).toBe(true);
       expect(record.outputSizeBytes).toBe(512);
+    });
+  });
+
+  describe('processEvents() — Antigravity pairing (raw tool name only on pre-event)', () => {
+    it('resolves toolName from the pre-event even though the post-event carries "unknown"', () => {
+      const processor = new HookEventProcessor({
+        store,
+        onRecord,
+        platformAdapter: new AntigravityAdapter(),
+      });
+
+      processor.processEvents([
+        makePreEvent({ tool: 'run_command', toolUseId: '19', timestamp: 1000 }),
+        makePostEvent({ tool: 'unknown', toolUseId: '19', timestamp: 1200 }),
+      ]);
+
+      expect(records).toHaveLength(1);
+      const record = records[0]!;
+      expect(record.toolName).toBe('Bash');
+      expect(record.toolUseId).toBe('19');
+      expect(record.durationMs).toBe(200);
+      expect(record.success).toBe(true);
     });
   });
 

--- a/src/platforms/antigravity-adapter.test.ts
+++ b/src/platforms/antigravity-adapter.test.ts
@@ -1,0 +1,138 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { AntigravityAdapter } from './antigravity-adapter.js';
+
+let stderrSpy: ReturnType<typeof jest.spyOn>;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  for (const key of ['MCP_CLIENT']) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('AntigravityAdapter', () => {
+  const adapter = new AntigravityAdapter();
+
+  it('has platformName "antigravity"', () => {
+    expect(adapter.platformName).toBe('antigravity');
+  });
+
+  it('declares visibilityLevel "full-hooks"', () => {
+    expect(adapter.visibilityLevel).toBe('full-hooks');
+  });
+
+  it('declares GEMINI.md and .agents/rules/ as instruction file paths', () => {
+    expect(adapter.capabilities.instructionFilePaths).toEqual(['GEMINI.md', '.agents/rules/']);
+  });
+
+  describe('mapToolName', () => {
+    const cases: [string, string][] = [
+      ['view_file', 'Read'],
+      ['write_to_file', 'Write'],
+      ['replace_file_content', 'Edit'],
+      ['multi_replace_file_content', 'MultiEdit'],
+      ['list_dir', 'Glob'],
+      ['find_by_name', 'Glob'],
+      ['grep_search', 'Grep'],
+      ['search_web', 'WebSearch'],
+      ['read_url_content', 'WebFetch'],
+      ['run_command', 'Bash'],
+      ['invoke_subagent', 'Agent'],
+    ];
+
+    for (const [platformName, expected] of cases) {
+      it(`maps "${platformName}" to "${expected}"`, () => {
+        expect(adapter.mapToolName(platformName)).toBe(expected);
+      });
+    }
+
+    it('leaves ask_question unmapped (returns "Unknown")', () => {
+      expect(adapter.mapToolName('ask_question')).toBe('Unknown');
+    });
+
+    it('leaves generate_image unmapped (returns "Unknown")', () => {
+      expect(adapter.mapToolName('generate_image')).toBe('Unknown');
+    });
+
+    it('returns "Unknown" for an unrecognized tool name', () => {
+      expect(adapter.mapToolName('totally_made_up_tool')).toBe('Unknown');
+    });
+  });
+
+  describe('normalizeToolCall', () => {
+    it('maps a known tool and preserves platform-specific fields', () => {
+      const normalized = adapter.normalizeToolCall({
+        tool: 'run_command',
+        timestamp: 3000,
+        success: true,
+        command: 'npm test',
+      });
+      expect(normalized.toolName).toBe('Bash');
+      expect(normalized.platformToolName).toBe('run_command');
+      expect(normalized.platform).toBe('antigravity');
+      expect(normalized.command).toBe('npm test');
+    });
+
+    it('defaults missing tool name to "unknown"', () => {
+      const normalized = adapter.normalizeToolCall({ timestamp: 3000 });
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.toolName).toBe('Unknown');
+    });
+
+    it('defaults success to true when not provided', () => {
+      const normalized = adapter.normalizeToolCall({ tool: 'view_file', timestamp: 3000 });
+      expect(normalized.success).toBe(true);
+    });
+
+    it('falls back to safe defaults when raw is not an object (e.g. null)', () => {
+      const normalized = adapter.normalizeToolCall(null);
+      expect(normalized.toolName).toBe('Unknown');
+      expect(normalized.platformToolName).toBe('unknown');
+      expect(normalized.platform).toBe('antigravity');
+      expect(normalized.success).toBe(true);
+      expect(normalized.durationMs).toBeNull();
+    });
+  });
+
+  describe('getSessionMetadata', () => {
+    it('returns platform "antigravity"', () => {
+      expect(adapter.getSessionMetadata()).toEqual({ platform: 'antigravity' });
+    });
+  });
+
+  describe('isSupported', () => {
+    it('returns true when MCP_CLIENT is "antigravity"', () => {
+      process.env.MCP_CLIENT = 'antigravity';
+      expect(adapter.isSupported()).toBe(true);
+    });
+
+    it('returns false in a non-Antigravity environment', () => {
+      expect(adapter.isSupported()).toBe(false);
+    });
+  });
+
+  describe('getHookInstallInstructions', () => {
+    it('returns non-empty instructions mentioning both mcp_config.json and hooks.json', () => {
+      const instructions = adapter.getHookInstallInstructions();
+      expect(instructions.length).toBeGreaterThan(0);
+      expect(instructions).toContain('mcp_config.json');
+      expect(instructions).toContain('hooks.json');
+    });
+  });
+
+  describe('initialize', () => {
+    it('completes without error', async () => {
+      await expect(adapter.initialize({})).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/platforms/antigravity-adapter.ts
+++ b/src/platforms/antigravity-adapter.ts
@@ -1,0 +1,144 @@
+import type {
+  NormalizedToolCall,
+  PlatformAdapter,
+  PlatformConfig,
+  PlatformSessionMetadata,
+} from './types.js';
+
+/**
+ * Maps Antigravity's built-in tool names (confirmed from the Hooks page's
+ * "Supported Tools" section — antigravity.google/docs/hooks, identical on
+ * /docs/ide/hooks) to the normalized Claude Code tool vocabulary.
+ * `list_dir` and `find_by_name` both map to 'Glob' — same "directory/file
+ * enumeration -> Glob" precedent as Zed's `list_directory`/Continue's `ls`.
+ * `invoke_subagent` -> 'Agent' mirrors Zed's `spawn_agent` -> 'Agent'.
+ * `manage_task`, `schedule`, `list_permissions`, `ask_permission`,
+ * `define_subagent`, `send_message`, `manage_subagents`, `ask_question`, and
+ * `generate_image` are deliberately left unmapped (-> 'Unknown', original
+ * name preserved) — no existing canonical Preflight tool covers
+ * agent-to-agent messaging, permission introspection, or image generation.
+ */
+const ANTIGRAVITY_TOOL_MAP: Record<string, string> = {
+  view_file: 'Read',
+  write_to_file: 'Write',
+  replace_file_content: 'Edit',
+  multi_replace_file_content: 'MultiEdit',
+  list_dir: 'Glob',
+  find_by_name: 'Glob',
+  grep_search: 'Grep',
+  search_web: 'WebSearch',
+  read_url_content: 'WebFetch',
+  run_command: 'Bash',
+  invoke_subagent: 'Agent',
+};
+
+interface AntigravityToolCallEvent {
+  tool?: string;
+  toolName?: string;
+  timestamp?: number;
+  durationMs?: number;
+  success?: boolean;
+  error?: string;
+  filePath?: string;
+  path?: string;
+  command?: string;
+  inputSizeBytes?: number;
+  outputSizeBytes?: number;
+  sessionId?: string;
+}
+
+function isAntigravityToolCallEvent(x: unknown): x is AntigravityToolCallEvent {
+  return typeof x === 'object' && x !== null;
+}
+
+export class AntigravityAdapter implements PlatformAdapter {
+  readonly platformName = 'antigravity';
+  readonly visibilityLevel = 'full-hooks' as const;
+  // Confirmed via antigravity.google/docs/ide/rules and /docs/rules-workflows:
+  // global rules live in ~/.gemini/GEMINI.md; workspace rules live in
+  // .agents/rules/ (with backward-compat support for the older .agent/rules/).
+  readonly capabilities = { instructionFilePaths: ['GEMINI.md', '.agents/rules/'] as const };
+
+  async initialize(_config: PlatformConfig): Promise<void> {
+    // Antigravity's built-in tool-call capture is delivered via a
+    // user-installed hooks.json (see getHookInstallInstructions()), parsed by
+    // src/hooks/collector-script.ts — not configured by this process, same
+    // no-op shape as every other full-hooks adapter.
+  }
+
+  normalizeToolCall(raw: unknown): NormalizedToolCall {
+    const event = isAntigravityToolCallEvent(raw) ? raw : {};
+    const platformToolName = event.tool ?? event.toolName ?? 'unknown';
+    const toolName = ANTIGRAVITY_TOOL_MAP[platformToolName] ?? 'Unknown';
+    const filePath = event.filePath ?? event.path;
+
+    return {
+      toolName,
+      platformToolName,
+      platform: this.platformName,
+      timestamp: event.timestamp ?? Date.now(),
+      durationMs: event.durationMs ?? null,
+      success: event.success ?? true,
+      ...(event.error !== undefined && { error: event.error }),
+      ...(event.inputSizeBytes !== undefined && { inputSizeBytes: event.inputSizeBytes }),
+      ...(event.outputSizeBytes !== undefined && { outputSizeBytes: event.outputSizeBytes }),
+      ...(filePath !== undefined && { filePath }),
+      ...(event.command !== undefined && { command: event.command }),
+      ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+    };
+  }
+
+  mapToolName(platformToolName: string): string {
+    return ANTIGRAVITY_TOOL_MAP[platformToolName] ?? 'Unknown';
+  }
+
+  getSessionMetadata(): PlatformSessionMetadata {
+    return {
+      platform: this.platformName,
+    };
+  }
+
+  getHookInstallInstructions(): string {
+    return [
+      'Google Antigravity Setup (2.0 / IDE / CLI):',
+      '',
+      '1. Register Preflight as an MCP server for its own nr_observe_* tools.',
+      '   Create or edit mcp_config.json — globally at',
+      '   ~/.gemini/config/mcp_config.json, or per-workspace at',
+      '   .agents/mcp_config.json:',
+      '   {',
+      '     "mcpServers": {',
+      '       "preflight": {',
+      '         "command": "npx",',
+      '         "args": ["preflight", "--stdio"],',
+      '         "env": {',
+      '           "MCP_CLIENT": "antigravity",',
+      '           "NEW_RELIC_LICENSE_KEY": "<your-key>",',
+      '           "NEW_RELIC_ACCOUNT_ID": "<your-account-id>"',
+      '         }',
+      '       }',
+      '     }',
+      '   }',
+      '2. Capture built-in tool calls (file edits, terminal, browser) via',
+      '   hooks.json — same global (~/.gemini/config/hooks.json) or workspace',
+      '   (.agents/hooks.json) location as mcp_config.json:',
+      '   {',
+      '     "preflight": {',
+      '       "PreToolUse": [',
+      '         { "matcher": "*", "hooks": [{ "command": "preflight-collector" }] }',
+      '       ],',
+      '       "PostToolUse": [',
+      '         { "matcher": "*", "hooks": [{ "command": "preflight-collector" }] }',
+      '       ]',
+      '     }',
+      '   }',
+      '3. Ensure preflight-collector is on your PATH (npm link, or',
+      '   npm install -g @newrelic/preflight).',
+      '4. Restart Antigravity (or reload the workspace).',
+    ].join('\n');
+  }
+
+  isSupported(): boolean {
+    return process.env.MCP_CLIENT === 'antigravity';
+  }
+}

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -21,6 +21,7 @@ export { CodexAdapter } from './codex-adapter.js';
 export { OpencodeAdapter } from './opencode-adapter.js';
 export { KiloCodeAdapter } from './kilo-code-adapter.js';
 export { PiAdapter } from './pi-adapter.js';
+export { AntigravityAdapter } from './antigravity-adapter.js';
 export { GenericMcpAdapter, validateReportToolCallInput } from './generic-mcp-adapter.js';
 export type {
   ReportToolCallInput,

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -16,6 +16,7 @@ import { CodexAdapter } from './codex-adapter.js';
 import { OpencodeAdapter } from './opencode-adapter.js';
 import { KiloCodeAdapter } from './kilo-code-adapter.js';
 import { PiAdapter } from './pi-adapter.js';
+import { AntigravityAdapter } from './antigravity-adapter.js';
 import type { PlatformAdapter, PlatformSessionMetadata, NormalizedToolCall } from './types.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -331,6 +332,15 @@ describe('PlatformRegistry', () => {
       expect(detected!.platformName).toBe('pi');
     });
 
+    it('selects Antigravity adapter when MCP_CLIENT is "antigravity"', () => {
+      process.env.MCP_CLIENT = 'antigravity';
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('antigravity');
+    });
+
     it('falls back to generic-mcp when no specific platform detected', () => {
       const registry = createDefaultRegistry();
 
@@ -389,7 +399,7 @@ describe('createDefaultRegistry', () => {
     const registry = createDefaultRegistry();
     const registered = registry.getRegistered();
 
-    expect(registered).toHaveLength(16);
+    expect(registered).toHaveLength(17);
     expect(registered[0]).toBeInstanceOf(ClaudeCodeAdapter);
     expect(registered[1]).toBeInstanceOf(CursorAdapter);
     expect(registered[2]).toBeInstanceOf(WindsurfAdapter);
@@ -405,10 +415,11 @@ describe('createDefaultRegistry', () => {
     expect(registered[12]).toBeInstanceOf(OpencodeAdapter);
     expect(registered[13]).toBeInstanceOf(KiloCodeAdapter);
     expect(registered[14]).toBeInstanceOf(PiAdapter);
-    expect(registered[15]).toBeInstanceOf(GenericMcpAdapter);
+    expect(registered[15]).toBeInstanceOf(AntigravityAdapter);
+    expect(registered[16]).toBeInstanceOf(GenericMcpAdapter);
   });
 
-  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, cline, codex, opencode, kilocode, and pi adapters', () => {
+  it('includes zed, continue, amazon-q, kiro, droid, gemini-cli, cline, codex, opencode, kilocode, pi, and antigravity adapters', () => {
     const registry = createDefaultRegistry();
     const names = registry.getRegistered().map((a) => a.platformName);
     expect(names).toContain('zed');
@@ -422,6 +433,7 @@ describe('createDefaultRegistry', () => {
     expect(names).toContain('opencode');
     expect(names).toContain('kilocode');
     expect(names).toContain('pi');
+    expect(names).toContain('antigravity');
   });
 
   it('ends with generic-mcp as fallback', () => {
@@ -505,6 +517,7 @@ describe('all adapters implement PlatformAdapter interface', () => {
     new OpencodeAdapter(),
     new KiloCodeAdapter(),
     new PiAdapter(),
+    new AntigravityAdapter(),
     new GenericMcpAdapter(),
   ];
 

--- a/src/platforms/platform-registry.ts
+++ b/src/platforms/platform-registry.ts
@@ -15,6 +15,7 @@ import { CodexAdapter } from './codex-adapter.js';
 import { OpencodeAdapter } from './opencode-adapter.js';
 import { KiloCodeAdapter } from './kilo-code-adapter.js';
 import { PiAdapter } from './pi-adapter.js';
+import { AntigravityAdapter } from './antigravity-adapter.js';
 import { GenericMcpAdapter } from './generic-mcp-adapter.js';
 
 const logger = createLogger('platform-registry');
@@ -75,6 +76,7 @@ export function createDefaultRegistry(): PlatformRegistry {
   registry.register(new OpencodeAdapter());
   registry.register(new KiloCodeAdapter());
   registry.register(new PiAdapter());
+  registry.register(new AntigravityAdapter());
   registry.register(new GenericMcpAdapter()); // always last
   return registry;
 }


### PR DESCRIPTION
## Summary

- Adds a `full-hooks` `AntigravityAdapter` for Google Antigravity (2.0 / IDE / CLI). Antigravity ships a real, first-party, documented `hooks.json` mechanism (`PreToolUse`/`PostToolUse`) covering every built-in tool call — this supersedes the `mcp-tools-only` classification originally scoped for this issue, since Antigravity has since shipped that mechanism (confirmed directly against `antigravity.google/docs/hooks`).
- Antigravity's hook payloads carry no field naming which event fired at all — `collector-script.ts` dispatches on payload *shape* instead (presence of a `toolCall` key means `PreToolUse`). Both events set `toolUseId` from `stepIdx` so pairing works correctly even though `PostToolUse` never carries a tool name.
- Registers the adapter, adds a full `docs/ADAPTERS.md` section, and bumps to `1.14.0`.

## Test plan

- [x] `npm run build && npm test` — clean, all covering tests pass
- [x] `npx jest -- src/platforms/antigravity-adapter.test.ts src/platforms/platform-registry.test.ts src/hooks/collector-script.test.ts src/hooks/event-processor.test.ts` — 357/357 pass
- [x] `npm run lint` / `npm run format:check` — clean

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)