### PR TITLE
Fix: native-Windows --stdio MCP never resolves session_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.1] - 2026-07-24
+
+### Fixed
+
+- **Native Windows session resolution** — the `--stdio` MCP server now resolves its Claude Code `session_id` on native Windows, where Claude Code interposes Git Bash between itself and the hook collector but launches the MCP server directly. The hook collector writes an additional breadcrumb keyed by the project's working directory (alongside the existing PID-keyed breadcrumb); the MCP server falls back to it, on any platform, whenever the PID-based lookup misses. Previously, affected sessions never resolved a real session ID, so dashboard History, weekly summaries, and model-performance metrics never populated for them.
+
 ## [1.14.0] - 2026-07-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -16,6 +16,7 @@ import {
   translateWslPath,
   getBufferPath,
   writePpidBreadcrumb,
+  writeCwdBreadcrumb,
   getLinuxAncestorPids,
   _procFs,
   readStdinSync,
@@ -1576,6 +1577,64 @@ describe('collector-script', () => {
       const ancestorCrumb = resolve(breadcrumbDir, `${fakeGrandpid}.txt`);
       expect(existsSync(ancestorCrumb)).toBe(true);
       expect(readFileSync(ancestorCrumb, 'utf-8')).toBe('sess-ancestor');
+    });
+  });
+
+  describe('writeCwdBreadcrumb()', () => {
+    beforeEach(() => {
+      delete process.env.NEW_RELIC_AI_MCP_BUFFER_PATH;
+      process.env.NEW_RELIC_AI_MCP_STORAGE_PATH = tmpDir;
+    });
+
+    it('writes <storage>/session-by-cwd/<sanitized-cwd>.txt with the sessionId', () => {
+      writeCwdBreadcrumb('sess-bread', '/projects/test');
+      const breadcrumbPath = resolve(tmpDir, 'session-by-cwd', '-projects-test.txt');
+      expect(existsSync(breadcrumbPath)).toBe(true);
+      expect(readFileSync(breadcrumbPath, 'utf-8')).toBe('sess-bread');
+    });
+
+    it('sanitizes a backslash-separated (Windows) cwd, stripping the drive-letter colon too', () => {
+      writeCwdBreadcrumb('sess-win', 'C:\\Users\\test\\myproject');
+      const breadcrumbPath = resolve(tmpDir, 'session-by-cwd', 'C--Users-test-myproject.txt');
+      expect(existsSync(breadcrumbPath)).toBe(true);
+      expect(readFileSync(breadcrumbPath, 'utf-8')).toBe('sess-win');
+    });
+
+    it('strips the drive-letter colon so the breadcrumb filename has no embedded colon', () => {
+      writeCwdBreadcrumb('sess-colon', 'C:\\Users\\test\\myproject');
+      expect(existsSync(resolve(tmpDir, 'session-by-cwd', 'C--Users-test-myproject.txt'))).toBe(
+        true,
+      );
+      expect(existsSync(resolve(tmpDir, 'session-by-cwd', 'C:-Users-test-myproject.txt'))).toBe(
+        false,
+      );
+    });
+
+    it('no-ops when cwd is missing or empty', () => {
+      writeCwdBreadcrumb('sess-nocwd', undefined);
+      writeCwdBreadcrumb('sess-nocwd', '');
+      expect(existsSync(resolve(tmpDir, 'session-by-cwd'))).toBe(false);
+    });
+
+    it('rejects malformed sessionIds without writing', () => {
+      writeCwdBreadcrumb('../../escape', '/projects/test');
+      expect(existsSync(resolve(tmpDir, 'session-by-cwd', '-projects-test.txt'))).toBe(false);
+    });
+
+    it('short-circuits when content already matches', () => {
+      writeCwdBreadcrumb('sess-stable', '/projects/test');
+      const breadcrumbPath = resolve(tmpDir, 'session-by-cwd', '-projects-test.txt');
+      for (let i = 0; i < 50; i++) writeCwdBreadcrumb('sess-stable', '/projects/test');
+      expect(readFileSync(breadcrumbPath, 'utf-8')).toBe('sess-stable');
+    });
+
+    it('processHook() drops the cwd breadcrumb on every fire', () => {
+      delete process.env.NEW_RELIC_AI_MCP_BUFFER_PATH;
+      process.env.NEW_RELIC_AI_MCP_STORAGE_PATH = tmpDir;
+
+      processHook(makePreToolUse({ session_id: 'sess-bc', cwd: '/projects/test' }));
+      const breadcrumbPath = resolve(tmpDir, 'session-by-cwd', '-projects-test.txt');
+      expect(readFileSync(breadcrumbPath, 'utf-8')).toBe('sess-bc');
     });
   });
 

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -350,15 +350,22 @@ function collectTranscriptTokens(data: {
 }
 
 // ---------------------------------------------------------------------------
-// PPID breadcrumb — lets the MCP server learn the Claude Code session_id
+// PPID + cwd breadcrumbs — let the MCP server learn the Claude Code session_id
 //
 // Claude Code spawns its MCP server and hook collector scripts as children of
 // the same process; they share a PPID. The MCP can read its own process.ppid
 // (= Claude Code's PID) and look up the matching session_id here.
 //
+// Some platforms interpose a shell between Claude Code and the hook collector
+// that the ancestor-PID walk below doesn't reach (native Windows via Git
+// Bash, for one) — there, the collector's ppid never matches the MCP's own
+// process.ppid. writeCwdBreadcrumb() writes a second breadcrumb keyed by the
+// sanitized project cwd instead, which the MCP server falls back to (via
+// resolveFromCwd() in session-resolver.ts) only when the PPID lookup misses.
+//
 // Hot-path: every PreToolUse / PostToolUse hook runs this. The
 // existsSync + content-equality short-circuit makes the steady state a single
-// stat() and one read — well under the <5ms budget.
+// stat() and one read per breadcrumb — well under the <5ms budget.
 // ---------------------------------------------------------------------------
 
 /**
@@ -453,6 +460,49 @@ function writePpidBreadcrumb(sessionId: string): void {
         `[preflight-collector] Warning: cannot write PPID breadcrumb: ${String(err)}\n`,
       );
       _breadcrumbWriteFailed = true;
+    }
+  }
+}
+
+let _cwdBreadcrumbWriteFailed = false;
+
+function writeCwdBreadcrumb(sessionId: string, cwd: string | undefined): void {
+  if (!SESSION_ID_RE.test(sessionId)) return;
+  if (typeof cwd !== 'string' || cwd.length === 0) return;
+
+  try {
+    const storageDir = process.env.NEW_RELIC_AI_MCP_STORAGE_PATH ?? DEFAULT_STORAGE_DIR;
+    const breadcrumbDir = resolve(storageDir, 'session-by-cwd');
+    mkdirSync(breadcrumbDir, { recursive: true, mode: 0o700 });
+
+    // Same sanitization scheme as getTranscriptPath() above, so the MCP
+    // server's resolveFromCwd() can derive an identical filename from its
+    // own process.cwd() without any shared state beyond this convention.
+    // Colons are also stripped (unlike getTranscriptPath) — a Windows drive
+    // letter like "C:" left in the filename gets misinterpreted by
+    // path.resolve() on win32 as a drive-relative path component rather than
+    // a literal character, which can write/read outside this storage dir.
+    const sanitizedCwd = cwd.replace(/[\\/:]/g, '-');
+    const breadcrumbPath = resolve(breadcrumbDir, `${sanitizedCwd}.txt`);
+
+    if (existsSync(breadcrumbPath)) {
+      try {
+        if (readFileSync(breadcrumbPath, 'utf-8').trim() === sessionId) {
+          _cwdBreadcrumbWriteFailed = false;
+          return;
+        }
+      } catch {
+        // Fall through to rewrite if the read failed.
+      }
+    }
+    writeFileSync(breadcrumbPath, sessionId, { mode: 0o600 });
+    _cwdBreadcrumbWriteFailed = false;
+  } catch (err) {
+    if (!_cwdBreadcrumbWriteFailed) {
+      process.stderr.write(
+        `[preflight-collector] Warning: cannot write cwd breadcrumb: ${String(err)}\n`,
+      );
+      _cwdBreadcrumbWriteFailed = true;
     }
   }
 }
@@ -690,6 +740,7 @@ function processHook(raw: string): void {
   // conversation_id would be a guess, not a fix.
   if (typeof data.session_id === 'string' && data.session_id.length > 0) {
     writePpidBreadcrumb(data.session_id);
+    writeCwdBreadcrumb(data.session_id, data.cwd);
   }
 
   // Claude Code sends PascalCase hook names ('PreToolUse'); Kiro sends
@@ -1158,6 +1209,7 @@ export {
   translateWslPath,
   getBufferPath,
   writePpidBreadcrumb,
+  writeCwdBreadcrumb,
   readStdinSync,
 };
 

--- a/src/hooks/session-resolver.test.ts
+++ b/src/hooks/session-resolver.test.ts
@@ -6,6 +6,7 @@ import {
   resolveSessionId,
   resolveFromJobDir,
   resolveFromBreadcrumb,
+  resolveFromCwd,
   nextDelayMs,
   isSyntheticSessionId,
 } from './session-resolver.js';
@@ -105,6 +106,41 @@ describe('session-resolver', () => {
     });
   });
 
+  describe('resolveFromCwd()', () => {
+    it('returns null when cwd is missing or empty', () => {
+      expect(resolveFromCwd(tmpDir, undefined)).toBeNull();
+      expect(resolveFromCwd(tmpDir, '')).toBeNull();
+    });
+
+    it('returns null when breadcrumb file is missing', () => {
+      expect(resolveFromCwd(tmpDir, '/projects/missing')).toBeNull();
+    });
+
+    it('returns the trimmed sessionId from <storage>/session-by-cwd/<sanitized-cwd>.txt', () => {
+      mkdirSync(resolve(tmpDir, 'session-by-cwd'), { recursive: true });
+      writeFileSync(resolve(tmpDir, 'session-by-cwd', '-projects-test.txt'), 'sess-from-cwd\n');
+      expect(resolveFromCwd(tmpDir, '/projects/test')).toBe('sess-from-cwd');
+    });
+
+    it('sanitizes a backslash-separated (Windows) cwd the same way as the collector', () => {
+      mkdirSync(resolve(tmpDir, 'session-by-cwd'), { recursive: true });
+      writeFileSync(resolve(tmpDir, 'session-by-cwd', 'C--Users-test-myproject.txt'), 'sess-win');
+      expect(resolveFromCwd(tmpDir, 'C:\\Users\\test\\myproject')).toBe('sess-win');
+    });
+
+    it('resolves correctly when cwd contains a Windows drive letter with colon', () => {
+      mkdirSync(resolve(tmpDir, 'session-by-cwd'), { recursive: true });
+      writeFileSync(resolve(tmpDir, 'session-by-cwd', 'C--Users-test-myproject.txt'), 'sess-drive');
+      expect(resolveFromCwd(tmpDir, 'C:\\Users\\test\\myproject')).toBe('sess-drive');
+    });
+
+    it('returns null when breadcrumb content fails the regex', () => {
+      mkdirSync(resolve(tmpDir, 'session-by-cwd'), { recursive: true });
+      writeFileSync(resolve(tmpDir, 'session-by-cwd', '-projects-test.txt'), 'has spaces');
+      expect(resolveFromCwd(tmpDir, '/projects/test')).toBeNull();
+    });
+  });
+
   describe('nextDelayMs()', () => {
     it('follows the exp-backoff schedule and saturates at 2s', () => {
       expect(nextDelayMs(0)).toBe(100);
@@ -139,6 +175,36 @@ describe('session-resolver', () => {
         storagePath: tmpDir,
       });
       expect(sid).toBe('sess-immediate');
+    });
+
+    it('falls back to the cwd breadcrumb when the ppid breadcrumb is missing (immediate)', async () => {
+      mkdirSync(resolve(tmpDir, 'session-by-cwd'), { recursive: true });
+      writeFileSync(
+        resolve(tmpDir, 'session-by-cwd', '-projects-winrepo.txt'),
+        'sess-cwd-fallback',
+      );
+      const sid = await resolveSessionId({
+        claudeJobDir: null,
+        ppid: 424242, // never has a matching breadcrumb
+        cwd: '/projects/winrepo',
+        storagePath: tmpDir,
+      });
+      expect(sid).toBe('sess-cwd-fallback');
+    });
+
+    it('prefers the ppid breadcrumb over the cwd breadcrumb when both are present', async () => {
+      const ppid = 111222;
+      mkdirSync(resolve(tmpDir, 'session-by-ppid'), { recursive: true });
+      mkdirSync(resolve(tmpDir, 'session-by-cwd'), { recursive: true });
+      writeFileSync(resolve(tmpDir, 'session-by-ppid', `${ppid}.txt`), 'sess-from-ppid');
+      writeFileSync(resolve(tmpDir, 'session-by-cwd', '-projects-both.txt'), 'sess-from-cwd');
+      const sid = await resolveSessionId({
+        claudeJobDir: null,
+        ppid,
+        cwd: '/projects/both',
+        storagePath: tmpDir,
+      });
+      expect(sid).toBe('sess-from-ppid');
     });
   });
 
@@ -176,6 +242,29 @@ describe('session-resolver', () => {
           signal: ac.signal,
         }),
       ).rejects.toThrow(/aborted/);
+    });
+
+    it('resolves via the cwd fallback once it appears, when the ppid breadcrumb never does (native-Windows Git-Bash-interposition scenario)', async () => {
+      const breadcrumbCwdDir = resolve(tmpDir, 'session-by-cwd');
+      mkdirSync(breadcrumbCwdDir, { recursive: true });
+
+      // The ppid the resolver looks for (the MCP's own process.ppid, i.e.
+      // claude.exe's pid) never gets a breadcrumb — only a transient,
+      // unrelated interposed-shell pid would have one, which this resolver
+      // call never sees. The cwd breadcrumb appears after a delay instead,
+      // exactly like the real collector writing it on the next hook fire.
+      setTimeout(() => {
+        writeFileSync(resolve(breadcrumbCwdDir, '-projects-native-win.txt'), 'sess-win-regression');
+      }, 150);
+
+      const sid = await resolveSessionId({
+        claudeJobDir: null,
+        ppid: 333444, // never resolves
+        cwd: '/projects/native-win',
+        storagePath: tmpDir,
+        suppressWarn: true,
+      });
+      expect(sid).toBe('sess-win-regression');
     });
   });
 });

--- a/src/hooks/session-resolver.ts
+++ b/src/hooks/session-resolver.ts
@@ -1,16 +1,25 @@
 /**
  * Resolve the Claude Code session_id for the running MCP process.
  *
- * Two sources, in order:
+ * Three sources, in order:
  *   1. `CLAUDE_JOB_DIR` env var → read `<dir>/state.json`, regex-extract the
  *      session UUID from the `linkScanPath` field's filename. Instant; used
  *      by background-job MCPs.
  *   2. PPID breadcrumb at `<storage>/session-by-ppid/<process.ppid>.txt` —
- *      written by the hook collector on every tool call. Polled at exponential
- *      backoff: 100ms, 200ms, 500ms, 1s, 2s, then steady at 2s. No hard
- *      timeout; logs a single WARN at 60s if still unresolved.
+ *      written by the hook collector on every tool call. Precise: no
+ *      cross-session collision risk when it resolves.
+ *   3. cwd breadcrumb at `<storage>/session-by-cwd/<sanitized-cwd>.txt` —
+ *      also written by the hook collector on every tool call, keyed by the
+ *      project directory instead of a PID. Fallback for platforms where the
+ *      PPID bridge never reaches the MCP's own `process.ppid` (e.g. native
+ *      Windows, where Claude Code interposes Git Bash between itself and the
+ *      hook collector but launches the MCP server directly). Only consulted
+ *      when #2 misses.
+ *   Both breadcrumb sources are polled together at exponential backoff:
+ *   100ms, 200ms, 500ms, 1s, 2s, then steady at 2s. No hard timeout; logs a
+ *   single WARN at 60s if still unresolved.
  *
- * The MCP must never fabricate its own session_id. If neither path resolves,
+ * The MCP must never fabricate its own session_id. If none of these resolve,
  * tool handlers should report "session_id not yet resolved" rather than make
  * one up.
  */
@@ -33,6 +42,8 @@ export interface SessionResolverOptions {
   readonly storagePath?: string;
   /** Override `process.ppid` (test seam). */
   readonly ppid?: number;
+  /** Override `process.cwd()` (test seam). */
+  readonly cwd?: string;
   /** Override `process.env.CLAUDE_JOB_DIR` (test seam). */
   readonly claudeJobDir?: string | null;
   /** When true, skip the WARN log (test seam). */
@@ -104,6 +115,33 @@ export function resolveFromBreadcrumb(
 }
 
 /**
+ * Try to resolve the session_id synchronously from the cwd breadcrumb file.
+ * Fallback for platforms where the PPID breadcrumb never matches (see the
+ * module doc comment above). Returns the validated session_id or null.
+ */
+export function resolveFromCwd(storagePath: string, cwd: string | undefined): string | null {
+  if (typeof cwd !== 'string' || cwd.length === 0) return null;
+  // Same sanitization scheme as the collector's writeCwdBreadcrumb() /
+  // getTranscriptPath() — must stay identical so both sides derive the same
+  // filename independently. Colons are stripped too (unlike
+  // getTranscriptPath) so a Windows drive letter never survives into the
+  // filename — see the matching comment in writeCwdBreadcrumb().
+  const sanitizedCwd = cwd.replace(/[\\/:]/g, '-');
+  const breadcrumbPath = resolve(storagePath, 'session-by-cwd', `${sanitizedCwd}.txt`);
+  if (!existsSync(breadcrumbPath)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(breadcrumbPath, 'utf-8');
+  } catch (err) {
+    logger.debug('cwd breadcrumb file unreadable', { error: String(err) });
+    return null;
+  }
+  const sid = raw.trim();
+  if (!SESSION_ID_RE.test(sid)) return null;
+  return sid;
+}
+
+/**
  * Returns the next poll delay for attempt index `i` (0-based).
  * Schedule: 100ms, 200ms, 500ms, 1s, 2s, then steady 2s.
  */
@@ -132,6 +170,7 @@ export async function resolveSessionId(
       ? options.claudeJobDir
       : (process.env.CLAUDE_JOB_DIR ?? null);
   const ppid = options.ppid ?? process.ppid;
+  const cwd = options.cwd ?? process.cwd();
   const storagePath = options.storagePath ?? DEFAULT_STORAGE_DIR;
 
   // Fast path: CLAUDE_JOB_DIR is set and contains a usable state.json. Used
@@ -142,12 +181,20 @@ export async function resolveSessionId(
     return fromJobDir;
   }
 
-  // Synchronous attempt before we wait — common case is the breadcrumb is
+  // Synchronous attempts before we wait — common case is a breadcrumb is
   // already on disk because the user already typed at least one message.
+  // PPID lookup is precise and tried first; cwd is only a fallback.
   const immediate = resolveFromBreadcrumb(storagePath, ppid);
   if (immediate) {
     logger.info('Resolved session_id from breadcrumb (immediate)', { sessionId: immediate });
     return immediate;
+  }
+  const immediateCwd = resolveFromCwd(storagePath, cwd);
+  if (immediateCwd) {
+    logger.info('Resolved session_id from cwd breadcrumb (ppid fallback, immediate)', {
+      sessionId: immediateCwd,
+    });
+    return immediateCwd;
   }
 
   const startTime = Date.now();
@@ -183,6 +230,17 @@ export async function resolveSessionId(
         logger.info('Resolved session_id from breadcrumb', { sessionId: sid, elapsedMs: elapsed });
         if (options.signal) options.signal.removeEventListener('abort', onAbort);
         resolvePromise(sid);
+        return;
+      }
+      const sidFromCwd = resolveFromCwd(storagePath, cwd);
+      if (sidFromCwd) {
+        const elapsed = Date.now() - startTime;
+        logger.info('Resolved session_id from cwd breadcrumb (ppid fallback)', {
+          sessionId: sidFromCwd,
+          elapsedMs: elapsed,
+        });
+        if (options.signal) options.signal.removeEventListener('abort', onAbort);
+        resolvePromise(sidFromCwd);
         return;
       }
       const elapsed = Date.now() - startTime;


### PR DESCRIPTION
## Summary

- Native Windows Claude Code sessions (hooks running through Git Bash) never resolved a real `session_id` for the `--stdio` MCP server — the hook collector's PID-keyed breadcrumb never matched the MCP server's own PID, so affected sessions stayed on a synthetic `pending-` ID forever. `sessions/`, dashboard History, weekly summaries, and MODEL PERFORMANCE never populated for those sessions.
- Adds a second breadcrumb, keyed by the sanitized project working directory instead of a PID, written by the hook collector (`writeCwdBreadcrumb`) alongside the existing PID-keyed one. The session resolver (`resolveFromCwd`) falls back to it, on any platform, only when the precise PID-based lookup misses — no behavior change for platforms where PID resolution already works.
- Also fixes a follow-up issue found during review: the cwd-sanitization scheme didn't strip the Windows drive-letter colon (`C:`), which `path.resolve()` can misinterpret as a drive-relative path segment — cross-drive setups (project and storage directory on different drives) could resolve the breadcrumb path outside the intended, permission-secured storage directory. Fixed by stripping `:` too, with regression tests covering the exact scenario.
- Version bumped 1.14.0 → 1.14.1 with a CHANGELOG entry.

Fixes #268

## Test plan

- [x] `npm run build && npm test && npm run lint` all pass
- [x] New unit tests for `writeCwdBreadcrumb()` and `resolveFromCwd()` / fallback-ordering / native-Windows scenario
- [x] Regression tests for the Windows drive-letter colon fix, verified against real `path.win32.resolve` behavior