### PR TITLE
Register generic-mcp self-report MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.2] - 2026-07-24
+
+### Fixed
+
+- **Generic-MCP self-report tools were never reachable** — `nr_observe_report_tool_call`, `nr_observe_report_session_start`, and `nr_observe_report_session_end` were fully implemented on `GenericMcpAdapter` but never registered on the running MCP server, so any client following the generic-MCP setup instructions in `docs/ADAPTERS.md` found no such tools on `tools/list`. They're now registered whenever the server starts in `--stdio` mode, with `nr_observe_report_tool_call` feeding into the same `SessionTracker`/ingest pipeline hook-driven platforms use.
+
 ## [1.14.1] - 2026-07-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import { EfficiencyScorer } from './metrics/efficiency-score.js';
 import { TrendAnalyzer } from './metrics/trend-analyzer.js';
 import { CollaborationProfiler } from './metrics/collaboration-profile.js';
 import { ClaudeMdTracker } from './metrics/claudemd-tracker.js';
-import { createDefaultRegistry } from './platforms/index.js';
+import { createDefaultRegistry, GenericMcpAdapter } from './platforms/index.js';
 import { CostPerOutcomeAnalyzer } from './metrics/cost-per-outcome.js';
 import { PersonalCoach } from './metrics/personal-coach.js';
 import { PromptFeedbackEngine } from './metrics/prompt-feedback.js';
@@ -906,6 +906,11 @@ async function main(): Promise<void> {
     const turnTracker = new TurnTracker();
     const gitEfficiencyTracker = new GitEfficiencyTracker();
     const workflowRunTracker = new WorkflowRunTracker();
+    // Always constructed (cheap, stateless until a client calls one of its
+    // report_* tools) so nr_observe_report_tool_call/_session_start/_session_end
+    // are available on every --stdio connection, matching docs/ADAPTERS.md's
+    // generic-mcp setup instructions.
+    const genericMcpAdapter = new GenericMcpAdapter();
 
     // Read-only filesystem reader for `/api/workflows` routes.
     // Constructed eagerly (not just inside the dashboard block) so when only
@@ -2140,6 +2145,8 @@ async function main(): Promise<void> {
               turnCostAttributor,
               turnTracker,
               gitEfficiencyTracker,
+              genericMcpAdapter,
+              nrIngestManager: nrIngest,
               sessionTraceId: realId,
               sessionStartMs,
               accountId: config!.accountId,
@@ -2212,6 +2219,8 @@ async function main(): Promise<void> {
           turnCostAttributor,
           turnTracker,
           gitEfficiencyTracker,
+          genericMcpAdapter,
+          nrIngestManager: nrIngest,
           sessionTraceId,
           sessionStartMs,
           accountId: config.accountId,

--- a/src/platforms/generic-mcp-adapter.test.ts
+++ b/src/platforms/generic-mcp-adapter.test.ts
@@ -2,6 +2,8 @@ import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals
 import {
   GenericMcpAdapter,
   validateReportToolCallInput,
+  validateReportSessionStartInput,
+  validateReportSessionEndInput,
   REPORT_TOOL_CALL_TOOL,
   REPORT_SESSION_START_TOOL,
   REPORT_SESSION_END_TOOL,
@@ -304,6 +306,81 @@ describe('validateReportToolCallInput', () => {
     expect(result.timestamp).toBe(1000);
     expect(result.error).toBe('timeout');
     expect(result.input).toEqual({ file_path: '/test' });
+  });
+});
+
+describe('validateReportSessionStartInput', () => {
+  it('passes valid input through', () => {
+    const result = validateReportSessionStartInput({
+      platform: 'my-ide',
+      model: 'gpt-4o',
+      developer: 'alice',
+    });
+    expect(result).toEqual({ platform: 'my-ide', model: 'gpt-4o', developer: 'alice' });
+  });
+
+  it('accepts platform alone', () => {
+    const result = validateReportSessionStartInput({ platform: 'my-ide' });
+    expect(result).toEqual({ platform: 'my-ide' });
+  });
+
+  it('rejects null', () => {
+    expect(() => validateReportSessionStartInput(null)).toThrow('Input must be an object');
+  });
+
+  it('rejects non-object', () => {
+    expect(() => validateReportSessionStartInput('string')).toThrow('Input must be an object');
+  });
+
+  it('rejects missing platform', () => {
+    expect(() => validateReportSessionStartInput({})).toThrow('Missing required field: platform');
+  });
+
+  it('rejects empty platform', () => {
+    expect(() => validateReportSessionStartInput({ platform: '' })).toThrow(
+      'Missing required field: platform',
+    );
+  });
+
+  it('rejects non-string model', () => {
+    expect(() => validateReportSessionStartInput({ platform: 'x', model: 42 })).toThrow(
+      'Field model must be a string when present',
+    );
+  });
+
+  it('rejects non-string developer', () => {
+    expect(() => validateReportSessionStartInput({ platform: 'x', developer: 42 })).toThrow(
+      'Field developer must be a string when present',
+    );
+  });
+});
+
+describe('validateReportSessionEndInput', () => {
+  it('passes valid input through', () => {
+    const result = validateReportSessionEndInput({ summary: 'Refactored auth module' });
+    expect(result).toEqual({ summary: 'Refactored auth module' });
+  });
+
+  it('accepts undefined input', () => {
+    expect(validateReportSessionEndInput(undefined)).toEqual({});
+  });
+
+  it('accepts empty object', () => {
+    expect(validateReportSessionEndInput({})).toEqual({});
+  });
+
+  it('rejects null', () => {
+    expect(() => validateReportSessionEndInput(null)).toThrow('Input must be an object');
+  });
+
+  it('rejects non-object', () => {
+    expect(() => validateReportSessionEndInput('string')).toThrow('Input must be an object');
+  });
+
+  it('rejects non-string summary', () => {
+    expect(() => validateReportSessionEndInput({ summary: 42 })).toThrow(
+      'Field summary must be a string when present',
+    );
   });
 });
 

--- a/src/platforms/generic-mcp-adapter.ts
+++ b/src/platforms/generic-mcp-adapter.ts
@@ -121,6 +121,40 @@ export function validateReportToolCallInput(raw: unknown): ReportToolCallInput {
   };
 }
 
+export function validateReportSessionStartInput(raw: unknown): ReportSessionStartInput {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('Input must be an object');
+  }
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.platform !== 'string' || obj.platform.length === 0) {
+    throw new Error('Missing required field: platform');
+  }
+  if (obj.model !== undefined && typeof obj.model !== 'string') {
+    throw new Error('Field model must be a string when present');
+  }
+  if (obj.developer !== undefined && typeof obj.developer !== 'string') {
+    throw new Error('Field developer must be a string when present');
+  }
+  return {
+    platform: obj.platform,
+    ...(obj.model !== undefined && { model: obj.model }),
+    ...(obj.developer !== undefined && { developer: obj.developer }),
+  };
+}
+
+export function validateReportSessionEndInput(raw: unknown): ReportSessionEndInput {
+  if (raw !== undefined && (typeof raw !== 'object' || raw === null)) {
+    throw new Error('Input must be an object');
+  }
+  const obj = (raw ?? {}) as Record<string, unknown>;
+  if (obj.summary !== undefined && typeof obj.summary !== 'string') {
+    throw new Error('Field summary must be a string when present');
+  }
+  return {
+    ...(obj.summary !== undefined && { summary: obj.summary }),
+  };
+}
+
 export class GenericMcpAdapter implements PlatformAdapter {
   readonly platformName = 'generic-mcp';
   readonly visibilityLevel = 'self-reported' as const;

--- a/src/tools/generic-mcp-tools.test.ts
+++ b/src/tools/generic-mcp-tools.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { GenericMcpAdapter } from '../platforms/generic-mcp-adapter.js';
+import { SessionTracker } from '../metrics/session-tracker.js';
+import type { ToolCallRecord } from '../storage/types.js';
+import {
+  handleReportToolCall,
+  handleReportSessionStart,
+  handleReportSessionEnd,
+  registerGenericMcpTools,
+} from './generic-mcp-tools.js';
+
+describe('handleReportToolCall()', () => {
+  it('normalizes input, records to SessionTracker, and calls nrIngestManager.ingestToolCall', () => {
+    const adapter = new GenericMcpAdapter();
+    const sessionTracker = new SessionTracker('sess-1');
+    const ingestToolCall = jest.fn();
+
+    const result = handleReportToolCall(
+      adapter,
+      { tool: 'Read', success: true, duration_ms: 42, input: { file_path: '/a.ts' } },
+      sessionTracker,
+      { ingestToolCall },
+      'sess-1',
+    );
+
+    const body = JSON.parse(result.content[0].text);
+    expect(body.recorded).toBe(true);
+    expect(body.tool).toBe('Read');
+
+    expect(sessionTracker.getMetrics().toolCallCount).toBe(1);
+    expect(ingestToolCall).toHaveBeenCalledTimes(1);
+    const recorded = ingestToolCall.mock.calls[0][0] as ToolCallRecord;
+    expect(recorded.toolName).toBe('Read');
+    expect(recorded.sessionId).toBe('sess-1');
+    expect(recorded.durationMs).toBe(42);
+    expect(recorded.filePath).toBe('/a.ts');
+  });
+
+  it('works with no sessionTracker or nrIngestManager provided', () => {
+    const adapter = new GenericMcpAdapter();
+    const result = handleReportToolCall(
+      adapter,
+      { tool: 'Bash', success: true },
+      undefined,
+      undefined,
+      undefined,
+    );
+    const body = JSON.parse(result.content[0].text);
+    expect(body.recorded).toBe(true);
+    expect(body.tool).toBe('Bash');
+  });
+
+  it('throws on invalid input (missing tool)', () => {
+    const adapter = new GenericMcpAdapter();
+    expect(() =>
+      handleReportToolCall(adapter, { success: true }, undefined, undefined, undefined),
+    ).toThrow('Missing required field: tool');
+  });
+});
+
+describe('handleReportSessionStart()', () => {
+  it('initializes adapter session metadata and returns the resolved platform', () => {
+    const adapter = new GenericMcpAdapter();
+    const result = handleReportSessionStart(adapter, {
+      platform: 'my-ide',
+      model: 'gpt-4o',
+    });
+    const body = JSON.parse(result.content[0].text);
+    expect(body.recorded).toBe(true);
+    expect(body.platform).toBe('my-ide');
+    expect(adapter.getSessionMetadata().model).toBe('gpt-4o');
+  });
+
+  it('throws on missing platform', () => {
+    const adapter = new GenericMcpAdapter();
+    expect(() => handleReportSessionStart(adapter, {})).toThrow('Missing required field: platform');
+  });
+});
+
+describe('handleReportSessionEnd()', () => {
+  it('acknowledges a report with a summary', () => {
+    const result = handleReportSessionEnd({ summary: 'Fixed the bug' });
+    const body = JSON.parse(result.content[0].text);
+    expect(body.recorded).toBe(true);
+    expect(body.summary).toBe('Fixed the bug');
+  });
+
+  it('acknowledges a report with no summary', () => {
+    const result = handleReportSessionEnd(undefined);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.recorded).toBe(true);
+    expect(body.summary).toBeNull();
+  });
+
+  it('throws on invalid summary type', () => {
+    expect(() => handleReportSessionEnd({ summary: 42 })).toThrow(
+      'Field summary must be a string when present',
+    );
+  });
+});
+
+describe('registerGenericMcpTools()', () => {
+  it('lists no tools when genericMcpAdapter is absent', () => {
+    const { tools } = registerGenericMcpTools({});
+    expect(tools).toHaveLength(0);
+  });
+
+  it('lists all three tools when genericMcpAdapter is present', () => {
+    const { tools } = registerGenericMcpTools({ genericMcpAdapter: new GenericMcpAdapter() });
+    const names = tools.map((t) => t.name);
+    expect(names).toEqual([
+      'nr_observe_report_tool_call',
+      'nr_observe_report_session_start',
+      'nr_observe_report_session_end',
+    ]);
+  });
+
+  it('nr_observe_report_tool_call handler returns an explanatory error when adapter is absent', async () => {
+    const { handlers } = registerGenericMcpTools({});
+    const result = await handlers.nr_observe_report_tool_call!({ tool: 'Read', success: true });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.error).toBe('GenericMcpAdapter not available');
+  });
+
+  it('nr_observe_report_tool_call handler returns an error result (not a throw) on invalid input', async () => {
+    const { handlers } = registerGenericMcpTools({ genericMcpAdapter: new GenericMcpAdapter() });
+    const result = await handlers.nr_observe_report_tool_call!({ success: true });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.error).toBe('Missing required field: tool');
+  });
+
+  it('nr_observe_report_session_start handler round-trips through the adapter', async () => {
+    const adapter = new GenericMcpAdapter();
+    const { handlers } = registerGenericMcpTools({ genericMcpAdapter: adapter });
+    const result = await handlers.nr_observe_report_session_start!({ platform: 'custom-ide' });
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.platform).toBe('custom-ide');
+  });
+
+  it('nr_observe_report_session_end handler acknowledges without requiring input', async () => {
+    const { handlers } = registerGenericMcpTools({ genericMcpAdapter: new GenericMcpAdapter() });
+    const result = await handlers.nr_observe_report_session_end!(undefined);
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.recorded).toBe(true);
+  });
+});

--- a/src/tools/generic-mcp-tools.ts
+++ b/src/tools/generic-mcp-tools.ts
@@ -1,0 +1,169 @@
+/**
+ * MCP tool handlers for the generic-mcp self-reported platform (GenericMcpAdapter).
+ *
+ * Defines:
+ *   - `nr_observe_report_tool_call`     — report a non-MCP tool call for tracking/ingest
+ *   - `nr_observe_report_session_start` — initialize session metadata (platform/model/developer)
+ *   - `nr_observe_report_session_end`   — acknowledge session completion
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import type { GenericMcpAdapter } from '../platforms/generic-mcp-adapter.js';
+import {
+  REPORT_TOOL_CALL_TOOL,
+  REPORT_SESSION_START_TOOL,
+  REPORT_SESSION_END_TOOL,
+  validateReportSessionStartInput,
+  validateReportSessionEndInput,
+} from '../platforms/generic-mcp-adapter.js';
+import type { SessionTracker } from '../metrics/session-tracker.js';
+import type { ToolCallRecord } from '../storage/types.js';
+import {
+  errorResult,
+  requireTracker,
+  buildToolSet,
+  type RegisteredToolSet,
+} from './tool-registry.js';
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+export function handleReportToolCall(
+  adapter: GenericMcpAdapter,
+  args: Record<string, unknown> | undefined,
+  sessionTracker: SessionTracker | undefined,
+  nrIngestManager: { ingestToolCall(record: ToolCallRecord): void } | undefined,
+  sessionTraceId: string | undefined,
+) {
+  const normalized = adapter.normalizeToolCall(args ?? {});
+
+  const record: ToolCallRecord = {
+    id: randomUUID(),
+    sessionId: sessionTraceId ?? null,
+    toolName: normalized.toolName,
+    toolUseId: randomUUID(),
+    timestamp: normalized.timestamp,
+    durationMs: normalized.durationMs,
+    success: normalized.success,
+    ...(normalized.error !== undefined && { error: normalized.error }),
+    ...(normalized.inputSizeBytes !== undefined && { inputSizeBytes: normalized.inputSizeBytes }),
+    ...(normalized.outputSizeBytes !== undefined && {
+      outputSizeBytes: normalized.outputSizeBytes,
+    }),
+    ...(normalized.filePath !== undefined && { filePath: normalized.filePath }),
+    ...(normalized.command !== undefined && { command: normalized.command }),
+  };
+
+  sessionTracker?.recordToolCall(record);
+  nrIngestManager?.ingestToolCall(record);
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          { recorded: true, tool: record.toolName, timestamp: record.timestamp },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+export function handleReportSessionStart(
+  adapter: GenericMcpAdapter,
+  args: Record<string, unknown> | undefined,
+) {
+  const input = validateReportSessionStartInput(args ?? {});
+  adapter.handleSessionStart(input);
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          { recorded: true, platform: adapter.getSessionMetadata().platform },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+export function handleReportSessionEnd(args: Record<string, unknown> | undefined) {
+  const input = validateReportSessionEndInput(args);
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ recorded: true, summary: input.summary ?? null }, null, 2),
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export interface GenericMcpToolsDeps {
+  genericMcpAdapter?: GenericMcpAdapter;
+  sessionTracker?: SessionTracker;
+  nrIngestManager?: { ingestToolCall(record: ToolCallRecord): void };
+  sessionTraceId?: string;
+}
+
+export function registerGenericMcpTools(deps: GenericMcpToolsDeps): RegisteredToolSet {
+  return buildToolSet([
+    {
+      definition: REPORT_TOOL_CALL_TOOL,
+      available: !!deps.genericMcpAdapter,
+      handle: (args) => {
+        const check = requireTracker(deps.genericMcpAdapter, 'GenericMcpAdapter');
+        if (!check.ok) return check.result;
+        try {
+          return handleReportToolCall(
+            check.value,
+            args,
+            deps.sessionTracker,
+            deps.nrIngestManager,
+            deps.sessionTraceId,
+          );
+        } catch (err) {
+          return errorResult(err instanceof Error ? err.message : String(err));
+        }
+      },
+    },
+    {
+      definition: REPORT_SESSION_START_TOOL,
+      available: !!deps.genericMcpAdapter,
+      handle: (args) => {
+        const check = requireTracker(deps.genericMcpAdapter, 'GenericMcpAdapter');
+        if (!check.ok) return check.result;
+        try {
+          return handleReportSessionStart(check.value, args);
+        } catch (err) {
+          return errorResult(err instanceof Error ? err.message : String(err));
+        }
+      },
+    },
+    {
+      definition: REPORT_SESSION_END_TOOL,
+      available: !!deps.genericMcpAdapter,
+      handle: (args) => {
+        const check = requireTracker(deps.genericMcpAdapter, 'GenericMcpAdapter');
+        if (!check.ok) return check.result;
+        try {
+          return handleReportSessionEnd(args);
+        } catch (err) {
+          return errorResult(err instanceof Error ? err.message : String(err));
+        }
+      },
+    },
+  ]);
+}

--- a/src/tools/session-stats.test.ts
+++ b/src/tools/session-stats.test.ts
@@ -12,6 +12,7 @@ import { BudgetTracker } from '../metrics/budget-tracker.js';
 import { ContextWindowTracker } from '../metrics/context-window-tracker.js';
 import { TaskDetector } from '../metrics/task-detector.js';
 import { SessionStore } from '../storage/session-store.js';
+import { GenericMcpAdapter } from '../platforms/generic-mcp-adapter.js';
 import { FeedbackCollector } from './workflow-tools.js';
 import {
   handleGetSessionStats,
@@ -1044,5 +1045,83 @@ describe('MCP protocol integration — direct registerTools() dispatch', () => {
     const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
     expect(body).toEqual(contextWindowTracker.getMetrics());
     expect(body.repeatedReadCount).toBe(1);
+  });
+
+  it('tools/list omits generic-mcp report tools when genericMcpAdapter is absent', async () => {
+    await connectDirect({});
+    const result = await client.listTools();
+    const names = result.tools.map((t) => t.name);
+    expect(names).not.toContain('nr_observe_report_tool_call');
+    expect(names).not.toContain('nr_observe_report_session_start');
+    expect(names).not.toContain('nr_observe_report_session_end');
+  });
+
+  it('tools/list includes generic-mcp report tools when genericMcpAdapter is provided', async () => {
+    await connectDirect({ genericMcpAdapter: new GenericMcpAdapter() });
+    const result = await client.listTools();
+    const names = result.tools.map((t) => t.name);
+    expect(names).toContain('nr_observe_report_tool_call');
+    expect(names).toContain('nr_observe_report_session_start');
+    expect(names).toContain('nr_observe_report_session_end');
+  });
+
+  it('calling nr_observe_report_tool_call records to SessionTracker and NrIngestManager', async () => {
+    const sessionTracker = new SessionTracker('gm-sess');
+    const ingestToolCall = jest.fn();
+    await connectDirect({
+      genericMcpAdapter: new GenericMcpAdapter(),
+      sessionTracker,
+      nrIngestManager: { ingestToolCall },
+      sessionTraceId: 'gm-sess',
+    });
+
+    const result = await client.callTool({
+      name: 'nr_observe_report_tool_call',
+      arguments: { tool: 'Read', success: true, duration_ms: 12 },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.recorded).toBe(true);
+    expect(body.tool).toBe('Read');
+    expect(sessionTracker.getMetrics().toolCallCount).toBe(1);
+    expect(ingestToolCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('calling nr_observe_report_tool_call with invalid input returns an error, not a thrown exception', async () => {
+    await connectDirect({ genericMcpAdapter: new GenericMcpAdapter() });
+    const result = await client.callTool({
+      name: 'nr_observe_report_tool_call',
+      arguments: { success: true },
+    });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.error).toBe('Missing required field: tool');
+  });
+
+  it('calling nr_observe_report_session_start updates adapter session metadata', async () => {
+    const adapter = new GenericMcpAdapter();
+    await connectDirect({ genericMcpAdapter: adapter });
+
+    const result = await client.callTool({
+      name: 'nr_observe_report_session_start',
+      arguments: { platform: 'my-custom-ide', model: 'gpt-4o' },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.platform).toBe('my-custom-ide');
+    expect(adapter.getSessionMetadata().model).toBe('gpt-4o');
+  });
+
+  it('calling nr_observe_report_session_end acknowledges without requiring arguments', async () => {
+    await connectDirect({ genericMcpAdapter: new GenericMcpAdapter() });
+    const result = await client.callTool({
+      name: 'nr_observe_report_session_end',
+      arguments: {},
+    });
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.recorded).toBe(true);
   });
 });

--- a/src/tools/session-stats.ts
+++ b/src/tools/session-stats.ts
@@ -54,6 +54,8 @@ import type { TurnTracker } from '../metrics/turn-tracker.js';
 import type { GitEfficiencyTracker } from '../metrics/git-efficiency-tracker.js';
 import { registerAnalyticsTools } from './analytics-tools.js';
 import { registerExtendedAnalyticsTools } from './extended-analytics-tools.js';
+import { registerGenericMcpTools } from './generic-mcp-tools.js';
+import type { GenericMcpAdapter } from '../platforms/generic-mcp-adapter.js';
 import {
   requireTracker,
   requireAvailable,
@@ -384,6 +386,8 @@ export interface ToolRegistrationOptions {
   turnCostAttributor?: TurnCostAttributor;
   turnTracker?: TurnTracker;
   gitEfficiencyTracker?: GitEfficiencyTracker;
+  genericMcpAdapter?: GenericMcpAdapter;
+  nrIngestManager?: { ingestToolCall(record: import('../storage/types.js').ToolCallRecord): void };
   sessionTraceId?: string;
   sessionStartMs?: number;
   accountId?: string;
@@ -572,6 +576,7 @@ export function registerTools(server: Server, options: ToolRegistrationOptions):
     registerCrossSessionTools(options),
     registerAnalyticsTools(options),
     registerExtendedAnalyticsTools(options),
+    registerGenericMcpTools(options),
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));


### PR DESCRIPTION
## Summary
- `GenericMcpAdapter`'s three self-report MCP tools (`nr_observe_report_tool_call`, `nr_observe_report_session_start`, `nr_observe_report_session_end`) were fully defined but never registered on the running server — a caller following `docs/ADAPTERS.md`'s generic-mcp setup instructions found no such tools existed (#270).
- Adds `validateReportSessionStartInput`/`validateReportSessionEndInput` to `GenericMcpAdapter`, a new `src/tools/generic-mcp-tools.ts` with the three tool handlers, and wires them into `registerTools()` (`session-stats.ts`) and `main()` (`index.ts`) — `nr_observe_report_tool_call` now feeds `SessionTracker.recordToolCall()` and (when present) `NrIngestManager.ingestToolCall()`, the same pipeline hook-driven platforms use.
- Version sync: bumps to 1.14.2 with a matching CHANGELOG entry

## Test plan
- [x] `npm test` — 5117 passed, 0 failed
- [x] `npm run build` — clean
- [x] Manual end-to-end `--stdio` JSON-RPC smoke test: `tools/list` now includes all three tools; `tools/call` round-trips correctly, including a clean structured error for invalid input

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)