### PR TITLE
Fix: GC .subagent-pos-*/.transcript-pos-* cursor files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.3] - 2026-07-24
+
+### Fixed
+
+- **Subagent and transcript cursor files were never garbage-collected** — `.subagent-pos-<sessionId>-<agentId>` (written once per spawned subagent, including workflow-spawned agents) and `.transcript-pos-<sessionId>` files in the storage root accumulated indefinitely; heavy subagent or workflow usage could leave thousands of small files behind with no cleanup path. The periodic maintenance sweep now removes a subagent cursor once its parent session is no longer active and the cursor is older than the watcher's cold-scan window, and removes a transcript cursor once its session is no longer active and no companion buffer file remains for it.
+
 ## [1.14.2] - 2026-07-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.2",
+      "version": "1.14.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -758,6 +758,10 @@ describe('stdio integration', () => {
       JSON.stringify({ linkScanPath: '/tmp/stdio-test-session.jsonl' }),
     );
 
+    // Isolate storage to a temp directory to prevent GC operations from
+    // affecting the real ~/.newrelic-preflight storage.
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-stdio-storage-'));
+
     const transport = new StdioClientTransport({
       command: 'node',
       args: [binPath, '--stdio'],
@@ -771,6 +775,7 @@ describe('stdio integration', () => {
         NR_AI_DASHBOARD_PORT: '0',
         CLAUDE_JOB_DIR: tmpJobDir,
         NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
       },
     });
 
@@ -792,6 +797,7 @@ describe('stdio integration', () => {
       await client.close();
     } finally {
       rmSync(tmpJobDir, { recursive: true, force: true });
+      rmSync(tmpStoragePath, { recursive: true, force: true });
     }
   }, 30000);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,11 +285,14 @@ export interface MaintenanceGcDeps {
   readonly liveSessionRegistry: LiveSessionRegistry | undefined;
 }
 
+/** Default cold-scan window for SubagentWatcher/WorkflowWatcher — mirrors DEFAULT_DISCOVERY_HOURS in subagent-watcher.ts. */
+const WATCHER_DISCOVERY_HOURS_DEFAULT = 24;
+
 /**
- * One orphan-buffer/breadcrumb/dead-instance GC pass. `gcOrphanBuffers()` is
- * rename-based, so concurrent processes each running this independently just
- * means an occasional benign "already moved" warning — no leader election
- * needed to call this from every process.
+ * One orphan-buffer/breadcrumb/dead-instance/cursor-file GC pass.
+ * `gcOrphanBuffers()` is rename-based, so concurrent processes each running
+ * this independently just means an occasional benign "already moved"
+ * warning — no leader election needed to call this from every process.
  */
 export function runMaintenanceGcPass(deps: MaintenanceGcDeps): void {
   const log = createLogger('mcp-cli');
@@ -304,6 +307,10 @@ export function runMaintenanceGcPass(deps: MaintenanceGcDeps): void {
       }
     }
     localStore.gcOrphanBuffers(live);
+    const envHours = parseInt(process.env.NR_AI_WATCHER_DISCOVERY_HOURS ?? '', 10);
+    const discoveryHours =
+      Number.isFinite(envHours) && envHours > 0 ? envHours : WATCHER_DISCOVERY_HOURS_DEFAULT;
+    localStore.gcWatcherCursors(live, discoveryHours);
   } catch (err) {
     log.warn('GC pass failed', { error: String(err) });
   }

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -969,6 +969,120 @@ describe('LocalStore', () => {
     });
   });
 
+  describe('gcWatcherCursors()', () => {
+    const PARENT_SESSION = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const AGENT_ID = 'a1234567890abcdef';
+    const OTHER_SESSION = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
+
+    function makeCursorFile(name: string, mtimeMs?: number): string {
+      const path = resolve(tmpDir, name);
+      writeFileSync(path, JSON.stringify({ bytePos: 0, partialLine: '' }));
+      if (mtimeMs !== undefined) {
+        const date = new Date(mtimeMs);
+        utimesSync(path, date, date);
+      }
+      return path;
+    }
+
+    it('preserves a subagent cursor whose parent session is live, regardless of mtime', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const path = makeCursorFile(
+        `.subagent-pos-${PARENT_SESSION}-${AGENT_ID}`,
+        Date.now() - 48 * 60 * 60 * 1000,
+      );
+
+      const store = new LocalStore(tmpDir);
+      const result = store.gcWatcherCursors(new Set([PARENT_SESSION]), 24);
+
+      expect(result.subagentCursors).toBe(0);
+      expect(existsSync(path)).toBe(true);
+    });
+
+    it('preserves a dead-session subagent cursor with recent mtime', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const path = makeCursorFile(`.subagent-pos-${PARENT_SESSION}-${AGENT_ID}`);
+
+      const store = new LocalStore(tmpDir);
+      const result = store.gcWatcherCursors(new Set(), 24);
+
+      expect(result.subagentCursors).toBe(0);
+      expect(existsSync(path)).toBe(true);
+    });
+
+    it('deletes a dead-session subagent cursor older than the discovery window', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const path = makeCursorFile(
+        `.subagent-pos-${PARENT_SESSION}-${AGENT_ID}`,
+        Date.now() - 48 * 60 * 60 * 1000,
+      );
+
+      const store = new LocalStore(tmpDir);
+      const result = store.gcWatcherCursors(new Set(), 24);
+
+      expect(result.subagentCursors).toBe(1);
+      expect(existsSync(path)).toBe(false);
+    });
+
+    it('preserves a transcript cursor while its companion buffer file exists', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(resolve(tmpDir, `buffer-${OTHER_SESSION}.jsonl`), '');
+      const path = makeCursorFile(
+        `.transcript-pos-${OTHER_SESSION}`,
+        Date.now() - 48 * 60 * 60 * 1000,
+      );
+
+      const store = new LocalStore(tmpDir);
+      const result = store.gcWatcherCursors(new Set(), 24);
+
+      expect(result.transcriptCursors).toBe(0);
+      expect(existsSync(path)).toBe(true);
+    });
+
+    it('deletes a dead-session transcript cursor once its buffer file is gone', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const path = makeCursorFile(`.transcript-pos-${OTHER_SESSION}`);
+
+      const store = new LocalStore(tmpDir);
+      const result = store.gcWatcherCursors(new Set(), 24);
+
+      expect(result.transcriptCursors).toBe(1);
+      expect(existsSync(path)).toBe(false);
+    });
+
+    it('preserves a transcript cursor whose session is live even with no buffer file', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const path = makeCursorFile(`.transcript-pos-${OTHER_SESSION}`);
+
+      const store = new LocalStore(tmpDir);
+      const result = store.gcWatcherCursors(new Set([OTHER_SESSION]), 24);
+
+      expect(result.transcriptCursors).toBe(0);
+      expect(existsSync(path)).toBe(true);
+    });
+
+    it('ignores malformed cursor filenames', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(resolve(tmpDir, '.subagent-pos-not-a-valid-agent-id'), '{}');
+      writeFileSync(resolve(tmpDir, '.transcript-pos-'), '{}');
+
+      const store = new LocalStore(tmpDir);
+      const result = store.gcWatcherCursors(new Set(), 24);
+
+      expect(result).toEqual({ subagentCursors: 0, transcriptCursors: 0 });
+      expect(existsSync(resolve(tmpDir, '.subagent-pos-not-a-valid-agent-id'))).toBe(true);
+      expect(existsSync(resolve(tmpDir, '.transcript-pos-'))).toBe(true);
+    });
+
+    it('returns zeros when storage path does not exist', () => {
+      const missing = resolve(tmpDir, 'nonexistent');
+      const store = new LocalStore(missing);
+      expect(store.gcWatcherCursors(new Set(), 24)).toEqual({
+        subagentCursors: 0,
+        transcriptCursors: 0,
+      });
+    });
+  });
+
   describe('getActiveSessionIdsFromHeartbeats()', () => {
     it('returns sessionIds whose PID is alive and skips dead ones', () => {
       mkdirSync(tmpDir, { recursive: true });

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -16,6 +16,8 @@ import type { HookEvent, AuditEntry } from './types.js';
 const logger = createLogger('local-store');
 
 const SESSION_ID_RE = /^[a-zA-Z0-9_-]{1,128}$/;
+const SUBAGENT_CURSOR_RE = /^\.subagent-pos-(.+)-(a[a-f0-9]{16})$/;
+const TRANSCRIPT_CURSOR_RE = /^\.transcript-pos-(.+)$/;
 
 /**
  * A buffer file is treated as orphan when its mtime is older than this AND
@@ -642,6 +644,87 @@ export class LocalStore {
     }
 
     return { archived, staleHeartbeats };
+  }
+
+  /**
+   * Garbage-collect SubagentWatcher and transcript-collector cursor files that
+   * can never be revisited:
+   *
+   *   - `.subagent-pos-<parentSessionId>-<agentId>`: removed once its parent
+   *     session is no longer live AND the cursor's mtime is older than
+   *     `discoveryHours` — past that window `SubagentWatcher.discoverFiles()`
+   *     will never cold-scan the corresponding transcript again, so the
+   *     cursor is dead by construction. Losing it costs at most one re-read
+   *     from byte 0 on a transcript that no longer exists, which downstream
+   *     dedupes by (agent_id, message.id).
+   *   - `.transcript-pos-<sessionId>`: removed once its session is no longer
+   *     live AND no `buffer-<sessionId>.jsonl` remains for it.
+   *
+   * @returns counts of each cursor kind removed
+   */
+  gcWatcherCursors(
+    activeSessionIds: ReadonlySet<string>,
+    discoveryHours: number,
+  ): { subagentCursors: number; transcriptCursors: number } {
+    if (!existsSync(this.storagePath)) {
+      return { subagentCursors: 0, transcriptCursors: 0 };
+    }
+    let entries: string[];
+    try {
+      entries = readdirSync(this.storagePath);
+    } catch (err) {
+      logger.warn('Failed to enumerate storage path for gcWatcherCursors', {
+        error: String(err),
+      });
+      return { subagentCursors: 0, transcriptCursors: 0 };
+    }
+
+    const cutoffMs = Date.now() - discoveryHours * 60 * 60 * 1000;
+    const bufferNames = new Set(
+      entries.filter((n) => n.startsWith('buffer-') && n.endsWith('.jsonl')),
+    );
+
+    let subagentCursors = 0;
+    let transcriptCursors = 0;
+
+    for (const name of entries) {
+      const subagentMatch = SUBAGENT_CURSOR_RE.exec(name);
+      if (subagentMatch) {
+        const parentSessionId = subagentMatch[1];
+        if (!SESSION_ID_RE.test(parentSessionId)) continue;
+        if (activeSessionIds.has(parentSessionId)) continue;
+        const path = resolve(this.storagePath, name);
+        try {
+          if (statSync(path).mtimeMs >= cutoffMs) continue;
+          unlinkSync(path);
+          subagentCursors++;
+        } catch (err) {
+          logger.debug('Failed to delete stale subagent cursor', { error: String(err) });
+        }
+        continue;
+      }
+
+      const transcriptMatch = TRANSCRIPT_CURSOR_RE.exec(name);
+      if (transcriptMatch) {
+        const sessionId = transcriptMatch[1];
+        if (!SESSION_ID_RE.test(sessionId)) continue;
+        if (activeSessionIds.has(sessionId)) continue;
+        if (bufferNames.has(`buffer-${sessionId}.jsonl`)) continue;
+        const path = resolve(this.storagePath, name);
+        try {
+          unlinkSync(path);
+          transcriptCursors++;
+        } catch (err) {
+          logger.debug('Failed to delete stale transcript cursor', { error: String(err) });
+        }
+      }
+    }
+
+    if (subagentCursors > 0 || transcriptCursors > 0) {
+      logger.info('Cleaned up watcher cursor files', { subagentCursors, transcriptCursors });
+    }
+
+    return { subagentCursors, transcriptCursors };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds `LocalStore.gcWatcherCursors()`, which garbage-collects `.subagent-pos-<parentSessionId>-<agentId>` and `.transcript-pos-<sessionId>` cursor files in the storage root — previously neither the periodic maintenance sweep nor the retention sweep touched them, so they accumulated forever (one `.subagent-pos-*` file per spawned subagent, including workflow-spawned agents).
- Wires the new method into the existing 5-minute maintenance GC pass, reusing the same live-session-id set already built for the sibling orphan-buffer GC.
- Also fixes a pre-existing test-isolation gap: the first `stdio integration` test in `src/index.test.ts` spawned the real compiled binary without a storage-path override, which meant every `npm test` run performed real GC operations against the developer's actual local storage directory. Isolated with the same temp-dir override pattern already used by the neighboring test.

Closes #281

## Test plan
- [x] `npm run build && npm test` passes
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] New `gcWatcherCursors()` unit tests cover: live session preserved regardless of mtime; dead session + recent mtime preserved; dead session + old mtime deleted; transcript cursor preserved while its buffer exists; transcript cursor deleted once buffer is gone; transcript cursor preserved while its session is live even with no buffer; malformed filenames ignored; missing storage dir returns zeros
- [x] Confirmed the real local storage directory's file count is unchanged before/after `npm test`