### PR TITLE
Docs: Add Starlight frontmatter to reference docs (#316)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+---
+title: Contributing
+description: Environment setup, architecture, code conventions, testing, and how to verify changes end-to-end.
+---
+
 # Contributing to NR AI Coding Observability: Preflight
 
 This guide covers everything you need to get productive in this repo: environment setup, project architecture, code conventions, testing, and how to verify your changes end-to-end.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -1,3 +1,8 @@
+---
+title: Platform Adapters
+description: Per-platform reference for what each Preflight adapter can and can't observe, detection, setup, and known gaps.
+---
+
 # Platform Adapters
 
 Preflight supports 16 named AI coding platforms plus a generic MCP fallback, each via a `PlatformAdapter` in `src/platforms/`. Adapters differ in one fundamental way: **what the platform actually exposes to a third-party observer.** Some platforms have a real hook/callback mechanism that fires on every built-in tool call; others only support MCP as a client, which means Preflight can see calls the platform's agent chooses to make to Preflight's own tools, but never a callback for the platform's _built-in_ tools (file reads, edits, terminal commands, etc).

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -1,3 +1,8 @@
+---
+title: Advanced Configuration
+description: Power-user features — OTLP export, proxy mode, local alerts, per-developer alerts, session backfill, and Terraform deployment.
+---
+
 # NR AI Coding Observability: Preflight — Advanced Configuration
 
 Power-user features: OTLP export, proxy mode, local alerts, per-developer alerts, session backfill, and Terraform deployment.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,8 @@
+---
+title: Architecture
+description: How Preflight collects, processes, and ships telemetry as a sidecar to your AI coding session.
+---
+
 # Preflight Architecture
 
 Preflight runs as a sidecar to your AI coding session. It collects hook events from the AI client, processes them into structured records, feeds metric trackers, and flushes telemetry to New Relic — all without interfering with the AI client itself.

--- a/docs/COMMANDS_TABLE.md
+++ b/docs/COMMANDS_TABLE.md
@@ -1,3 +1,8 @@
+---
+title: MCP Commands Reference
+description: Every MCP tool Preflight exposes, what it returns, and which trackers it queries.
+---
+
 # NR AI Coding Observability: Preflight — MCP Commands Reference
 
 Every MCP tool exposed by the `preflight`, what it returns, how it computes each finding, and which trackers it queries.

--- a/docs/METRICS_TABLE.md
+++ b/docs/METRICS_TABLE.md
@@ -1,3 +1,8 @@
+---
+title: Metrics Reference
+description: Every metric and event Preflight sends to New Relic, organized by delivery API and source package.
+---
+
 # NR AI Coding Observability: Preflight — Metrics Reference
 
 Every metric and event that this project sends to New Relic, organized by delivery API and source package.

--- a/docs/TEST_PATTERNS.md
+++ b/docs/TEST_PATTERNS.md
@@ -1,3 +1,8 @@
+---
+title: Test Patterns
+description: Testing conventions, infrastructure, and patterns used in this repo.
+---
+
 # NR AI Coding Observability: Preflight — Test Patterns
 
 This document covers the testing conventions, infrastructure, and patterns used in this repo. Read this before writing your first test.


### PR DESCRIPTION
Part of #288

Adds title/description YAML frontmatter to the 6 docs/*.md reference files and CONTRIBUTING.md, so they render correctly for the docs site in #285. Content bodies unchanged.

This unblocks #285's build, which currently fails on these files' missing frontmatter.