### PR TITLE
Fix: Correct PRIVACY.md's inaccurate ai.collaboration.* transmission claims

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -13,8 +13,11 @@ The following is written to `~/.newrelic-preflight/` on the developer's machine 
 - Bash commands executed, after credential-pattern redaction.
 - Session-level counts: tool calls, files touched, session duration, token usage (counts only — not message text).
 - An audit log of every tool invocation, including flags for sensitive file access (`.env`, `.pem`, SSH keys) and destructive commands.
+- A per-developer collaboration profile — behavioral scores (specificity, autonomy, correction rate, task complexity) and a classification label (`"Power User"`, `"Delegator"`, `"Learning"`, or `"Collaborative"`) — computed on demand from local session history. Returned only to your own AI assistant when it calls the `nr_observe_get_collaboration_profile` MCP tool. This is never transmitted to New Relic, in any mode.
 
 Local storage uses restrictive permissions (`0o700` directories, `0o600` files). See [SECURITY.md](./SECURITY.md) for details on file system safety and redaction patterns.
+
+**A note on behavioral classification data:** the collaboration profile above differs from the rest of this list in what it characterizes — rather than recording what the AI assistant did, it's an inferred characterization of how a developer works. It stays local and is never queryable from a New Relic account, but organizations deploying this tool in a workplace context may still want to determine whether internal policy governs locally-computed behavioral characterizations of individual developers, independently of this document's cloud-telemetry guidance below.
 
 ---
 
@@ -22,25 +25,24 @@ Local storage uses restrictive permissions (`0o700` directories, `0o600` files).
 
 When `mode` is `cloud` or `both`, the following is transmitted to New Relic as custom events and metrics. The table below notes the privacy implication of each field — not just what it is, but why it warrants review before enabling.
 
-| Field                 | NR Event / Metric                               | Privacy note                                                                                                                                                                                           |
-| --------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Developer identifier  | All events, `developer` dimension               | Defaults to the OS username (`$USER`) or `git config user.name`. This is a real person's identifier attached to every event and metric in the account.                                                 |
-| Working directory     | `AiToolCall.cwd`                                | An absolute path that typically embeds the OS username (e.g. `/Users/jjang/...`).                                                                                                                      |
-| File paths            | `AiToolCall.filePath`, `AiAuditEvent.file_path` | Absolute paths for every file the AI reads, writes, or edits. May embed usernames and reveal project structure.                                                                                        |
-| Bash commands         | `AiToolCall.command`                            | Full command string after credential-pattern redaction. May contain hostnames, usernames in arguments, or internal service names.                                                                      |
-| Grep patterns         | `AiToolCall.pattern`                            | Search terms the AI used in the codebase. Can reveal what the AI was looking for, which may be sensitive.                                                                                              |
-| Agent descriptions    | `AiToolCall.agentDescription`                   | Free-text description of spawned sub-agent tasks. User-authored; no content scanning beyond credential redaction.                                                                                      |
-| Task subjects         | `AiToolCall.taskSubject`                        | Free-text subject from task creation. User-authored; may contain project names, customer references, or ticket numbers.                                                                                |
-| Session metrics       | `ai.session.*`                                  | Per-developer duration, file counts, cost in USD, efficiency scores.                                                                                                                                   |
-| Audit events          | `AiAuditEvent`, `SecurityAlert`                 | Every classified tool call; security alerts include the triggering file path or command.                                                                                                               |
-| Collaboration profile | `ai.collaboration.*`                            | Behavioral scores per developer (specificity, autonomy, correction rate, task complexity) and a classification label. Emitted with the `developer` dimension, queryable by any user in the NR account. |
-| Repository identifier | `project_id`                                    | Inferred from `git remote get-url origin` (e.g. `org/repo`) unless set explicitly. May expose internal repository names.                                                                               |
+| Field                 | NR Event / Metric                               | Privacy note                                                                                                                                           |
+| --------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Developer identifier  | All events, `developer` dimension               | Defaults to the OS username (`$USER`) or `git config user.name`. This is a real person's identifier attached to every event and metric in the account. |
+| Working directory     | `AiToolCall.cwd`                                | An absolute path that typically embeds the OS username (e.g. `/Users/jjang/...`).                                                                      |
+| File paths            | `AiToolCall.filePath`, `AiAuditEvent.file_path` | Absolute paths for every file the AI reads, writes, or edits. May embed usernames and reveal project structure.                                        |
+| Bash commands         | `AiToolCall.command`                            | Full command string after credential-pattern redaction. May contain hostnames, usernames in arguments, or internal service names.                      |
+| Grep patterns         | `AiToolCall.pattern`                            | Search terms the AI used in the codebase. Can reveal what the AI was looking for, which may be sensitive.                                              |
+| Agent descriptions    | `AiToolCall.agentDescription`                   | Free-text description of spawned sub-agent tasks. User-authored; no content scanning beyond credential redaction.                                      |
+| Task subjects         | `AiToolCall.taskSubject`                        | Free-text subject from task creation. User-authored; may contain project names, customer references, or ticket numbers.                                |
+| Session metrics       | `ai.session.*`                                  | Per-developer duration, file counts, cost in USD, efficiency scores.                                                                                   |
+| Audit events          | `AiAuditEvent`, `SecurityAlert`                 | Every classified tool call; security alerts include the triggering file path or command.                                                               |
+| Repository identifier | `project_id`                                    | Inferred from `git remote get-url origin` (e.g. `org/repo`) unless set explicitly. May expose internal repository names.                               |
 
 ---
 
 ## Who Can See This Data in Your New Relic Account
 
-Data sent to New Relic is visible to any user in the target account who has NRQL query access. This includes the `developer` identifier, individual file paths and commands in `AiAuditEvent`, and the per-developer collaboration profile metrics.
+Data sent to New Relic is visible to any user in the target account who has NRQL query access. This includes the `developer` identifier and individual file paths and commands in `AiAuditEvent`.
 
 Before enabling cloud telemetry, review who has access to the account and what query permissions they hold. New Relic's user management documentation is here:
 


### PR DESCRIPTION
Closes #290

## Summary

Prompted by #278, which added privacy guidance for the `ai.collaboration.*` behavioral-classification data (specificity/autonomy/correction-rate/task-complexity, plus a "Power User"/"Delegator"/"Learning"/"Collaborative" classification label). While reviewing #278, I traced the actual code and found the premise it built on — and two statements already in `PRIVACY.md` before #278 ever touched it — don't match reality:

- `CollaborationProfiler.emitMetrics()` (`src/metrics/collaboration-profile.ts`) is never called anywhere in the running server. The real harvest loop (`src/transport/nr-ingest.ts:1270-1272`) only emits `costTracker`, `efficiencyScorer`, and `feedbackCollector`.
- Every real use of `collaborationProfiler` only backs local MCP tools (`nr_observe_get_collaboration_profile` and the recommendation/prompt-feedback engines that read from it) — never routed through `src/transport/` or `src/shared/events/`.
- `docs/METRICS_TABLE.md` (this project's own canonical "every metric sent to New Relic" reference) has zero mentions of `ai.collaboration`.

**This data never reaches New Relic today, in any mode.** `PRIVACY.md` said otherwise in two places — the data-inventory table (`Collaboration profile | ai.collaboration.*`) and the "Who Can See This Data" section — both predating #278.

## What this PR does

- Removes both inaccurate statements.
- Moves an accurate description into "What Is Always Collected (Local Only by Default)": this data is computed on demand from local session history and returned only to your own AI assistant via `nr_observe_get_collaboration_profile` — never transmitted.
- Keeps the part of #278's contribution that's still worth preserving: the observation that behavioral characterization of individual developers is a distinct, sensitive category worth flagging for organizational policy review — reframed accurately (local computation, not cloud exposure).

## Why not just merge #278 with edits

#278's new sections and checklist items are built entirely on the premise that this data is cloud-bound (`mode: 'local'` "prevents this data from being transmitted", visibility to "any user in the NR account", etc.) — since that premise doesn't hold, most of that specific framing doesn't carry over. The underlying instinct — that this category of data deserves explicit privacy documentation — was correct and is preserved here, just grounded in what the code actually does.

## Test plan

- [x] `npx prettier --check PRIVACY.md` passes
- [x] Re-verified the "never emitted" claim via four independent checks: no call to `collaborationProfiler.emitMetrics()` anywhere in `src/`, no inline emission of collaboration/specificity/autonomy data in `src/transport/` or `src/shared/`, the MCP tool handler has no side effects, and `docs/METRICS_TABLE.md`/`docs/COMMANDS_TABLE.md` are silent on cloud transmission for this tool