### PR TITLE
Fix: Reject SSRF-vulnerable hosts on outbound NR ingest requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.5] - 2026-07-29
+
+### Security
+
+- Outbound HTTP requests to the configured New Relic ingest endpoint are now validated against the same SSRF guard used for OTLP endpoints, rejecting cloud-metadata and private/loopback hosts before sending.
+- OTLP endpoint validation now rejects cloud-metadata hosts under any scheme, and rejects plaintext `http://` to private-network hosts (previously only logged a warning) — use `https://` for a non-loopback collector.
+
+### Changed
+
+- Unified the `highSecurity` → `recordContent` gate behind a single helper function; no behavior change.
+- Updated `BatchLogRecordProcessor` construction for the current OpenTelemetry Logs SDK API, and bumped the OpenTelemetry logs/exporter family (`sdk-logs`, `exporter-logs-otlp-http`, `exporter-metrics-otlp-http`, `exporter-trace-otlp-http`) from 0.219.0 to 0.221.0 to match.
+
 ## [1.14.4] - 2026-07-29
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.4",
+      "version": "1.14.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.219.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.221.0",
         "@opentelemetry/resources": "2.10.0",
-        "@opentelemetry/sdk-logs": "0.219.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
         "@opentelemetry/sdk-metrics": "2.10.0",
         "@opentelemetry/sdk-trace-node": "2.10.0",
         "commander": "15.0.0",
@@ -1646,9 +1646,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
-      "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -1685,16 +1685,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.219.0.tgz",
-      "integrity": "sha512-mhl2HL6GmZI8b8PwPfqMws/5ovJfbRTxwc9Y5agVVHiQ+e5SL1btsFr/kJDgt7YCexDtsUn5HAreHQO9szFS0A==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-nKXkr4Tomi6fjYVOf+ytcW3dZAVr4v4Bv5gsT6dr2gvpUPJpKgHB4XbMufMsPotRE3g0XH2GwVVCkN2w6SON+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.219.0",
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.219.0",
-        "@opentelemetry/otlp-transformer": "0.219.0",
-        "@opentelemetry/sdk-logs": "0.219.0"
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-logs": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1704,67 +1702,33 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.219.0.tgz",
-      "integrity": "sha512-6CaDRbMVHZSDWzNXwrR8y/H4B/Z1eMNnkHiPQlTx3Ojz2OHY4X/aff/UC4P/3pHUQSuTfi3oh2UsPPZppw+Vrg==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-sRfCKbOzgy8xZQV2as0RzIZlnCmCseCKZGLfRcrpo2CBngJDr+rPtX0zkG0+oUCV5kfQPUoW3W3C96Ag3Y/Clg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.219.0",
-        "@opentelemetry/otlp-transformer": "0.219.0",
-        "@opentelemetry/resources": "2.8.0",
-        "@opentelemetry/sdk-metrics": "2.8.0"
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-metrics": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.8.0.tgz",
-      "integrity": "sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.219.0.tgz",
-      "integrity": "sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.219.0",
-        "@opentelemetry/otlp-transformer": "0.219.0",
-        "@opentelemetry/resources": "2.8.0",
-        "@opentelemetry/sdk-trace-base": "2.8.0"
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1773,30 +1737,14 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
-      "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/otlp-transformer": "0.219.0"
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1806,55 +1754,23 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
-      "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.221.0.tgz",
+      "integrity": "sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.219.0",
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
-        "@opentelemetry/sdk-logs": "0.219.0",
-        "@opentelemetry/sdk-metrics": "2.8.0",
-        "@opentelemetry/sdk-trace-base": "2.8.0"
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.8.0.tgz",
-      "integrity": "sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
@@ -1874,14 +1790,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
-      "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.221.0.tgz",
+      "integrity": "sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.219.0",
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -1889,22 +1805,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
@@ -1931,39 +1831,6 @@
       "dependencies": {
         "@opentelemetry/core": "2.10.0",
         "@opentelemetry/resources": "2.10.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
-      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,
@@ -70,11 +70,11 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.219.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+    "@opentelemetry/exporter-logs-otlp-http": "0.221.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.221.0",
     "@opentelemetry/resources": "2.10.0",
-    "@opentelemetry/sdk-logs": "0.219.0",
+    "@opentelemetry/sdk-logs": "0.221.0",
     "@opentelemetry/sdk-metrics": "2.10.0",
     "@opentelemetry/sdk-trace-node": "2.10.0",
     "commander": "15.0.0",

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -2,6 +2,7 @@ import type { LogLevel } from './logger.js';
 import { createLogger } from './logger.js';
 import type { TransportMode } from './transport/types.js';
 import { DEFAULT_CLIENT_NAME, sanitizeClientString } from './transport/otlp-shared.js';
+import { resolveRecordContent } from './record-content-gate.js';
 
 const ENV_TRUTHY = new Set(['true', '1', 'yes', 'on']);
 const ENV_FALSY = new Set(['false', '0', 'no', 'off']);
@@ -333,11 +334,15 @@ export function loadConfig(overrides?: AgentConfigInput): Readonly<AgentConfig> 
 
   const highSecurity = overrides?.highSecurity ?? envBool('NEW_RELIC_AI_HIGH_SECURITY', false);
 
-  // highSecurity forcibly disables content recording, silently overriding any
-  // explicit recordContent override.
-  const recordContent = highSecurity
-    ? false
-    : (overrides?.recordContent ?? envBool('NEW_RELIC_AI_RECORD_CONTENT', false));
+  // NEW_RELIC_AI_RECORD_CONTENT is this package's own namespaced env var for
+  // the recordContent override; other consumers of the same gate rule read
+  // their own namespaced env var into their own explicitValue before calling
+  // resolveRecordContent() — the shared piece is the gate application, not
+  // the env var name.
+  const recordContent = resolveRecordContent(
+    highSecurity,
+    overrides?.recordContent ?? envBool('NEW_RELIC_AI_RECORD_CONTENT', false),
+  );
 
   const attributionDefaults = buildAttributionDefaults(overrides?.attributionDefaults);
 

--- a/src/shared/index.test.ts
+++ b/src/shared/index.test.ts
@@ -4,6 +4,7 @@ import {
   redact,
   safeForLog,
   loadConfig,
+  resolveRecordContent,
   createAiRequest,
   createAiResponse,
   createAiMessage,
@@ -65,6 +66,7 @@ describe('shared package', () => {
     // Type-only exports are checked by the TypeScript build.
     const symbols = [
       createLogger,
+      resolveRecordContent,
       redact,
       safeForLog,
       loadConfig,

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,6 +1,7 @@
 export { createLogger } from './logger.js';
 export type { Logger, LogLevel } from './logger.js';
 export { redact, safeForLog } from './redact.js';
+export { resolveRecordContent } from './record-content-gate.js';
 export { loadConfig } from './config.js';
 export type { AgentConfig, AgentConfigInput } from './config.js';
 export {

--- a/src/shared/record-content-gate.test.ts
+++ b/src/shared/record-content-gate.test.ts
@@ -1,0 +1,13 @@
+import { resolveRecordContent } from './record-content-gate.js';
+
+describe('resolveRecordContent', () => {
+  it('returns false when highSecurity is true, regardless of explicitValue', () => {
+    expect(resolveRecordContent(true, true)).toBe(false);
+    expect(resolveRecordContent(true, false)).toBe(false);
+  });
+
+  it('returns explicitValue unchanged when highSecurity is false', () => {
+    expect(resolveRecordContent(false, true)).toBe(true);
+    expect(resolveRecordContent(false, false)).toBe(false);
+  });
+});

--- a/src/shared/record-content-gate.ts
+++ b/src/shared/record-content-gate.ts
@@ -1,0 +1,10 @@
+/**
+ * Applies the "highSecurity forcibly disables content recording" rule.
+ * `explicitValue` is the recordContent value already resolved from an
+ * override or env var by the caller — this function only applies the gate,
+ * so the rule can't drift between call sites that each resolve their own
+ * `explicitValue` from a differently-named env var.
+ */
+export function resolveRecordContent(highSecurity: boolean, explicitValue: boolean): boolean {
+  return highSecurity ? false : explicitValue;
+}

--- a/src/shared/security/ssrf.test.ts
+++ b/src/shared/security/ssrf.test.ts
@@ -1,0 +1,120 @@
+import { isCloudMetadataHost, isPrivateOrLoopbackHost, validateSsrfUrl } from './ssrf.js';
+
+describe('isCloudMetadataHost', () => {
+  it('matches known cloud metadata FQDNs, case-insensitively', () => {
+    expect(isCloudMetadataHost('metadata.google.internal')).toBe(true);
+    expect(isCloudMetadataHost('METADATA.GOOGLE.INTERNAL')).toBe(true);
+    expect(isCloudMetadataHost('metadata.azure.com')).toBe(true);
+    expect(isCloudMetadataHost('ec2.internal')).toBe(true);
+    expect(isCloudMetadataHost('ec2.amazonaws.com')).toBe(true);
+  });
+
+  it('matches the known cloud metadata IP', () => {
+    expect(isCloudMetadataHost('100.100.100.200')).toBe(true);
+    expect(isCloudMetadataHost('169.254.169.254')).toBe(true);
+  });
+
+  it('strips a trailing FQDN dot before matching', () => {
+    expect(isCloudMetadataHost('metadata.google.internal.')).toBe(true);
+  });
+
+  it('does not match ordinary public hosts', () => {
+    expect(isCloudMetadataHost('example.com')).toBe(false);
+    expect(isCloudMetadataHost('insights-collector.newrelic.com')).toBe(false);
+    expect(isCloudMetadataHost('8.8.8.8')).toBe(false);
+  });
+});
+
+describe('isPrivateOrLoopbackHost', () => {
+  it('matches loopback', () => {
+    expect(isPrivateOrLoopbackHost('127.0.0.1')).toBe(true);
+    expect(isPrivateOrLoopbackHost('127.255.255.255')).toBe(true);
+    expect(isPrivateOrLoopbackHost('localhost')).toBe(true);
+    expect(isPrivateOrLoopbackHost('::1')).toBe(true);
+  });
+
+  it('matches RFC-1918 private ranges', () => {
+    expect(isPrivateOrLoopbackHost('10.0.0.1')).toBe(true);
+    expect(isPrivateOrLoopbackHost('172.16.0.1')).toBe(true);
+    expect(isPrivateOrLoopbackHost('172.31.255.255')).toBe(true);
+    expect(isPrivateOrLoopbackHost('192.168.1.1')).toBe(true);
+  });
+
+  it('does not match addresses just outside the 172.16/12 range', () => {
+    expect(isPrivateOrLoopbackHost('172.15.255.255')).toBe(false);
+    expect(isPrivateOrLoopbackHost('172.32.0.1')).toBe(false);
+  });
+
+  it('matches link-local, multicast, and 0.0.0.0', () => {
+    expect(isPrivateOrLoopbackHost('169.254.169.254')).toBe(true);
+    expect(isPrivateOrLoopbackHost('224.0.0.1')).toBe(true);
+    expect(isPrivateOrLoopbackHost('239.255.255.255')).toBe(true);
+    expect(isPrivateOrLoopbackHost('0.0.0.0')).toBe(true);
+  });
+
+  it('matches IPv6 unspecified, ULA, and link-local', () => {
+    expect(isPrivateOrLoopbackHost('::')).toBe(true);
+    expect(isPrivateOrLoopbackHost('fc00::1')).toBe(true);
+    expect(isPrivateOrLoopbackHost('fd12::1')).toBe(true);
+    expect(isPrivateOrLoopbackHost('fe80::1')).toBe(true);
+  });
+
+  it('matches bracketed IPv6 forms (as returned by URL.hostname)', () => {
+    expect(isPrivateOrLoopbackHost('[::1]')).toBe(true);
+    expect(isPrivateOrLoopbackHost('[fe80::1]')).toBe(true);
+  });
+
+  it('matches hex-normalized IPv4-mapped IPv6 directly via the main pattern', () => {
+    expect(isPrivateOrLoopbackHost('::ffff:7f00:1')).toBe(true); // 127.0.0.1
+    expect(isPrivateOrLoopbackHost('[::ffff:7f00:1]')).toBe(true);
+  });
+
+  it('matches decimal-form IPv4-mapped IPv6 via extractIPv4FromMappedIPv6', () => {
+    expect(isPrivateOrLoopbackHost('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateOrLoopbackHost('::ffff:192.168.1.1')).toBe(true);
+  });
+
+  it('matches numeric-encoded IPv4 bypass attempts', () => {
+    expect(isPrivateOrLoopbackHost('2130706433')).toBe(true); // decimal for 127.0.0.1
+    expect(isPrivateOrLoopbackHost('0177.0.0.1')).toBe(true); // octal for 127.0.0.1
+    expect(isPrivateOrLoopbackHost('0x7f.0.0.1')).toBe(true); // hex for 127.0.0.1
+  });
+
+  it('does not match ordinary public hosts or IPs', () => {
+    expect(isPrivateOrLoopbackHost('example.com')).toBe(false);
+    expect(isPrivateOrLoopbackHost('insights-collector.newrelic.com')).toBe(false);
+    expect(isPrivateOrLoopbackHost('8.8.8.8')).toBe(false);
+  });
+});
+
+describe('validateSsrfUrl', () => {
+  it('throws for a cloud metadata host', () => {
+    expect(() => validateSsrfUrl('test', new URL('http://metadata.google.internal/'))).toThrow(
+      /cloud metadata service endpoint/,
+    );
+  });
+
+  it('throws for a private/loopback host', () => {
+    expect(() => validateSsrfUrl('test', new URL('http://127.0.0.1/'))).toThrow(
+      /private or loopback address/,
+    );
+    expect(() => validateSsrfUrl('test', new URL('https://10.0.0.1/'))).toThrow(
+      /private or loopback address/,
+    );
+  });
+
+  it('includes the label in the thrown message', () => {
+    expect(() => validateSsrfUrl('sendWithRetry', new URL('http://127.0.0.1/'))).toThrow(
+      /^sendWithRetry:/,
+    );
+  });
+
+  it('does not throw for an ordinary public host', () => {
+    expect(() =>
+      validateSsrfUrl(
+        'test',
+        new URL('https://insights-collector.newrelic.com/v1/accounts/1/events'),
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/shared/security/ssrf.ts
+++ b/src/shared/security/ssrf.ts
@@ -1,0 +1,151 @@
+/**
+ * SSRF guards for outbound requests to consumer-configurable endpoints
+ * (NR ingest `collectorHost`, OTLP `otlpEndpoint`). String/IP-literal
+ * validation only — no DNS-rebinding protection (that would require
+ * routing `fetch()` through a custom `undici` `Agent` dispatcher with a
+ * validating `connect.lookup`, an explicitly out-of-scope addition here).
+ *
+ * Split into two predicates so callers can apply different rules to the
+ * metadata check vs. the private/loopback check — `otlp-shared.ts` allows
+ * private-range addresses over `https:` (a legitimate internal-VPC OTel
+ * collector topology) but never allows a cloud metadata target under any
+ * scheme.
+ */
+
+// Cloud metadata service FQDNs that resolve to internal addresses within
+// cloud accounts. Blocking these prevents SSRF attacks from exfiltrating
+// cloud credentials.
+const BLOCKED_METADATA_FQDNS = new Set([
+  'metadata.google.internal',
+  'metadata.azure.com',
+  'ec2.internal',
+  'ec2.amazonaws.com',
+]);
+
+// Cloud metadata service IPs not covered by the RFC-1918/link-local pattern below.
+const BLOCKED_METADATA_IPS = new Set(['100.100.100.200', '169.254.169.254']);
+
+// Matches loopback, RFC-1918 private ranges, link-local (169.254/16), and
+// IPv4 multicast (224.0.0.0/4, i.e. 224-239.x.x.x). Also blocks IPv6
+// unspecified (::), IPv6 loopback (::1), IPv6 ULA (fc00::/7, fd00::/8), and
+// IPv6 link-local (fe80::/10). Matches the hex-normalized IPv4-mapped IPv6
+// form Node's URL parser produces (::ffff:7f00:1 for ::ffff:127.0.0.1).
+// URL.hostname returns IPv6 addresses bracketed (e.g. [::1]); the optional
+// [...] wrapper here handles that without requiring callers to strip it.
+const PRIVATE_OR_LOOPBACK_HOST_RE =
+  /^(?:\[)?(?:127\.(?:\d{1,3}\.)*\d{1,3}|10\.(?:\d{1,3}\.)*\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.(?:\d{1,3}\.)*\d{1,3}|192\.168\.(?:\d{1,3}\.)*\d{1,3}|169\.254\.(?:\d{1,3}\.)*\d{1,3}|(?:22[4-9]|23[0-9])\.(?:\d{1,3}\.)*\d{1,3}|::1|::|::ffff:(?:7f[0-9a-f]{2}|0a[0-9a-f]{2}|ac1[0-9a-f]|c0a8|a9fe)[0-9a-f]*:[0-9a-f]+|fc[0-9a-f]{2}:[0-9a-f:]*|fd[0-9a-f]{2}:[0-9a-f:]*|fe[89ab][0-9a-f]:[0-9a-f:]*|0\.0\.0\.0|localhost)(?:\])?$/i;
+
+// Extracts an embedded IPv4 from a decimal-form IPv4-mapped IPv6 address
+// (::ffff:127.0.0.1) or its hex form (::ffff:7f00:1). Returns null when the
+// input isn't a recognized mapped address. The hex form is already caught
+// directly by PRIVATE_OR_LOOPBACK_HOST_RE; this exists for the decimal form,
+// which is not.
+function extractIPv4FromMappedIPv6(host: string): string | null {
+  const trimmed = host.replace(/[[\]]/g, '');
+
+  const decimalMatch =
+    /^::ffff:((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))$/i.exec(
+      trimmed,
+    );
+  if (decimalMatch) {
+    return decimalMatch[1];
+  }
+
+  const hexMatch = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(trimmed);
+  if (hexMatch) {
+    const part1 = parseInt(hexMatch[1], 16);
+    const part2 = parseInt(hexMatch[2], 16);
+    const b1 = (part1 >> 8) & 0xff;
+    const b2 = part1 & 0xff;
+    const b3 = (part2 >> 8) & 0xff;
+    const b4 = part2 & 0xff;
+    return `${b1}.${b2}.${b3}.${b4}`;
+  }
+
+  return null;
+}
+
+// Canonicalizes decimal/octal/hex-encoded numeric IPv4 host literals
+// (2130706433, 0177.0.0.1, 0x7f.0.0.1 — all 127.0.0.1) to dotted-decimal
+// form. Returns null when the input isn't a recognized numeric encoding.
+// Node's own URL parser already normalizes most of these before a hostname
+// reaches this module (see plan doc), but isPrivateOrLoopbackHost is also
+// called directly with raw, non-URL-parsed strings, where this still matters.
+function canonicalizeNumericIP(host: string): string | null {
+  if (/^\d+$/.test(host)) {
+    const num = BigInt(host);
+    if (num >= 0n && num <= 0xffffffffn) {
+      const b1 = Number((num >> 24n) & 0xffn);
+      const b2 = Number((num >> 16n) & 0xffn);
+      const b3 = Number((num >> 8n) & 0xffn);
+      const b4 = Number(num & 0xffn);
+      return `${b1}.${b2}.${b3}.${b4}`;
+    }
+    return null;
+  }
+
+  const parts = host.split('.');
+  if (parts.length === 4) {
+    const octets: number[] = [];
+    for (const part of parts) {
+      let value: number;
+      if (part.startsWith('0x') || part.startsWith('0X')) {
+        value = parseInt(part, 16);
+      } else if (part.startsWith('0') && part.length > 1 && /^[0-7]+$/.test(part.slice(1))) {
+        value = parseInt(part, 8);
+      } else if (/^\d+$/.test(part)) {
+        value = parseInt(part, 10);
+      } else {
+        return null;
+      }
+      if (value < 0 || value > 255) {
+        return null;
+      }
+      octets.push(value);
+    }
+    return octets.join('.');
+  }
+
+  return null;
+}
+
+/** True if `hostname` is a known cloud-metadata-service FQDN or IP. */
+export function isCloudMetadataHost(hostname: string): boolean {
+  const host = hostname.replace(/\.$/, '');
+  if (BLOCKED_METADATA_FQDNS.has(host.toLowerCase())) return true;
+  if (BLOCKED_METADATA_IPS.has(host)) return true;
+  return false;
+}
+
+/**
+ * True if `hostname` is loopback, RFC-1918-private, link-local, multicast,
+ * an IPv4-mapped-IPv6 form of any of the above, or a numeric encoding
+ * (decimal/octal/hex) of any of the above.
+ */
+export function isPrivateOrLoopbackHost(hostname: string): boolean {
+  const host = hostname.replace(/\.$/, '');
+
+  const canonicalIP = canonicalizeNumericIP(host);
+  if (canonicalIP && PRIVATE_OR_LOOPBACK_HOST_RE.test(canonicalIP)) return true;
+
+  if (PRIVATE_OR_LOOPBACK_HOST_RE.test(host)) return true;
+
+  const embeddedIPv4 = extractIPv4FromMappedIPv6(host);
+  if (embeddedIPv4 && PRIVATE_OR_LOOPBACK_HOST_RE.test(embeddedIPv4)) return true;
+
+  return false;
+}
+
+/**
+ * Throws if `url`'s host is a cloud-metadata endpoint or a private/loopback
+ * address. Does not check scheme — callers already enforce their own scheme
+ * rules before or after calling this.
+ */
+export function validateSsrfUrl(label: string, url: URL): void {
+  if (isCloudMetadataHost(url.hostname)) {
+    throw new Error(`${label}: host "${url.hostname}" is a cloud metadata service endpoint`);
+  }
+  if (isPrivateOrLoopbackHost(url.hostname)) {
+    throw new Error(`${label}: host "${url.hostname}" resolves to a private or loopback address`);
+  }
+}

--- a/src/shared/transport/http-client.test.ts
+++ b/src/shared/transport/http-client.test.ts
@@ -258,6 +258,41 @@ describe('sendWithRetry', () => {
     fetchSpy.mockRestore();
   });
 
+  // SSRF guard — blocks a private/loopback/metadata collectorHost override
+  // before any request is attempted. statusCode: null (like the gzip-failure
+  // path above) distinguishes this from an HTTP-level failure so callers
+  // don't retry it as if the network request itself failed.
+  it('returns statusCode: null and does not call fetch when the URL targets a private host', async () => {
+    const result = await sendWithRetry(
+      baseOptions({ url: 'https://127.0.0.1/v1/accounts/1/events' }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBeNull();
+    expect(result.error).toContain('private or loopback address');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns statusCode: null and does not call fetch when the URL targets a cloud metadata host', async () => {
+    const result = await sendWithRetry(
+      baseOptions({ url: 'http://metadata.google.internal/latest/meta-data/' }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBeNull();
+    expect(result.error).toContain('cloud metadata service endpoint');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('still sends normally for an ordinary NR ingest URL', async () => {
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    const result = await sendWithRetry(baseOptions());
+
+    expect(result.success).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   // 4. Verifies gzip headers
   it('sends gzip-compressed body with correct headers', async () => {
     fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }));

--- a/src/shared/transport/http-client.ts
+++ b/src/shared/transport/http-client.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { createLogger } from '../logger.js';
 import type { HttpSendOptions, TransportResult } from './types.js';
 import { buildUserAgent } from './otlp-shared.js';
+import { validateSsrfUrl } from '../security/ssrf.js';
 
 const gzipAsync = promisify(gzip);
 const logger = createLogger('transport');
@@ -259,6 +260,14 @@ export async function sendWithRetry(options: HttpSendOptions): Promise<Transport
   const { url, body, licenseKey, maxRetries, baseDelayMs, maxDelayMs, requestTimeoutMs } = options;
 
   const requestId = newRequestId();
+
+  try {
+    validateSsrfUrl('sendWithRetry', new URL(url));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error('Blocked outbound request to disallowed host', { requestId, error: message });
+    return { success: false, statusCode: null, retryCount: 0, error: message };
+  }
 
   let compressed: Buffer;
   try {

--- a/src/shared/transport/otlp-event-bridge.ts
+++ b/src/shared/transport/otlp-event-bridge.ts
@@ -55,7 +55,7 @@ export class OtlpEventBridge {
 
     this.loggerProvider = new LoggerProvider({
       resource: resourceFromAttributes({ 'service.name': options.appName }),
-      processors: [new BatchLogRecordProcessor(exporter)],
+      processors: [new BatchLogRecordProcessor({ exporter })],
     });
 
     this.otelLogger = this.loggerProvider.getLogger(clientName, clientVersion || undefined);

--- a/src/shared/transport/otlp-shared.test.ts
+++ b/src/shared/transport/otlp-shared.test.ts
@@ -3,6 +3,7 @@ import {
   sanitizeClientString,
   buildUserAgent,
   hasOtlpAuthHeader,
+  validateOtlpEndpoint,
 } from './otlp-shared.js';
 
 describe('hasOtlpAuthHeader', () => {
@@ -77,5 +78,60 @@ describe('buildUserAgent', () => {
 
   it('falls back to DEFAULT_CLIENT_NAME when name is empty', () => {
     expect(buildUserAgent('', '1.0.0')).toBe(`${DEFAULT_CLIENT_NAME}/1.0.0`);
+  });
+});
+
+describe('validateOtlpEndpoint', () => {
+  it('throws for an invalid URL', () => {
+    expect(() => validateOtlpEndpoint('not a url', 'Test')).toThrow('invalid OTLP endpoint URL');
+  });
+
+  it('throws for a non-http(s) scheme', () => {
+    expect(() => validateOtlpEndpoint('ftp://example.com', 'Test')).toThrow('must use http(s)');
+  });
+
+  it('allows https to an ordinary public host', () => {
+    expect(() => validateOtlpEndpoint('https://otlp.nr-data.net', 'Test')).not.toThrow();
+  });
+
+  it('allows http to loopback', () => {
+    expect(() => validateOtlpEndpoint('http://localhost:4318', 'Test')).not.toThrow();
+    expect(() => validateOtlpEndpoint('http://127.0.0.1:4318', 'Test')).not.toThrow();
+  });
+
+  it('allows https to a private-range address (internal-VPC collector topology)', () => {
+    expect(() => validateOtlpEndpoint('https://10.0.0.5:4318', 'Test')).not.toThrow();
+    expect(() => validateOtlpEndpoint('https://192.168.1.10:4318', 'Test')).not.toThrow();
+  });
+
+  it('blocks plain http to a private-range, non-loopback address', () => {
+    expect(() => validateOtlpEndpoint('http://10.0.0.5:4318', 'Test')).toThrow(
+      'private-network host',
+    );
+    expect(() => validateOtlpEndpoint('http://192.168.1.10:4318', 'Test')).toThrow(
+      'private-network host',
+    );
+  });
+
+  it('blocks a cloud metadata host regardless of scheme', () => {
+    expect(() => validateOtlpEndpoint('http://metadata.google.internal', 'Test')).toThrow(
+      'cloud metadata service',
+    );
+    expect(() => validateOtlpEndpoint('https://metadata.google.internal', 'Test')).toThrow(
+      'cloud metadata service',
+    );
+    expect(() => validateOtlpEndpoint('http://169.254.169.254', 'Test')).toThrow(
+      'cloud metadata service',
+    );
+    expect(() => validateOtlpEndpoint('https://169.254.169.254', 'Test')).toThrow(
+      'cloud metadata service',
+    );
+  });
+
+  it('still only warns for plain http to an ordinary public non-loopback host', () => {
+    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => validateOtlpEndpoint('http://example.com', 'Test')).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/src/shared/transport/otlp-shared.ts
+++ b/src/shared/transport/otlp-shared.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '../logger.js';
+import { isCloudMetadataHost, isPrivateOrLoopbackHost } from '../security/ssrf.js';
 
 const logger = createLogger('otlp-shared');
 
@@ -43,11 +44,6 @@ export function hasOtlpAuthHeader(headers: Record<string, string>): boolean {
   return false;
 }
 
-// Validate OTLP endpoint scheme. https:// is required for
-// any non-localhost destination because the payload may contain user prompt
-// fragments (PII). Plain http:// is allowed only against loopback to support
-// local development and testing. Shared by OtlpTransport and OtlpEventBridge
-// (deduplicates previously identical implementations).
 export function validateOtlpEndpoint(endpoint: string, source: string): void {
   let parsed: URL;
   try {
@@ -55,19 +51,37 @@ export function validateOtlpEndpoint(endpoint: string, source: string): void {
   } catch {
     throw new Error(`${source}: invalid OTLP endpoint URL: ${endpoint}`);
   }
+
+  // Never a legitimate target under any scheme — block before the
+  // scheme-based branches below so an https:// metadata target isn't
+  // waved through by the "https is always fine" early return.
+  if (isCloudMetadataHost(parsed.hostname)) {
+    throw new Error(`${source}: OTLP endpoint targets a cloud metadata service: ${endpoint}`);
+  }
+
   if (parsed.protocol === 'https:') return;
   if (parsed.protocol !== 'http:') {
     throw new Error(`${source}: OTLP endpoint must use http(s); got ${parsed.protocol}`);
   }
-  // http://: only acceptable on loopback
+
+  // http://: only acceptable on loopback, or (for now) on a private-range
+  // address — an internal-VPC OTel collector is a common, legitimate
+  // deployment topology, not a misconfiguration. 0.0.0.0 is a wildcard that
+  // binds to ALL interfaces, not loopback only — cleartext traffic to it is
+  // reachable from any network, so it's covered by isPrivateOrLoopbackHost
+  // below rather than treated as loopback.
   const host = parsed.hostname;
-  // 0.0.0.0 is a wildcard that binds to ALL interfaces, not loopback only —
-  // cleartext traffic to it is reachable from any network.
   const isLoopback = host === 'localhost' || host === '127.0.0.1' || host === '::1';
-  if (!isLoopback) {
-    logger.warn(
-      `${source}: OTLP endpoint uses plain http:// to a non-loopback host — payload may contain PII and should not be transmitted in cleartext`,
-      { endpoint },
+  if (isLoopback) return;
+
+  if (isPrivateOrLoopbackHost(host)) {
+    throw new Error(
+      `${source}: OTLP endpoint uses plain http:// to a private-network host — use https:// for a non-loopback collector`,
     );
   }
+
+  logger.warn(
+    `${source}: OTLP endpoint uses plain http:// to a non-loopback host — payload may contain PII and should not be transmitted in cleartext`,
+    { endpoint },
+  );
 }

--- a/src/shared/transport/otlp-transport.test.ts
+++ b/src/shared/transport/otlp-transport.test.ts
@@ -890,12 +890,10 @@ describe('OtlpTransport', () => {
       expect(stderrText).toMatch(/internal-collector\.example\.com/);
     });
 
-    it('emits a cleartext warning for http://0.0.0.0 — wildcard, not loopback', () => {
+    it('throws for http://0.0.0.0 — wildcard bind address, not a legitimate collector target', () => {
       expect(
         () => new OtlpTransport({ endpoint: 'http://0.0.0.0:4318', appName: 'test-app' }),
-      ).not.toThrow();
-      const stderrText = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? '')).join('\n');
-      expect(stderrText).toMatch(/plain http:\/\//);
+      ).toThrow(/private-network host/);
     });
 
     it('throws on a non-http(s) scheme', () => {


### PR DESCRIPTION
Fixes #297

## Summary
- Adds an SSRF guard applied to outbound New Relic ingest requests (previously only OTLP endpoints had one) — rejects cloud-metadata and private/loopback hosts before sending; plaintext `http://` to a private host now throws instead of only warning
- Unifies the `highSecurity` → `recordContent` gate behind a single `resolveRecordContent()` helper (no behavior change), and updates `BatchLogRecordProcessor` construction for the current OpenTelemetry Logs SDK constructor shape
- The SDK update unblocks the OTel logs/exporter family bump (`sdk-logs`, `exporter-logs-otlp-http`, `exporter-metrics-otlp-http`, `exporter-trace-otlp-http`: 0.219.0 → 0.221.0) that was previously deferred
- Bumps package version to 1.14.5 with a CHANGELOG entry

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 158/159 suites, 5156 tests passing (1 suite skipped, expected)