### PR TITLE
Fix dead docs/ADAPTERS.md references; document docs/site relationship

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,9 @@ preflight/
     policy.json                     # Policy metadata (name, incident preference)
     conditions/                     # NRQL alert condition JSON files
   dashboards/                       # Pre-built NR dashboard JSON files (data, not source)
+  docs/                             # Markdown reference docs (architecture, adapters, advanced config, etc.)
   scripts/                          # backfill-sessions.ts, check-bundle-size.ts
+  site/                             # Astro Starlight docs site (newrelic-experimental.github.io/preflight) — mirrors docs/ at build time via an explicit glob allowlist in site/src/content.config.ts, not a copy
 ```
 
 ## Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,7 +305,7 @@ The MCP server registers an adapter per AI coding platform and auto-detects the 
 
 Platform capabilities vary: some platforms expose a real hook mechanism that captures every built-in tool call, others only support MCP as a client (so Preflight can only see calls routed to its own MCP tools, not the platform's built-in file/shell tools).
 
-See **[docs/ADAPTERS.md](./docs/ADAPTERS.md)** for the full per-platform reference — integration mechanism, detection env vars, tool-name mapping, known gaps, and setup steps.
+See **[docs/ADAPTERS.md](https://newrelic-experimental.github.io/preflight/adapters/)** for the full per-platform reference — integration mechanism, detection env vars, tool-name mapping, known gaps, and setup steps.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,18 +98,18 @@ Proxy mode is a **separate, mutually exclusive** code path. It does not use hook
 
 ## Component Reference
 
-| Component              | File                           | Purpose                                                                                                                          |
-| ---------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `collector-script.ts`  | `src/hooks/`                   | Spawned by Claude Code hooks; reads hook JSON from stdin, appends to buffer file. Must complete in < 5 ms.                       |
-| `buffer-SESSION.jsonl` | `~/.newrelic-preflight/`       | Ring buffer of raw hook events. Written by collector, drained by `HookEventProcessor`.                                           |
-| `HookEventProcessor`   | `src/hooks/event-processor.ts` | Polls buffer every 100 ms. Pairs `PreToolUse` and `PostToolUse` events into `ToolCallRecord` objects.                            |
-| `PlatformRegistry`     | `src/platforms/`               | Detects the active AI coding platform and normalizes its tool names to Preflight's vocabulary. See [ADAPTERS.md](./ADAPTERS.md). |
-| Metric trackers (~15)  | `src/metrics/`                 | Each tracker receives every `ToolCallRecord` and maintains a typed metrics snapshot.                                             |
-| `NrIngestManager`      | `src/transport/nr-ingest.ts`   | Wraps `HarvestScheduler`; flushes events (5 s), metrics (60 s), and logs (5 s) to New Relic.                                     |
-| MCP tools              | `src/tools/`                   | Registered via `registerTools()`; read tracker state and return it as MCP tool responses. Active in `--stdio` mode.              |
-| Dashboard server       | `src/index.ts`                 | HTTP server on port 7777 serving the local web UI. Active in `--local` mode.                                                     |
-| `ProxyManager`         | `src/proxy/proxy-manager.ts`   | HTTP proxy that forwards MCP traffic to upstream servers and intercepts it for telemetry. Active in proxy mode only.             |
-| `OtlpReceiver`         | `src/proxy/`                   | Receives enriched OTLP payloads from `ProxyManager` and forwards to New Relic OTLP endpoint.                                     |
+| Component              | File                           | Purpose                                                                                                                                                                        |
+| ---------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `collector-script.ts`  | `src/hooks/`                   | Spawned by Claude Code hooks; reads hook JSON from stdin, appends to buffer file. Must complete in < 5 ms.                                                                     |
+| `buffer-SESSION.jsonl` | `~/.newrelic-preflight/`       | Ring buffer of raw hook events. Written by collector, drained by `HookEventProcessor`.                                                                                         |
+| `HookEventProcessor`   | `src/hooks/event-processor.ts` | Polls buffer every 100 ms. Pairs `PreToolUse` and `PostToolUse` events into `ToolCallRecord` objects.                                                                          |
+| `PlatformRegistry`     | `src/platforms/`               | Detects the active AI coding platform and normalizes its tool names to Preflight's vocabulary. See [ADAPTERS.md](https://newrelic-experimental.github.io/preflight/adapters/). |
+| Metric trackers (~15)  | `src/metrics/`                 | Each tracker receives every `ToolCallRecord` and maintains a typed metrics snapshot.                                                                                           |
+| `NrIngestManager`      | `src/transport/nr-ingest.ts`   | Wraps `HarvestScheduler`; flushes events (5 s), metrics (60 s), and logs (5 s) to New Relic.                                                                                   |
+| MCP tools              | `src/tools/`                   | Registered via `registerTools()`; read tracker state and return it as MCP tool responses. Active in `--stdio` mode.                                                            |
+| Dashboard server       | `src/index.ts`                 | HTTP server on port 7777 serving the local web UI. Active in `--local` mode.                                                                                                   |
+| `ProxyManager`         | `src/proxy/proxy-manager.ts`   | HTTP proxy that forwards MCP traffic to upstream servers and intercepts it for telemetry. Active in proxy mode only.                                                           |
+| `OtlpReceiver`         | `src/proxy/`                   | Receives enriched OTLP payloads from `ProxyManager` and forwards to New Relic OTLP endpoint.                                                                                   |
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -58,7 +58,7 @@ Restart your AI tool after editing the config.
 
 **Symptom:** Preflight is configured as an MCP server for the Claude Desktop app, but the dashboard never shows any activity from it.
 
-**Cause:** This is expected — **Claude Desktop is not a supported platform for automatic observability.** Preflight's automatic capture relies on a hook/callback mechanism (`PreToolUse`/`PostToolUse`) that fires on every built-in tool call. Claude Desktop can load Preflight as an MCP server, but it has no such hook mechanism — see [ADAPTERS.md](./ADAPTERS.md) for how visibility tiers work across platforms. Without hooks, none of Desktop's built-in tool calls are ever reported to Preflight, so there's nothing for the dashboard to show.
+**Cause:** This is expected — **Claude Desktop is not a supported platform for automatic observability.** Preflight's automatic capture relies on a hook/callback mechanism (`PreToolUse`/`PostToolUse`) that fires on every built-in tool call. Claude Desktop can load Preflight as an MCP server, but it has no such hook mechanism — see [ADAPTERS.md](https://newrelic-experimental.github.io/preflight/adapters/) for how visibility tiers work across platforms. Without hooks, none of Desktop's built-in tool calls are ever reported to Preflight, so there's nothing for the dashboard to show.
 
 **Fix:** none — this is a platform limitation, not a bug. Use one of the platforms listed under [Works With](../README.md#works-with) (Claude Code, Cursor, Windsurf, GitHub Copilot, Zed, Continue.dev, Amazon Q Developer, Amazon Kiro) for automatic capture.
 

--- a/src/platforms/kilo-code-adapter.ts
+++ b/src/platforms/kilo-code-adapter.ts
@@ -193,7 +193,7 @@ export class KiloCodeAdapter implements PlatformAdapter {
       'metadata (exit codes, match counts, etc.) is captured. kilo-playwright_*',
       "(Kilo's built-in Playwright MCP) tool calls are observable through this",
       'same plugin mechanism but report as Unknown, same as any unrecognized',
-      'MCP tool call — see docs/ADAPTERS.md for details.',
+      'MCP tool call — see https://newrelic-experimental.github.io/preflight/adapters/ for details.',
     ].join('\n');
   }
 

--- a/src/platforms/opencode-adapter.ts
+++ b/src/platforms/opencode-adapter.ts
@@ -171,7 +171,7 @@ export class OpencodeAdapter implements PlatformAdapter {
       'tool call reports success unconditionally. Only bash/read/edit/write',
       "get structured input metadata; other tools' arg shapes (including apply_patch)",
       'are undocumented and forwarded as-is. No output-side metadata (exit codes,',
-      'match counts, etc.) is captured — see docs/ADAPTERS.md for details.',
+      'match counts, etc.) is captured — see https://newrelic-experimental.github.io/preflight/adapters/ for details.',
     ].join('\n');
   }
 

--- a/src/platforms/pi-adapter.ts
+++ b/src/platforms/pi-adapter.ts
@@ -153,7 +153,7 @@ export class PiAdapter implements PlatformAdapter {
       'explicitly enable them via --tools. event.input is forwarded as-is for',
       "every tool rather than remapped to Claude Code's own field names, so",
       "collector-script.ts's tool-specific input extractors (file_path, etc.)",
-      'will not populate for Pi calls. See docs/ADAPTERS.md for details.',
+      'will not populate for Pi calls. See https://newrelic-experimental.github.io/preflight/adapters/ for details.',
     ].join('\n');
   }
 


### PR DESCRIPTION
Fixes #301

## Summary
- Rewrite five dead/broken references to `docs/ADAPTERS.md` — two markdown cross-links that 404 on the live docs site (which uses kebab-case slugs, not file paths) and three adapter runtime warning strings that referenced a path never shipped in the npm package — to the live site URL `https://newrelic-experimental.github.io/preflight/adapters/`.
- Fix the same dead-reference class in `CONTRIBUTING.md`.
- Add `docs/` and `site/` entries to CLAUDE.md's project-structure tree, documenting that `site/` mirrors `docs/` at build time rather than being a separate copy.

## Test plan
- [x] `npm run build && npm test` — passing, 0 failures
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] Confirmed the fixed links resolve on the live site instead of 404ing