### PR TITLE
Fix: Subagent spend aggregation and disabled-watcher banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.6] - 2026-07-30
+
+### Fixed
+
+- **Subagent spend on the Today dashboard only reflected whichever session happened to be serving the dashboard** — with multiple Claude Code sessions running concurrently (a common pattern with subagents and workflows), only one process's own in-memory tracker ever backed the "subagent spend" figure, silently excluding subagent activity from every other session. It's now aggregated from each session's persisted totals, the same way overall spend already was.
+- **The "subagent cost tracking is disabled" banner named the wrong cause for background dashboard processes** — a dashboard running in standalone/background mode doesn't run its own subagent watcher by default (by design), which the banner incorrectly attributed to the `NR_AI_ENABLE_SUBAGENT_WATCHER` environment variable even when that variable was never set. The banner now distinguishes the two cases and gives accurate guidance for each.
+- **Closed a related double-counting risk**: opting a background dashboard process into its own subagent tracking (`NR_AI_WATCHER_MODE=local`) could have caused subagent spend it discovered to be counted twice — once via the originating session's own persisted total, and again via the background process's own unscoped watcher. That process's own live total is no longer added on top of already-persisted sessions' totals.
+
 ## [1.14.5] - 2026-07-29
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.5",
+      "version": "1.14.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1445,6 +1445,115 @@ describe('api-handler GET /api/sessions/today/aggregate', () => {
     expect(parsed.subagentUsd).toBeCloseTo(6, 3);
   });
 
+  it('does not add its own live today-portion when the live session id is an unscoped aggregator (--local/proxy)', async () => {
+    // A `--local` process's SubagentWatcher runs unscoped (parentSessionId:
+    // undefined) — if NR_AI_WATCHER_MODE=local is set, its own live
+    // CostTracker may hold cost that belongs to OTHER, already-separately-
+    // persisted sessions. Adding it on top of the (empty, here) persisted-
+    // sessions sum would double-count. Session id prefix 'local-' signals
+    // this process is such an unscoped aggregator, not a single real session.
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({ sessionId: 'local-1785400000000', sessionStartTime: Date.now() }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+      costTracker: {
+        getMetrics: () => ({ sessionTotalCostUsd: 0 }),
+        getCostForDay: () => 9,
+        getSubagentCostForDay: () => 6,
+      } as unknown as Parameters<typeof createApiHandler>[0]['costTracker'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { totalCostUsd: number; subagentUsd: number };
+    expect(parsed.totalCostUsd).toBe(0);
+    expect(parsed.subagentUsd).toBe(0);
+  });
+
+  it('still adds its own live today-portion for a pending-* provisional stdio session', async () => {
+    // A pending-<ts> id is still exactly one real --stdio session mid
+    // session-ID-resolution, not an unscoped aggregator — its live cost is
+    // genuinely its own and must still be added.
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({ sessionId: 'pending-1785400000000', sessionStartTime: Date.now() }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+      costTracker: {
+        getMetrics: () => ({ sessionTotalCostUsd: 0 }),
+        getCostForDay: () => 9,
+        getSubagentCostForDay: () => 6,
+      } as unknown as Parameters<typeof createApiHandler>[0]['costTracker'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { totalCostUsd: number; subagentUsd: number };
+    expect(parsed.totalCostUsd).toBeCloseTo(9, 3);
+    expect(parsed.subagentUsd).toBeCloseTo(6, 3);
+  });
+
+  it('sums subagentCostUsd across every persisted session today, not just the live process', async () => {
+    const now = Date.now();
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+    const startMs = startOfDay.getTime();
+
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        // Two sessions persisted by OTHER Claude Code processes — their
+        // subagent activity was never seen by this process's own live
+        // CostTracker/SubagentWatcher.
+        loadTodaySessions: () => [
+          {
+            sessionId: 'other-session-A',
+            startTime: startMs + 10_000,
+            endTime: startMs + 20_000,
+            estimatedCostUsd: 5,
+            subagentCostUsd: 1.5,
+          },
+          {
+            sessionId: 'other-session-B',
+            startTime: startMs + 30_000,
+            endTime: startMs + 40_000,
+            estimatedCostUsd: 3,
+            subagentCostUsd: 2.25,
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      // This process's own live tracker never saw any subagent turns.
+      costTracker: {
+        getMetrics: () => ({ sessionTotalCostUsd: 0 }),
+        getCostForDay: () => 0,
+        getSubagentCostForDay: () => 0,
+      } as unknown as Parameters<typeof createApiHandler>[0]['costTracker'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { subagentUsd: number };
+    // 1.5 + 2.25 — summed across both other sessions, not read from the
+    // (empty) live process tracker.
+    expect(parsed.subagentUsd).toBeCloseTo(3.75, 3);
+  });
+
   it('skips events older than the start of today', async () => {
     const startOfDay = new Date();
     startOfDay.setHours(0, 0, 0, 0);
@@ -1658,6 +1767,7 @@ describe('api-handler GET /api/observability-health', () => {
       parseErrors: 0,
       watcherDisabledByLock: false,
       costSelfCheckDeltaPct: null,
+      watcherDisabledReason: null,
     };
     const handler = createApiHandler({
       observabilityHealth: { getSnapshot: () => snapshot },

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1,7 +1,13 @@
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { localDateKey, localStartOfDay, todayPortionOfSessionCost } from '../../lib/date.js';
+import {
+  localDateKey,
+  localStartOfDay,
+  todayPortionOfSessionCost,
+  todayPortionRatio,
+} from '../../lib/date.js';
 import { redactSensitive, normalizeDeveloperName } from '../../config.js';
+import { isUnscopedAggregatorSessionId } from '../../hooks/session-resolver.js';
 import { handleSendDigest } from '../../tools/cross-session-tools.js';
 import type { WeeklySummaryGenerator } from '../../storage/weekly-summary.js';
 import type { McpServerConfig } from '../../config.js';
@@ -337,6 +343,18 @@ export interface ObservabilityHealthSnapshot {
   readonly parseErrors: number;
   readonly watcherDisabledByLock: boolean;
   readonly costSelfCheckDeltaPct: number | null;
+  /**
+   * Why `watcherActive` is false; null when it's true. `activeSubagentWatcher`
+   * (src/index.ts) is only non-null when BOTH `subagentWatcherEnabled` (the
+   * `NR_AI_ENABLE_SUBAGENT_WATCHER` flag) AND `watcherShouldRun` (this
+   * process's mode matches `NR_AI_WATCHER_MODE`, default 'stdio') hold — two
+   * unrelated conditions collapsed into one boolean. `'mode_mismatch'` is the
+   * common, by-design case for a `--local` dashboard daemon; `'env_var'` is
+   * the explicit opt-out. Distinguishing them matters because the UI's
+   * `'env_var'` messaging tells the user to unset a variable — which is
+   * actively wrong advice when the real cause is `'mode_mismatch'`.
+   */
+  readonly watcherDisabledReason: 'env_var' | 'mode_mismatch' | null;
 }
 
 export interface ApiHandlerDeps {
@@ -1102,6 +1120,12 @@ export function createApiHandler(
     let totalDurationMs = 0;
     let durationSamples = 0;
     let totalCostUsd = 0;
+    // Summed across every today session's PERSISTED subagentCostUsd (see (2b)
+    // below), not read from this one process's live CostTracker. A session
+    // watched by a different concurrent `--stdio` process never touches this
+    // process's in-memory tracker, so reading only the live tracker silently
+    // dropped subagent spend from every other concurrently-running session.
+    let subagentUsd = 0;
     let antiPatternCount = 0;
     const sessionsSeen = new Set<string>();
 
@@ -1211,14 +1235,22 @@ export function createApiHandler(
         startTime: number;
         endTime: number;
         estimatedCostUsd: number | null;
+        subagentCostUsd?: number;
         antiPatterns?: ReadonlyArray<unknown>;
         timeline?: ReadonlyArray<{ timestamp: number }>;
       };
       // Skip the live session here — its today-portion is added below from
-      // costTracker.getCostForDay(), which is more accurate (per-token-event)
-      // than pro-rating from a periodically-persisted snapshot.
+      // costTracker.getCostForDay()/getSubagentCostForDay(), which is more
+      // accurate (per-token-event) than pro-rating from a periodically-
+      // persisted snapshot.
       if (s.sessionId === liveSid) continue;
       totalCostUsd += todayPortionOfSessionCost(s, now);
+      // (2b) subagent-only portion of the same session, same pro-rating.
+      // This is what makes the "subagent spend" KPI cross-session: each
+      // `--stdio` process persists its own subagentCostUsd, so summing it
+      // here (rather than reading only THIS process's live CostTracker)
+      // picks up subagent activity that happened in any concurrent session.
+      subagentUsd += (s.subagentCostUsd ?? 0) * todayPortionRatio(s, now);
       // Count anti-patterns and session for cross-midnight sessions not already
       // captured by the todaySessions loop (which filtered by start-date).
       if (typeof s.sessionId === 'string' && !sessionsSeen.has(s.sessionId)) {
@@ -1235,7 +1267,17 @@ export function createApiHandler(
       (s) => (s as { sessionId?: string }).sessionId === liveSid,
     );
 
-    if (!liveAlreadyPersisted) {
+    // An unscoped aggregator (--local/proxy session id) runs its
+    // SubagentWatcher unscoped — its own live CostTracker may already hold
+    // cost belonging to OTHER, already-separately-persisted sessions (see
+    // isUnscopedAggregatorSessionId's docstring). Adding it here on top of
+    // the persisted-sessions sum above would double-count that cost, so skip
+    // the live top-up entirely for such a process — unlike a genuine
+    // `--stdio` session (including one still on a pending-* provisional id),
+    // whose live cost really is exclusively its own.
+    const liveIsUnscopedAggregator = isUnscopedAggregatorSessionId(liveSid);
+
+    if (!liveAlreadyPersisted && !liveIsUnscopedAggregator) {
       const todayKey = localDateKey(now);
       const liveTodayUsd = deps.costTracker?.getCostForDay?.(todayKey) ?? null;
       if (typeof liveTodayUsd === 'number') {
@@ -1254,6 +1296,12 @@ export function createApiHandler(
           totalCostUsd += sessionCost;
         }
       }
+      // This MCP's own live subagent-for-day figure — the (2b) loop above
+      // already summed every OTHER today session's persisted subagentCostUsd;
+      // this process's own session isn't in that persisted set yet, so its
+      // contribution comes from the live, per-day-bucketed CostTracker value
+      // instead (same reasoning as liveTodayUsd above).
+      subagentUsd += deps.costTracker?.getSubagentCostForDay?.(todayKey) ?? 0;
     }
 
     // Live session anti-patterns (in-memory, not yet persisted).
@@ -1267,15 +1315,13 @@ export function createApiHandler(
 
     const avgDurationMs = durationSamples > 0 ? totalDurationMs / durationSamples : 0;
 
-    // Subagent breakdown for the Today KPI strip. Read directly
-    // off the in-memory tracker; if the workflow store is wired, also count
-    // workflow runs that started today.
-    // Today-scoped subagent spend so the "subagent spend" KPI lines up with the
-    // day-bucketed "spend today" (totalCostUsd) above — both are today-only.
+    // Subagent breakdown for the Today KPI strip; if the workflow store is
+    // wired, also count workflow runs that started today. `subagentUsd` was
+    // already accumulated above — summed across every today session's
+    // persisted subagentCostUsd, plus this MCP's own live today-portion.
     // IMPORTANT: getCostForDay and persisted estimatedCostUsd are already all-in
     // (parent + subagent), so totalCostUsd ALREADY includes subagent cost. This
     // is the breakdown, NOT an addend — do not add it to totalCostUsd.
-    const subagentUsd = deps.costTracker?.getSubagentCostForDay?.(localDateKey(now)) ?? 0;
     let subagentTurnCount = 0;
     let workflowRunCount = 0;
     if (deps.workflowStore) {

--- a/src/hooks/session-resolver.test.ts
+++ b/src/hooks/session-resolver.test.ts
@@ -9,6 +9,7 @@ import {
   resolveFromCwd,
   nextDelayMs,
   isSyntheticSessionId,
+  isUnscopedAggregatorSessionId,
 } from './session-resolver.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -292,5 +293,41 @@ describe('isSyntheticSessionId', () => {
 
   it('returns false for undefined', () => {
     expect(isSyntheticSessionId(undefined)).toBe(false);
+  });
+});
+
+describe('isUnscopedAggregatorSessionId', () => {
+  it('returns true for local- prefix', () => {
+    // A --local process's SubagentWatcher runs unscoped (parentSessionId:
+    // undefined) — it may have parsed transcripts belonging to other real
+    // sessions, so its own live cost is not exclusively-its-own.
+    expect(isUnscopedAggregatorSessionId('local-1234567890')).toBe(true);
+  });
+
+  it('returns true for proxy- prefix', () => {
+    expect(isUnscopedAggregatorSessionId('proxy-1234567890')).toBe(true);
+  });
+
+  it('returns false for pending- prefix', () => {
+    // A pending-<ts> id is still exactly one real --stdio session mid-
+    // resolution — its live cost genuinely is exclusively its own, so it
+    // must NOT be treated the same as an unscoped aggregator.
+    expect(isUnscopedAggregatorSessionId('pending-1234567890')).toBe(false);
+  });
+
+  it('returns false for a real session ID', () => {
+    expect(isUnscopedAggregatorSessionId('abc-123-real-session')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isUnscopedAggregatorSessionId('')).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isUnscopedAggregatorSessionId(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isUnscopedAggregatorSessionId(undefined)).toBe(false);
   });
 });

--- a/src/hooks/session-resolver.ts
+++ b/src/hooks/session-resolver.ts
@@ -276,3 +276,22 @@ export function isSyntheticSessionId(id: string | null | undefined): boolean {
   if (!id) return false;
   return id.startsWith('local-') || id.startsWith('proxy-') || id.startsWith('pending-');
 }
+
+/**
+ * Returns true for session IDs whose owning process's SubagentWatcher (if
+ * any) runs unscoped — `--local`/proxy processes discover subagent
+ * transcripts across every session, not just their own. Their own live
+ * CostTracker therefore is NOT exclusively their own cost: some of it may
+ * belong to other, already-separately-persisted sessions.
+ *
+ * Deliberately narrower than `isSyntheticSessionId`: a `pending-*` id is
+ * still exactly one real `--stdio` session (mid session-ID resolution), so
+ * its live cost genuinely is exclusively its own and must NOT be excluded
+ * the same way. Callers deciding whether to add a process's own live
+ * today-portion on top of an already-persisted-sessions sum (to avoid
+ * double-counting) should check this, not `isSyntheticSessionId`.
+ */
+export function isUnscopedAggregatorSessionId(id: string | null | undefined): boolean {
+  if (!id) return false;
+  return id.startsWith('local-') || id.startsWith('proxy-');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1324,12 +1324,26 @@ async function main(): Promise<void> {
               // => a zeroed "disabled" snapshot. costSelfCheckDeltaPct stays
               // null until the 1h self-check is wired.
               const stats = activeSubagentWatcher?.getHealthStats();
+              const watcherActive = activeSubagentWatcher !== null;
+              // Re-derive which of the two independent conditions caused a
+              // null binding, rather than reading the `subagentWatcherEnabled`/
+              // `watcherShouldRun` consts from the outer closure — this way
+              // the reason is always self-consistent with the actual env var
+              // at snapshot time, with no scope-ordering dependency on where
+              // those consts are declared in this large startup function.
+              const watcherDisabledReason: ObservabilityHealthSnapshot['watcherDisabledReason'] =
+                watcherActive
+                  ? null
+                  : process.env['NR_AI_ENABLE_SUBAGENT_WATCHER'] === '0'
+                    ? 'env_var'
+                    : 'mode_mismatch';
               return {
-                watcherActive: activeSubagentWatcher !== null,
+                watcherActive,
                 filesWatched: stats?.filesWatched ?? 0,
                 parseErrors: stats?.parseErrors ?? 0,
                 watcherDisabledByLock: stats?.watcherDisabledByLock ?? false,
                 costSelfCheckDeltaPct: null,
+                watcherDisabledReason,
               };
             },
           },

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -3,6 +3,7 @@ import {
   localDateKey,
   localStartOfDay,
   todayPortionOfSessionCost,
+  todayPortionRatio,
 } from './date.js';
 
 describe('localStartOfDay', () => {
@@ -139,5 +140,74 @@ describe('todayPortionOfSessionCost', () => {
     expect(todayPortionOfSessionCost({ ...base, estimatedCostUsd: null }, refTs)).toBe(0);
     expect(todayPortionOfSessionCost({ ...base, estimatedCostUsd: 0 }, refTs)).toBe(0);
     expect(todayPortionOfSessionCost({ ...base, estimatedCostUsd: -1 }, refTs)).toBe(0);
+  });
+});
+
+describe('todayPortionRatio', () => {
+  // Same reference instant and fixtures as todayPortionOfSessionCost above,
+  // so the ratio can be cross-checked against that function's known-good
+  // outputs (ratio * cost === todayPortionOfSessionCost's result).
+  const refTs = new Date(2026, 5, 10, 14, 0).getTime();
+  const startOfToday = new Date(2026, 5, 10, 0, 0).getTime();
+  const startOfYesterday = new Date(2026, 5, 9, 0, 0).getTime();
+  const endOfToday = startOfToday + 86_400_000;
+
+  it('returns 0 for sessions entirely before today', () => {
+    const session = {
+      startTime: startOfYesterday + 9 * 3_600_000,
+      endTime: startOfYesterday + 11 * 3_600_000,
+    };
+    expect(todayPortionRatio(session, refTs)).toBe(0);
+  });
+
+  it('returns 0 for sessions in the future relative to refTs', () => {
+    const session = {
+      startTime: endOfToday + 1_000,
+      endTime: endOfToday + 60_000,
+    };
+    expect(todayPortionRatio(session, refTs)).toBe(0);
+  });
+
+  it('returns 1 for sessions entirely within today', () => {
+    const session = {
+      startTime: startOfToday + 9 * 3_600_000,
+      endTime: startOfToday + 11 * 3_600_000,
+    };
+    expect(todayPortionRatio(session, refTs)).toBe(1);
+  });
+
+  it('pro-rates by timeline tool-call count when timeline is present', () => {
+    // Same shape as the todayPortionOfSessionCost timeline test: 4 entries,
+    // 1 of them today → ratio 0.25.
+    const session = {
+      startTime: startOfYesterday + 22 * 3_600_000,
+      endTime: startOfToday + 2 * 3_600_000,
+      timeline: [
+        { timestamp: startOfYesterday + 22 * 3_600_000 + 1_000 },
+        { timestamp: startOfYesterday + 22 * 3_600_000 + 30 * 60_000 },
+        { timestamp: startOfYesterday + 23 * 3_600_000 },
+        { timestamp: startOfToday + 60_000 },
+      ],
+    };
+    expect(todayPortionRatio(session, refTs)).toBe(0.25);
+  });
+
+  it('pro-rates by elapsed-time overlap when no timeline is present', () => {
+    // 22:00 yesterday → 02:00 today = 4h total, 2h within today → ratio 0.5.
+    const session = {
+      startTime: startOfYesterday + 22 * 3_600_000,
+      endTime: startOfToday + 2 * 3_600_000,
+    };
+    expect(todayPortionRatio(session, refTs)).toBe(0.5);
+  });
+
+  it('agrees with todayPortionOfSessionCost when multiplied by cost', () => {
+    const session = {
+      startTime: startOfYesterday + 22 * 3_600_000,
+      endTime: startOfToday + 2 * 3_600_000,
+      estimatedCostUsd: 8,
+    };
+    const ratio = todayPortionRatio(session, refTs);
+    expect(ratio * session.estimatedCostUsd).toBe(todayPortionOfSessionCost(session, refTs));
   });
 });

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -53,17 +53,54 @@ export function localDateKey(ts?: number): string {
 }
 
 /**
- * How much of `session.estimatedCostUsd` was spent during today's local day,
- * given the session's start, end, and timeline. Fixes the cross-midnight bug
- * where whole-session cost was attributed to the day a session started.
+ * What fraction of a session's activity fell within today's local day, given
+ * its start, end, and timeline. Shared by every "how much of this session's
+ * X counts toward today" calculation (currently cost, via
+ * `todayPortionOfSessionCost`) so each new per-session metric that needs the
+ * same cross-midnight pro-rating doesn't reimplement it.
  *
  * Strategy:
  *  - Session entirely before today's local day: return 0.
  *  - Session entirely after today's local day: return 0.
- *  - Session entirely within today: return total cost.
+ *  - Session entirely within today: return 1.
  *  - Session straddling midnight: pro-rate by tool-call count when a timeline
- *    is available (better correlated with cost than wall time, which can
- *    include long idle stretches), else by elapsed-time overlap.
+ *    is available (better correlated with per-event metrics than wall time,
+ *    which can include long idle stretches), else by elapsed-time overlap.
+ */
+export function todayPortionRatio(
+  session: {
+    startTime: number;
+    endTime: number;
+    timeline?: ReadonlyArray<{ timestamp: number }>;
+  },
+  refTs?: number,
+): number {
+  const dayStart = localStartOfDay(refTs);
+  const dayEnd = dayStart + 86_400_000;
+
+  if (session.endTime < dayStart) return 0;
+  if (session.startTime >= dayEnd) return 0;
+
+  const entirelyToday = session.startTime >= dayStart && session.endTime < dayEnd;
+  if (entirelyToday) return 1;
+
+  if (session.timeline && session.timeline.length > 0) {
+    const total = session.timeline.length;
+    const todayCount = session.timeline.filter(
+      (t) => t.timestamp >= dayStart && t.timestamp < dayEnd,
+    ).length;
+    if (total > 0) return todayCount / total;
+  }
+
+  const overlapMs = Math.min(session.endTime, dayEnd) - Math.max(session.startTime, dayStart);
+  const totalMs = Math.max(1, session.endTime - session.startTime);
+  return overlapMs / totalMs;
+}
+
+/**
+ * How much of `session.estimatedCostUsd` was spent during today's local day.
+ * Fixes the cross-midnight bug where whole-session cost was attributed to the
+ * day a session started. See `todayPortionRatio` for the pro-rating strategy.
  */
 export function todayPortionOfSessionCost(
   session: {
@@ -76,25 +113,5 @@ export function todayPortionOfSessionCost(
 ): number {
   const cost = session.estimatedCostUsd;
   if (cost == null || cost <= 0) return 0;
-
-  const dayStart = localStartOfDay(refTs);
-  const dayEnd = dayStart + 86_400_000;
-
-  if (session.endTime < dayStart) return 0;
-  if (session.startTime >= dayEnd) return 0;
-
-  const entirelyToday = session.startTime >= dayStart && session.endTime < dayEnd;
-  if (entirelyToday) return cost;
-
-  if (session.timeline && session.timeline.length > 0) {
-    const total = session.timeline.length;
-    const todayCount = session.timeline.filter(
-      (t) => t.timestamp >= dayStart && t.timestamp < dayEnd,
-    ).length;
-    if (total > 0) return cost * (todayCount / total);
-  }
-
-  const overlapMs = Math.min(session.endTime, dayEnd) - Math.max(session.startTime, dayStart);
-  const totalMs = Math.max(1, session.endTime - session.startTime);
-  return cost * (overlapMs / totalMs);
+  return cost * todayPortionRatio(session, refTs);
 }

--- a/src/metrics/claudemd-tracker.test.ts
+++ b/src/metrics/claudemd-tracker.test.ts
@@ -52,6 +52,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     buildRunCount: 1,
     buildPassCount: 1,
     estimatedCostUsd: 0.05,
+    subagentCostUsd: 0,
     tokensInput: 5000,
     tokensOutput: 2000,
     tokensThinking: 1000,

--- a/src/metrics/collaboration-profile.test.ts
+++ b/src/metrics/collaboration-profile.test.ts
@@ -49,6 +49,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     buildRunCount: 1,
     buildPassCount: 1,
     estimatedCostUsd: 0.05,
+    subagentCostUsd: 0,
     tokensInput: 5000,
     tokensOutput: 2000,
     tokensThinking: 1000,

--- a/src/metrics/prompt-feedback.test.ts
+++ b/src/metrics/prompt-feedback.test.ts
@@ -54,6 +54,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     buildRunCount: 1,
     buildPassCount: 1,
     estimatedCostUsd: 0.05,
+    subagentCostUsd: 0,
     tokensInput: 5000,
     tokensOutput: 2000,
     tokensThinking: 1000,

--- a/src/metrics/recommendation-engine.test.ts
+++ b/src/metrics/recommendation-engine.test.ts
@@ -55,6 +55,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     buildRunCount: 1,
     buildPassCount: 1,
     estimatedCostUsd: 0.05,
+    subagentCostUsd: 0,
     tokensInput: 5000,
     tokensOutput: 2000,
     tokensThinking: 1000,

--- a/src/metrics/trend-analyzer.test.ts
+++ b/src/metrics/trend-analyzer.test.ts
@@ -54,6 +54,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     buildRunCount: 1,
     buildPassCount: 1,
     estimatedCostUsd: 0.05,
+    subagentCostUsd: 0,
     tokensInput: 5000,
     tokensOutput: 2000,
     tokensThinking: 1000,

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -59,6 +59,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     buildRunCount: 1,
     buildPassCount: 1,
     estimatedCostUsd: 0.05,
+    subagentCostUsd: 0,
     tokensInput: 5000,
     tokensOutput: 2000,
     tokensThinking: 1000,
@@ -970,8 +971,8 @@ describe('buildSessionSummary', () => {
       reportCount: 2,
       estimationCount: 0,
       latestCostBreakdown: null,
-      subagentCostUsd: 0,
-      parentCostUsd: 0.05,
+      subagentCostUsd: 0.021,
+      parentCostUsd: 0.029,
       costByWorkflowRunId: {},
     } satisfies CostMetrics);
     const summary = buildSessionSummary({
@@ -982,6 +983,15 @@ describe('buildSessionSummary', () => {
     expect(summary.tokensCacheRead).toBe(5_000);
     expect(summary.tokensCacheCreation).toBe(1_500);
     expect(summary.cacheSavingsUsd).toBe(0.018);
+    expect(summary.subagentCostUsd).toBe(0.021);
+  });
+
+  it('defaults subagentCostUsd to 0 when no CostTracker is provided', () => {
+    const summary = buildSessionSummary({
+      sessionTracker: makeSessionTracker(),
+      developer: 'dev',
+    });
+    expect(summary.subagentCostUsd).toBe(0);
   });
 
   it('threads the platform field through when provided', () => {
@@ -1060,6 +1070,33 @@ describe('buildSessionSummary', () => {
     expect(result.tokensCacheRead).toBe(0);
     expect(result.tokensCacheCreation).toBe(0);
     expect(result.cacheSavingsUsd).toBe(0);
+  });
+
+  it('deserializeFullSessionSummary round-trips subagentCostUsd', () => {
+    const raw = {
+      sessionId: 'sess-subagent',
+      startTime: 1_700_000_000_000,
+      endTime: 1_700_003_600_000,
+      durationMs: 3_600_000,
+      toolCallCount: 5,
+      developer: 'dev',
+      subagentCostUsd: 0.0345,
+    };
+    const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
+    expect(result.subagentCostUsd).toBe(0.0345);
+  });
+
+  it('deserializeFullSessionSummary defaults subagentCostUsd to 0 for pre-fix session files', () => {
+    const raw = {
+      sessionId: 'sess-old',
+      startTime: 1_700_000_000_000,
+      endTime: 1_700_003_600_000,
+      durationMs: 3_600_000,
+      toolCallCount: 5,
+      developer: 'dev',
+    };
+    const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
+    expect(result.subagentCostUsd).toBe(0);
   });
 
   it('handles missing optional trackers gracefully', () => {

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -47,6 +47,12 @@ export interface FullSessionSummary extends SessionSummary {
   readonly buildRunCount: number;
   readonly buildPassCount: number;
   readonly estimatedCostUsd: number | null;
+  /**
+   * Portion of estimatedCostUsd attributed to subagent (ctx.agentId) calls —
+   * see CostMetrics.subagentCostUsd. 0 for pre-fix session files (subagent
+   * cost was never tracked) and for sessions with no subagent activity.
+   */
+  readonly subagentCostUsd: number;
   readonly tokensInput: number;
   readonly tokensOutput: number;
   readonly tokensThinking: number;
@@ -403,6 +409,7 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     buildRunCount: totalBuildsRun,
     buildPassCount: totalBuildsPassed,
     estimatedCostUsd: costMetrics?.sessionTotalCostUsd ?? null,
+    subagentCostUsd: costMetrics?.subagentCostUsd ?? 0,
     tokensInput: costMetrics?.totalInputTokens ?? 0,
     tokensOutput: costMetrics?.totalOutputTokens ?? 0,
     tokensThinking: costMetrics?.totalThinkingTokens ?? 0,
@@ -490,6 +497,7 @@ interface SerializedFullSessionSummary {
   readonly buildRunCount?: unknown;
   readonly buildPassCount?: unknown;
   readonly estimatedCostUsd?: unknown;
+  readonly subagentCostUsd?: unknown;
   readonly tokensInput?: unknown;
   readonly tokensOutput?: unknown;
   readonly tokensThinking?: unknown;
@@ -565,6 +573,7 @@ export function deserializeFullSessionSummary(
     buildRunCount: typeof obj.buildRunCount === 'number' ? obj.buildRunCount : 0,
     buildPassCount: typeof obj.buildPassCount === 'number' ? obj.buildPassCount : 0,
     estimatedCostUsd: typeof obj.estimatedCostUsd === 'number' ? obj.estimatedCostUsd : null,
+    subagentCostUsd: typeof obj.subagentCostUsd === 'number' ? obj.subagentCostUsd : 0,
     tokensInput: typeof obj.tokensInput === 'number' ? obj.tokensInput : 0,
     tokensOutput: typeof obj.tokensOutput === 'number' ? obj.tokensOutput : 0,
     tokensThinking: typeof obj.tokensThinking === 'number' ? obj.tokensThinking : 0,

--- a/src/storage/weekly-summary.test.ts
+++ b/src/storage/weekly-summary.test.ts
@@ -54,6 +54,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     buildRunCount: 1,
     buildPassCount: 1,
     estimatedCostUsd: 0.05,
+    subagentCostUsd: 0,
     tokensInput: 5000,
     tokensOutput: 2000,
     tokensThinking: 1000,

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -81,6 +81,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     buildRunCount: 1,
     buildPassCount: 1,
     estimatedCostUsd: 0.05,
+    subagentCostUsd: 0,
     tokensInput: 5000,
     tokensOutput: 2000,
     tokensThinking: 1000,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -825,6 +825,9 @@ export interface ObservabilityHealthResponse {
   readonly watcherDisabledByLock?: boolean;
   readonly filesWatched?: number;
   readonly parseErrors?: number;
+  // Absent on older server builds — treat as equivalent to 'env_var' (the
+  // banner's original, pre-fix behavior) rather than hiding the message.
+  readonly watcherDisabledReason?: 'env_var' | 'mode_mismatch' | null;
 }
 
 export const fetchObservabilityHealth = (): Promise<ObservabilityHealthResponse> =>

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -241,23 +241,59 @@ describe('Today view', () => {
     expect(screen.getByText(/insufficient data/i)).toBeInTheDocument();
   });
 
-  it('shows the subagent-tracking-disabled banner when watcherActive is false', async () => {
+  function stubObservabilityHealth(body: Record<string, unknown>): void {
     globalThis.fetch = vi.fn(async (input) => {
       const url = String(input);
       if (url.includes('/api/observability-health')) {
-        return new Response(
-          JSON.stringify({ watcherActive: false, watcherDisabledByLock: false }),
-          { status: 200, headers: { 'content-type': 'application/json' } },
-        );
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
       }
       return new Response(JSON.stringify([]), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
     }) as typeof fetch;
+  }
+
+  it('shows the env-var-disabled banner when watcherDisabledReason is env_var', async () => {
+    stubObservabilityHealth({
+      watcherActive: false,
+      watcherDisabledByLock: false,
+      watcherDisabledReason: 'env_var',
+    });
 
     renderToday();
     expect(await screen.findByText(/subagent cost tracking is disabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/NR_AI_ENABLE_SUBAGENT_WATCHER=0/)).toBeInTheDocument();
+  });
+
+  it('falls back to the env-var-disabled banner when watcherDisabledReason is absent (older server)', async () => {
+    // No watcherDisabledReason field at all — simulates a dashboard daemon
+    // running an older build that predates this field. Must not silently
+    // hide the (still broadly correct) message in that case.
+    stubObservabilityHealth({ watcherActive: false, watcherDisabledByLock: false });
+
+    renderToday();
+    expect(await screen.findByText(/subagent cost tracking is disabled/i)).toBeInTheDocument();
+  });
+
+  it('shows a mode-mismatch banner (not the env-var message) when watcherDisabledReason is mode_mismatch', async () => {
+    // This is the --local dashboard daemon's default state: the watcher only
+    // auto-starts in --stdio mode, so watcherActive is false here by design,
+    // NOT because NR_AI_ENABLE_SUBAGENT_WATCHER is set to 0. Telling the user
+    // to unset a variable that was never set would be actively misleading.
+    stubObservabilityHealth({
+      watcherActive: false,
+      watcherDisabledByLock: false,
+      watcherDisabledReason: 'mode_mismatch',
+    });
+
+    renderToday();
+    expect(await screen.findByText(/subagent activity from other sessions/i)).toBeInTheDocument();
+    expect(screen.queryByText(/subagent cost tracking is disabled/i)).toBeNull();
+    expect(screen.queryByText(/NR_AI_ENABLE_SUBAGENT_WATCHER=0/)).toBeNull();
   });
 });
 

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -321,14 +321,28 @@ export function Today(): JSX.Element {
               Check Settings &rarr; Observability health.
             </div>
           )}
-          {healthApi?.watcherActive === false && subagentStats.turns === 0 && (
-            <div className="rounded-lg border border-border-subtle bg-surface-5 px-4 py-3 text-sm text-ink-muted mb-4">
-              Subagent cost tracking is disabled (
-              <code className="font-mono text-xs">NR_AI_ENABLE_SUBAGENT_WATCHER=0</code>), so spend
-              shown here excludes subagents. Unset that variable (it is on by default) and restart
-              to see full spend.
-            </div>
-          )}
+          {healthApi?.watcherActive === false &&
+            subagentStats.turns === 0 &&
+            healthApi?.watcherDisabledReason !== 'mode_mismatch' && (
+              <div className="rounded-lg border border-border-subtle bg-surface-5 px-4 py-3 text-sm text-ink-muted mb-4">
+                Subagent cost tracking is disabled (
+                <code className="font-mono text-xs">NR_AI_ENABLE_SUBAGENT_WATCHER=0</code>), so
+                spend shown here excludes subagents. Unset that variable (it is on by default) and
+                restart to see full spend.
+              </div>
+            )}
+          {healthApi?.watcherActive === false &&
+            subagentStats.turns === 0 &&
+            healthApi?.watcherDisabledReason === 'mode_mismatch' && (
+              <div className="rounded-lg border border-border-subtle bg-surface-5 px-4 py-3 text-sm text-ink-muted mb-4">
+                This dashboard process isn&rsquo;t running its own subagent watcher — expected for a
+                background <code className="font-mono text-xs">--local</code> dashboard (the watcher
+                only auto-starts in <code className="font-mono text-xs">--stdio</code> mode). Spend
+                shown here still includes subagent activity from other sessions, read from their
+                persisted totals. To track subagents live from this process too, set{' '}
+                <code className="font-mono text-xs">NR_AI_WATCHER_MODE=local</code> and restart.
+              </div>
+            )}
           <AnimatedCard index={0} className="mb-4">
             <Card padding="lg" tone="elevated" glow="green">
               <div className="grid grid-cols-5 gap-4">


### PR DESCRIPTION
Fixes #303

## Summary
- Sum subagent spend from every persisted session's own total on the Today dashboard's aggregate endpoint, instead of reading only the single process currently serving the dashboard — fixes subagent spend silently excluding activity from other concurrent sessions.
- Distinguish, in the "subagent cost tracking is disabled" banner, between the watcher being explicitly disabled (`NR_AI_ENABLE_SUBAGENT_WATCHER=0`) and a background dashboard process simply not running its own watcher by default — the old message blamed the env var even when it was never set.
- Add `isUnscopedAggregatorSessionId()` and use it to stop a background dashboard process's own live subagent total from being added on top of an already-persisted session's total, closing a double-counting path that opting such a process into its own watcher (`NR_AI_WATCHER_MODE=local`) would otherwise open.
- Bump to v1.14.6, CHANGELOG entry.

## Test plan
- [x] `npm test` (Jest) — 5175 passed
- [x] `npx vitest run` (web) — 34 passed in `Today.test.tsx`
- [x] `npm run lint` — clean
- [x] `npx tsc -b .` and `npx tsc --noEmit -p tsconfig.web.json` — clean
- [x] `npm run build` — clean
- [x] New tests added TDD-first for: `todayPortionRatio`, persisted `subagentCostUsd` round-trip, cross-session aggregate summation, `isUnscopedAggregatorSessionId`, and the banner's three states (env_var / mode_mismatch / absent-field fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)