### PR TITLE
Fix: cross-process races between --local and --stdio (v1.14.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.7] - 2026-07-30
+
+### Fixed
+
+- **A `--local` dashboard process running alongside active `--stdio` sessions could silently steal a portion of a session's tool-call and token events.** Both processes poll for new events on the same per-session buffer file; `--local`'s cross-session drain had no way to tell that a `--stdio` process already owned and was draining that exact file itself. Whichever side won a given poll cycle kept the events, and the other side saw nothing, with no error on either side — silently undercounting that session's own stats and cost tracking, and, for a session configured for cloud telemetry, dropping those events from New Relic entirely. `--local` now skips any per-session buffer that has a live `--stdio` owner.
+- **Opting a `--local` process into its own subagent watcher (`NR_AI_WATCHER_MODE=local`) while a `--stdio` sibling was also running caused both processes to redundantly tail the same subagent transcripts and race over the same cursor files.** The unfiltered watcher now skips any session that already has a live `--stdio` owner, the same way the buffer-drain fix above does.
+
 ## [1.14.6] - 2026-07-30
 
 ### Fixed

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -87,6 +87,22 @@ If `NEW_RELIC_LICENSE_KEY`, `NEW_RELIC_ACCOUNT_ID`, or `NEW_RELIC_API_KEY` are s
 
 ---
 
+## Running `--local` Standalone (No `--stdio` Session)
+
+The subagent/workflow transcript watchers only auto-start under `--stdio` by default (`NR_AI_WATCHER_MODE=stdio`) — a `--local` dashboard process doesn't run its own copy, since a `--stdio` session normally already covers the same data, scoped to itself, and the Today view's spend figures already aggregate every session's _persisted_ totals regardless of which process is currently serving the dashboard. If `watcherActive` is `false` for this reason, the dashboard shows a banner explaining it (distinct from the `NR_AI_ENABLE_SUBAGENT_WATCHER=0` banner, which is an explicit opt-out rather than this mode default).
+
+| Setting                         | What it does                                                                                             | Default  |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- | -------- |
+| `NR_AI_WATCHER_MODE`            | Which side runs the subagent/workflow transcript watchers — `"stdio"` or `"local"`.                      | `stdio`  |
+| `NR_AI_ENABLE_SUBAGENT_WATCHER` | Set to `0` to disable subagent cost tracking entirely (whichever side owns it per `NR_AI_WATCHER_MODE`). | enabled  |
+| `NR_AI_ENABLE_WORKFLOW_WATCHER` | Set to `1` to enable script-workflow tracking (whichever side owns it per `NR_AI_WATCHER_MODE`).         | disabled |
+
+**When to set `NR_AI_WATCHER_MODE=local` yourself:** if your `--local` process never has a `--stdio` sibling to defer to — a fully standalone deployment (container, systemd unit, or any platform with no MCP client to auto-launch `--stdio`) — nothing else will ever track subagent cost for it. Setting this makes the `--local` process discover and tail every session's subagent transcripts itself.
+
+This is safe to combine with concurrently-running `--stdio` sessions: a `--local` process running with `NR_AI_WATCHER_MODE=local` skips any session that already has a live `--stdio` heartbeat, so it only picks up sessions with no other owner rather than redundantly re-tailing (and racing over the same cursor files as) a session's own scoped watcher.
+
+---
+
 ## Local Alerts
 
 Local-mode users get threshold alerting evaluated in-process, with no New Relic dependency. The engine reads rules from `~/.newrelic-preflight/alerts/rules.json`, evaluates them on a fixed cadence (default 30s), and surfaces firing/clearing events through the embedded dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.6",
+  "version": "1.14.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.6",
+      "version": "1.14.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.6",
+  "version": "1.14.7",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/subagent-watcher.test.ts
+++ b/src/hooks/subagent-watcher.test.ts
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SubagentWatcher, buildSubagentCursorPath } from './subagent-watcher.js';
+import { LocalStore } from '../storage/local-store.js';
 
 const STDERR_WRITE = process.stderr.write;
 
@@ -207,6 +208,78 @@ describe('SubagentWatcher', () => {
           .map((l) => JSON.parse(l))
           .filter((l) => l.mode === 'subagent_token');
     expect(tokenLines).toHaveLength(0);
+  });
+
+  describe('unfiltered discovery (--local mode, no parentSessionId)', () => {
+    // High PID sentinel — see local-store.test.ts's gcOrphanBuffers() block
+    // for the same rationale (well above Linux/macOS pid_max ceilings).
+    const DEAD_PID = 9_999_999;
+
+    it('discovers files across every session when no parentSessionId filter is set', () => {
+      writeFileSync(agentJsonl, makeAssistantLine({ messageId: 'msg_1' }) + '\n');
+      const watcher = new SubagentWatcher({ storagePath, projectsDir });
+      watcher.poll();
+      const buf = readFileSync(join(storagePath, `buffer-${PARENT_SESSION}.jsonl`), 'utf-8');
+      const tokenLines = buf
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l))
+        .filter((l) => l.mode === 'subagent_token');
+      expect(tokenLines).toHaveLength(1);
+    });
+
+    it("skips a session whose --stdio owner is alive, so it doesn't race that session's own scoped watcher over the same cursor file", () => {
+      writeFileSync(agentJsonl, makeAssistantLine({ messageId: 'msg_1' }) + '\n');
+      // A live heartbeat means a --stdio process already owns and tails this
+      // session's subagent transcripts with its own scoped SubagentWatcher.
+      writeFileSync(join(storagePath, `active-${PARENT_SESSION}.pid`), String(process.pid));
+
+      const watcher = new SubagentWatcher({
+        storagePath,
+        projectsDir,
+        localStore: new LocalStore(storagePath),
+      });
+      watcher.poll();
+
+      const bufPath = join(storagePath, `buffer-${PARENT_SESSION}.jsonl`);
+      expect(existsSync(bufPath)).toBe(false);
+    });
+
+    it('still discovers a session whose heartbeat PID is dead (orphaned session)', () => {
+      writeFileSync(agentJsonl, makeAssistantLine({ messageId: 'msg_1' }) + '\n');
+      writeFileSync(join(storagePath, `active-${PARENT_SESSION}.pid`), String(DEAD_PID));
+
+      const watcher = new SubagentWatcher({
+        storagePath,
+        projectsDir,
+        localStore: new LocalStore(storagePath),
+      });
+      watcher.poll();
+
+      const buf = readFileSync(join(storagePath, `buffer-${PARENT_SESSION}.jsonl`), 'utf-8');
+      const tokenLines = buf
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l))
+        .filter((l) => l.mode === 'subagent_token');
+      expect(tokenLines).toHaveLength(1);
+    });
+
+    it('discovers every session when no localStore is provided (no regression for callers that omit it)', () => {
+      writeFileSync(agentJsonl, makeAssistantLine({ messageId: 'msg_1' }) + '\n');
+      writeFileSync(join(storagePath, `active-${PARENT_SESSION}.pid`), String(process.pid));
+
+      const watcher = new SubagentWatcher({ storagePath, projectsDir });
+      watcher.poll();
+
+      const buf = readFileSync(join(storagePath, `buffer-${PARENT_SESSION}.jsonl`), 'utf-8');
+      const tokenLines = buf
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l))
+        .filter((l) => l.mode === 'subagent_token');
+      expect(tokenLines).toHaveLength(1);
+    });
   });
 
   it('rejects synthetic models', () => {

--- a/src/hooks/subagent-watcher.ts
+++ b/src/hooks/subagent-watcher.ts
@@ -216,6 +216,7 @@ export class SubagentWatcher {
   private readonly discoveryHours: number;
   private readonly parentSessionFilter: string | null;
   private readonly costSelfCheck: SubagentWatcherOptions['costSelfCheck'];
+  private readonly localStore: LocalStore | undefined;
 
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private healthIntervalId: ReturnType<typeof setInterval> | null = null;
@@ -271,6 +272,7 @@ export class SubagentWatcher {
       (Number.isFinite(envHours) && envHours > 0 ? envHours : DEFAULT_DISCOVERY_HOURS);
     this.parentSessionFilter = options.parentSessionId ?? null;
     this.costSelfCheck = options.costSelfCheck;
+    this.localStore = options.localStore;
     this.loadFingerprints();
   }
 
@@ -358,6 +360,17 @@ export class SubagentWatcher {
     if (!existsSync(this.projectsDir)) return out;
     const cutoffMs = Date.now() - this.discoveryHours * 60 * 60 * 1000;
 
+    // Unfiltered (--local) mode discovers every session on disk. A session
+    // with a live --stdio heartbeat already has its own scoped SubagentWatcher
+    // tailing these exact files — discovering it here too would race that
+    // watcher's cursor reads/writes over the same `.subagent-pos-*` files with
+    // no coordination between the two processes. --stdio's own heartbeat is
+    // never written until its watcher is about to start (see index.ts), so
+    // this only ever excludes sessions that already have their own owner.
+    const liveOwnedSessionIds = this.parentSessionFilter
+      ? null
+      : (this.localStore?.getActiveSessionIdsFromHeartbeats() ?? null);
+
     let projectEntries: string[];
     try {
       projectEntries = readdirSync(this.projectsDir);
@@ -390,6 +403,7 @@ export class SubagentWatcher {
       for (const sessionId of sessionEntries) {
         if (!SESSION_ID_RE.test(sessionId)) continue;
         if (this.parentSessionFilter && sessionId !== this.parentSessionFilter) continue;
+        if (liveOwnedSessionIds?.has(sessionId)) continue;
         const sessionDir = join(projectPath, sessionId);
         const subDir = join(sessionDir, 'subagents');
         if (!existsSync(subDir)) continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1925,6 +1925,9 @@ async function main(): Promise<void> {
         activeSubagentWatcher = new SubagentWatcher({
           storagePath: config!.storagePath,
           parentSessionId: isStdioWatcher ? watcherSessionId : undefined,
+          // Only meaningful when unfiltered (--local) — lets discoverFiles()
+          // skip sessions that already have a live --stdio owner tailing them.
+          localStore,
           // Runtime cost-self-check: a drift > 5% surfaces as an
           // `AiObservabilityHealth { event: 'cost_self_check' }` event. We
           // compare like-with-like from two INDEPENDENT code paths so a

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -551,6 +551,37 @@ describe('LocalStore', () => {
       const all = drainAll.drainAllBuffers();
       expect(all.map((e) => e.tool)).toEqual(['real']);
     });
+
+    // Same DEAD_PID rationale as the gcOrphanBuffers() describe block below:
+    // 9_999_999 is above both Linux's and macOS's pid_max ceilings.
+    const DEAD_PID = 9_999_999;
+
+    it("skips a per-session buffer whose owner heartbeat is alive, so it does not race that --stdio process's own scoped drainBuffer()", () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const owned = new LocalStore(tmpDir, 'sess-owned');
+      owned.appendToBuffer(makeEvent({ tool: 'owned-event' }));
+      owned.writeHeartbeat(process.pid);
+      new LocalStore(tmpDir, 'sess-orphan').appendToBuffer(makeEvent({ tool: 'orphan-event' }));
+
+      const drainAll = new LocalStore(tmpDir);
+      const all = drainAll.drainAllBuffers();
+
+      // Only the orphaned session's event comes back — the live-owned
+      // session's buffer is left untouched for its own process to drain.
+      expect(all.map((e) => e.tool)).toEqual(['orphan-event']);
+      expect(existsSync(resolve(tmpDir, 'buffer-sess-owned.jsonl'))).toBe(true);
+      expect(owned.drainBuffer().map((e) => e.tool)).toEqual(['owned-event']);
+    });
+
+    it('still drains a per-session buffer whose heartbeat PID is dead', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      new LocalStore(tmpDir, 'sess-dead-owner').appendToBuffer(makeEvent({ tool: 'dead-owner' }));
+      writeFileSync(resolve(tmpDir, 'active-sess-dead-owner.pid'), String(DEAD_PID));
+
+      const drainAll = new LocalStore(tmpDir);
+      const all = drainAll.drainAllBuffers();
+      expect(all.map((e) => e.tool)).toEqual(['dead-owner']);
+    });
   });
 
   describe('migrateLegacyBuffer()', () => {

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -177,6 +177,15 @@ export class LocalStore {
    * sessions' events. Each file is drained atomically (rename-then-read) so a
    * concurrent writer for that session can't lose events; orphan files (whose
    * MCP isn't running) are picked up too.
+   *
+   * A per-session buffer whose `active-<sessionId>.pid` heartbeat names a
+   * live PID is skipped: that session's own `--stdio` process is already
+   * polling and draining that exact file via its own scoped drainBuffer() on
+   * the same cadence. Draining it here too would race that rename-then-read
+   * against the owner's — whichever process wins a given poll cycle silently
+   * keeps the batch, and the loser sees nothing, with no error on either
+   * side. The owner's copy always wins fairly since this call skips the file
+   * outright rather than racing it.
    */
   drainAllBuffers(): HookEvent[] {
     const all: HookEvent[] = [];
@@ -193,12 +202,36 @@ export class LocalStore {
       // buffer.jsonl so a freshly-upgraded user's pre-existing events still flow.
       if (!name.endsWith('.jsonl')) continue;
       if (name !== 'buffer.jsonl' && !name.startsWith('buffer-')) continue;
+
+      if (name !== 'buffer.jsonl' && this.hasLiveOwner(name)) continue;
+
       const drained = this.drainPath(resolve(this.storagePath, name));
       if (drained.length > 0) {
         for (const event of drained) all.push(event);
       }
     }
     return all;
+  }
+
+  /**
+   * True when `buffer-<sessionId>.jsonl`'s matching `active-<sessionId>.pid`
+   * heartbeat names a currently-alive PID. `bufferFileName` must already be
+   * confirmed to start with `buffer-` and end with `.jsonl` (checked by the
+   * caller) and not be the legacy shared `buffer.jsonl`.
+   */
+  private hasLiveOwner(bufferFileName: string): boolean {
+    const sessionId = bufferFileName.slice('buffer-'.length, -'.jsonl'.length);
+    if (!SESSION_ID_RE.test(sessionId)) return false;
+    const heartbeatPath = resolve(this.storagePath, `active-${sessionId}.pid`);
+    if (!existsSync(heartbeatPath)) return false;
+    try {
+      const pid = Number.parseInt(readFileSync(heartbeatPath, 'utf-8').trim(), 10);
+      return isPidAlive(pid);
+    } catch {
+      // Unreadable heartbeat — treat as not-live; gcOrphanBuffers() cleans up
+      // a genuinely dead/corrupt heartbeat file separately.
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #307

## Summary

- **Buffer-drain race**: a `--local` dashboard process's cross-session buffer drain could race a live `--stdio` session's own scoped drain over the exact same per-session buffer file, with no coordination. Whichever process won a given poll cycle (every 100ms) kept that batch of tool-call/token events; the other saw nothing, with no error on either side — silently undercounting that session's own stats/cost, and for a session configured for cloud telemetry, dropping those events from New Relic entirely. The cross-session drain now skips any per-session buffer whose heartbeat names a live PID.
- **Subagent-watcher race**: opting a `--local` process into its own subagent watcher (`NR_AI_WATCHER_MODE=local`) while a `--stdio` sibling was also running caused both to redundantly tail the same subagent transcripts and race over the same cursor files. The unfiltered watcher now skips any session with a live `--stdio` heartbeat, the same way.
- `docs/ADVANCED.md` updated to describe when to set `NR_AI_WATCHER_MODE=local` yourself, and that it's now safe to combine with concurrently-running `--stdio` sessions.

Related: #305 (a separate, still-open gap — Pi's `--local`-only dashboard has no `--stdio` sibling to ever defer to, so it needs its own fix to enable subagent tracking by default).

## Test plan

- [x] New test coverage for both races
- [x] `npm run lint` — clean
- [x] `npx tsc -b .` — clean
- [x] `npx jest` — all passing