### PR TITLE
Fix: cross-midnight sessions invisible to Today heatmap/concurrency chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.8] - 2026-07-30
+
+### Fixed
+
+- **The Today dashboard's activity heatmap and concurrency chart could show a gap for a session that started before local midnight and was still running** — both read only sessions whose _start_ date matched today's, so a session crossing midnight was invisible to them even though its today-portion should have counted (the "spend today" figure already handled this case correctly via a separate helper). Both now include cross-midnight sessions, counting only their activity that actually falls within today.
+
 ## [1.14.7] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.7",
+  "version": "1.14.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.7",
+      "version": "1.14.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.7",
+  "version": "1.14.8",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -2020,6 +2020,34 @@ describe('api-handler GET /api/concurrency (96-bucket grid)', () => {
     for (const c of counts) expect(c).toBeLessThanOrEqual(bucketMax);
   });
 
+  it('includes a cross-midnight session (started yesterday, still active) via loadSessionsOverlappingToday', async () => {
+    // Session started 10min before local midnight and is still active 5min
+    // after — loadTodaySessions() would exclude it (filename date = yesterday),
+    // but loadSessionsOverlappingToday() must pick it up so its today-portion
+    // still counts toward concurrency.
+    const crossMidnightSessions = [{ sessionId: 'cross-midnight', timeline: makeTimeline(-10, 5) }];
+    const handler = createApiHandler({
+      concurrencyTracker: makeConcurrencyTracker(),
+      liveSessionRegistry: makeLiveRegistry(),
+      sessionStore: {
+        loadTodaySessions: () => [],
+        loadSessionsOverlappingToday: () => crossMidnightSessions,
+        loadAllSessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/concurrency' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body());
+    // The session is active at 00:00 (bucket 0) regardless of its 00:00-before start.
+    expect(result.buckets[0].count).toBe(1);
+    const maxBucket = Math.max(...result.buckets.map((b: { count: number }) => b.count));
+    expect(maxBucket).toBe(1);
+  });
+
   it("counts a live session's buffered activity as discrete 3-minute windows, not a continuous span to now", async () => {
     // A live session's not-yet-persisted activity comes from the tool-call
     // buffer. Each cluster of activity is a 3-minute window — an idle gap
@@ -3664,6 +3692,42 @@ describe('api-handler GET /api/activity-heatmap', () => {
     const result = JSON.parse(body());
     // Both events land in bucket 0 (00:00-00:15) → count 2.
     expect(result.buckets[0]).toBe(2);
+  });
+
+  it('includes a cross-midnight session (started yesterday, still active) via loadSessionsOverlappingToday', async () => {
+    const now = Date.now();
+    const startMs = new Date(now);
+    startMs.setHours(0, 0, 0, 0);
+    const start = startMs.getTime();
+    const handler = createApiHandler({
+      toolCallBuffer: { getRecords: () => [] },
+      sessionStore: {
+        // Excluded by loadTodaySessions() — its filename date is yesterday's.
+        loadTodaySessions: () => [],
+        // loadSessionsOverlappingToday() must supply it instead. Its timeline
+        // has one entry before local midnight (must be excluded from the
+        // bucket count) and one entry after (must be included).
+        loadSessionsOverlappingToday: () => [
+          {
+            sessionId: 'cross-midnight',
+            timeline: [
+              { timestamp: start - 60_000, toolName: 'Read', success: true },
+              { timestamp: start + 61_000, toolName: 'Edit', success: true },
+            ],
+          },
+        ],
+        loadAllSessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/activity-heatmap?view=today' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body());
+    // Only the post-midnight entry counts.
+    expect(result.buckets[0]).toBe(1);
   });
 
   it('returns view=history days aggregated by UTC date, respecting the weeks param', async () => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1605,10 +1605,19 @@ export function createApiHandler(
         allSessions as readonly SessionActivityLike[],
       );
 
-      // loadTodaySessions() already excludes synthetic session ids, so the
-      // chart buckets below agree with the session list shown alongside the
-      // chart without re-filtering here.
-      const todaySessions = deps.sessionStore?.loadTodaySessions() ?? [];
+      // Prefer loadSessionsOverlappingToday() so a session that started
+      // yesterday and is still running isn't invisible to the chart —
+      // loadTodaySessions() filters by filename date (= start date) and
+      // would otherwise silently drop it. Downstream window-building already
+      // clamps each session's activity to [startTimestamp, dayEnd], so widening
+      // the input set here can't leak yesterday's activity into today's buckets.
+      // loadAllSessions()/loadTodaySessions() already exclude synthetic session
+      // ids, so the chart buckets below agree with the session list shown
+      // alongside the chart without re-filtering here.
+      const todaySessions =
+        deps.sessionStore?.loadSessionsOverlappingToday?.() ??
+        deps.sessionStore?.loadTodaySessions() ??
+        [];
 
       // 96 × 15-minute fixed-grid buckets covering today (local midnight →
       // local midnight + 24h). Each bucket holds the peak concurrent
@@ -1674,7 +1683,16 @@ export function createApiHandler(
           }
         }
 
-        const todaySessions = deps.sessionStore?.loadTodaySessions() ?? [];
+        // Prefer loadSessionsOverlappingToday() so a session that started
+        // yesterday and is still running isn't invisible here —
+        // loadTodaySessions() filters by filename date (= start date) and
+        // would otherwise silently drop it. The `entry.timestamp >= startMs`
+        // check just below already excludes that session's yesterday-side
+        // entries, so widening the input set can't double-count anything.
+        const todaySessions =
+          deps.sessionStore?.loadSessionsOverlappingToday?.() ??
+          deps.sessionStore?.loadTodaySessions() ??
+          [];
         for (const s of todaySessions) {
           const session = s as { timeline?: readonly { timestamp: number }[] };
           if (session.timeline) {


### PR DESCRIPTION
Fixes #309

## Summary
- The Today dashboard's activity heatmap and concurrency chart both read `sessionStore.loadTodaySessions()`, which filters sessions by *start* date (derived from the persisted filename). A session that started before local midnight and is still running never matches that filter, so its today-portion silently disappeared from both charts — even though the "spend today" KPI already handled this exact case via a separate helper (`loadSessionsOverlappingToday()`).
- Both routes now prefer `loadSessionsOverlappingToday()`, falling back to `loadTodaySessions()` if the store doesn't implement it. Each route already clamps individual timestamps/windows to today's boundary downstream, so widening the input session set can't leak yesterday's activity into today's buckets.
- Bumped to v1.14.8 with a CHANGELOG entry.

## Test plan
- [x] Added a failing-first test to both the `/api/concurrency` and `/api/activity-heatmap` describe blocks in `api-handler.test.ts`, each covering a session that started before local midnight and is still active — confirmed both failed before the fix (bucket count 0 instead of 1).
- [x] Implemented the fix; both new tests pass.
- [x] Full suite, lint, and build all pass in this clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)