### PR TITLE
Fix: Today dashboard cross-session blind spots (efficiency KPI + anti-pattern banner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.9] - 2026-07-30
+
+### Fixed
+
+- **The Today dashboard's efficiency KPI only reflected whichever process happened to be serving the dashboard** — with multiple Claude Code sessions running concurrently, only one process's own in-memory efficiency tracker ever backed the "efficiency" figure, silently excluding coding productivity data from every other session. It's now aggregated across today's sessions, the same way the other Today KPIs (activity, concurrency, spend) already were.
+- **The anti-pattern detail banner could show a blank pattern name and file even when the flags count above it was non-zero** — the banner only checked the dashboard-serving process's own live anti-pattern detections, so when a pattern was detected in a different session that persisted its own state to disk, the banner had no way to retrieve it and remained blank. It now falls back to already-persisted anti-pattern data from each session, the same way the efficiency KPI now does.
+
 ## [1.14.8] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.8",
+      "version": "1.14.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1686,6 +1686,91 @@ describe('api-handler GET /api/sessions/today/aggregate', () => {
       Date.now = realNow;
     }
   });
+
+  it('averages efficiencyScore across today persisted sessions', async () => {
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [
+          { sessionId: 'a', efficiencyScore: 0.8 },
+          { sessionId: 'b', efficiencyScore: 0.6 },
+          // null efficiencyScore must be excluded from the average, not treated as 0.
+          { sessionId: 'c', efficiencyScore: null },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { avgEfficiencyScore: number | null };
+    // (0.8 + 0.6) / 2 = 0.7
+    expect(parsed.avgEfficiencyScore).toBeCloseTo(0.7);
+  });
+
+  it('folds in this process own live efficiency score when its session is not yet persisted', async () => {
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [{ sessionId: 'other', efficiencyScore: 0.5 }],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: { getMetrics: () => ({ sessionId: 'live-1' }) } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['sessionTracker'],
+      efficiencyScorer: { getSessionAverage: () => ({ score: 0.9 }) },
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { avgEfficiencyScore: number | null };
+    // (0.5 + 0.9) / 2 = 0.7 — 'live-1' isn't in loadTodaySessions(), so its live score is added.
+    expect(parsed.avgEfficiencyScore).toBeCloseTo(0.7);
+  });
+
+  it('does not double-count the live score when its session is already persisted', async () => {
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [{ sessionId: 'live-1', efficiencyScore: 0.5 }],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: { getMetrics: () => ({ sessionId: 'live-1' }) } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['sessionTracker'],
+      efficiencyScorer: { getSessionAverage: () => ({ score: 0.9 }) },
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { avgEfficiencyScore: number | null };
+    // Only the persisted 0.5 counts — 'live-1' is already in loadTodaySessions(), so its
+    // live 0.9 must NOT be added again.
+    expect(parsed.avgEfficiencyScore).toBeCloseTo(0.5);
+  });
+
+  it('returns null avgEfficiencyScore when no session has a score yet', async () => {
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { avgEfficiencyScore: number | null };
+    expect(parsed.avgEfficiencyScore).toBeNull();
+  });
 });
 
 describe('api-handler GET /api/workflows', () => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1313,6 +1313,27 @@ export function createApiHandler(
       antiPatternCount += live.length;
     }
 
+    // Efficiency KPI: average `efficiencyScore` across today's persisted sessions, plus
+    // this process's own live score when its own session isn't in that persisted set yet
+    // (same liveAlreadyPersisted guard already used for cost/anti-patterns above).
+    let efficiencyScoreSum = 0;
+    let efficiencyScoreCount = 0;
+    for (const s of todaySessions) {
+      if (typeof s.efficiencyScore === 'number') {
+        efficiencyScoreSum += s.efficiencyScore;
+        efficiencyScoreCount++;
+      }
+    }
+    if (!liveAlreadyPersisted) {
+      const liveScore = deps.efficiencyScorer?.getSessionAverage()?.score ?? null;
+      if (typeof liveScore === 'number') {
+        efficiencyScoreSum += liveScore;
+        efficiencyScoreCount++;
+      }
+    }
+    const avgEfficiencyScore =
+      efficiencyScoreCount > 0 ? efficiencyScoreSum / efficiencyScoreCount : null;
+
     const avgDurationMs = durationSamples > 0 ? totalDurationMs / durationSamples : 0;
 
     // Subagent breakdown for the Today KPI strip; if the workflow store is
@@ -1342,6 +1363,7 @@ export function createApiHandler(
       subagentUsd: Math.round(subagentUsd * 1000) / 1000,
       subagentTurnCount,
       workflowRunCount,
+      avgEfficiencyScore,
     };
     aggregateCache = { bucket: currentBucket, payload };
     jsonOk(res, payload);

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -144,6 +144,7 @@ export interface TodayAggregateResponse {
   readonly subagentUsd?: number;
   readonly subagentTurnCount?: number;
   readonly workflowRunCount?: number;
+  readonly avgEfficiencyScore?: number | null;
 }
 
 // /api/sessions returns a heterogeneous mix of full persisted session

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -136,6 +136,44 @@ describe('Today view', () => {
     expect(screen.queryByText(/\?× on/)).toBeNull();
   });
 
+  it('renders anti-pattern detail from a persisted session when no live/API detail exists', async () => {
+    useLiveStore.setState({ antiPatterns: [] });
+    const startOfToday = new Date();
+    startOfToday.setHours(1, 0, 0, 0);
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (url === '/api/anti-patterns') {
+        // This process's own live detector saw nothing.
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.startsWith('/api/sessions?')) {
+        // A persisted session from a DIFFERENT process already has a flagged pattern.
+        return new Response(
+          JSON.stringify([
+            {
+              sessionId: 'other-process-session',
+              startTime: startOfToday.getTime(),
+              toolCallCount: 12,
+              antiPatterns: [{ type: 'stuck_loop', command: 'npm run build', repeatCount: 6 }],
+            },
+          ]),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+
+    await waitFor(() => expect(screen.getByText(/6× on/)).toBeInTheDocument());
+    expect(screen.getByText(/npm run build/)).toBeInTheDocument();
+  });
+
   it('does not show the empty state while concurrency/heatmap/liveSessions are still pending', async () => {
     // Zero out the cost/antiPatterns/tool-call state that resetStore() (in
     // the outer beforeEach) set to non-zero values, so calls === 0,
@@ -447,6 +485,41 @@ describe('Today view — aggregate endpoint', () => {
     expect(await screen.findByText('42')).toBeInTheDocument();
     expect(screen.getByText('$7.75')).toBeInTheDocument();
     expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('renders the efficiency KPI from the aggregate endpoint, not session/current', async () => {
+    globalThis.fetch = vi.fn(async (input: string | RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/session/current')) {
+        // This process's own live score is null — it must NOT be what renders.
+        return new Response(JSON.stringify({ efficiencyScore: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(
+          JSON.stringify({
+            toolCallCount: 1,
+            totalCostUsd: 0.01,
+            antiPatternCount: 0,
+            avgDurationMs: 100,
+            sessionCount: 1,
+            sparkline: { startTimestamp: 0, bucketSizeMs: 60_000, points: [1] },
+            avgEfficiencyScore: 0.85,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+
+    await waitFor(() => expect(screen.getByText('85%')).toBeInTheDocument());
   });
 });
 

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -82,13 +82,6 @@ interface CostApiResponse {
 }
 
 // Minimal view of the /api/session/current payload.
-interface SessionCurrentApiResponse {
-  readonly efficiencyScore?: number | null;
-  readonly toolSuccessRate?: number | null;
-  readonly toolErrorCount?: number;
-  readonly toolCallCount?: number;
-}
-
 interface SessionAntiPattern {
   readonly type: string;
   readonly count?: number;
@@ -157,16 +150,6 @@ export function Today(): JSX.Element {
     queryKey: qk.cost,
     queryFn: fetchCost,
   });
-  // The dashboard owner's session_current is arbitrary across
-  // N concurrent sessions, so we keep the call only for the efficiencyScore
-  // KPI (which is local to whichever MCP holds the dashboard). All other
-  // KPIs now derive from the aggregate endpoint, which fans out across every
-  // per-session buffer + persisted session.
-  const { data: sessionCurrent } = useQuery<SessionCurrentApiResponse>({
-    queryKey: qk.sessionCurrent,
-    queryFn: fetchSessionCurrent,
-    refetchInterval: 10_000,
-  });
   const { data: aggregate, isPending: aggregatePending } = useQuery<TodayAggregateResponse>({
     queryKey: qk.sessionsTodayAggregate,
     queryFn: fetchTodayAggregate,
@@ -213,6 +196,15 @@ export function Today(): JSX.Element {
     [todaySessions],
   );
   const hourlySpend = useMemo(() => buildHourlySpend(todaySessions ?? []), [todaySessions]);
+
+  // Fallback source for the anti-pattern detail banner when neither the live
+  // SSE store nor this process's own /api/anti-patterns has anything — the
+  // pattern may have been detected by a different process, but its persisted
+  // session record (already fetched for the KPI strip) still has it.
+  const persistedAntiPatterns = useMemo(
+    () => (todaySessions ?? []).flatMap((s) => s.antiPatterns ?? []),
+    [todaySessions],
+  );
 
   // Prefer the cross-session aggregate when present; fall
   // back to the legacy persisted-sessions math during the loading window so
@@ -266,7 +258,7 @@ export function Today(): JSX.Element {
     return () => clearInterval(id);
   }, []);
 
-  const effScore = sessionCurrent?.efficiencyScore ?? null;
+  const effScore = aggregate?.avgEfficiencyScore ?? null;
   const effDisplay =
     effScore !== null && Number.isFinite(effScore) ? `${Math.round(effScore * 100)}%` : '—';
   const effSub =
@@ -412,7 +404,9 @@ export function Today(): JSX.Element {
           </AnimatedCard>
 
           {flagsCount > 0 &&
-            (antiPatterns.length > 0 || (apiAntiPatterns && apiAntiPatterns.length > 0)) && (
+            (antiPatterns.length > 0 ||
+              (apiAntiPatterns && apiAntiPatterns.length > 0) ||
+              persistedAntiPatterns.length > 0) && (
               <AnimatedCard index={2} className="mb-3">
                 <Card padding="sm" tone="warning" className="text-xs">
                   {antiPatterns.length > 0 ? (
@@ -449,6 +443,28 @@ export function Today(): JSX.Element {
                       </span>
                       <code className="bg-surface-5 px-1 rounded">
                         {apiAntiPatterns[0].file ?? apiAntiPatterns[0].command ?? 'unknown'}
+                      </code>
+                    </>
+                  ) : persistedAntiPatterns.length > 0 ? (
+                    <>
+                      <Pill tone="warning" size="sm" className="mr-2">
+                        {persistedAntiPatterns[0].type}
+                      </Pill>
+                      <span className="text-ink-muted">— </span>
+                      <span>
+                        {persistedAntiPatterns[0].count ??
+                          persistedAntiPatterns[0].iterations ??
+                          persistedAntiPatterns[0].readCount ??
+                          persistedAntiPatterns[0].repeatCount ??
+                          persistedAntiPatterns[0].editCount ??
+                          persistedAntiPatterns[0].agentCount ??
+                          '?'}
+                        × on{' '}
+                      </span>
+                      <code className="bg-surface-5 px-1 rounded">
+                        {persistedAntiPatterns[0].file ??
+                          persistedAntiPatterns[0].command ??
+                          'unknown'}
                       </code>
                     </>
                   ) : null}


### PR DESCRIPTION
Fixes #311

## Summary
- **Efficiency KPI**: the Today dashboard's "efficiency" figure only reflected whichever process happened to be serving the dashboard (e.g. a persistent `--local` background daemon), not today's actual coding sessions running in separate `--stdio` processes. It's now averaged across today's sessions via `/api/sessions/today/aggregate`'s new `avgEfficiencyScore` field, the same way the other Today KPIs already aggregate.
- **Anti-pattern detail banner**: the banner naming which anti-pattern fired (and on which file) could stay blank even when the flags count above it was non-zero, because it only checked the dashboard-serving process's own live detection. It now falls back to already-persisted session data when neither the live SSE store nor this process's own `/api/anti-patterns` has anything.
- Bumped to v1.14.9 with a CHANGELOG entry covering both.

## Test plan
- [x] Both fixes built via TDD (failing test first, confirmed RED, minimal implementation, confirmed GREEN).
- [x] Each change independently reviewed (spec + quality) and approved, plus a clean whole-branch review.
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean.
- [x] `npm test` (Jest) — 5187 passed, 3 pre-existing skips.
- [x] `npm run test:web` (Vitest) — 419 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)