### PR TITLE
Fix: cross-process live-session detection (v1.14.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.10] - 2026-07-30
+
+### Fixed
+
+- **The live-sessions list and the "current concurrency" count only saw sessions that the dashboard-serving process itself had handled** — with multiple Claude Code sessions running against different concurrent processes, a session live in another process never appeared in the Today selector or counted toward current concurrency, even though its activity was visible on disk. Both now also check every process's pending activity buffer, so a session shows up as live regardless of which process is serving the dashboard.
+
 ## [1.14.9] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.9",
+  "version": "1.14.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.9",
+      "version": "1.14.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.9",
+  "version": "1.14.10",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { createApiHandler } from './api-handler.js';
+import { createApiHandler, computeCrossProcessLiveSessionIds } from './api-handler.js';
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
 import * as fs from 'node:fs';
@@ -1316,6 +1316,32 @@ describe('api-handler GET /api/sessions/live', () => {
     expect(parsed[0]!.lastActivity).toBe(9_000_000);
   });
 
+  it('includes a session seen only via peekAllBuffers, not touched by this process', async () => {
+    const now = Date.now();
+    const handler = createApiHandler({
+      liveSessionRegistry: {
+        getLiveSessions: () => ['owned-by-this-process'],
+        getSessionName: () => null,
+        getLastActivity: () => now,
+      },
+      localStore: {
+        peekAllBuffers: () => [
+          { mode: 'post', sessionId: 'owned-by-other-process', timestamp: now - 1_000 },
+        ],
+      },
+      toolCallBuffer: { getRecords: () => [] },
+    });
+    const req = { method: 'GET', url: '/api/sessions/live' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as Array<{ sessionId: string }>;
+    expect(parsed.map((p) => p.sessionId).sort()).toEqual([
+      'owned-by-other-process',
+      'owned-by-this-process',
+    ]);
+  });
+
   it('returns 503 when liveSessionRegistry is missing', async () => {
     const handler = createApiHandler({});
     const req = { method: 'GET', url: '/api/sessions/live' } as IncomingMessage;
@@ -2482,6 +2508,35 @@ describe('api-handler GET /api/concurrency (96-bucket grid)', () => {
     const result = JSON.parse(body());
     expect(result.dailyPeaks).toHaveLength(3);
     expect(result.dailyPeaks[2].peak).toBe(2);
+  });
+
+  it('counts a session seen only via peekAllBuffers in the current field', async () => {
+    const now = Date.now();
+    const handler = createApiHandler({
+      concurrencyTracker: makeConcurrencyTracker(),
+      liveSessionRegistry: {
+        getLiveSessions: () => ['owned-by-this-process'],
+        getSessionName: () => null,
+        getLastActivity: () => now,
+      },
+      localStore: {
+        peekAllBuffers: () => [
+          { mode: 'post', sessionId: 'owned-by-other-process', timestamp: now - 1_000 },
+        ],
+      },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        loadAllSessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/concurrency' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body()) as { current: number };
+    expect(result.current).toBe(2);
   });
 });
 
@@ -4049,5 +4104,64 @@ describe('api-handler GET /api/workflows/:runId', () => {
     const { res, status } = fakeRes();
     await handler(req, res);
     expect(status()).toBe(404);
+  });
+});
+
+describe('computeCrossProcessLiveSessionIds', () => {
+  it('unions registry-live ids with recent buffer-only ids', () => {
+    const now = Date.now();
+    const ids = computeCrossProcessLiveSessionIds({
+      liveSessionRegistry: { getLiveSessions: () => ['from-registry'], getSessionName: () => null },
+      localStore: {
+        peekAllBuffers: () => [
+          { mode: 'post', sessionId: 'from-buffer-only', timestamp: now - 1_000 },
+        ],
+      },
+    } as unknown as Parameters<typeof createApiHandler>[0]);
+    expect(ids.sort()).toEqual(['from-buffer-only', 'from-registry']);
+  });
+
+  it('excludes buffer ids older than the staleness threshold', () => {
+    const now = Date.now();
+    const ids = computeCrossProcessLiveSessionIds({
+      liveSessionRegistry: { getLiveSessions: () => [], getSessionName: () => null },
+      localStore: {
+        peekAllBuffers: () => [
+          { mode: 'post', sessionId: 'stale', timestamp: now - 200_000 },
+          { mode: 'post', sessionId: 'fresh', timestamp: now - 1_000 },
+        ],
+      },
+    } as unknown as Parameters<typeof createApiHandler>[0]);
+    expect(ids).toEqual(['fresh']);
+  });
+
+  it('excludes synthetic session ids seen only via the buffer', () => {
+    const now = Date.now();
+    const ids = computeCrossProcessLiveSessionIds({
+      liveSessionRegistry: { getLiveSessions: () => [], getSessionName: () => null },
+      localStore: {
+        peekAllBuffers: () => [
+          { mode: 'post', sessionId: 'local-1730000000000', timestamp: now - 1_000 },
+          { mode: 'post', sessionId: 'real-session', timestamp: now - 1_000 },
+        ],
+      },
+    } as unknown as Parameters<typeof createApiHandler>[0]);
+    expect(ids).toEqual(['real-session']);
+  });
+
+  it('dedups an id present in both the registry and the buffer', () => {
+    const now = Date.now();
+    const ids = computeCrossProcessLiveSessionIds({
+      liveSessionRegistry: { getLiveSessions: () => ['shared'], getSessionName: () => null },
+      localStore: {
+        peekAllBuffers: () => [{ mode: 'post', sessionId: 'shared', timestamp: now - 1_000 }],
+      },
+    } as unknown as Parameters<typeof createApiHandler>[0]);
+    expect(ids).toEqual(['shared']);
+  });
+
+  it('returns an empty array when neither dependency is available', () => {
+    const ids = computeCrossProcessLiveSessionIds({} as Parameters<typeof createApiHandler>[0]);
+    expect(ids).toEqual([]);
   });
 });

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -7,7 +7,10 @@ import {
   todayPortionRatio,
 } from '../../lib/date.js';
 import { redactSensitive, normalizeDeveloperName } from '../../config.js';
-import { isUnscopedAggregatorSessionId } from '../../hooks/session-resolver.js';
+import {
+  isSyntheticSessionId,
+  isUnscopedAggregatorSessionId,
+} from '../../hooks/session-resolver.js';
 import { handleSendDigest } from '../../tools/cross-session-tools.js';
 import type { WeeklySummaryGenerator } from '../../storage/weekly-summary.js';
 import type { McpServerConfig } from '../../config.js';
@@ -35,10 +38,10 @@ import type { GitEfficiencyMetrics } from '../../metrics/git-efficiency-tracker.
 import type { QualityProxyMetrics } from '../../metrics/quality-proxy-tracker.js';
 import type { ToolSelectionMetrics } from '../../metrics/tool-selection-scorer.js';
 import type { ModelUsageMetrics } from '../../metrics/model-usage-tracker.js';
+import { DEFAULT_STALE_THRESHOLD_MS } from '../../metrics/live-session-registry.js';
 import type { ContextTrackerMetrics } from '../../metrics/context-tracker.js';
 import type { AntiPattern } from '../../metrics/anti-patterns.js';
 import type { AuditRecord } from '../../security/audit-trail.js';
-import { isSyntheticSessionId } from '../../hooks/session-resolver.js';
 // ---------------------------------------------------------------------------
 // Aggregate quality-proxy metrics from today's persisted sessions so the
 // panel isn't empty on page refresh (when the live tracker has no signals).
@@ -906,6 +909,27 @@ function buildReplayResponse(
   return null;
 }
 
+// Unions this process's own LiveSessionRegistry with session IDs seen recently in any
+// process's undrained buffer (peekAllBuffers() is read-only and covers every --stdio
+// process, not just this one). A session actively running in a different process never
+// touches this process's LiveSessionRegistry, so without this union it never shows up as
+// "live" to a dashboard served by a different process. "Recently" uses the registry's own
+// staleness window so both sources agree on what counts as live.
+export function computeCrossProcessLiveSessionIds(deps: ApiHandlerDeps): string[] {
+  const ids = new Set<string>(deps.liveSessionRegistry?.getLiveSessions() ?? []);
+  const now = Date.now();
+  const peeked = deps.localStore?.peekAllBuffers() ?? [];
+  for (const ev of peeked) {
+    const sid = (ev as { sessionId?: unknown }).sessionId;
+    if (typeof sid !== 'string' || sid.length === 0) continue;
+    if (isSyntheticSessionId(sid)) continue;
+    const ts = (ev as { timestamp?: unknown }).timestamp;
+    if (typeof ts !== 'number') continue;
+    if (now - ts <= DEFAULT_STALE_THRESHOLD_MS) ids.add(sid);
+  }
+  return Array.from(ids);
+}
+
 export function createApiHandler(
   deps: ApiHandlerDeps,
 ): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
@@ -1045,12 +1069,12 @@ export function createApiHandler(
   // yet, startTime defaults to lastActivity (or now() if both are missing).
   routes.set('GET /api/sessions/live', (_req, res) => {
     if (!deps.liveSessionRegistry) return unavailable(res, 'liveSessionRegistry');
-    // getLiveSessions() already excludes synthetic session identities used by
-    // --local / proxy modes (`local-<ts>`, `proxy-<ts>`, `pending-<ts>`) —
-    // MCP-internal bookkeeping IDs, not real Claude Code sessions, so they
-    // shouldn't appear as clickable rows in the dashboard's live-sessions
-    // selector.
-    const ids = deps.liveSessionRegistry.getLiveSessions();
+    // computeCrossProcessLiveSessionIds() unions the registry and buffer-derived
+    // session IDs, filtering out synthetic session identities (`local-<ts>`,
+    // `proxy-<ts>`, `pending-<ts>`) — MCP-internal bookkeeping IDs, not real
+    // Claude Code sessions, so they shouldn't appear as clickable rows in the
+    // dashboard's live-sessions selector.
+    const ids = computeCrossProcessLiveSessionIds(deps);
     const records = deps.toolCallBuffer?.getRecords() ?? [];
     const perSession = new Map<string, { firstTs: number; lastTs: number }>();
     for (const r of records) {
@@ -1670,7 +1694,7 @@ export function createApiHandler(
       const historicalPeak = buckets.reduce((max, b) => Math.max(max, b.count), 0);
 
       jsonOk(res, {
-        current: deps.concurrencyTracker.getConcurrentCount(),
+        current: computeCrossProcessLiveSessionIds(deps).length,
         peak: historicalPeak,
         allTimePeak: Math.max(livePeak, historicalPeak, allTimePeak),
         bucketSizeMs: CONCURRENCY_BUCKET_SIZE_MS,

--- a/src/metrics/live-session-registry.test.ts
+++ b/src/metrics/live-session-registry.test.ts
@@ -1,4 +1,4 @@
-import { LiveSessionRegistry } from './live-session-registry.js';
+import { LiveSessionRegistry, DEFAULT_STALE_THRESHOLD_MS } from './live-session-registry.js';
 
 describe('LiveSessionRegistry', () => {
   beforeEach(() => {
@@ -101,6 +101,10 @@ describe('LiveSessionRegistry', () => {
     reg.reset();
     expect(reg.getLiveSessions()).toEqual([]);
     expect(reg.isLive('sess-a')).toBe(false);
+  });
+
+  it('exports DEFAULT_STALE_THRESHOLD_MS matching the constructor default', () => {
+    expect(DEFAULT_STALE_THRESHOLD_MS).toBe(180_000);
   });
 
   describe('concurrency tracking', () => {

--- a/src/metrics/live-session-registry.ts
+++ b/src/metrics/live-session-registry.ts
@@ -6,7 +6,7 @@
 import { basename } from 'node:path';
 import { isSyntheticSessionId } from '../hooks/session-resolver.js';
 
-const DEFAULT_STALE_THRESHOLD_MS = 180_000; // 3 minutes
+export const DEFAULT_STALE_THRESHOLD_MS = 180_000; // 3 minutes
 const MAX_CONCURRENCY_SAMPLES = 2880; // 24h at 30s intervals
 const SAMPLE_INTERVAL_MS = 30_000;
 


### PR DESCRIPTION
Fixes #313

## Summary
- The live-sessions list and the "current concurrency" count only saw sessions handled by the exact process serving the dashboard, missing sessions live in a different concurrently-running process.
- Adds a shared helper that unions the per-process live-session registry with session IDs seen in any process's pending activity buffer, reusing the registry's own staleness window and synthetic-session-id filtering.
- Wires the helper into both the live-sessions and concurrency routes. The concurrency count now also excludes synthetic session ids, matching the peak/all-time-peak fields already in that response (previously inconsistent).

## Test plan
- [x] `npm run build && npm test` — 5195 passing, 0 failures
- [x] `npm run test:web` — 419 passing, 0 failures
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] New tests cover: union of registry- and buffer-derived session ids, staleness boundary exclusion, synthetic-id exclusion, dedup, both routes' wiring
- [x] Version bumped to 1.14.10, CHANGELOG updated