### PR TITLE
Fix: /api/context sees sessions live in other processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.11] - 2026-07-30
+
+### Fixed
+
+- **The context-window bar could go blank for a session that was live only in a different process than the one serving the dashboard** — it read only that one process's own in-memory tracker, so any session running elsewhere had no context-window data to show even while active. It now recomputes the same metrics on demand from that session's pending activity, the same way the other cross-process Today dashboard fixes already do.
+
 ## [1.14.10] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.10",
+  "version": "1.14.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.10",
+      "version": "1.14.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.10",
+  "version": "1.14.11",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1,5 +1,9 @@
 import { jest } from '@jest/globals';
-import { createApiHandler, computeCrossProcessLiveSessionIds } from './api-handler.js';
+import {
+  createApiHandler,
+  computeCrossProcessLiveSessionIds,
+  buildContextReplayEvents,
+} from './api-handler.js';
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
 import * as fs from 'node:fs';
@@ -3749,6 +3753,127 @@ describe('api-handler GET /api/context', () => {
     expect(status()).toBe(200);
     expect(JSON.parse(body())).toEqual(fakeMetrics);
     expect(getMetrics).toHaveBeenCalledWith('sess-abc');
+  });
+
+  it("recomputes metrics from peekAllBuffers when this process's own registry has zero turns for the session", async () => {
+    const emptyMetrics = {
+      turnCount: 0,
+      growth: { startTokens: 0, currentTokens: 0, deltaTokens: 0 },
+      currentBreakdown: { system: 0, tools: 0, user: 0, assistant: 0 },
+      fillPercent: 0,
+      contextWindow: 200_000,
+      toolContributions: [],
+      history: [],
+    };
+    const handler = createApiHandler({
+      contextTracker: { getMetrics: () => emptyMetrics },
+      localStore: {
+        peekAllBuffers: () => [
+          {
+            mode: 'post',
+            sessionId: 'sess-other-process',
+            timestamp: 1_000,
+            tool: 'Read',
+            outputSize: 40_000,
+          },
+          {
+            mode: 'token',
+            sessionId: 'sess-other-process',
+            timestamp: 2_000,
+            inputTokens: 10_000,
+            outputTokens: 5_000,
+            cacheReadTokens: 50_000,
+            cacheCreationTokens: 20_000,
+            model: 'claude-opus-4-6',
+          },
+        ],
+      },
+    });
+    const req = {
+      method: 'GET',
+      url: '/api/context?sessionId=sess-other-process',
+    } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body()) as { turnCount: number; fillPercent: number };
+    expect(result.turnCount).toBe(1);
+    expect(result.fillPercent).toBe(40);
+  });
+
+  it('falls back to the empty local default when no buffer events match the session either', async () => {
+    const emptyMetrics = {
+      turnCount: 0,
+      growth: { startTokens: 0, currentTokens: 0, deltaTokens: 0 },
+      currentBreakdown: { system: 0, tools: 0, user: 0, assistant: 0 },
+      fillPercent: 0,
+      contextWindow: 200_000,
+      toolContributions: [],
+      history: [],
+    };
+    const handler = createApiHandler({
+      contextTracker: { getMetrics: () => emptyMetrics },
+      localStore: {
+        peekAllBuffers: () => [{ mode: 'token', sessionId: 'unrelated-session', timestamp: 2_000 }],
+      },
+    });
+    const req = {
+      method: 'GET',
+      url: '/api/context?sessionId=sess-with-no-data',
+    } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(JSON.parse(body())).toEqual(emptyMetrics);
+  });
+});
+
+describe('buildContextReplayEvents', () => {
+  it('maps a post event to a tool replay event using tool/outputSize fields', () => {
+    const events = buildContextReplayEvents(
+      [{ mode: 'post', sessionId: 'sess-1', timestamp: 1_000, tool: 'Bash', outputSize: 500 }],
+      'sess-1',
+    );
+    expect(events).toEqual([
+      { kind: 'tool', timestamp: 1_000, toolName: 'Bash', outputSizeBytes: 500 },
+    ]);
+  });
+
+  it('maps a token event to a token replay event, defaulting missing numeric fields to 0', () => {
+    const events = buildContextReplayEvents(
+      [{ mode: 'token', sessionId: 'sess-1', timestamp: 2_000, inputTokens: 100 }],
+      'sess-1',
+    );
+    expect(events).toEqual([
+      {
+        kind: 'token',
+        timestamp: 2_000,
+        inputTokens: 100,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        model: 'unknown',
+      },
+    ]);
+  });
+
+  it('ignores pre events and events belonging to a different session', () => {
+    const events = buildContextReplayEvents(
+      [
+        { mode: 'pre', sessionId: 'sess-1', timestamp: 1_000, tool: 'Bash' },
+        { mode: 'post', sessionId: 'sess-2', timestamp: 1_000, tool: 'Bash', outputSize: 500 },
+      ],
+      'sess-1',
+    );
+    expect(events).toEqual([]);
+  });
+
+  it('skips events with a non-numeric timestamp', () => {
+    const events = buildContextReplayEvents(
+      [{ mode: 'token', sessionId: 'sess-1', timestamp: 'not-a-number', inputTokens: 100 }],
+      'sess-1',
+    );
+    expect(events).toEqual([]);
   });
 });
 

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -39,7 +39,8 @@ import type { QualityProxyMetrics } from '../../metrics/quality-proxy-tracker.js
 import type { ToolSelectionMetrics } from '../../metrics/tool-selection-scorer.js';
 import type { ModelUsageMetrics } from '../../metrics/model-usage-tracker.js';
 import { DEFAULT_STALE_THRESHOLD_MS } from '../../metrics/live-session-registry.js';
-import type { ContextTrackerMetrics } from '../../metrics/context-tracker.js';
+import { computeContextMetricsFromEvents } from '../../metrics/context-tracker.js';
+import type { ContextReplayEvent, ContextTrackerMetrics } from '../../metrics/context-tracker.js';
 import type { AntiPattern } from '../../metrics/anti-patterns.js';
 import type { AuditRecord } from '../../security/audit-trail.js';
 // ---------------------------------------------------------------------------
@@ -930,6 +931,44 @@ export function computeCrossProcessLiveSessionIds(deps: ApiHandlerDeps): string[
   return Array.from(ids);
 }
 
+// Narrows this MCP's own peekAllBuffers() rows (raw buffer-file lines from
+// EVERY --stdio process, read-only) into the two event kinds
+// computeContextMetricsFromEvents() understands, scoped to one session.
+// Mirrors the mode-based narrowing computeCrossProcessLiveSessionIds() above
+// already does — 'post' is a completed tool call, 'token' is a cost/context
+// event with no tool-call semantics, 'pre' has neither and is ignored.
+export function buildContextReplayEvents(
+  peeked: readonly { readonly [key: string]: unknown }[],
+  sessionId: string,
+): ContextReplayEvent[] {
+  const events: ContextReplayEvent[] = [];
+  for (const ev of peeked) {
+    if (ev.sessionId !== sessionId) continue;
+    const timestamp = typeof ev.timestamp === 'number' ? ev.timestamp : null;
+    if (timestamp === null) continue;
+    if (ev.mode === 'post' && typeof ev.tool === 'string') {
+      events.push({
+        kind: 'tool',
+        timestamp,
+        toolName: ev.tool,
+        outputSizeBytes: typeof ev.outputSize === 'number' ? ev.outputSize : undefined,
+      });
+    } else if (ev.mode === 'token') {
+      events.push({
+        kind: 'token',
+        timestamp,
+        inputTokens: typeof ev.inputTokens === 'number' ? ev.inputTokens : 0,
+        outputTokens: typeof ev.outputTokens === 'number' ? ev.outputTokens : 0,
+        cacheReadTokens: typeof ev.cacheReadTokens === 'number' ? ev.cacheReadTokens : 0,
+        cacheCreationTokens:
+          typeof ev.cacheCreationTokens === 'number' ? ev.cacheCreationTokens : 0,
+        model: typeof ev.model === 'string' ? ev.model : 'unknown',
+      });
+    }
+  }
+  return events;
+}
+
 export function createApiHandler(
   deps: ApiHandlerDeps,
 ): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
@@ -1608,7 +1647,20 @@ export function createApiHandler(
     if (!deps.contextTracker) return unavailable(res, 'contextTracker');
     const url = new URL(req.url ?? '/', 'http://localhost');
     const sessionId = url.searchParams.get('sessionId') ?? undefined;
-    jsonOk(res, deps.contextTracker.getMetrics(sessionId));
+    const local = deps.contextTracker.getMetrics(sessionId);
+    // A session live only in a different --stdio process never touches this
+    // process's own ContextTrackerRegistry, so local.turnCount stays 0 even
+    // when the session has real activity elsewhere. Recompute from any
+    // process's undrained buffer before falling back to the (correctly)
+    // empty default.
+    if (local.turnCount === 0 && sessionId && deps.localStore) {
+      const events = buildContextReplayEvents(deps.localStore.peekAllBuffers(), sessionId);
+      if (events.length > 0) {
+        jsonOk(res, computeContextMetricsFromEvents(events));
+        return;
+      }
+    }
+    jsonOk(res, local);
   });
 
   routes.set('GET /api/concurrency', (req, res) => {

--- a/src/metrics/context-tracker.test.ts
+++ b/src/metrics/context-tracker.test.ts
@@ -1,4 +1,9 @@
-import { ContextTracker, ContextTrackerRegistry } from './context-tracker.js';
+import {
+  ContextTracker,
+  ContextTrackerRegistry,
+  computeContextMetricsFromEvents,
+} from './context-tracker.js';
+import type { ContextReplayEvent } from './context-tracker.js';
 import type { TokenEvent, ToolCallRecord } from '../storage/types.js';
 
 function makeTokenEvent(overrides: Partial<TokenEvent> = {}): TokenEvent {
@@ -376,5 +381,80 @@ describe('ContextTrackerRegistry', () => {
 
     expect(snapshot).toBeNull();
     expect(registry.getSessionIds()).toHaveLength(0);
+  });
+});
+
+describe('computeContextMetricsFromEvents', () => {
+  it('replays tool and token events into the same metrics as incremental recording', () => {
+    const events: ContextReplayEvent[] = [
+      { kind: 'tool', timestamp: 1_000, toolName: 'Read', outputSizeBytes: 40_000 },
+      {
+        kind: 'token',
+        timestamp: 2_000,
+        inputTokens: 10_000,
+        outputTokens: 5_000,
+        cacheReadTokens: 50_000,
+        cacheCreationTokens: 20_000,
+        model: 'claude-opus-4-6',
+      },
+    ];
+
+    const replayed = computeContextMetricsFromEvents(events, { modelContextWindow: 200_000 });
+
+    const direct = new ContextTracker({ modelContextWindow: 200_000 });
+    direct.recordToolCall(makeRecord({ toolName: 'Read', outputSizeBytes: 40_000 }));
+    direct.recordTurn(
+      makeTokenEvent({
+        timestamp: 2_000,
+        inputTokens: 10_000,
+        outputTokens: 5_000,
+        cacheReadTokens: 50_000,
+        cacheCreationTokens: 20_000,
+      }),
+    );
+
+    expect(replayed).toEqual(direct.getMetrics());
+    expect(replayed.turnCount).toBe(1);
+    expect(replayed.currentBreakdown.tools).toBe(10_000);
+    expect(replayed.currentBreakdown.system).toBe(20_000);
+  });
+
+  it('sorts events by timestamp before replaying, independent of input order', () => {
+    const events: ContextReplayEvent[] = [
+      {
+        kind: 'token',
+        timestamp: 5_000,
+        inputTokens: 60_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        model: 'claude-opus-4-6',
+      },
+      {
+        kind: 'token',
+        timestamp: 1_000,
+        inputTokens: 40_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 10_000,
+        model: 'claude-opus-4-6',
+      },
+    ];
+
+    const metrics = computeContextMetricsFromEvents(events);
+
+    // Turn 1 (timestamp 1000) sets the baseline; turn 2 (timestamp 5000) is current —
+    // this only holds if the events were sorted before replay, since they were passed
+    // in reverse-chronological order above.
+    expect(metrics.turnCount).toBe(2);
+    expect(metrics.growth.startTokens).toBe(50_000); // 40000 + 10000
+    expect(metrics.growth.currentTokens).toBe(60_000);
+  });
+
+  it('returns zeroed metrics for an empty events array', () => {
+    const metrics = computeContextMetricsFromEvents([]);
+    expect(metrics.turnCount).toBe(0);
+    expect(metrics.growth).toEqual({ startTokens: 0, currentTokens: 0, deltaTokens: 0 });
+    expect(metrics.currentBreakdown).toEqual({ system: 0, tools: 0, user: 0, assistant: 0 });
   });
 });

--- a/src/metrics/context-tracker.ts
+++ b/src/metrics/context-tracker.ts
@@ -52,6 +52,12 @@ export interface ContextTrackerOptions {
   readonly bytesPerToken?: number;
 }
 
+// Narrower input for recordToolCall: only the two fields it actually reads.
+// A full ToolCallRecord still satisfies this structurally (every existing
+// caller passes one), but it also lets a replayed/reconstructed event that
+// only has these two fields flow through the same method.
+export type ContextToolCallInput = Pick<ToolCallRecord, 'toolName' | 'outputSizeBytes'>;
+
 // ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
@@ -90,7 +96,7 @@ export class ContextTracker {
     this.bytesPerToken = options?.bytesPerToken ?? DEFAULT_BYTES_PER_TOKEN;
   }
 
-  recordToolCall(record: ToolCallRecord): void {
+  recordToolCall(record: ContextToolCallInput): void {
     const bytes = record.outputSizeBytes;
     if (bytes == null || bytes <= 0) return;
     const current = this.toolOutputBytes.get(record.toolName) ?? 0;
@@ -232,6 +238,57 @@ export class ContextTracker {
 
     return { system, tools, user, assistant };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Pure replay — computes the same metrics as incremental recording, from a
+// snapshot of events instead of a live, continuously-fed tracker. Lets a
+// caller who only has a point-in-time batch of events (e.g. a buffer-file
+// snapshot from a different process's session) get identical output to what
+// that process's own live ContextTracker would have produced.
+// ---------------------------------------------------------------------------
+
+export interface ContextReplayToolEvent {
+  readonly kind: 'tool';
+  readonly timestamp: number;
+  readonly toolName: string;
+  readonly outputSizeBytes?: number;
+}
+
+export interface ContextReplayTokenEvent {
+  readonly kind: 'token';
+  readonly timestamp: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheCreationTokens: number;
+  readonly model: string;
+}
+
+export type ContextReplayEvent = ContextReplayToolEvent | ContextReplayTokenEvent;
+
+export function computeContextMetricsFromEvents(
+  events: readonly ContextReplayEvent[],
+  options?: ContextTrackerOptions,
+): ContextTrackerMetrics {
+  const tracker = new ContextTracker(options);
+  const sorted = [...events].sort((a, b) => a.timestamp - b.timestamp);
+  for (const ev of sorted) {
+    if (ev.kind === 'tool') {
+      tracker.recordToolCall({ toolName: ev.toolName, outputSizeBytes: ev.outputSizeBytes });
+    } else {
+      tracker.recordTurn({
+        mode: 'token',
+        timestamp: ev.timestamp,
+        inputTokens: ev.inputTokens,
+        outputTokens: ev.outputTokens,
+        cacheReadTokens: ev.cacheReadTokens,
+        cacheCreationTokens: ev.cacheCreationTokens,
+        model: ev.model,
+      });
+    }
+  }
+  return tracker.getMetrics();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extracts the context-window tracker's scoring logic into a pure replay function, so metrics can be computed from a snapshot of events instead of only via incremental live recording.
- The context API now falls back to recomputing metrics from every process's pending activity when the dashboard-serving process's own tracker has no data for the requested session — fixing the context bar going blank for a session live only in a different process.
- No new persistence: everything needed is already present in the existing cross-process activity snapshot.
- Bumps version to 1.14.11 with a matching CHANGELOG entry.

Fixes #314

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors/warnings
- [x] `npm test` — 5204/5207 passing (3 pre-existing skips)
- [x] `npm run test:web` — 419/419 passing