### PR TITLE
Fix: Latency panel reflects tool calls from every session today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.12] - 2026-07-31
+
+### Fixed
+
+- **The Today dashboard's Latency panel only reflected tool calls handled by whichever process happened to be serving the dashboard** — its p50/p95/p99 figures came from that one process's own in-memory tracker, silently excluding latency data from every other concurrently running session. It's now computed from every today session's activity, the same way the other cross-process Today dashboard fixes already are.
+
 ## [1.14.11] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.11",
+  "version": "1.14.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.11",
+      "version": "1.14.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.11",
+  "version": "1.14.12",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1423,6 +1423,101 @@ describe('api-handler GET /api/sessions/today/aggregate', () => {
     expect(parsed.sparkline.points.length).toBeGreaterThan(0);
   });
 
+  it('includes cross-session latency percentiles in the aggregate payload', async () => {
+    const now = Date.now();
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+    const startMs = startOfDay.getTime();
+
+    const handler = createApiHandler({
+      localStore: {
+        peekAllBuffers: () => [
+          {
+            mode: 'post',
+            sessionId: 's1',
+            timestamp: startMs + 10_000,
+            durationMs: 100,
+            tool: 'Read',
+          },
+          {
+            mode: 'post',
+            sessionId: 's1',
+            timestamp: startMs + 20_000,
+            durationMs: 200,
+            tool: 'Edit',
+          },
+          {
+            mode: 'post',
+            sessionId: 's1',
+            timestamp: startMs + 30_000,
+            durationMs: 300,
+            tool: 'Read',
+          },
+        ],
+      },
+      sessionStore: {
+        loadTodaySessions: () => [
+          {
+            sessionId: 'persisted-1',
+            timeline: [
+              { timestamp: startMs + 40_000, durationMs: 400, toolName: 'Edit', success: true },
+              { timestamp: startMs + 50_000, durationMs: 500, toolName: 'Read', success: true },
+            ],
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      latency: {
+        overall: {
+          p50: number;
+          p95: number;
+          p99: number;
+          min: number;
+          max: number;
+          count: number;
+        } | null;
+        byTool: Record<
+          string,
+          { p50: number; p95: number; p99: number; min: number; max: number; count: number } | null
+        >;
+      };
+    };
+    // Overall sorted durations: [100, 200, 300, 400, 500], n=5
+    expect(parsed.latency.overall).toEqual({
+      p50: 300,
+      p95: 400,
+      p99: 400,
+      min: 100,
+      max: 500,
+      count: 5,
+    });
+    // Read: [100, 300, 500], n=3
+    expect(parsed.latency.byTool.Read).toEqual({
+      p50: 300,
+      p95: 300,
+      p99: 300,
+      min: 100,
+      max: 500,
+      count: 3,
+    });
+    // Edit: [200, 400], n=2
+    expect(parsed.latency.byTool.Edit).toEqual({
+      p50: 200,
+      p95: 200,
+      p99: 200,
+      min: 200,
+      max: 400,
+      count: 2,
+    });
+  });
+
   it('returns zeros when no data is present', async () => {
     const handler = createApiHandler({
       localStore: { peekAllBuffers: () => [] },

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -21,6 +21,8 @@ import {
 import { getIsoWeekId } from '../../storage/weekly-summary.js';
 import { analyzeReplayTimeline } from './replay-analyzer.js';
 import type { AntiPatternSegment } from './replay-analyzer.js';
+import { computeLatencyPercentiles } from './latency-percentiles.js';
+import type { LatencySample, AggregateLatencyMetrics } from './latency-percentiles.js';
 import type { ReplayTimelineEntry, ToolCallRecord } from '../../storage/types.js';
 import type { FullSessionSummary, SessionFileInfo } from '../../storage/session-store.js';
 import type { WorkflowRunRow, WorkflowAgentRow } from '../workflow-store.js';
@@ -603,6 +605,7 @@ interface TodayAggregatePayload {
   readonly subagentUsd: number;
   readonly subagentTurnCount: number;
   readonly workflowRunCount: number;
+  readonly latency: AggregateLatencyMetrics;
 }
 
 // Build activity windows for every session with activity today, using the SAME
@@ -1165,6 +1168,10 @@ export function createApiHandler(
   // computation per bucket. TTL is short enough that the live-feel KPI
   // (sparkline tail, tool-call count) lags by at most ~5s.
   const AGGREGATE_TTL_MS = 5_000;
+  // Cap on latency samples collected per aggregate computation — bounds
+  // response size and per-request CPU on a very busy day. Matches the
+  // MAX_OVERALL_SAMPLES cap LatencyTracker itself already uses per-process.
+  const MAX_AGGREGATE_LATENCY_SAMPLES = 5_000;
   let aggregateCache: { bucket: number; payload: TodayAggregatePayload } | null = null;
 
   routes.set('GET /api/sessions/today/aggregate', (_req, res) => {
@@ -1191,6 +1198,10 @@ export function createApiHandler(
     let subagentUsd = 0;
     let antiPatternCount = 0;
     const sessionsSeen = new Set<string>();
+    const latencySamples: LatencySample[] = [];
+    const pushLatencySample = (sample: LatencySample): void => {
+      if (latencySamples.length < MAX_AGGREGATE_LATENCY_SAMPLES) latencySamples.push(sample);
+    };
 
     // (1) live, undrained per-session buffer events
     const peeked = deps.localStore?.peekAllBuffers() ?? [];
@@ -1225,6 +1236,10 @@ export function createApiHandler(
         if (dur !== null) {
           totalDurationMs += dur;
           durationSamples++;
+          pushLatencySample({
+            durationMs: dur,
+            toolName: typeof ev.tool === 'string' ? ev.tool : 'Unknown',
+          });
         }
       }
     }
@@ -1241,7 +1256,11 @@ export function createApiHandler(
         toolCallCount?: number;
         estimatedCostUsd?: number | null;
         antiPatterns?: ReadonlyArray<unknown>;
-        timeline?: ReadonlyArray<{ timestamp: number; durationMs: number | null }>;
+        timeline?: ReadonlyArray<{
+          timestamp: number;
+          durationMs: number | null;
+          toolName: string;
+        }>;
       };
       if (typeof session.sessionId === 'string') sessionsSeen.add(session.sessionId);
       // Cost is summed in a separate pass below so cross-midnight sessions
@@ -1270,6 +1289,7 @@ export function createApiHandler(
           if (entry.durationMs !== null) {
             totalDurationMs += entry.durationMs;
             durationSamples++;
+            pushLatencySample({ durationMs: entry.durationMs, toolName: entry.toolName });
           }
         }
       }
@@ -1427,6 +1447,7 @@ export function createApiHandler(
       subagentTurnCount,
       workflowRunCount,
       avgEfficiencyScore,
+      latency: computeLatencyPercentiles(latencySamples),
     };
     aggregateCache = { bucket: currentBucket, payload };
     jsonOk(res, payload);

--- a/src/dashboard/routes/latency-percentiles.test.ts
+++ b/src/dashboard/routes/latency-percentiles.test.ts
@@ -1,0 +1,42 @@
+import { computeLatencyPercentiles } from './latency-percentiles.js';
+import type { LatencySample } from './latency-percentiles.js';
+
+describe('computeLatencyPercentiles', () => {
+  it('returns null overall and an empty byTool map for an empty samples array', () => {
+    const result = computeLatencyPercentiles([]);
+    expect(result).toEqual({ overall: null, byTool: {} });
+  });
+
+  it('computes overall and per-tool percentiles across mixed-tool samples', () => {
+    const samples: LatencySample[] = [
+      { durationMs: 100, toolName: 'Read' },
+      { durationMs: 200, toolName: 'Edit' },
+      { durationMs: 300, toolName: 'Read' },
+      { durationMs: 400, toolName: 'Edit' },
+      { durationMs: 500, toolName: 'Read' },
+    ];
+
+    const result = computeLatencyPercentiles(samples);
+
+    // Overall sorted: [100, 200, 300, 400, 500], n=5
+    expect(result.overall).toEqual({ p50: 300, p95: 400, p99: 400, min: 100, max: 500, count: 5 });
+    // Read sorted: [100, 300, 500], n=3
+    expect(result.byTool.Read).toEqual({
+      p50: 300,
+      p95: 300,
+      p99: 300,
+      min: 100,
+      max: 500,
+      count: 3,
+    });
+    // Edit sorted: [200, 400], n=2
+    expect(result.byTool.Edit).toEqual({
+      p50: 200,
+      p95: 200,
+      p99: 200,
+      min: 200,
+      max: 400,
+      count: 2,
+    });
+  });
+});

--- a/src/dashboard/routes/latency-percentiles.ts
+++ b/src/dashboard/routes/latency-percentiles.ts
@@ -1,0 +1,56 @@
+import { computePercentile } from '../../metrics/percentile.js';
+import type { LatencyPercentiles } from '../../metrics/latency-tracker.js';
+
+export interface LatencySample {
+  readonly durationMs: number;
+  readonly toolName: string;
+}
+
+export interface AggregateLatencyMetrics {
+  readonly overall: LatencyPercentiles | null;
+  readonly byTool: Readonly<Record<string, LatencyPercentiles | null>>;
+}
+
+function computePercentilesFromDurations(durations: readonly number[]): LatencyPercentiles | null {
+  if (durations.length === 0) return null;
+  const sorted = [...durations].sort((a, b) => a - b);
+  const count = sorted.length;
+  return {
+    p50: computePercentile(sorted, 0.5) ?? 0,
+    p95: computePercentile(sorted, 0.95) ?? 0,
+    p99: computePercentile(sorted, 0.99) ?? 0,
+    min: sorted[0]!,
+    max: sorted[count - 1]!,
+    count,
+  };
+}
+
+// Computes the same p50/p95/p99/min/max/count shape LatencyTracker produces
+// incrementally for one process, but from a flat snapshot of samples
+// gathered across every process/session active today — see the aggregate
+// route in api-handler.ts, which is the only caller.
+export function computeLatencyPercentiles(
+  samples: readonly LatencySample[],
+): AggregateLatencyMetrics {
+  const byToolDurations = new Map<string, number[]>();
+  const allDurations: number[] = [];
+  for (const sample of samples) {
+    allDurations.push(sample.durationMs);
+    const arr = byToolDurations.get(sample.toolName);
+    if (arr) {
+      arr.push(sample.durationMs);
+    } else {
+      byToolDurations.set(sample.toolName, [sample.durationMs]);
+    }
+  }
+
+  const byTool: Record<string, LatencyPercentiles | null> = {};
+  for (const [toolName, durations] of byToolDurations) {
+    byTool[toolName] = computePercentilesFromDurations(durations);
+  }
+
+  return {
+    overall: computePercentilesFromDurations(allDurations),
+    byTool,
+  };
+}

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -145,6 +145,10 @@ export interface TodayAggregateResponse {
   readonly subagentTurnCount?: number;
   readonly workflowRunCount?: number;
   readonly avgEfficiencyScore?: number | null;
+  readonly latency?: {
+    readonly overall: LatencyPercentiles | null;
+    readonly byTool: Readonly<Record<string, LatencyPercentiles | null>>;
+  };
 }
 
 // /api/sessions returns a heterogeneous mix of full persisted session

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -521,6 +521,49 @@ describe('Today view — aggregate endpoint', () => {
 
     await waitFor(() => expect(screen.getByText('85%')).toBeInTheDocument());
   });
+
+  it("renders the Latency panel from the aggregate endpoint's latency field, not /api/latency", async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(
+          JSON.stringify({
+            toolCallCount: 1,
+            totalCostUsd: 0.01,
+            antiPatternCount: 0,
+            avgDurationMs: 100,
+            sessionCount: 1,
+            sparkline: { startTimestamp: 0, bucketSizeMs: 60_000, points: [1] },
+            latency: {
+              overall: { p50: 111, p95: 222, p99: 333, min: 50, max: 400, count: 5 },
+              byTool: {
+                Read: { p50: 90, p95: 444, p99: 444, min: 50, max: 444, count: 3 },
+                Edit: { p50: 130, p95: 555, p99: 555, min: 100, max: 555, count: 2 },
+              },
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/latency')) {
+        throw new Error(
+          'LatencyPanel must read latency from the aggregate endpoint, not /api/latency',
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+
+    expect(await screen.findByText('111')).toBeInTheDocument();
+    expect(screen.getByText('222')).toBeInTheDocument();
+    expect(screen.getByText('333')).toBeInTheDocument();
+    expect(screen.getByText('444ms p95')).toBeInTheDocument();
+    expect(screen.getByText('555ms p95')).toBeInTheDocument();
+  });
 });
 
 describe('Today view — selector default + Session ended badge', () => {

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -34,7 +34,6 @@ import {
   fetchToolSelectionScore,
   fetchConcurrency,
   fetchActivityHeatmap,
-  fetchLatency,
   fetchModelUsage,
   fetchLiveSessions,
   fetchTodayAggregate,
@@ -475,7 +474,7 @@ export function Today(): JSX.Element {
           <AnimatedCard index={3} className="grid grid-cols-3 gap-3 mb-3">
             <QualityProxyPanel />
             <ToolSelectionPanel />
-            <LatencyPanel />
+            <LatencyPanel aggregate={aggregate} />
             <ModelUsagePanel />
             <CacheHealthPanel />
           </AnimatedCard>
@@ -617,18 +616,12 @@ interface LatencyPercentiles {
   readonly count: number;
 }
 
-interface LatencyMetrics {
-  readonly overall: LatencyPercentiles | null;
-  readonly byTool: Readonly<Record<string, LatencyPercentiles | null>>;
-  readonly slowestCalls: ReadonlyArray<{ toolName: string; durationMs: number }>;
-}
-
-function LatencyPanel(): JSX.Element {
-  const { data } = useQuery<LatencyMetrics>({
-    queryKey: qk.latency,
-    queryFn: fetchLatency,
-    refetchInterval: QUALITY_REFETCH_MS,
-  });
+function LatencyPanel({
+  aggregate,
+}: {
+  aggregate: TodayAggregateResponse | undefined;
+}): JSX.Element {
+  const data = aggregate?.latency;
 
   // Guard `data.byTool` separately — the API can return `data` with `byTool`
   // missing (or `null`) when no tool calls have been recorded yet, and


### PR DESCRIPTION
Fixes #316

## Summary
- The Today dashboard's Latency panel (p50/p95/p99) only reflected tool calls from whichever process happened to be serving the dashboard, missing latency data from any concurrently running session in a different process.
- Extends the existing cross-session aggregate route (which already unions every process's undrained buffer plus every persisted session's timeline for other KPIs) to also collect duration/tool samples and compute percentiles via a new pure `computeLatencyPercentiles()` function.
- Updates the Latency panel to read the new field from the aggregate payload instead of querying the separate per-process latency endpoint (unchanged — still used elsewhere).
- No new persistence — everything comes from data the aggregate route already reads.
- Version bump to 1.14.12 + CHANGELOG entry.

## Test plan
- [x] `npm test` — full suite passing
- [x] `npm run test:web` — 420/420 passing
- [x] `npm run lint` — 0 errors/warnings
- [x] New unit tests: pure percentile function, aggregate route latency field, frontend panel (asserts it does not fall back to the per-process endpoint)