### PR TITLE
Fix: Cache Health panel reflects token usage from every session today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.13] - 2026-07-30
+
+### Fixed
+
+- **The Today dashboard's Cache Health panel only reflected token usage seen by whichever process happened to be serving the dashboard** — its hit-rate percentage and dollar savings came from that one process's own in-memory tracker, silently excluding cache activity from every other concurrently running session. It's now computed from every today session's token usage, the same way the other cross-process Today dashboard fixes already are.
+
 ## [1.14.12] - 2026-07-31
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.12",
+  "version": "1.14.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.12",
+      "version": "1.14.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.12",
+  "version": "1.14.13",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1896,6 +1896,223 @@ describe('api-handler GET /api/sessions/today/aggregate', () => {
     const parsed = JSON.parse(body()) as { avgEfficiencyScore: number | null };
     expect(parsed.avgEfficiencyScore).toBeNull();
   });
+
+  it('blends cache tokens from live buffer events and persisted sessions into cacheHealth', async () => {
+    const now = Date.now();
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+    const startMs = startOfDay.getTime();
+
+    const handler = createApiHandler({
+      localStore: {
+        peekAllBuffers: () => [
+          // Live, undrained token event for a session not yet persisted.
+          {
+            mode: 'token',
+            sessionId: 'live-1',
+            timestamp: startMs + 10_000,
+            inputTokens: 100,
+            cacheReadTokens: 300,
+            cacheCreationTokens: 0,
+          },
+          // Yesterday — must be ignored.
+          {
+            mode: 'token',
+            sessionId: 'live-1',
+            timestamp: startMs - 1,
+            inputTokens: 9_999,
+            cacheReadTokens: 9_999,
+            cacheCreationTokens: 0,
+          },
+        ],
+      },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        loadSessionsOverlappingToday: () => [
+          {
+            sessionId: 'persisted-1',
+            startTime: startMs + 1_000,
+            endTime: startMs + 2_000,
+            estimatedCostUsd: 0,
+            tokensInput: 100,
+            tokensCacheRead: 100,
+            tokensCacheCreation: 0,
+            cacheSavingsUsd: 0.01,
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      cacheHealth: {
+        status: string;
+        cacheHitRatePct: number | null;
+        totalCacheReadTokens: number;
+        totalCacheCreationTokens: number;
+        totalSavingsUsd: number;
+      };
+    };
+    // read: 300 (live) + 100 (persisted) = 400; input: 100 (live) + 100 (persisted) = 200
+    // hit rate = 400 / (200 + 400 + 0) = 0.6667 -> 67%
+    expect(parsed.cacheHealth.totalCacheReadTokens).toBe(400);
+    expect(parsed.cacheHealth.totalCacheCreationTokens).toBe(0);
+    expect(parsed.cacheHealth.cacheHitRatePct).toBe(67);
+    expect(parsed.cacheHealth.totalSavingsUsd).toBeCloseTo(0.01);
+    // 67% >= the 60% "excellent" threshold.
+    expect(parsed.cacheHealth.status).toBe('excellent');
+  });
+
+  it("pro-rates a cross-midnight persisted session's cache tokens by todayPortionRatio", async () => {
+    const now = Date.now();
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+    const startMs = startOfDay.getTime();
+
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        loadSessionsOverlappingToday: () => [
+          {
+            sessionId: 'cross-midnight-1',
+            // Started 2h before midnight, ended 2h after — no timeline, so
+            // todayPortionRatio falls back to elapsed-time overlap: 2h of 4h = 0.5.
+            startTime: startMs - 2 * 60 * 60 * 1000,
+            endTime: startMs + 2 * 60 * 60 * 1000,
+            estimatedCostUsd: 0,
+            tokensInput: 1000,
+            tokensCacheRead: 1000,
+            tokensCacheCreation: 0,
+            cacheSavingsUsd: 1.0,
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      cacheHealth: { totalCacheReadTokens: number; totalSavingsUsd: number };
+    };
+    expect(parsed.cacheHealth.totalCacheReadTokens).toBe(500);
+    expect(parsed.cacheHealth.totalSavingsUsd).toBeCloseTo(0.5);
+  });
+
+  it('tops up cacheHealth savings AND token counts with this process own live session when not yet persisted', async () => {
+    const now = Date.now();
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+    const startMs = startOfDay.getTime();
+
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({ sessionId: 'live-1', sessionStartTime: startMs + 5_000 }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+      costTracker: {
+        getMetrics: () => ({
+          totalCacheSavingsUsd: 0.25,
+          totalCacheReadTokens: 800,
+          totalCacheCreationTokens: 0,
+          totalInputTokens: 200,
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['costTracker'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      cacheHealth: {
+        totalSavingsUsd: number;
+        totalCacheReadTokens: number;
+        cacheHitRatePct: number | null;
+      };
+    };
+    // Without this top-up, totalSavingsUsd would show 0.25 while
+    // totalCacheReadTokens/cacheHitRatePct stayed at 0 — an inconsistent
+    // panel for the session someone is actively watching. Both must move
+    // together: read tokens = 800, hit rate = 800 / (200 + 800 + 0) = 80%.
+    expect(parsed.cacheHealth.totalSavingsUsd).toBeCloseTo(0.25);
+    expect(parsed.cacheHealth.totalCacheReadTokens).toBe(800);
+    expect(parsed.cacheHealth.cacheHitRatePct).toBe(80);
+  });
+
+  it('sums cache tokens from both the buffer and a persisted checkpoint for a session live in another process (documents the accepted no-cutoff overlap risk shared with cost/subagentUsd)', async () => {
+    const now = Date.now();
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+    const startMs = startOfDay.getTime();
+
+    const handler = createApiHandler({
+      localStore: {
+        peekAllBuffers: () => [
+          // peekAllBuffers() spans every process's buffer files, so this
+          // shows up even though it belongs to a session this process
+          // isn't running.
+          {
+            mode: 'token',
+            sessionId: 'other-live-1',
+            timestamp: startMs + 10_000,
+            inputTokens: 50,
+            cacheReadTokens: 200,
+            cacheCreationTokens: 0,
+          },
+        ],
+      },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        loadSessionsOverlappingToday: () => [
+          {
+            sessionId: 'other-live-1',
+            startTime: startMs + 1_000,
+            endTime: startMs + 5_000,
+            estimatedCostUsd: 0,
+            tokensInput: 50,
+            tokensCacheRead: 200,
+            tokensCacheCreation: 0,
+            cacheSavingsUsd: 0.02,
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({ sessionId: 'this-process-1' }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      cacheHealth: { totalCacheReadTokens: number; totalSavingsUsd: number };
+    };
+    // Both sources are summed with no cross-source cutoff for a session
+    // live in ANOTHER process: 200 (buffer) + 200 (persisted, ratio 1.0
+    // since fully within today) = 400 read tokens. This mirrors the
+    // pre-existing, equally-unguarded totalCostUsd/subagentUsd overlap in
+    // the same (2b) loop — see the comment above cacheReadTokensSum's
+    // accumulation in api-handler.ts. Not asserting this is "correct",
+    // only that it's the known, accepted current behavior. Dollar savings
+    // only comes from the persisted checkpoint (buffer 'token' events
+    // carry no savings field), so it's unaffected: 0.02.
+    expect(parsed.cacheHealth.totalCacheReadTokens).toBe(400);
+    expect(parsed.cacheHealth.totalSavingsUsd).toBeCloseTo(0.02);
+  });
 });
 
 describe('api-handler GET /api/workflows', () => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -23,6 +23,8 @@ import { analyzeReplayTimeline } from './replay-analyzer.js';
 import type { AntiPatternSegment } from './replay-analyzer.js';
 import { computeLatencyPercentiles } from './latency-percentiles.js';
 import type { LatencySample, AggregateLatencyMetrics } from './latency-percentiles.js';
+import { computeCacheHealth } from './cache-health-aggregate.js';
+import type { CacheHealthTotals, AggregateCacheHealth } from './cache-health-aggregate.js';
 import type { ReplayTimelineEntry, ToolCallRecord } from '../../storage/types.js';
 import type { FullSessionSummary, SessionFileInfo } from '../../storage/session-store.js';
 import type { WorkflowRunRow, WorkflowAgentRow } from '../workflow-store.js';
@@ -387,6 +389,7 @@ export interface ApiHandlerDeps {
       totalCacheReadTokens?: number;
       totalCacheCreationTokens?: number;
       totalCacheSavingsUsd?: number;
+      totalInputTokens?: number;
     };
     // Optional: per-day cost attribution. Fixes the cross-midnight bug where
     // a session that started yesterday counted its full cost as today's. When
@@ -606,6 +609,7 @@ interface TodayAggregatePayload {
   readonly subagentTurnCount: number;
   readonly workflowRunCount: number;
   readonly latency: AggregateLatencyMetrics;
+  readonly cacheHealth: AggregateCacheHealth;
 }
 
 // Build activity windows for every session with activity today, using the SAME
@@ -1202,6 +1206,10 @@ export function createApiHandler(
     const pushLatencySample = (sample: LatencySample): void => {
       if (latencySamples.length < MAX_AGGREGATE_LATENCY_SAMPLES) latencySamples.push(sample);
     };
+    let cacheReadTokensSum = 0;
+    let cacheCreationTokensSum = 0;
+    let cacheInputTokensSum = 0;
+    let cacheSavingsUsdSum = 0;
 
     // (1) live, undrained per-session buffer events
     const peeked = deps.localStore?.peekAllBuffers() ?? [];
@@ -1241,6 +1249,11 @@ export function createApiHandler(
             toolName: typeof ev.tool === 'string' ? ev.tool : 'Unknown',
           });
         }
+      } else if (ev.mode === 'token') {
+        cacheReadTokensSum += typeof ev.cacheReadTokens === 'number' ? ev.cacheReadTokens : 0;
+        cacheCreationTokensSum +=
+          typeof ev.cacheCreationTokens === 'number' ? ev.cacheCreationTokens : 0;
+        cacheInputTokensSum += typeof ev.inputTokens === 'number' ? ev.inputTokens : 0;
       }
     }
 
@@ -1319,6 +1332,10 @@ export function createApiHandler(
         endTime: number;
         estimatedCostUsd: number | null;
         subagentCostUsd?: number;
+        tokensInput?: number;
+        tokensCacheRead?: number;
+        tokensCacheCreation?: number;
+        cacheSavingsUsd?: number;
         antiPatterns?: ReadonlyArray<unknown>;
         timeline?: ReadonlyArray<{ timestamp: number }>;
       };
@@ -1333,7 +1350,26 @@ export function createApiHandler(
       // `--stdio` process persists its own subagentCostUsd, so summing it
       // here (rather than reading only THIS process's live CostTracker)
       // picks up subagent activity that happened in any concurrent session.
-      subagentUsd += (s.subagentCostUsd ?? 0) * todayPortionRatio(s, now);
+      const ratio = todayPortionRatio(s, now);
+      subagentUsd += (s.subagentCostUsd ?? 0) * ratio;
+      // Cache token/dollar sums below carry the same unguarded overlap
+      // characteristic subagentUsd/totalCostUsd already have on this line:
+      // a session that's concurrently live in ANOTHER process (so
+      // peekAllBuffers() — which spans every process's buffer files, not
+      // just this one — sees its undrained 'token' tail in step (1)) AND
+      // has a periodic persisted checkpoint picked up here has no
+      // timestamp-based cutoff between the two sources, unlike the
+      // toolCallCount/latency path above (which has bufferStartBySession
+      // for exactly this reason). Adding one here would fix cache alone
+      // while leaving the pre-existing cost/subagentUsd sums on this same
+      // line unprotected — an inconsistent, ticket-scope-creeping fix — so
+      // this intentionally matches the accepted risk already present for
+      // cost/subagentUsd rather than introducing a new, metric-specific
+      // guard.
+      cacheReadTokensSum += (s.tokensCacheRead ?? 0) * ratio;
+      cacheCreationTokensSum += (s.tokensCacheCreation ?? 0) * ratio;
+      cacheInputTokensSum += (s.tokensInput ?? 0) * ratio;
+      cacheSavingsUsdSum += (s.cacheSavingsUsd ?? 0) * ratio;
       // Count anti-patterns and session for cross-midnight sessions not already
       // captured by the todaySessions loop (which filtered by start-date).
       if (typeof s.sessionId === 'string' && !sessionsSeen.has(s.sessionId)) {
@@ -1385,6 +1421,26 @@ export function createApiHandler(
       // contribution comes from the live, per-day-bucketed CostTracker value
       // instead (same reasoning as liveTodayUsd above).
       subagentUsd += deps.costTracker?.getSubagentCostForDay?.(todayKey) ?? 0;
+      // Cache top-up (dollars AND token counts) for this process's own live,
+      // not-yet-persisted session. These are session-cumulative totals with
+      // no per-day equivalent (unlike getCostForDay above), so — mirroring
+      // the startedToday guard the cost fallback above needs for the exact
+      // same reason — only add them when this live session actually started
+      // today; a cross-midnight live session's cumulative totals would
+      // otherwise leak yesterday's activity in too. Token counts must be
+      // topped up alongside the dollar figure: step (1)'s buffer union only
+      // sees the last undrained tail since the previous periodic checkpoint,
+      // so without this, totalSavingsUsd could reflect a session's full
+      // accumulated savings while totalCacheReadTokens/cacheHitRatePct/status
+      // reflected almost none of the activity that produced them.
+      const liveStartedTs = deps.sessionTracker?.getMetrics().sessionStartTime ?? null;
+      if (typeof liveStartedTs === 'number' && localDateKey(liveStartedTs) === todayKey) {
+        const liveCostMetrics = deps.costTracker?.getMetrics();
+        cacheSavingsUsdSum += liveCostMetrics?.totalCacheSavingsUsd ?? 0;
+        cacheReadTokensSum += liveCostMetrics?.totalCacheReadTokens ?? 0;
+        cacheCreationTokensSum += liveCostMetrics?.totalCacheCreationTokens ?? 0;
+        cacheInputTokensSum += liveCostMetrics?.totalInputTokens ?? 0;
+      }
     }
 
     // Live session anti-patterns (in-memory, not yet persisted).
@@ -1436,6 +1492,13 @@ export function createApiHandler(
       }
     }
 
+    const cacheHealth = computeCacheHealth({
+      cacheReadTokens: cacheReadTokensSum,
+      cacheCreationTokens: cacheCreationTokensSum,
+      inputTokens: cacheInputTokensSum,
+      savingsUsd: cacheSavingsUsdSum,
+    } satisfies CacheHealthTotals);
+
     const payload = {
       toolCallCount,
       totalCostUsd: Math.round(totalCostUsd * 1000) / 1000,
@@ -1448,6 +1511,7 @@ export function createApiHandler(
       workflowRunCount,
       avgEfficiencyScore,
       latency: computeLatencyPercentiles(latencySamples),
+      cacheHealth,
     };
     aggregateCache = { bucket: currentBucket, payload };
     jsonOk(res, payload);

--- a/src/dashboard/routes/cache-health-aggregate.test.ts
+++ b/src/dashboard/routes/cache-health-aggregate.test.ts
@@ -1,0 +1,79 @@
+import { computeCacheHealth } from './cache-health-aggregate.js';
+
+describe('computeCacheHealth', () => {
+  it('returns no_cache_activity with a null pct when there are no tokens at all', () => {
+    const result = computeCacheHealth({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      inputTokens: 0,
+      savingsUsd: 0,
+    });
+    expect(result).toEqual({
+      status: 'no_cache_activity',
+      cacheHitRatePct: null,
+      totalCacheReadTokens: 0,
+      totalCacheCreationTokens: 0,
+      totalSavingsUsd: 0,
+    });
+  });
+
+  it('returns no_cache_activity when there are input tokens but no cache activity at all', () => {
+    // Denominator > 0 but both cache counters are 0 — mirrors
+    // CostTracker.computeCacheHitRate's same null-guard.
+    const result = computeCacheHealth({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      inputTokens: 1000,
+      savingsUsd: 0,
+    });
+    expect(result.status).toBe('no_cache_activity');
+    expect(result.cacheHitRatePct).toBeNull();
+  });
+
+  it('computes hit rate as cacheRead / (input + cacheRead + cacheCreation)', () => {
+    const result = computeCacheHealth({
+      cacheReadTokens: 700,
+      cacheCreationTokens: 100,
+      inputTokens: 200,
+      savingsUsd: 0.05,
+    });
+    // 700 / (200 + 700 + 100) = 0.7 -> 70%
+    expect(result.cacheHitRatePct).toBe(70);
+    expect(result.totalCacheReadTokens).toBe(700);
+    expect(result.totalCacheCreationTokens).toBe(100);
+    expect(result.totalSavingsUsd).toBe(0.05);
+  });
+
+  it('bands >=60% as excellent', () => {
+    const result = computeCacheHealth({
+      cacheReadTokens: 60,
+      cacheCreationTokens: 0,
+      inputTokens: 40,
+      savingsUsd: 0,
+    });
+    expect(result.cacheHitRatePct).toBe(60);
+    expect(result.status).toBe('excellent');
+  });
+
+  it('bands 30%-59% as can_improve', () => {
+    const result = computeCacheHealth({
+      cacheReadTokens: 30,
+      cacheCreationTokens: 0,
+      inputTokens: 70,
+      savingsUsd: 0,
+    });
+    expect(result.cacheHitRatePct).toBe(30);
+    expect(result.status).toBe('can_improve');
+  });
+
+  it('bands below 30% as needs_attention', () => {
+    const result = computeCacheHealth({
+      cacheReadTokens: 29,
+      cacheCreationTokens: 0,
+      inputTokens: 71,
+      savingsUsd: 0,
+    });
+    expect(result.cacheHitRatePct).toBe(29);
+    expect(result.status).toBe('needs_attention');
+  });
+});

--- a/src/dashboard/routes/cache-health-aggregate.ts
+++ b/src/dashboard/routes/cache-health-aggregate.ts
@@ -1,0 +1,51 @@
+export interface CacheHealthTotals {
+  readonly cacheReadTokens: number;
+  readonly cacheCreationTokens: number;
+  readonly inputTokens: number;
+  readonly savingsUsd: number;
+}
+
+export type CacheHealthStatus =
+  'no_cache_activity' | 'needs_attention' | 'can_improve' | 'excellent';
+
+export interface AggregateCacheHealth {
+  readonly status: CacheHealthStatus;
+  readonly cacheHitRatePct: number | null;
+  readonly totalCacheReadTokens: number;
+  readonly totalCacheCreationTokens: number;
+  readonly totalSavingsUsd: number;
+}
+
+// Turns raw token/dollar totals accumulated across every process/session
+// active today (see the aggregate route in api-handler.ts, the only caller)
+// into the hit-rate percentage and status band the Cache Health panel
+// renders. Mirrors CostTracker.computeCacheHitRate's null-handling rule
+// exactly: no percentage at all (not 0%) when there's no cache activity to
+// report, and the same >=60 / >=30 banding thresholds /api/cache-health
+// already uses.
+export function computeCacheHealth(totals: CacheHealthTotals): AggregateCacheHealth {
+  const denominator = totals.inputTokens + totals.cacheReadTokens + totals.cacheCreationTokens;
+  let cacheHitRatePct: number | null = null;
+  if (denominator > 0 && (totals.cacheReadTokens > 0 || totals.cacheCreationTokens > 0)) {
+    cacheHitRatePct = Math.round((totals.cacheReadTokens / denominator) * 100);
+  }
+
+  let status: CacheHealthStatus;
+  if (cacheHitRatePct === null) {
+    status = 'no_cache_activity';
+  } else if (cacheHitRatePct >= 60) {
+    status = 'excellent';
+  } else if (cacheHitRatePct >= 30) {
+    status = 'can_improve';
+  } else {
+    status = 'needs_attention';
+  }
+
+  return {
+    status,
+    cacheHitRatePct,
+    totalCacheReadTokens: totals.cacheReadTokens,
+    totalCacheCreationTokens: totals.cacheCreationTokens,
+    totalSavingsUsd: totals.savingsUsd,
+  };
+}

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -149,6 +149,13 @@ export interface TodayAggregateResponse {
     readonly overall: LatencyPercentiles | null;
     readonly byTool: Readonly<Record<string, LatencyPercentiles | null>>;
   };
+  readonly cacheHealth?: {
+    readonly status: 'no_cache_activity' | 'needs_attention' | 'can_improve' | 'excellent';
+    readonly cacheHitRatePct: number | null;
+    readonly totalCacheReadTokens: number;
+    readonly totalCacheCreationTokens: number;
+    readonly totalSavingsUsd: number;
+  };
 }
 
 // /api/sessions returns a heterogeneous mix of full persisted session

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -779,6 +779,26 @@ describe('Today view — Cache Health panel', () => {
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(
+          JSON.stringify({
+            toolCallCount: 0,
+            totalCostUsd: 0,
+            antiPatternCount: 0,
+            avgDurationMs: 0,
+            sessionCount: 1,
+            sparkline: { startTimestamp: 0, bucketSizeMs: 60_000, points: [] },
+            cacheHealth: {
+              status: 'can_improve',
+              cacheHitRatePct: 48,
+              totalCacheReadTokens: 10000,
+              totalCacheCreationTokens: 2000,
+              totalSavingsUsd: 0.0012,
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
       return new Response(JSON.stringify([]), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -806,6 +826,26 @@ describe('Today view — Cache Health panel', () => {
             total_cache_creation_tokens: 1000,
             total_savings_usd: 0,
             week_over_week_delta_pts: -3,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(
+          JSON.stringify({
+            toolCallCount: 0,
+            totalCostUsd: 0,
+            antiPatternCount: 0,
+            avgDurationMs: 0,
+            sessionCount: 1,
+            sparkline: { startTimestamp: 0, bucketSizeMs: 60_000, points: [] },
+            cacheHealth: {
+              status: 'needs_attention',
+              cacheHitRatePct: 18,
+              totalCacheReadTokens: 5000,
+              totalCacheCreationTokens: 1000,
+              totalSavingsUsd: 0,
+            },
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -841,6 +881,26 @@ describe('Today view — Cache Health panel', () => {
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(
+          JSON.stringify({
+            toolCallCount: 0,
+            totalCostUsd: 0,
+            antiPatternCount: 0,
+            avgDurationMs: 0,
+            sessionCount: 1,
+            sparkline: { startTimestamp: 0, bucketSizeMs: 60_000, points: [] },
+            cacheHealth: {
+              status: 'needs_attention',
+              cacheHitRatePct: 12,
+              totalCacheReadTokens: 3000,
+              totalCacheCreationTokens: 500,
+              totalSavingsUsd: 0,
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
       return new Response(JSON.stringify([]), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -855,6 +915,59 @@ describe('Today view — Cache Health panel', () => {
     );
     expect(await screen.findByText(/Cache hit rate is 12%/)).toBeInTheDocument();
     expect(await screen.findByText(/above 60%/)).toBeInTheDocument();
+  });
+
+  it('renders the cache hit rate from the aggregate endpoint, not the per-process cache-health snapshot', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/cache-health')) {
+        // This process's own live tracker has zero cache activity — it must
+        // NOT be what renders the headline percentage.
+        return new Response(
+          JSON.stringify({
+            status: 'no_cache_activity',
+            cache_hit_rate_pct: null,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_savings_usd: 0,
+            week_over_week_delta_pts: null,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(
+          JSON.stringify({
+            toolCallCount: 0,
+            totalCostUsd: 0,
+            antiPatternCount: 0,
+            avgDurationMs: 0,
+            sessionCount: 1,
+            sparkline: { startTimestamp: 0, bucketSizeMs: 60_000, points: [] },
+            cacheHealth: {
+              status: 'excellent',
+              cacheHitRatePct: 72,
+              totalCacheReadTokens: 700,
+              totalCacheCreationTokens: 100,
+              totalSavingsUsd: 0.5,
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <Today />
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByText('72%')).toBeInTheDocument();
   });
 });
 

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -476,7 +476,7 @@ export function Today(): JSX.Element {
             <ToolSelectionPanel />
             <LatencyPanel aggregate={aggregate} />
             <ModelUsagePanel />
-            <CacheHealthPanel />
+            <CacheHealthPanel aggregate={aggregate} />
           </AnimatedCard>
 
           <AnimatedCard index={4}>
@@ -745,7 +745,7 @@ function ModelUsagePanel(): JSX.Element {
 }
 
 function cacheRecommendationText(
-  status: CacheHealthResponse['status'],
+  status: 'no_cache_activity' | 'needs_attention' | 'can_improve' | 'excellent',
   hitRatePct: number | null,
 ): string {
   const pct = hitRatePct !== null ? `${hitRatePct}%` : null;
@@ -762,15 +762,19 @@ function cacheRecommendationText(
     : 'Restructure your system prompt so stable context appears at the top.';
 }
 
-function CacheHealthPanel(): JSX.Element {
-  const { data } = useQuery<CacheHealthResponse>({
+function CacheHealthPanel({
+  aggregate,
+}: {
+  aggregate: TodayAggregateResponse | undefined;
+}): JSX.Element {
+  const { data: trendData } = useQuery<CacheHealthResponse>({
     queryKey: qk.cacheHealth,
     queryFn: fetchCacheHealth,
     refetchInterval: QUALITY_REFETCH_MS,
   });
 
-  const noActivity =
-    !data || data.status === 'no_cache_activity' || data.cache_hit_rate_pct == null;
+  const data = aggregate?.cacheHealth;
+  const noActivity = !data || data.status === 'no_cache_activity' || data.cacheHitRatePct == null;
 
   return (
     <Card padding="sm" className="h-full">
@@ -793,29 +797,30 @@ function CacheHealthPanel(): JSX.Element {
                     : 'text-ink-base'
               }`}
             >
-              {data.cache_hit_rate_pct}%
+              {data.cacheHitRatePct}%
             </span>
             <Pill tone={data.status === 'needs_attention' ? 'warning' : 'neutral'} size="sm">
               {data.status === 'excellent' ? 'excellent' : data.status.replace('_', ' ')}
             </Pill>
           </div>
-          {data.total_savings_usd > 0 && (
+          {data.totalSavingsUsd > 0 && (
             <div className="text-xs text-accent-green mb-1">
-              ${data.total_savings_usd.toFixed(4)} saved
+              ${data.totalSavingsUsd.toFixed(4)} saved
             </div>
           )}
-          {data.week_over_week_delta_pts !== null && data.week_over_week_delta_pts !== 0 && (
-            <div
-              className={`text-[10px] font-medium mb-1 ${
-                data.week_over_week_delta_pts > 0 ? 'text-accent-green' : 'text-accent-amber'
-              }`}
-            >
-              {data.week_over_week_delta_pts > 0 ? '↑' : '↓'}
-              {Math.abs(data.week_over_week_delta_pts)}pts vs last week
-            </div>
-          )}
+          {trendData?.week_over_week_delta_pts != null &&
+            trendData.week_over_week_delta_pts !== 0 && (
+              <div
+                className={`text-[10px] font-medium mb-1 ${
+                  trendData.week_over_week_delta_pts > 0 ? 'text-accent-green' : 'text-accent-amber'
+                }`}
+              >
+                {trendData.week_over_week_delta_pts > 0 ? '↑' : '↓'}
+                {Math.abs(trendData.week_over_week_delta_pts)}pts vs last week
+              </div>
+            )}
           <div className="text-[10px] text-ink-subtle/70 leading-snug">
-            {cacheRecommendationText(data.status, data.cache_hit_rate_pct)}
+            {cacheRecommendationText(data.status, data.cacheHitRatePct)}
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary
- The Today dashboard's Cache Health panel (hit rate %, status, dollar savings) previously read only the dashboard-serving process's own in-memory cost tracker, silently excluding cache activity from every other concurrently running session.
- Adds a `cacheHealth` field to the existing cross-session `GET /api/sessions/today/aggregate` route, blending live undrained token events across every process with persisted per-session token totals (pro-rated for cross-midnight sessions), via a new pure `computeCacheHealth()` helper mirroring the existing latency-percentiles aggregation.
- The frontend Cache Health panel now reads hit rate/savings/status from that aggregate field; it keeps its existing per-process query only for the week-over-week trend figure, which has no cross-process bug since it's already derived from persisted weekly summaries.

Fixes #318

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — full suite passing
- [x] `npm run test:web` — full suite passing
- [x] `npm run lint` — 0 errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)