### PR TITLE
Fix: Tool Selection panel reflects cross-process activity today (v1.14.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.14] - 2026-07-31
+
+### Fixed
+
+- **The Today dashboard's Tool Selection panel only reflected tool calls handled by whichever process happened to be serving the dashboard** — its score and redundant-read/repeated-failure/unused-output counts came from that one process's own in-memory buffer, silently excluding activity from every other concurrently running session and resetting whenever that process restarted. It's now computed from every today session's activity, the same way the other cross-process Today dashboard fixes already are.
+
 ## [1.14.13] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.13",
+  "version": "1.14.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.13",
+      "version": "1.14.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.13",
+  "version": "1.14.14",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -10,6 +10,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { getIsoWeekId } from '../../storage/weekly-summary.js';
+import {
+  ToolSelectionScorer,
+  toToolSelectionSummary,
+} from '../../metrics/tool-selection-scorer.js';
+import { localStartOfDay } from '../../lib/date.js';
 
 import type { ToolCallRecord } from '../../storage/types.js';
 
@@ -3722,12 +3727,42 @@ describe('api-handler GET /api/tool-selection-score', () => {
     expect(JSON.parse(body())).toEqual({ error: 'unavailable', what: 'toolSelectionScorer' });
   });
 
-  it('scores the current toolCallBuffer records', async () => {
-    const fakeCalls = [{ id: 'c1' }, { id: 'c2' }] as unknown as ReturnType<
+  it('scores only this process live records when nothing else is wired in (no cross-process, no persisted)', async () => {
+    const now = Date.now();
+    const ownRecords = [
+      {
+        id: 'o1',
+        sessionId: 'sess-own',
+        toolName: 'Read',
+        toolUseId: 'o1',
+        timestamp: now,
+        durationMs: 5,
+        success: true,
+        filePath: '/a.ts',
+      },
+      {
+        id: 'o2',
+        sessionId: 'sess-own',
+        toolName: 'Read',
+        toolUseId: 'o2',
+        timestamp: now,
+        durationMs: 5,
+        success: true,
+        filePath: '/b.ts',
+      },
+    ] as unknown as ReturnType<
       NonNullable<Parameters<typeof createApiHandler>[0]['toolCallBuffer']>['getRecords']
     >;
-    const fakeScore = {
-      score: 0.9,
+    const handler = createApiHandler({
+      toolSelectionScorer: new ToolSelectionScorer(),
+      toolCallBuffer: { getRecords: () => ownRecords },
+    });
+    const req = { method: 'GET', url: '/api/tool-selection-score' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(JSON.parse(body())).toEqual({
+      score: 1,
       totalCalls: 2,
       penalizedCalls: 0,
       penalties: [],
@@ -3735,22 +3770,16 @@ describe('api-handler GET /api/tool-selection-score', () => {
       redundantReadCount: 0,
       repeatedFailureCount: 0,
       unusedOutputCount: 0,
-    };
-    const scoreSession = jest.fn(() => fakeScore);
-    const handler = createApiHandler({
-      toolSelectionScorer: { scoreSession },
-      toolCallBuffer: { getRecords: () => fakeCalls },
     });
+  });
+
+  it('returns the trivial empty result when nothing is wired in at all', async () => {
+    const handler = createApiHandler({ toolSelectionScorer: new ToolSelectionScorer() });
     const req = { method: 'GET', url: '/api/tool-selection-score' } as IncomingMessage;
     const { res, status, body } = fakeRes();
     await handler(req, res);
     expect(status()).toBe(200);
-    expect(JSON.parse(body())).toEqual(fakeScore);
-    expect(scoreSession).toHaveBeenCalledWith(fakeCalls);
-  });
-
-  it('scores an empty session (score with []) when toolCallBuffer is absent', async () => {
-    const fakeScore = {
+    expect(JSON.parse(body())).toEqual({
       score: 1,
       totalCalls: 0,
       penalizedCalls: 0,
@@ -3759,15 +3788,305 @@ describe('api-handler GET /api/tool-selection-score', () => {
       redundantReadCount: 0,
       repeatedFailureCount: 0,
       unusedOutputCount: 0,
-    };
-    const scoreSession = jest.fn(() => fakeScore);
-    const handler = createApiHandler({ toolSelectionScorer: { scoreSession } });
+    });
+  });
+
+  it('blends another process live activity (via peekAllBuffers pairing) into the score', async () => {
+    const now = Date.now();
+    // Three reads of the same file from a DIFFERENT process's live session —
+    // the 3rd read (index 2, 0-based) is the first one past the "one
+    // re-read is normal" allowance, so it's the one penalized.
+    const peekedEvents = [
+      {
+        mode: 'pre',
+        tool: 'Read',
+        timestamp: now,
+        toolUseId: 'x1',
+        sessionId: 'sess-other',
+        toolInput: { file_path: '/g.ts' },
+      },
+      {
+        mode: 'post',
+        tool: 'Read',
+        timestamp: now,
+        toolUseId: 'x1',
+        sessionId: 'sess-other',
+        toolOutput: {},
+        outputSize: 100,
+        success: true,
+      },
+      {
+        mode: 'pre',
+        tool: 'Read',
+        timestamp: now + 1,
+        toolUseId: 'x2',
+        sessionId: 'sess-other',
+        toolInput: { file_path: '/g.ts' },
+      },
+      {
+        mode: 'post',
+        tool: 'Read',
+        timestamp: now + 1,
+        toolUseId: 'x2',
+        sessionId: 'sess-other',
+        toolOutput: {},
+        outputSize: 100,
+        success: true,
+      },
+      {
+        mode: 'pre',
+        tool: 'Read',
+        timestamp: now + 2,
+        toolUseId: 'x3',
+        sessionId: 'sess-other',
+        toolInput: { file_path: '/g.ts' },
+      },
+      {
+        mode: 'post',
+        tool: 'Read',
+        timestamp: now + 2,
+        toolUseId: 'x3',
+        sessionId: 'sess-other',
+        toolOutput: {},
+        outputSize: 100,
+        success: true,
+      },
+    ] as unknown as ReturnType<
+      NonNullable<Parameters<typeof createApiHandler>[0]['localStore']>['peekAllBuffers']
+    >;
+    const handler = createApiHandler({
+      toolSelectionScorer: new ToolSelectionScorer(),
+      localStore: { peekAllBuffers: () => peekedEvents },
+    });
     const req = { method: 'GET', url: '/api/tool-selection-score' } as IncomingMessage;
     const { res, status, body } = fakeRes();
     await handler(req, res);
     expect(status()).toBe(200);
-    expect(JSON.parse(body())).toEqual(fakeScore);
-    expect(scoreSession).toHaveBeenCalledWith([]);
+    const parsed = JSON.parse(body());
+    expect(parsed.totalCalls).toBe(3);
+    expect(parsed.redundantReadCount).toBe(1);
+    expect(parsed.penalizedCalls).toBe(1);
+    expect(parsed.score).toBe(0.97); // 1 - (1 * DEFAULT_REDUNDANT_READ_PENALTY of 0.03)
+  });
+
+  it('excludes cross-process buffer events from before today', async () => {
+    const beforeToday = localStartOfDay(Date.now()) - 60_000;
+    const peekedEvents = [
+      {
+        mode: 'pre',
+        tool: 'Read',
+        timestamp: beforeToday,
+        toolUseId: 'y1',
+        sessionId: 'sess-other',
+        toolInput: { file_path: '/g.ts' },
+      },
+      {
+        mode: 'post',
+        tool: 'Read',
+        timestamp: beforeToday,
+        toolUseId: 'y1',
+        sessionId: 'sess-other',
+        toolOutput: {},
+        outputSize: 100,
+        success: true,
+      },
+    ] as unknown as ReturnType<
+      NonNullable<Parameters<typeof createApiHandler>[0]['localStore']>['peekAllBuffers']
+    >;
+    const handler = createApiHandler({
+      toolSelectionScorer: new ToolSelectionScorer(),
+      localStore: { peekAllBuffers: () => peekedEvents },
+    });
+    const req = { method: 'GET', url: '/api/tool-selection-score' } as IncomingMessage;
+    const { res, body } = fakeRes();
+    await handler(req, res);
+    expect(JSON.parse(body()).totalCalls).toBe(0);
+  });
+
+  it('excludes this own live session id from cross-process reconstruction (no double count)', async () => {
+    const now = Date.now();
+    const peekedEvents = [
+      {
+        mode: 'pre',
+        tool: 'Read',
+        timestamp: now,
+        toolUseId: 'z1',
+        sessionId: 'sess-own',
+        toolInput: { file_path: '/g.ts' },
+      },
+      {
+        mode: 'post',
+        tool: 'Read',
+        timestamp: now,
+        toolUseId: 'z1',
+        sessionId: 'sess-own',
+        toolOutput: {},
+        outputSize: 100,
+        success: true,
+      },
+    ] as unknown as ReturnType<
+      NonNullable<Parameters<typeof createApiHandler>[0]['localStore']>['peekAllBuffers']
+    >;
+    const handler = createApiHandler({
+      toolSelectionScorer: new ToolSelectionScorer(),
+      localStore: { peekAllBuffers: () => peekedEvents },
+      sessionTracker: {
+        getMetrics: () =>
+          ({ sessionId: 'sess-own' }) as unknown as ReturnType<
+            NonNullable<Parameters<typeof createApiHandler>[0]['sessionTracker']>['getMetrics']
+          >,
+      },
+    });
+    const req = { method: 'GET', url: '/api/tool-selection-score' } as IncomingMessage;
+    const { res, body } = fakeRes();
+    await handler(req, res);
+    expect(JSON.parse(body()).totalCalls).toBe(0);
+  });
+
+  it('blends a persisted today session summary into the combined score', async () => {
+    const persistedToday = [
+      {
+        // Real FullSessionSummary rows always carry a sessionId; give this
+        // fixture a distinct one so it isn't coincidentally treated as the
+        // (unset, i.e. undefined) live session in this test.
+        sessionId: 'sess-other-persisted',
+        toolSelectionMetrics: {
+          score: 0.5,
+          totalCalls: 5,
+          penalizedCalls: 3,
+          redundantReadCount: 0,
+          repeatedFailureCount: 3,
+          unusedOutputCount: 0,
+        },
+      },
+    ] as unknown as ReturnType<
+      NonNullable<Parameters<typeof createApiHandler>[0]['sessionStore']>['loadTodaySessions']
+    >;
+    const handler = createApiHandler({
+      toolSelectionScorer: new ToolSelectionScorer(),
+      sessionStore: {
+        loadTodaySessions: () => persistedToday,
+        listSessions: () => [],
+        loadSession: () => null,
+      },
+    });
+    const req = { method: 'GET', url: '/api/tool-selection-score' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body());
+    // Combining {score:1, totalCalls:0, ...} (live, empty) with the persisted
+    // summary above: repeatedFailureCount=3 * DEFAULT_REPEATED_FAILURE_PENALTY
+    // of 0.08 = 0.24 raw penalty -> score = 1 - 0.24 = 0.76.
+    expect(parsed.totalCalls).toBe(5);
+    expect(parsed.penalizedCalls).toBe(3);
+    expect(parsed.repeatedFailureCount).toBe(3);
+    expect(parsed.score).toBe(0.76);
+  });
+
+  it('does not double-count this own live session when its own in-progress checkpoint is also persisted today', async () => {
+    // Regression test for the bug where index.ts's periodic 30s checkpoint
+    // writes THIS process's own in-progress session to disk (outcome:
+    // 'in progress') with a toolSelectionMetrics summary computed from the
+    // exact same in-memory tool calls toolCallBuffer.getRecords() also
+    // exposes. loadTodaySessions() returns that checkpoint with no
+    // exclusion, so before the fix the route summed the own session's
+    // contribution twice: once via ownRecords -> liveMetrics, and again via
+    // its own persisted checkpoint inside persistedSummaries.
+    const now = Date.now();
+    const ownSessionId = 'sess-own';
+    // 3 reads of the same file: the 3rd is the first past the "one re-read
+    // is normal" allowance, so it draws exactly one redundant-read penalty —
+    // enough to make a doubled penalty (2x) diverge in score from the
+    // correct single application.
+    const ownRecords = [
+      {
+        id: 'r1',
+        sessionId: ownSessionId,
+        toolName: 'Read',
+        toolUseId: 'r1',
+        timestamp: now,
+        durationMs: 5,
+        success: true,
+        filePath: '/dup.ts',
+      },
+      {
+        id: 'r2',
+        sessionId: ownSessionId,
+        toolName: 'Read',
+        toolUseId: 'r2',
+        timestamp: now + 1,
+        durationMs: 5,
+        success: true,
+        filePath: '/dup.ts',
+      },
+      {
+        id: 'r3',
+        sessionId: ownSessionId,
+        toolName: 'Read',
+        toolUseId: 'r3',
+        timestamp: now + 2,
+        durationMs: 5,
+        success: true,
+        filePath: '/dup.ts',
+      },
+    ] as unknown as ReturnType<
+      NonNullable<Parameters<typeof createApiHandler>[0]['toolCallBuffer']>['getRecords']
+    >;
+
+    // Score the own records once with a real scorer, exactly as the
+    // periodic checkpoint (buildSessionSummary in session-store.ts) would
+    // have when it persisted this same session's in-progress state today.
+    const scorer = new ToolSelectionScorer();
+    const expectedOwnMetrics = scorer.scoreSession(
+      ownRecords as unknown as Parameters<typeof scorer.scoreSession>[0],
+    );
+    const expectedOwnSummary = toToolSelectionSummary(expectedOwnMetrics);
+    // Sanity: this fixture must actually exercise a penalty, or a doubling
+    // bug wouldn't move the score and the test would pass vacuously.
+    expect(expectedOwnSummary.redundantReadCount).toBe(1);
+    expect(expectedOwnSummary.totalCalls).toBe(3);
+
+    const persistedToday = [
+      {
+        sessionId: ownSessionId,
+        toolSelectionMetrics: expectedOwnSummary,
+      },
+    ] as unknown as ReturnType<
+      NonNullable<Parameters<typeof createApiHandler>[0]['sessionStore']>['loadTodaySessions']
+    >;
+
+    const handler = createApiHandler({
+      toolSelectionScorer: new ToolSelectionScorer(),
+      toolCallBuffer: { getRecords: () => ownRecords },
+      sessionTracker: {
+        getMetrics: () =>
+          ({ sessionId: ownSessionId }) as unknown as ReturnType<
+            NonNullable<Parameters<typeof createApiHandler>[0]['sessionTracker']>['getMetrics']
+          >,
+      },
+      sessionStore: {
+        loadTodaySessions: () => persistedToday,
+        listSessions: () => [],
+        loadSession: () => null,
+      },
+    });
+    const req = { method: 'GET', url: '/api/tool-selection-score' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body());
+
+    // The own session's 3 calls must be counted exactly once, not twice
+    // (6) via the undeduplicated own-checkpoint-in-persistedSummaries path.
+    expect(parsed.totalCalls).toBe(expectedOwnSummary.totalCalls);
+    expect(parsed.penalizedCalls).toBe(expectedOwnSummary.penalizedCalls);
+    expect(parsed.redundantReadCount).toBe(expectedOwnSummary.redundantReadCount);
+    expect(parsed.repeatedFailureCount).toBe(expectedOwnSummary.repeatedFailureCount);
+    expect(parsed.unusedOutputCount).toBe(expectedOwnSummary.unusedOutputCount);
+    // Score must match the single (correct) application of penalties, not
+    // the deflated score a doubled penalty would produce.
+    expect(parsed.score).toBe(expectedOwnSummary.score);
   });
 });
 

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -25,7 +25,8 @@ import { computeLatencyPercentiles } from './latency-percentiles.js';
 import type { LatencySample, AggregateLatencyMetrics } from './latency-percentiles.js';
 import { computeCacheHealth } from './cache-health-aggregate.js';
 import type { CacheHealthTotals, AggregateCacheHealth } from './cache-health-aggregate.js';
-import type { ReplayTimelineEntry, ToolCallRecord } from '../../storage/types.js';
+import { pairToolCallsFromBufferEvents } from './tool-selection-aggregate.js';
+import type { HookEvent, ReplayTimelineEntry, ToolCallRecord } from '../../storage/types.js';
 import type { FullSessionSummary, SessionFileInfo } from '../../storage/session-store.js';
 import type { WorkflowRunRow, WorkflowAgentRow } from '../workflow-store.js';
 import type {
@@ -40,7 +41,11 @@ import type { LatencyMetrics } from '../../metrics/latency-tracker.js';
 import type { PersonalInsightsResult } from '../../metrics/personal-coach.js';
 import type { GitEfficiencyMetrics } from '../../metrics/git-efficiency-tracker.js';
 import type { QualityProxyMetrics } from '../../metrics/quality-proxy-tracker.js';
-import type { ToolSelectionMetrics } from '../../metrics/tool-selection-scorer.js';
+import type {
+  ToolSelectionMetrics,
+  ToolSelectionSummary,
+} from '../../metrics/tool-selection-scorer.js';
+import { toToolSelectionSummary } from '../../metrics/tool-selection-scorer.js';
 import type { ModelUsageMetrics } from '../../metrics/model-usage-tracker.js';
 import { DEFAULT_STALE_THRESHOLD_MS } from '../../metrics/live-session-registry.js';
 import { computeContextMetricsFromEvents } from '../../metrics/context-tracker.js';
@@ -473,6 +478,7 @@ export interface ApiHandlerDeps {
   readonly qualityProxyTracker?: { getMetrics: () => QualityProxyMetrics };
   readonly toolSelectionScorer?: {
     scoreSession: (calls: readonly ToolCallRecord[]) => ToolSelectionMetrics;
+    combineSummaries: (summaries: readonly ToolSelectionSummary[]) => ToolSelectionMetrics;
   };
   readonly modelUsageTracker?: { getMetrics: () => ModelUsageMetrics };
   readonly toolCallBuffer?: { getRecords: () => readonly ToolCallRecord[] };
@@ -1719,8 +1725,47 @@ export function createApiHandler(
 
   routes.set('GET /api/tool-selection-score', (_req, res) => {
     if (!deps.toolSelectionScorer) return unavailable(res, 'toolSelectionScorer');
-    const calls = deps.toolCallBuffer?.getRecords() ?? [];
-    jsonOk(res, deps.toolSelectionScorer.scoreSession(calls));
+    const startMs = localStartOfDay(Date.now());
+
+    // (1) this process's own already-paired, already-parsed live records —
+    // full fidelity, same source the old code used.
+    const ownRecords = (deps.toolCallBuffer?.getRecords() ?? []).filter(
+      (r) => r.timestamp >= startMs,
+    );
+
+    // (2) every OTHER process's still-undrained buffer, paired into full
+    // ToolCallRecords (see tool-selection-aggregate.ts). This process's own
+    // buffer file is typically already drained into (1) by the time it's
+    // peeked, but exclude its sessionId defensively so a change in drain
+    // timing can never double-count.
+    const ownSessionId = deps.sessionTracker?.getMetrics().sessionId;
+    const peeked = deps.localStore?.peekAllBuffers() ?? [];
+    const crossProcessRecords = pairToolCallsFromBufferEvents(
+      peeked as unknown as readonly HookEvent[],
+    ).filter((r) => r.timestamp >= startMs && r.sessionId !== ownSessionId);
+
+    // Score all of today's live, not-yet-persisted activity together so
+    // redundant-read/repeated-failure detection sees real cross-call
+    // sequencing (not just independently-summed per-session counts).
+    const liveMetrics = deps.toolSelectionScorer.scoreSession([
+      ...ownRecords,
+      ...crossProcessRecords,
+    ]);
+
+    // (3) sessions already completed and persisted today — each carries its
+    // own toolSelectionMetrics summary computed at save time (see
+    // buildSessionSummary in session-store.ts), before outputSizeBytes was
+    // gone for good.
+    const persistedSummaries = (deps.sessionStore?.loadTodaySessions() ?? [])
+      .filter((s) => s.sessionId !== ownSessionId)
+      .map((s) => s.toolSelectionMetrics)
+      .filter((m): m is ToolSelectionSummary => m != null);
+
+    const combined = deps.toolSelectionScorer.combineSummaries([
+      toToolSelectionSummary(liveMetrics),
+      ...persistedSummaries,
+    ]);
+    jsonOk(res, combined);
   });
 
   routes.set('GET /api/git-efficiency', (_req, res) => {

--- a/src/dashboard/routes/tool-selection-aggregate.test.ts
+++ b/src/dashboard/routes/tool-selection-aggregate.test.ts
@@ -1,0 +1,85 @@
+import { pairToolCallsFromBufferEvents } from './tool-selection-aggregate.js';
+import type { PreHookEvent, PostHookEvent } from '../../storage/types.js';
+
+function pre(overrides: Partial<PreHookEvent> = {}): PreHookEvent {
+  return {
+    mode: 'pre',
+    tool: 'Read',
+    timestamp: 1000,
+    toolUseId: 'tu-1',
+    sessionId: 'sess-a',
+    toolInput: { file_path: '/src/foo.ts' },
+    ...overrides,
+  };
+}
+
+function post(overrides: Partial<PostHookEvent> = {}): PostHookEvent {
+  return {
+    mode: 'post',
+    tool: 'Read',
+    timestamp: 1010,
+    toolUseId: 'tu-1',
+    sessionId: 'sess-a',
+    toolOutput: {},
+    outputSize: 5000,
+    success: true,
+    ...overrides,
+  } as PostHookEvent;
+}
+
+describe('pairToolCallsFromBufferEvents', () => {
+  it('pairs a matching pre/post by (sessionId, toolUseId) into a ToolCallRecord with filePath and outputSizeBytes', () => {
+    const records = pairToolCallsFromBufferEvents([pre(), post()]);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      sessionId: 'sess-a',
+      toolName: 'Read',
+      toolUseId: 'tu-1',
+      timestamp: 1010,
+      success: true,
+      outputSizeBytes: 5000,
+      filePath: '/src/foo.ts',
+    });
+  });
+
+  it('pairs correctly regardless of array order (pre after post)', () => {
+    const records = pairToolCallsFromBufferEvents([post(), pre()]);
+    expect(records).toHaveLength(1);
+    expect(records[0]?.filePath).toBe('/src/foo.ts');
+  });
+
+  it('defaults success to true when the post event omits it', () => {
+    const records = pairToolCallsFromBufferEvents([pre(), post({ success: undefined })]);
+    expect(records[0]?.success).toBe(true);
+  });
+
+  it('skips unmatched post events (no corresponding pre)', () => {
+    const records = pairToolCallsFromBufferEvents([post({ toolUseId: 'orphan' })]);
+    expect(records).toHaveLength(0);
+  });
+
+  it('skips post events without a toolUseId', () => {
+    const records = pairToolCallsFromBufferEvents([
+      pre({ toolUseId: undefined }),
+      post({ toolUseId: undefined }),
+    ]);
+    expect(records).toHaveLength(0);
+  });
+
+  it('does not cross-pair events from different sessions sharing the same toolUseId', () => {
+    const records = pairToolCallsFromBufferEvents([
+      pre({ sessionId: 'sess-a' }),
+      post({ sessionId: 'sess-b' }),
+    ]);
+    expect(records).toHaveLength(0);
+  });
+
+  it('ignores token/subagent_token/observability_health/workflow_run events', () => {
+    const records = pairToolCallsFromBufferEvents([
+      pre(),
+      post(),
+      { mode: 'token', tool: '', timestamp: 1020, inputTokens: 10, outputTokens: 5 },
+    ]);
+    expect(records).toHaveLength(1);
+  });
+});

--- a/src/dashboard/routes/tool-selection-aggregate.ts
+++ b/src/dashboard/routes/tool-selection-aggregate.ts
@@ -1,0 +1,63 @@
+import type { HookEvent, PreHookEvent, ToolCallRecord } from '../../storage/types.js';
+import { parseToolSpecificFields } from '../../hooks/tool-parsers.js';
+
+function pairKey(sessionId: string, toolUseId: string): string {
+  return `${sessionId}:${toolUseId}`;
+}
+
+// Reconstructs full-fidelity ToolCallRecord[] from raw buffer-file events —
+// the ONLY source that still carries outputSizeBytes for not-yet-persisted
+// activity (see the ToolSelectionSummary doc comment in
+// src/metrics/tool-selection-scorer.ts for why persisted sessions can't).
+// filePath/command aren't on the wire directly (see PreHookEvent/PostHookEvent
+// in src/storage/types.ts) — HookEventProcessor derives them in-memory via
+// parseToolSpecificFields from the pre event's raw toolInput, which this
+// function replicates for pre/post pairs read from ANY process's buffer file
+// via LocalStore.peekAllBuffers().
+//
+// Two passes (collect all `pre` events first, then match `post` events)
+// rather than a single left-to-right scan — peekAllBuffers() concatenates
+// multiple processes' buffer files in directory-listing order, not
+// chronological order, so a post event can appear before its matching pre.
+//
+// Pairs missing a toolUseId, or with no matching partner, are silently
+// skipped — modern collector versions always set toolUseId; this only
+// affects very old buffer data from other concurrent processes, a narrow
+// and self-correcting gap (it heals itself the moment that process upgrades).
+export function pairToolCallsFromBufferEvents(events: readonly HookEvent[]): ToolCallRecord[] {
+  const pending = new Map<string, PreHookEvent>();
+  for (const event of events) {
+    if (event.mode !== 'pre') continue;
+    if (!event.sessionId || !event.toolUseId) continue;
+    pending.set(pairKey(event.sessionId, event.toolUseId), event);
+  }
+
+  const records: ToolCallRecord[] = [];
+  for (const event of events) {
+    if (event.mode !== 'post') continue;
+    if (!event.sessionId || !event.toolUseId) continue;
+    const matchedPre = pending.get(pairKey(event.sessionId, event.toolUseId));
+    if (!matchedPre) continue;
+
+    const fields = parseToolSpecificFields(event.tool, matchedPre.toolInput, event.toolOutput);
+
+    // PostHookEvent doesn't declare durationMs (see src/storage/types.ts) even
+    // though real buffer-file JSON lines carry one at runtime — same duck-typed
+    // access api-handler.ts already uses for this exact field.
+    const raw = event as unknown as Record<string, unknown>;
+    const durationMs = typeof raw.durationMs === 'number' ? raw.durationMs : null;
+
+    records.push({
+      id: pairKey(event.sessionId, event.toolUseId),
+      sessionId: event.sessionId,
+      toolName: event.tool,
+      toolUseId: event.toolUseId,
+      timestamp: event.timestamp,
+      durationMs,
+      success: event.success ?? true,
+      outputSizeBytes: typeof event.outputSize === 'number' ? event.outputSize : undefined,
+      ...fields,
+    });
+  }
+  return records;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1828,6 +1828,7 @@ async function main(): Promise<void> {
           taskDetector,
           antiPatternDetector,
           efficiencyScorer,
+          toolSelectionScorer,
           transcriptMessageTracker,
           developer: config.developer ?? 'unknown',
           repoName: currentRepoName,

--- a/src/metrics/claudemd-tracker.test.ts
+++ b/src/metrics/claudemd-tracker.test.ts
@@ -60,6 +60,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     tokensCacheCreation: 0,
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
+    toolSelectionMetrics: null,
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/collaboration-profile.test.ts
+++ b/src/metrics/collaboration-profile.test.ts
@@ -57,6 +57,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     tokensCacheCreation: 0,
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
+    toolSelectionMetrics: null,
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/prompt-feedback.test.ts
+++ b/src/metrics/prompt-feedback.test.ts
@@ -62,6 +62,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     tokensCacheCreation: 0,
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
+    toolSelectionMetrics: null,
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/recommendation-engine.test.ts
+++ b/src/metrics/recommendation-engine.test.ts
@@ -63,6 +63,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     tokensCacheCreation: 0,
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
+    toolSelectionMetrics: null,
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/tool-selection-scorer.test.ts
+++ b/src/metrics/tool-selection-scorer.test.ts
@@ -1,4 +1,4 @@
-import { ToolSelectionScorer } from './tool-selection-scorer.js';
+import { ToolSelectionScorer, toToolSelectionSummary } from './tool-selection-scorer.js';
 import type { ToolCallRecord } from '../storage/types.js';
 
 const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -206,5 +206,133 @@ describe('ToolSelectionScorer', () => {
 
     const metrics = scorer.scoreSession(calls);
     expect(metrics.unusedOutputCount).toBe(0);
+  });
+});
+
+describe('toToolSelectionSummary', () => {
+  it('drops penalties and worstOffenders, keeps the 6 scalar fields', () => {
+    const scorer = new ToolSelectionScorer();
+    const metrics = scorer.scoreSession([]);
+    const summary = toToolSelectionSummary({
+      ...metrics,
+      penalties: [
+        {
+          callId: 'x',
+          toolName: 'Read',
+          reason: 'redundant_read',
+          penaltyScore: 0.03,
+          detail: 'd',
+        },
+      ],
+      worstOffenders: [],
+    });
+    expect(summary).toEqual({
+      score: 1,
+      totalCalls: 0,
+      penalizedCalls: 0,
+      redundantReadCount: 0,
+      repeatedFailureCount: 0,
+      unusedOutputCount: 0,
+    });
+    expect(summary).not.toHaveProperty('penalties');
+    expect(summary).not.toHaveProperty('worstOffenders');
+  });
+});
+
+describe('ToolSelectionScorer.combineSummaries', () => {
+  it('returns the trivial empty result for an empty summary list', () => {
+    const scorer = new ToolSelectionScorer();
+    expect(scorer.combineSummaries([])).toEqual({
+      score: 1,
+      totalCalls: 0,
+      penalizedCalls: 0,
+      penalties: [],
+      worstOffenders: [],
+      redundantReadCount: 0,
+      repeatedFailureCount: 0,
+      unusedOutputCount: 0,
+    });
+  });
+
+  it('matches scoring the concatenated call list directly (below the 0.7 penalty cap)', () => {
+    const scorer = new ToolSelectionScorer();
+    // Session A: 2 redundant reads of the same file (3rd+ read, no edit between).
+    const callsA = [
+      {
+        id: 'a1',
+        sessionId: 's-a',
+        toolName: 'Read',
+        toolUseId: 'a1',
+        timestamp: 1,
+        durationMs: 5,
+        success: true,
+        filePath: '/f.ts',
+      },
+      {
+        id: 'a2',
+        sessionId: 's-a',
+        toolName: 'Read',
+        toolUseId: 'a2',
+        timestamp: 2,
+        durationMs: 5,
+        success: true,
+        filePath: '/f.ts',
+      },
+      {
+        id: 'a3',
+        sessionId: 's-a',
+        toolName: 'Read',
+        toolUseId: 'a3',
+        timestamp: 3,
+        durationMs: 5,
+        success: true,
+        filePath: '/f.ts',
+      },
+      {
+        id: 'a4',
+        sessionId: 's-a',
+        toolName: 'Read',
+        toolUseId: 'a4',
+        timestamp: 4,
+        durationMs: 5,
+        success: true,
+        filePath: '/f.ts',
+      },
+    ];
+    // Session B: one repeated Bash failure.
+    const callsB = [
+      {
+        id: 'b1',
+        sessionId: 's-b',
+        toolName: 'Bash',
+        toolUseId: 'b1',
+        timestamp: 10,
+        durationMs: 5,
+        success: false,
+      },
+      {
+        id: 'b2',
+        sessionId: 's-b',
+        toolName: 'Bash',
+        toolUseId: 'b2',
+        timestamp: 11,
+        durationMs: 5,
+        success: false,
+      },
+    ];
+
+    const summaryA = toToolSelectionSummary(scorer.scoreSession(callsA));
+    const summaryB = toToolSelectionSummary(scorer.scoreSession(callsB));
+    const combined = scorer.combineSummaries([summaryA, summaryB]);
+    const direct = scorer.scoreSession([...callsA, ...callsB]);
+
+    expect(combined.score).toBe(direct.score);
+    expect(combined.totalCalls).toBe(direct.totalCalls);
+    expect(combined.penalizedCalls).toBe(direct.penalizedCalls);
+    expect(combined.redundantReadCount).toBe(direct.redundantReadCount);
+    expect(combined.repeatedFailureCount).toBe(direct.repeatedFailureCount);
+    expect(combined.unusedOutputCount).toBe(direct.unusedOutputCount);
+    expect(combined.penalties).toEqual([]);
+    expect(combined.worstOffenders).toEqual([]);
   });
 });

--- a/src/metrics/tool-selection-scorer.ts
+++ b/src/metrics/tool-selection-scorer.ts
@@ -23,6 +23,34 @@ export interface ToolSelectionMetrics {
   readonly unusedOutputCount: number;
 }
 
+// Trimmed projection of ToolSelectionMetrics with no per-call detail —
+// persisted per session on FullSessionSummary (src/storage/session-store.ts)
+// and used to recombine multiple sessions' scores via combineSummaries()
+// below. Dropping `penalties`/`worstOffenders` avoids needing to redact
+// their `detail` strings (which interpolate raw file paths) before
+// persisting, mirroring how the cross-session cache-health/latency
+// aggregates (src/dashboard/routes/cache-health-aggregate.ts,
+// latency-percentiles.ts) also only carry summary numbers, not per-item detail.
+export interface ToolSelectionSummary {
+  readonly score: number;
+  readonly totalCalls: number;
+  readonly penalizedCalls: number;
+  readonly redundantReadCount: number;
+  readonly repeatedFailureCount: number;
+  readonly unusedOutputCount: number;
+}
+
+export function toToolSelectionSummary(metrics: ToolSelectionMetrics): ToolSelectionSummary {
+  return {
+    score: metrics.score,
+    totalCalls: metrics.totalCalls,
+    penalizedCalls: metrics.penalizedCalls,
+    redundantReadCount: metrics.redundantReadCount,
+    repeatedFailureCount: metrics.repeatedFailureCount,
+    unusedOutputCount: metrics.unusedOutputCount,
+  };
+}
+
 export interface ToolSelectionScorerOptions {
   readonly redundantReadPenalty?: number;
   readonly repeatedFailurePenalty?: number;
@@ -121,6 +149,60 @@ export class ToolSelectionScorer {
       redundantReadCount: penalties.filter((p) => p.reason === 'redundant_read').length,
       repeatedFailureCount: penalties.filter((p) => p.reason === 'repeated_failure').length,
       unusedOutputCount: penalties.filter((p) => p.reason === 'unused_output').length,
+    };
+  }
+
+  /**
+   * Recombines per-session summaries (each already scored independently —
+   * e.g. one per session completed today) into one aggregate
+   * ToolSelectionMetrics, reapplying this instance's own configured penalty
+   * weights to the summed counts. Per-call detail (`penalties`/
+   * `worstOffenders`) isn't reconstructable from summaries alone, so both
+   * come back empty — see the ToolSelectionSummary doc comment above.
+   */
+  combineSummaries(summaries: readonly ToolSelectionSummary[]): ToolSelectionMetrics {
+    let totalCalls = 0;
+    let penalizedCalls = 0;
+    let redundantReadCount = 0;
+    let repeatedFailureCount = 0;
+    let unusedOutputCount = 0;
+    for (const s of summaries) {
+      totalCalls += s.totalCalls;
+      penalizedCalls += s.penalizedCalls;
+      redundantReadCount += s.redundantReadCount;
+      repeatedFailureCount += s.repeatedFailureCount;
+      unusedOutputCount += s.unusedOutputCount;
+    }
+
+    if (totalCalls === 0) {
+      return {
+        score: 1,
+        totalCalls: 0,
+        penalizedCalls: 0,
+        penalties: [],
+        worstOffenders: [],
+        redundantReadCount: 0,
+        repeatedFailureCount: 0,
+        unusedOutputCount: 0,
+      };
+    }
+
+    const rawPenalty =
+      redundantReadCount * this.redundantReadPenalty +
+      repeatedFailureCount * this.repeatedFailurePenalty +
+      unusedOutputCount * this.unusedOutputPenalty;
+    const totalPenalty = Math.min(rawPenalty, 0.7);
+    const score = Math.max(0, Math.round((1 - totalPenalty) * 1000) / 1000);
+
+    return {
+      score,
+      totalCalls,
+      penalizedCalls,
+      penalties: [],
+      worstOffenders: [],
+      redundantReadCount,
+      repeatedFailureCount,
+      unusedOutputCount,
     };
   }
 

--- a/src/metrics/trend-analyzer.test.ts
+++ b/src/metrics/trend-analyzer.test.ts
@@ -62,6 +62,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     tokensCacheCreation: 0,
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
+    toolSelectionMetrics: null,
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -16,6 +16,7 @@ import type { TaskDetector } from '../metrics/task-detector.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
 import type { TranscriptMessageTracker } from '../metrics/transcript-message-tracker.js';
 import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
+import { ToolSelectionScorer, toToolSelectionSummary } from '../metrics/tool-selection-scorer.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -67,6 +68,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     tokensCacheCreation: 0,
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
+    toolSelectionMetrics: null,
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,
@@ -1139,6 +1141,165 @@ describe('buildSessionSummary', () => {
     expect(summary.antiPatterns).toEqual([]);
     expect(summary.filesRead).toEqual([]);
     expect(summary.filesModified).toEqual([]);
+  });
+
+  it('computes toolSelectionMetrics from the full in-memory tool calls when a scorer is provided', () => {
+    const toolCalls = [
+      {
+        id: 'c1',
+        sessionId: 'test-session',
+        toolName: 'Read',
+        toolUseId: 'c1',
+        timestamp: 1,
+        durationMs: 5,
+        success: true,
+        filePath: '/f.ts',
+      },
+      {
+        id: 'c2',
+        sessionId: 'test-session',
+        toolName: 'Read',
+        toolUseId: 'c2',
+        timestamp: 2,
+        durationMs: 5,
+        success: true,
+        filePath: '/f.ts',
+      },
+      {
+        id: 'c3',
+        sessionId: 'test-session',
+        toolName: 'Read',
+        toolUseId: 'c3',
+        timestamp: 3,
+        durationMs: 5,
+        success: true,
+        filePath: '/f.ts',
+      },
+    ];
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 3,
+        toolCallCountByTool: { Read: 3 },
+        toolDurationMsByTool: {},
+        toolSuccessRate: 1,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 1,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+    const mockTaskDetector = {
+      getCurrentTask: () => null,
+      getMetrics: () => ({
+        totalTasksCompleted: 1,
+        currentTaskActive: false,
+        currentTaskToolCalls: 0,
+        averageTaskDurationMs: 1000,
+        averageToolCallsPerTask: 3,
+        completedTasks: [
+          {
+            taskId: 't1',
+            startTime: 1,
+            endTime: 3,
+            durationMs: 2,
+            toolCallCount: 3,
+            toolCallsByType: { Read: 3 },
+            filesRead: ['/f.ts'],
+            filesModified: [],
+            linesChanged: 0,
+            linesAdded: 0,
+            linesRemoved: 0,
+            bashCommandsRun: 0,
+            testsRun: 0,
+            testsPassed: 0,
+            buildRun: 0,
+            buildPassed: 0,
+            estimatedCostUsd: 0,
+            tokensUsed: 0,
+            askedUserQuestions: 0,
+            subAgentsSpawned: 0,
+            toolCalls,
+          },
+        ],
+      }),
+    };
+    const scorer = new ToolSelectionScorer();
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      taskDetector: mockTaskDetector as unknown as TaskDetector,
+      toolSelectionScorer: scorer,
+      developer: 'alice',
+    });
+
+    expect(summary.toolSelectionMetrics).toEqual(
+      toToolSelectionSummary(scorer.scoreSession(toolCalls)),
+    );
+    expect(summary.toolSelectionMetrics?.redundantReadCount).toBe(1);
+  });
+
+  it('leaves toolSelectionMetrics null when no scorer is provided', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: null,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      developer: 'alice',
+    });
+    expect(summary.toolSelectionMetrics).toBeNull();
+  });
+
+  it('round-trips toolSelectionMetrics through JSON serialization', () => {
+    const original = makeSummary({
+      toolSelectionMetrics: {
+        score: 0.91,
+        totalCalls: 20,
+        penalizedCalls: 2,
+        redundantReadCount: 1,
+        repeatedFailureCount: 0,
+        unusedOutputCount: 1,
+      },
+    });
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(JSON.stringify(original)) as Parameters<typeof deserializeFullSessionSummary>[0],
+    );
+    expect(roundTripped.toolSelectionMetrics).toEqual(original.toolSelectionMetrics);
+  });
+
+  it('defaults toolSelectionMetrics to null for legacy session files missing the field', () => {
+    const legacy = makeSummary();
+    const { toolSelectionMetrics: _toolSelectionMetrics, ...withoutField } = legacy;
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(JSON.stringify(withoutField)) as Parameters<
+        typeof deserializeFullSessionSummary
+      >[0],
+    );
+    expect(roundTripped.toolSelectionMetrics).toBeNull();
   });
 });
 

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -25,6 +25,11 @@ import type { AntiPatternDetector } from '../metrics/anti-patterns.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
 import type { TranscriptMessageTracker } from '../metrics/transcript-message-tracker.js';
 import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
+import {
+  ToolSelectionScorer,
+  toToolSelectionSummary,
+  type ToolSelectionSummary,
+} from '../metrics/tool-selection-scorer.js';
 
 const logger = createLogger('session-store');
 
@@ -73,6 +78,14 @@ export interface FullSessionSummary extends SessionSummary {
   readonly platform?: string;
   readonly instructionPromptHash?: string | null;
   readonly timeline?: ReplayTimelineEntry[];
+  /**
+   * Tool-selection quality summary for this session, computed once at save
+   * time from the full in-memory ToolCallRecord[] — the only point where
+   * outputSizeBytes (needed for unused-output detection) is still available;
+   * it is never persisted anywhere else, including `timeline` above. null
+   * for pre-fix session files and for sessions with no tool calls.
+   */
+  readonly toolSelectionMetrics: ToolSelectionSummary | null;
 }
 
 export interface SessionFileInfo {
@@ -286,6 +299,7 @@ export interface BuildSessionSummarySources {
   antiPatternDetector?: AntiPatternDetector;
   efficiencyScorer?: EfficiencyScorer;
   transcriptMessageTracker?: TranscriptMessageTracker;
+  toolSelectionScorer?: ToolSelectionScorer;
   developer: string;
   repoName?: string | null;
   /**
@@ -363,6 +377,15 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     }
   }
 
+  // Tool-selection quality: same allToolCalls used for anti-pattern analysis
+  // above, still holding real outputSizeBytes at this point — see the
+  // ToolSelectionSummary doc comment on FullSessionSummary for why this is
+  // the only place that's true.
+  const toolSelectionResult =
+    sources.toolSelectionScorer && allToolCalls.length > 0
+      ? toToolSelectionSummary(sources.toolSelectionScorer.scoreSession(allToolCalls))
+      : null;
+
   // Efficiency score
   const efficiencyAvg = efficiencyScorer?.getSessionAverage() ?? null;
 
@@ -430,6 +453,7 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     platform: sources.platform,
     instructionPromptHash: sources.instructionPromptHash ?? null,
     timeline: timeline.length > 0 ? timeline : undefined,
+    toolSelectionMetrics: toolSelectionResult,
   };
 }
 
@@ -518,6 +542,7 @@ interface SerializedFullSessionSummary {
   readonly platform?: unknown;
   readonly instructionPromptHash?: unknown;
   readonly timeline?: Array<Record<string, unknown>>;
+  readonly toolSelectionMetrics?: unknown;
 }
 
 /**
@@ -546,6 +571,30 @@ export function deserializeFullSessionSummary(
       }
     }
   }
+
+  const toolSelectionMetrics: ToolSelectionSummary | null = (() => {
+    const t = obj.toolSelectionMetrics;
+    if (typeof t !== 'object' || t === null) return null;
+    const r = t as Record<string, unknown>;
+    if (
+      typeof r.score !== 'number' ||
+      typeof r.totalCalls !== 'number' ||
+      typeof r.penalizedCalls !== 'number' ||
+      typeof r.redundantReadCount !== 'number' ||
+      typeof r.repeatedFailureCount !== 'number' ||
+      typeof r.unusedOutputCount !== 'number'
+    ) {
+      return null;
+    }
+    return {
+      score: r.score,
+      totalCalls: r.totalCalls,
+      penalizedCalls: r.penalizedCalls,
+      redundantReadCount: r.redundantReadCount,
+      repeatedFailureCount: r.repeatedFailureCount,
+      unusedOutputCount: r.unusedOutputCount,
+    };
+  })();
 
   return {
     sessionId:
@@ -616,6 +665,7 @@ export function deserializeFullSessionSummary(
             errorType: typeof e.errorType === 'string' ? e.errorType : undefined,
           }))
       : undefined,
+    toolSelectionMetrics,
   };
 }
 

--- a/src/storage/weekly-summary.test.ts
+++ b/src/storage/weekly-summary.test.ts
@@ -62,6 +62,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     tokensCacheCreation: 0,
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
+    toolSelectionMetrics: null,
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -89,6 +89,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     tokensCacheCreation: 0,
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
+    toolSelectionMetrics: null,
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -573,7 +573,7 @@ function ToolSelectionPanel(): JSX.Element {
         <EmptyState
           icon="radar"
           title="Waiting for tool calls"
-          subtitle="Start a Claude Code session to begin scoring. Resets when the process restarts."
+          subtitle="Start a Claude Code session to begin scoring. Reflects today's activity across all sessions."
         />
       ) : (
         <>


### PR DESCRIPTION
## Summary

- \`GET /api/tool-selection-score\` (the Today dashboard's Tool Selection panel) previously scored only the dashboard-serving process's own in-memory tool-call buffer since it last restarted, silently excluding activity from every other concurrently running session and every session already completed today.
- Persists a \`toolSelectionMetrics\` summary (score + 5 penalty counts, no raw call detail) on each session at save time, computed from the full in-memory tool-call list while \`outputSizeBytes\` is still available — it's never available again once a session is only reachable from disk.
- Reconstructs full-fidelity tool-call records for still-live activity in other processes by pairing raw pre/post hook-event buffer lines, then blends that with every session completed today via a new \`ToolSelectionScorer.combineSummaries()\` that reapplies the scorer's own penalty weights to the summed counts.
- Includes a fix for a cross-task double-count bug caught in final review: the route was summing the dashboard's own live session twice — once from its live buffer, once from its own periodic "in progress" checkpoint — mirroring the guard the sibling \`/api/sessions/today/aggregate\` route already uses.
- Bumps version to 1.14.14 with a matching CHANGELOG entry.

Fixes #321

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 161/162 suites, 5236/5239 tests passing (3 pre-existing skips)
- [x] \`npm run test:web\` — 37/37 suites, 421/421 tests passing
- [x] \`npm run lint\` — 0 errors, 0 warnings
- [x] New unit tests: \`tool-selection-scorer.test.ts\`, \`session-store.test.ts\`, \`tool-selection-aggregate.test.ts\` (new file), \`api-handler.test.ts\` (replaces 2 stale tests, adds 8 new including the own-session-double-count regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)