### PR TITLE
Fix: Forecast · End of Day reflects cross-process activity today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.15] - 2026-07-31
+
+### Fixed
+
+- **The Today dashboard's "Forecast · End of Day" card only projected spend from whichever process happened to be serving the dashboard** — its burn-rate calculation came from that one process's own in-memory cost tracker, which is empty on a dashboard-only process with no coding activity of its own, so the forecast silently failed to account for spend happening in other concurrently running sessions. It's now computed from every today session's activity, the same way the other cross-process Today dashboard fixes already are.
+
 ## [1.14.14] - 2026-07-31
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.14",
+  "version": "1.14.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.14",
+      "version": "1.14.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.14",
+  "version": "1.14.15",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -2118,6 +2118,135 @@ describe('api-handler GET /api/sessions/today/aggregate', () => {
     expect(parsed.cacheHealth.totalCacheReadTokens).toBe(400);
     expect(parsed.cacheHealth.totalSavingsUsd).toBeCloseTo(0.02);
   });
+
+  it('sets forecastEndOfDayUsd (not null) from a live buffer timestamp when no session has been persisted yet', async () => {
+    const now = Date.now();
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+    const startMs = startOfDay.getTime();
+
+    const handler = createApiHandler({
+      localStore: {
+        peekAllBuffers: () => [
+          { mode: 'post', sessionId: 'live-1', timestamp: startMs + 5_000, durationMs: 10 },
+        ],
+      },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      totalCostUsd: number;
+      forecastEndOfDayUsd: number | null;
+    };
+    // No cost anywhere yet, so totalCostUsd is 0 and buildCostForecastFromInputs
+    // takes its deterministic "nothing spent yet" branch (forecastEndOfDayUsd: 0,
+    // not null). Asserting it's 0 rather than null proves a `dailyFirstActivityMs`
+    // anchor WAS established from the buffer event — if it hadn't been, the whole
+    // forecast computation would have been skipped and this would be null.
+    expect(parsed.totalCostUsd).toBe(0);
+    expect(parsed.forecastEndOfDayUsd).toBe(0);
+  });
+
+  it("anchors the forecast to a cross-midnight session's first TODAY-scoped timeline entry, not its startTime", async () => {
+    const now = Date.now();
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+    const startMs = startOfDay.getTime();
+
+    // Started 1h before midnight, still active. loadTodaySessions() (file-date
+    // = start date = yesterday) excludes it entirely; only
+    // loadSessionsOverlappingToday() sees it. 1 of its 4 timeline entries is
+    // before midnight, 3 are after -> todayPortionRatio = 0.75 -> today's cost
+    // contribution is 10 * 0.75 = 7.5.
+    const crossMidnightSession = {
+      sessionId: 'cross-midnight-1',
+      startTime: startMs - 60 * 60 * 1000,
+      endTime: startMs + 10_000,
+      estimatedCostUsd: 10,
+      timeline: [
+        { timestamp: startMs - 30 * 60 * 1000 },
+        { timestamp: startMs + 1_000 },
+        { timestamp: startMs + 2_000 },
+        { timestamp: startMs + 3_000 },
+      ],
+    };
+
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        loadSessionsOverlappingToday: () => [crossMidnightSession],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      totalCostUsd: number;
+      forecastEndOfDayUsd: number | null;
+    };
+    expect(parsed.totalCostUsd).toBeCloseTo(7.5, 3);
+    // Must not be null: the session has real spend today, so a null forecast
+    // here means dailyFirstActivityMs was never anchored for it.
+    expect(parsed.forecastEndOfDayUsd).not.toBeNull();
+    // effectiveBaseUsd is totalCostUsd and the rate is >= 0, so the forecast
+    // can never be less than the amount already spent today.
+    expect(parsed.forecastEndOfDayUsd as number).toBeGreaterThanOrEqual(parsed.totalCostUsd);
+  });
+
+  it('returns forecastEndOfDayUsd null when there is no activity today from any source', async () => {
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { forecastEndOfDayUsd: number | null };
+    expect(parsed.forecastEndOfDayUsd).toBeNull();
+  });
+
+  it("tops up dailyFirstActivityMs from this process's own CostTracker when neither the buffer nor persisted sessions have it", async () => {
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      costTracker: {
+        getMetrics: () => ({ sessionTotalCostUsd: 0 }),
+        getCostForDay: () => 9,
+        getFirstActivityMsForDay: () => Date.now() - 60_000,
+      } as unknown as Parameters<typeof createApiHandler>[0]['costTracker'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      totalCostUsd: number;
+      forecastEndOfDayUsd: number | null;
+    };
+    expect(parsed.totalCostUsd).toBeCloseTo(9, 3);
+    expect(parsed.forecastEndOfDayUsd).not.toBeNull();
+    expect(parsed.forecastEndOfDayUsd as number).toBeGreaterThanOrEqual(parsed.totalCostUsd);
+  });
 });
 
 describe('api-handler GET /api/workflows', () => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -35,6 +35,7 @@ import type {
   LiveWorkflowRunDetail,
 } from '../subagent-timeline-store.js';
 import type { CostForecast } from '../../metrics/cost-forecast.js';
+import { buildCostForecastFromInputs } from '../../metrics/cost-forecast.js';
 import type { AlertEvent } from '../live-event-bus.js';
 import type { BudgetStatus } from '../../metrics/budget-tracker.js';
 import type { LatencyMetrics } from '../../metrics/latency-tracker.js';
@@ -403,6 +404,11 @@ export interface ApiHandlerDeps {
     // Today-scoped subagent spend (matches the day-bucketed "spend today"),
     // distinct from getSubagentMetrics().subagentUsd which is session-cumulative.
     getSubagentCostForDay?: (dayKey: string) => number;
+    // Per-day first-activity timestamp — mirrors getCostForDay's per-day
+    // bucketing. Used by the aggregate route to anchor the cross-process
+    // EoD forecast's burn rate without diluting it across idle overnight
+    // hours (see CostForecastInputs.dailyFirstActivityMs's docstring).
+    getFirstActivityMsForDay?: (dayKey: string) => number | null;
     // Subagent (workflow-attributed) spend share, used for the Today
     // KPI + reconciliation banner.
     getSubagentMetrics?: () => {
@@ -616,6 +622,7 @@ interface TodayAggregatePayload {
   readonly workflowRunCount: number;
   readonly latency: AggregateLatencyMetrics;
   readonly cacheHealth: AggregateCacheHealth;
+  readonly forecastEndOfDayUsd: number | null;
 }
 
 // Build activity windows for every session with activity today, using the SAME
@@ -1216,6 +1223,10 @@ export function createApiHandler(
     let cacheCreationTokensSum = 0;
     let cacheInputTokensSum = 0;
     let cacheSavingsUsdSum = 0;
+    // Earliest today-scoped activity across every process/session, used to
+    // anchor the cross-process EoD forecast's burn rate. null means no
+    // activity has been observed today from any source below.
+    let dailyFirstActivityMs: number | null = null;
 
     // (1) live, undrained per-session buffer events
     const peeked = deps.localStore?.peekAllBuffers() ?? [];
@@ -1233,6 +1244,7 @@ export function createApiHandler(
     for (const ev of peeked) {
       const ts = typeof ev.timestamp === 'number' ? ev.timestamp : 0;
       if (ts < startMs) continue;
+      if (dailyFirstActivityMs === null || ts < dailyFirstActivityMs) dailyFirstActivityMs = ts;
       const sid = ev.sessionId;
       if (typeof sid === 'string' && sid.length > 0) {
         sessionsSeen.add(sid);
@@ -1302,6 +1314,9 @@ export function createApiHandler(
         for (const entry of session.timeline) {
           if (entry.timestamp < startMs) continue;
           if (bufferCutoff !== undefined && entry.timestamp >= bufferCutoff) continue;
+          if (dailyFirstActivityMs === null || entry.timestamp < dailyFirstActivityMs) {
+            dailyFirstActivityMs = entry.timestamp;
+          }
           toolCallCount++;
           const idx = Math.floor((entry.timestamp - startMs) / 60_000);
           if (idx >= 0 && idx < sparkline.length) sparkline[idx]++;
@@ -1350,6 +1365,20 @@ export function createApiHandler(
       // accurate (per-token-event) than pro-rating from a periodically-
       // persisted snapshot.
       if (s.sessionId === liveSid) continue;
+      // Cross-midnight sessions that started before today aren't covered by
+      // the todaySessions timeline walk above (loadTodaySessions() filters
+      // by file-date = start date, so a session that started yesterday never
+      // appears there). Derive its first-today activity from its OWN
+      // timeline, not `s.startTime` — using startTime here would reintroduce
+      // the exact dilution bug dailyFirstActivityMs exists to avoid.
+      if (s.startTime < startMs && Array.isArray(s.timeline)) {
+        for (const entry of s.timeline) {
+          if (entry.timestamp < startMs) continue;
+          if (dailyFirstActivityMs === null || entry.timestamp < dailyFirstActivityMs) {
+            dailyFirstActivityMs = entry.timestamp;
+          }
+        }
+      }
       totalCostUsd += todayPortionOfSessionCost(s, now);
       // (2b) subagent-only portion of the same session, same pro-rating.
       // This is what makes the "subagent spend" KPI cross-session: each
@@ -1419,6 +1448,15 @@ export function createApiHandler(
         const startedToday = typeof startedTs === 'number' && localDateKey(startedTs) === todayKey;
         if (typeof sessionCost === 'number' && startedToday) {
           totalCostUsd += sessionCost;
+        }
+      }
+      // This process's own first-activity-today, covering the gap between
+      // "drained from the buffer" and "persisted to a session file" — the
+      // same gap liveTodayUsd above already covers for cost.
+      const liveFirstActivityMs = deps.costTracker?.getFirstActivityMsForDay?.(todayKey) ?? null;
+      if (typeof liveFirstActivityMs === 'number') {
+        if (dailyFirstActivityMs === null || liveFirstActivityMs < dailyFirstActivityMs) {
+          dailyFirstActivityMs = liveFirstActivityMs;
         }
       }
       // This MCP's own live subagent-for-day figure — the (2b) loop above
@@ -1505,6 +1543,19 @@ export function createApiHandler(
       savingsUsd: cacheSavingsUsdSum,
     } satisfies CacheHealthTotals);
 
+    const forecast =
+      dailyFirstActivityMs !== null
+        ? buildCostForecastFromInputs(
+            {
+              sessionSpentUsd: totalCostUsd,
+              sessionStartMs: dailyFirstActivityMs,
+              dailySpentUsd: totalCostUsd,
+              dailyFirstActivityMs,
+            },
+            now,
+          )
+        : null;
+
     const payload = {
       toolCallCount,
       totalCostUsd: Math.round(totalCostUsd * 1000) / 1000,
@@ -1518,6 +1569,10 @@ export function createApiHandler(
       avgEfficiencyScore,
       latency: computeLatencyPercentiles(latencySamples),
       cacheHealth,
+      forecastEndOfDayUsd:
+        forecast?.forecastEndOfDayUsd != null
+          ? Math.round(forecast.forecastEndOfDayUsd * 1000) / 1000
+          : null,
     };
     aggregateCache = { bucket: currentBucket, payload };
     jsonOk(res, payload);

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -145,6 +145,7 @@ export interface TodayAggregateResponse {
   readonly subagentTurnCount?: number;
   readonly workflowRunCount?: number;
   readonly avgEfficiencyScore?: number | null;
+  readonly forecastEndOfDayUsd?: number | null;
   readonly latency?: {
     readonly overall: LatencyPercentiles | null;
     readonly byTool: Readonly<Record<string, LatencyPercentiles | null>>;

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -279,6 +279,28 @@ describe('Today view', () => {
     expect(screen.getByText(/insufficient data/i)).toBeInTheDocument();
   });
 
+  it('falls back to the cross-process aggregate forecast when the SSE cost push is unavailable', async () => {
+    useLiveStore.setState({ cost: null });
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(JSON.stringify({ totalCostUsd: 5, forecastEndOfDayUsd: 8 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+    await waitFor(() => expect(screen.getByText('$8.00')).toBeInTheDocument());
+    // delta = 8 - 5 = 3
+    expect(screen.getByText(/\+\$3\.00/)).toBeInTheDocument();
+  });
+
   function stubObservabilityHealth(body: Record<string, unknown>): void {
     globalThis.fetch = vi.fn(async (input) => {
       const url = String(input);

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -145,7 +145,7 @@ export function Today(): JSX.Element {
     refetchInterval: 30_000,
   });
 
-  const { data: costApi, isPending: costPending } = useQuery<CostApiResponse>({
+  const { isPending: costPending } = useQuery<CostApiResponse>({
     queryKey: qk.cost,
     queryFn: fetchCost,
   });
@@ -380,12 +380,7 @@ export function Today(): JSX.Element {
               forecastEod={
                 spendLoading
                   ? null
-                  : (cost?.forecastEodUsd ??
-                    (costApi?.forecast?.forecastEndOfDayUsd != null
-                      ? todayTotal +
-                        costApi.forecast.forecastEndOfDayUsd -
-                        (costApi.sessionTodayUsd ?? 0)
-                      : null))
+                  : (cost?.forecastEodUsd ?? aggregate?.forecastEndOfDayUsd ?? null)
               }
               hourlySpend={hourlySpend}
               subagentUsd={subagentUsd}


### PR DESCRIPTION
## Summary
- The Today dashboard's "Forecast · End of Day" card only projected spend from whichever process happened to be serving the dashboard — its burn-rate anchor came from that one process's own in-memory cost tracker, which is empty on a dashboard-only process with no coding activity of its own.
- `/api/sessions/today/aggregate` now derives the earliest today-scoped activity across the live cross-process buffer union, persisted same-day sessions, cross-midnight sessions, and this process's own live tracker, and computes `forecastEndOfDayUsd` from it — the same route the other cross-session Today dashboard KPIs already use.
- The Today view now consumes that field as its fallback when the per-session live push (which reflects only this process's own session, correctly, and stays first-priority) is unavailable, replacing an older client-side delta-math workaround.

Fixes #325

## Test plan
- [x] `npm run build`
- [x] `npm test` (5240/5243 passing, 3 pre-existing skips, 0 failures)
- [x] `npm run test:web` (422/422 passing)
- [x] `npm run lint` (0 errors/warnings)