### PR TITLE
Fix: Model Usage panel reflects cross-process activity today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.16] - 2026-07-31
+
+### Fixed
+
+- **The Today dashboard's Model Usage panel only reflected model/token/cost activity from whichever process happened to be serving the dashboard** — its per-model request counts and cost-per-token figures came from that one process's own in-memory tracker, silently excluding activity from every other concurrently running session and resetting whenever that process restarted. It's now computed from every today session's activity, the same way the other cross-process Today dashboard fixes already are.
+
 ## [1.14.15] - 2026-07-31
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.15",
+  "version": "1.14.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.15",
+      "version": "1.14.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.15",
+  "version": "1.14.16",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -14,6 +14,7 @@ import {
   ToolSelectionScorer,
   toToolSelectionSummary,
 } from '../../metrics/tool-selection-scorer.js';
+import { ModelUsageTracker } from '../../metrics/model-usage-tracker.js';
 import { localStartOfDay } from '../../lib/date.js';
 
 import type { ToolCallRecord } from '../../storage/types.js';
@@ -4229,31 +4230,98 @@ describe('api-handler GET /api/model-usage', () => {
     expect(JSON.parse(body())).toEqual({ error: 'unavailable', what: 'modelUsageTracker' });
   });
 
-  it('returns modelUsageTracker.getMetrics() as JSON', async () => {
-    const fakeMetrics = {
-      byModel: {
-        'claude-sonnet-5': {
-          requestCount: 40,
-          totalInputTokens: 1000,
-          totalOutputTokens: 500,
-          totalCostUsd: 3.2,
-          costPerOutputToken: 0.0064,
-          costPerMillionTokens: 2133.33,
-          avgOutputTokensPerRequest: 12.5,
+  it('returns just this process live breakdown when no persisted-today sessions exist', async () => {
+    const tracker = new ModelUsageTracker();
+    tracker.recordUsage('claude-sonnet-5', 1000, 500, 3.2);
+    const handler = createApiHandler({ modelUsageTracker: tracker });
+    const req = { method: 'GET', url: '/api/model-usage' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(JSON.parse(body())).toEqual(tracker.getMetrics());
+  });
+
+  it('combines this process live breakdown with every other persisted-today session, excluding its own already-persisted entry', async () => {
+    const tracker = new ModelUsageTracker();
+    // Live, not-yet-persisted: $1 / 100 output tokens.
+    tracker.recordUsage('model-a', 0, 100, 1);
+    const persistedToday = [
+      {
+        // Same session as the live tracker above — must NOT be double
+        // counted on top of the live breakdown.
+        sessionId: 'sess-own',
+        modelBreakdown: {
+          'model-a': {
+            requestCount: 1,
+            totalInputTokens: 0,
+            totalOutputTokens: 100,
+            totalCostUsd: 1,
+          },
         },
       },
-      mostUsedModel: 'claude-sonnet-5',
-      mostEfficientModel: 'claude-sonnet-5',
-      totalModelsUsed: 1,
-    };
+      {
+        sessionId: 'sess-other',
+        modelBreakdown: {
+          'model-a': {
+            requestCount: 9,
+            totalInputTokens: 0,
+            totalOutputTokens: 900,
+            totalCostUsd: 1,
+          },
+        },
+      },
+    ] as unknown as ReturnType<
+      NonNullable<Parameters<typeof createApiHandler>[0]['sessionStore']>['loadTodaySessions']
+    >;
     const handler = createApiHandler({
-      modelUsageTracker: { getMetrics: () => fakeMetrics },
+      modelUsageTracker: tracker,
+      sessionTracker: {
+        getMetrics: () =>
+          ({ sessionId: 'sess-own' }) as unknown as ReturnType<
+            NonNullable<Parameters<typeof createApiHandler>[0]['sessionTracker']>['getMetrics']
+          >,
+      },
+      sessionStore: {
+        loadTodaySessions: () => persistedToday,
+        listSessions: () => [],
+        loadSession: () => null,
+      },
     });
     const req = { method: 'GET', url: '/api/model-usage' } as IncomingMessage;
     const { res, status, body } = fakeRes();
     await handler(req, res);
     expect(status()).toBe(200);
-    expect(JSON.parse(body())).toEqual(fakeMetrics);
+    const parsed = JSON.parse(body());
+    // Own live ($1/100tok) is not double-counted with its own persisted entry
+    // (also $1/100tok) — only sess-other's persisted entry is added on top:
+    // 100 (live) + 900 (other) = 1000 output tokens, $1 + $1 = $2 total.
+    // Weighted: $2 / 1000 = $0.002/token — not the naive average of $0.01 and
+    // ~$0.00111 (~$0.0056), which would be wrong.
+    expect(parsed.byModel['model-a'].totalOutputTokens).toBe(1000);
+    expect(parsed.byModel['model-a'].totalCostUsd).toBeCloseTo(2);
+    expect(parsed.byModel['model-a'].costPerOutputToken).toBeCloseTo(0.002);
+    expect(parsed.byModel['model-a'].requestCount).toBe(10);
+  });
+
+  it('ignores persisted-today sessions with no modelBreakdown field (legacy files)', async () => {
+    const tracker = new ModelUsageTracker();
+    tracker.recordUsage('model-a', 100, 50, 0.5);
+    const persistedToday = [{ sessionId: 'sess-legacy' }] as unknown as ReturnType<
+      NonNullable<Parameters<typeof createApiHandler>[0]['sessionStore']>['loadTodaySessions']
+    >;
+    const handler = createApiHandler({
+      modelUsageTracker: tracker,
+      sessionStore: {
+        loadTodaySessions: () => persistedToday,
+        listSessions: () => [],
+        loadSession: () => null,
+      },
+    });
+    const req = { method: 'GET', url: '/api/model-usage' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(JSON.parse(body())).toEqual(tracker.getMetrics());
   });
 });
 

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -47,7 +47,7 @@ import type {
   ToolSelectionSummary,
 } from '../../metrics/tool-selection-scorer.js';
 import { toToolSelectionSummary } from '../../metrics/tool-selection-scorer.js';
-import type { ModelUsageMetrics } from '../../metrics/model-usage-tracker.js';
+import type { ModelUsageMetrics, ModelBreakdownEntry } from '../../metrics/model-usage-tracker.js';
 import { DEFAULT_STALE_THRESHOLD_MS } from '../../metrics/live-session-registry.js';
 import { computeContextMetricsFromEvents } from '../../metrics/context-tracker.js';
 import type { ContextReplayEvent, ContextTrackerMetrics } from '../../metrics/context-tracker.js';
@@ -486,7 +486,13 @@ export interface ApiHandlerDeps {
     scoreSession: (calls: readonly ToolCallRecord[]) => ToolSelectionMetrics;
     combineSummaries: (summaries: readonly ToolSelectionSummary[]) => ToolSelectionMetrics;
   };
-  readonly modelUsageTracker?: { getMetrics: () => ModelUsageMetrics };
+  readonly modelUsageTracker?: {
+    getMetrics: () => ModelUsageMetrics;
+    getRawBreakdown: () => Readonly<Record<string, ModelBreakdownEntry>>;
+    combineBreakdowns: (
+      breakdowns: ReadonlyArray<Readonly<Record<string, ModelBreakdownEntry>>>,
+    ) => ModelUsageMetrics;
+  };
   readonly toolCallBuffer?: { getRecords: () => readonly ToolCallRecord[] };
   readonly liveSessionRegistry?: {
     getLiveSessions: () => string[];
@@ -1684,7 +1690,21 @@ export function createApiHandler(
 
   routes.set('GET /api/model-usage', (_req, res) => {
     if (!deps.modelUsageTracker) return unavailable(res, 'modelUsageTracker');
-    jsonOk(res, deps.modelUsageTracker.getMetrics());
+    // Same own-live + persisted-today, excluding-own-already-persisted-session
+    // pattern as GET /api/tool-selection-score below: this process's live
+    // breakdown is always included, and every OTHER today session's persisted
+    // breakdown is added on top — never this process's own persisted entry,
+    // which would double-count activity already reflected in the live
+    // tracker.
+    const ownSessionId = deps.sessionTracker?.getMetrics().sessionId;
+    const persistedBreakdowns = (deps.sessionStore?.loadTodaySessions() ?? [])
+      .filter((s) => s.sessionId !== ownSessionId)
+      .map((s) => s.modelBreakdown ?? {});
+    const combined = deps.modelUsageTracker.combineBreakdowns([
+      deps.modelUsageTracker.getRawBreakdown(),
+      ...persistedBreakdowns,
+    ]);
+    jsonOk(res, combined);
   });
 
   routes.set('GET /api/cache-health', (_req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1829,6 +1829,7 @@ async function main(): Promise<void> {
           antiPatternDetector,
           efficiencyScorer,
           toolSelectionScorer,
+          modelUsageTracker,
           transcriptMessageTracker,
           developer: config.developer ?? 'unknown',
           repoName: currentRepoName,

--- a/src/metrics/claudemd-tracker.test.ts
+++ b/src/metrics/claudemd-tracker.test.ts
@@ -61,6 +61,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
+    modelBreakdown: {},
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/collaboration-profile.test.ts
+++ b/src/metrics/collaboration-profile.test.ts
@@ -58,6 +58,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
+    modelBreakdown: {},
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/model-usage-tracker.test.ts
+++ b/src/metrics/model-usage-tracker.test.ts
@@ -117,3 +117,116 @@ describe('ModelUsageTracker', () => {
     expect(m.byModel).toEqual({});
   });
 });
+
+describe('ModelUsageTracker.getRawBreakdown', () => {
+  it('returns raw counters with no derived fields for a new tracker', () => {
+    const t = new ModelUsageTracker();
+    expect(t.getRawBreakdown()).toEqual({});
+  });
+
+  it('returns raw counters matching what was recorded, without derived ratios', () => {
+    const t = new ModelUsageTracker();
+    t.recordUsage('model-a', 1000, 500, 0.01);
+    expect(t.getRawBreakdown()).toEqual({
+      'model-a': {
+        requestCount: 1,
+        totalInputTokens: 1000,
+        totalOutputTokens: 500,
+        totalCostUsd: 0.01,
+      },
+    });
+  });
+
+  it('accumulates across multiple recordUsage calls for the same model', () => {
+    const t = new ModelUsageTracker();
+    t.recordUsage('model-a', 1000, 500, 0.01);
+    t.recordUsage('model-a', 2000, 800, 0.02);
+    expect(t.getRawBreakdown()['model-a']).toEqual({
+      requestCount: 2,
+      totalInputTokens: 3000,
+      totalOutputTokens: 1300,
+      totalCostUsd: 0.03,
+    });
+  });
+});
+
+describe('ModelUsageTracker.combineBreakdowns', () => {
+  it('returns empty metrics for an empty array', () => {
+    const t = new ModelUsageTracker();
+    const combined = t.combineBreakdowns([]);
+    expect(combined).toEqual({
+      byModel: {},
+      mostUsedModel: null,
+      mostEfficientModel: null,
+      totalModelsUsed: 0,
+    });
+  });
+
+  it('sums raw counters across breakdowns before deriving ratios, rather than averaging per-source ratios', () => {
+    const t = new ModelUsageTracker();
+    // Source A alone: $1 / 100 output tokens = $0.01/token.
+    const sourceA = {
+      'model-a': { requestCount: 1, totalInputTokens: 0, totalOutputTokens: 100, totalCostUsd: 1 },
+    };
+    // Source B alone: $1 / 900 output tokens ≈ $0.00111/token.
+    const sourceB = {
+      'model-a': { requestCount: 9, totalInputTokens: 0, totalOutputTokens: 900, totalCostUsd: 1 },
+    };
+    const combined = t.combineBreakdowns([sourceA, sourceB]);
+    // Correct: sum first ($2 / 1000 tokens = $0.002/token). A naive average of
+    // the two per-source ratios ($0.01 and ~$0.00111) would give ~$0.0056/token,
+    // which is wrong — it treats both sources as equally weighted regardless
+    // of how much volume each actually contributed.
+    expect(combined.byModel['model-a']?.requestCount).toBe(10);
+    expect(combined.byModel['model-a']?.totalOutputTokens).toBe(1000);
+    expect(combined.byModel['model-a']?.totalCostUsd).toBeCloseTo(2);
+    expect(combined.byModel['model-a']?.costPerOutputToken).toBeCloseTo(0.002);
+  });
+
+  it('sums distinct models independently', () => {
+    const t = new ModelUsageTracker();
+    const a = {
+      'model-a': {
+        requestCount: 1,
+        totalInputTokens: 10,
+        totalOutputTokens: 10,
+        totalCostUsd: 0.1,
+      },
+    };
+    const b = {
+      'model-b': {
+        requestCount: 2,
+        totalInputTokens: 20,
+        totalOutputTokens: 20,
+        totalCostUsd: 0.2,
+      },
+    };
+    const combined = t.combineBreakdowns([a, b]);
+    expect(combined.totalModelsUsed).toBe(2);
+    expect(combined.byModel['model-a']?.requestCount).toBe(1);
+    expect(combined.byModel['model-b']?.requestCount).toBe(2);
+  });
+
+  it('recomputes mostUsedModel and mostEfficientModel from the combined totals', () => {
+    const t = new ModelUsageTracker();
+    const a = {
+      cheap: { requestCount: 1, totalInputTokens: 0, totalOutputTokens: 100, totalCostUsd: 0.05 },
+    };
+    const b = {
+      cheap: { requestCount: 5, totalInputTokens: 0, totalOutputTokens: 500, totalCostUsd: 0.25 },
+    };
+    const c = {
+      pricey: { requestCount: 1, totalInputTokens: 0, totalOutputTokens: 100, totalCostUsd: 1 },
+    };
+    const combined = t.combineBreakdowns([a, b, c]);
+    expect(combined.mostUsedModel).toBe('cheap');
+    expect(combined.mostEfficientModel).toBe('cheap');
+  });
+
+  it('is consistent with getMetrics() when combining a single source equal to this tracker own raw breakdown', () => {
+    const t = new ModelUsageTracker();
+    t.recordUsage('model-a', 1000, 500, 0.01);
+    t.recordUsage('model-b', 2000, 800, 0.02);
+    expect(t.combineBreakdowns([t.getRawBreakdown()])).toEqual(t.getMetrics());
+  });
+});

--- a/src/metrics/model-usage-tracker.ts
+++ b/src/metrics/model-usage-tracker.ts
@@ -1,8 +1,11 @@
-export interface ModelStats {
+export interface ModelBreakdownEntry {
   readonly requestCount: number;
   readonly totalInputTokens: number;
   readonly totalOutputTokens: number;
   readonly totalCostUsd: number;
+}
+
+export interface ModelStats extends ModelBreakdownEntry {
   readonly costPerOutputToken: number | null;
   /**
    * Per-model rate: totalCostUsd / (totalInputTokens + totalOutputTokens) * 1M.
@@ -30,6 +33,68 @@ interface MutableModelStats {
 
 import type { Resettable } from './tracker-contracts.js';
 
+// Pure derivation: raw per-model counters -> the full ModelStats shape (raw +
+// derived ratios) plus the mostUsed/mostEfficient picks. Shared by getMetrics()
+// (this tracker's own live counters) and combineBreakdowns() (counters summed
+// across multiple sessions/processes) so a ratio is always computed exactly
+// once, from a fully-summed numerator/denominator — never averaged across
+// sources, which would silently misweight sources with different token
+// volumes.
+function deriveModelUsageMetrics(
+  byModelRaw: Readonly<Record<string, ModelBreakdownEntry>>,
+): ModelUsageMetrics {
+  const byModel: Record<string, ModelStats> = {};
+  let mostUsedModel: string | null = null;
+  let maxRequests = 0;
+  let mostEfficientModel: string | null = null;
+  let lowestCostPerOutputToken = Infinity;
+
+  for (const [model, stats] of Object.entries(byModelRaw)) {
+    const costPerOutputToken =
+      stats.totalOutputTokens > 0 ? stats.totalCostUsd / stats.totalOutputTokens : null;
+    const totalTokens = stats.totalInputTokens + stats.totalOutputTokens;
+    const costPerMillionTokens =
+      totalTokens > 0 ? (stats.totalCostUsd / totalTokens) * 1_000_000 : null;
+    const avgOutputTokensPerRequest =
+      stats.requestCount > 0 ? stats.totalOutputTokens / stats.requestCount : null;
+
+    byModel[model] = {
+      requestCount: stats.requestCount,
+      totalInputTokens: stats.totalInputTokens,
+      totalOutputTokens: stats.totalOutputTokens,
+      totalCostUsd: stats.totalCostUsd,
+      costPerOutputToken,
+      costPerMillionTokens,
+      avgOutputTokensPerRequest,
+    };
+
+    if (stats.requestCount > maxRequests) {
+      maxRequests = stats.requestCount;
+      mostUsedModel = model;
+    }
+
+    // On an exact tie, prefer the alphabetically-first model name for a
+    // deterministic result regardless of iteration order. '￿' (U+FFFF) sorts
+    // after every realistic model name, so `mostEfficientModel ?? '￿'` always
+    // loses the very first comparison and lets the first real candidate win.
+    if (
+      costPerOutputToken !== null &&
+      (costPerOutputToken < lowestCostPerOutputToken ||
+        (costPerOutputToken === lowestCostPerOutputToken && model < (mostEfficientModel ?? '￿')))
+    ) {
+      lowestCostPerOutputToken = costPerOutputToken;
+      mostEfficientModel = model;
+    }
+  }
+
+  return {
+    byModel,
+    mostUsedModel,
+    mostEfficientModel,
+    totalModelsUsed: Object.keys(byModelRaw).length,
+  };
+}
+
 export class ModelUsageTracker implements Resettable {
   private byModel = new Map<string, MutableModelStats>();
 
@@ -45,58 +110,47 @@ export class ModelUsageTracker implements Resettable {
     stats.totalCostUsd += costUsd;
   }
 
-  getMetrics(): ModelUsageMetrics {
-    const byModel: Record<string, ModelStats> = {};
-    let mostUsedModel: string | null = null;
-    let maxRequests = 0;
-    let mostEfficientModel: string | null = null;
-    let lowestCostPerOutputToken = Infinity;
-
+  // Raw per-model counters only — no derived ratios. This is the shape
+  // persisted onto FullSessionSummary.modelBreakdown (session-store.ts) so a
+  // session file never stores a stale derived ratio; ratios are always
+  // recomputed at read time via getMetrics()/combineBreakdowns().
+  getRawBreakdown(): Readonly<Record<string, ModelBreakdownEntry>> {
+    const out: Record<string, ModelBreakdownEntry> = {};
     for (const [model, stats] of this.byModel) {
-      const costPerOutputToken =
-        stats.totalOutputTokens > 0 ? stats.totalCostUsd / stats.totalOutputTokens : null;
-      const totalTokens = stats.totalInputTokens + stats.totalOutputTokens;
-      const costPerMillionTokens =
-        totalTokens > 0 ? (stats.totalCostUsd / totalTokens) * 1_000_000 : null;
-      const avgOutputTokensPerRequest =
-        stats.requestCount > 0 ? stats.totalOutputTokens / stats.requestCount : null;
+      out[model] = { ...stats };
+    }
+    return out;
+  }
 
-      byModel[model] = {
-        requestCount: stats.requestCount,
-        totalInputTokens: stats.totalInputTokens,
-        totalOutputTokens: stats.totalOutputTokens,
-        totalCostUsd: stats.totalCostUsd,
-        costPerOutputToken,
-        costPerMillionTokens,
-        avgOutputTokensPerRequest,
-      };
+  getMetrics(): ModelUsageMetrics {
+    return deriveModelUsageMetrics(this.getRawBreakdown());
+  }
 
-      if (stats.requestCount > maxRequests) {
-        maxRequests = stats.requestCount;
-        mostUsedModel = model;
-      }
-
-      // On an exact tie, prefer the alphabetically-first model name for a
-      // deterministic result regardless of Map iteration order. '￿' (U+FFFF)
-      // sorts after every realistic model name, so `mostEfficientModel ?? '￿'`
-      // always loses the very first comparison and lets the first real
-      // candidate win.
-      if (
-        costPerOutputToken !== null &&
-        (costPerOutputToken < lowestCostPerOutputToken ||
-          (costPerOutputToken === lowestCostPerOutputToken && model < (mostEfficientModel ?? '￿')))
-      ) {
-        lowestCostPerOutputToken = costPerOutputToken;
-        mostEfficientModel = model;
+  // Combines raw per-model counters from multiple sources (e.g. this
+  // process's own live counters plus every other today session's persisted
+  // snapshot) by summing matching model keys, then derives ratios exactly
+  // once from the summed totals — see deriveModelUsageMetrics's doc comment
+  // for why this must never average each source's own ratio.
+  combineBreakdowns(
+    breakdowns: ReadonlyArray<Readonly<Record<string, ModelBreakdownEntry>>>,
+  ): ModelUsageMetrics {
+    const summed: Record<string, MutableModelStats> = {};
+    for (const breakdown of breakdowns) {
+      for (const [model, entry] of Object.entries(breakdown)) {
+        const existing = summed[model] ?? {
+          requestCount: 0,
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
+          totalCostUsd: 0,
+        };
+        existing.requestCount += entry.requestCount;
+        existing.totalInputTokens += entry.totalInputTokens;
+        existing.totalOutputTokens += entry.totalOutputTokens;
+        existing.totalCostUsd += entry.totalCostUsd;
+        summed[model] = existing;
       }
     }
-
-    return {
-      byModel,
-      mostUsedModel,
-      mostEfficientModel,
-      totalModelsUsed: this.byModel.size,
-    };
+    return deriveModelUsageMetrics(summed);
   }
 
   reset(_sessionId: string): void {

--- a/src/metrics/prompt-feedback.test.ts
+++ b/src/metrics/prompt-feedback.test.ts
@@ -63,6 +63,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
+    modelBreakdown: {},
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/recommendation-engine.test.ts
+++ b/src/metrics/recommendation-engine.test.ts
@@ -64,6 +64,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
+    modelBreakdown: {},
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/trend-analyzer.test.ts
+++ b/src/metrics/trend-analyzer.test.ts
@@ -63,6 +63,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
+    modelBreakdown: {},
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -17,6 +17,7 @@ import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
 import type { TranscriptMessageTracker } from '../metrics/transcript-message-tracker.js';
 import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
 import { ToolSelectionScorer, toToolSelectionSummary } from '../metrics/tool-selection-scorer.js';
+import type { ModelUsageTracker } from '../metrics/model-usage-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -69,6 +70,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
+    modelBreakdown: {},
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,
@@ -1633,5 +1635,137 @@ describe('SessionStore deserialization', () => {
     expect(session!.antiPatterns).toEqual([]);
     expect(session!.filesRead).toEqual([]);
     expect(session!.outcome).toBe('unknown');
+  });
+});
+
+describe('modelBreakdown field', () => {
+  it('buildSessionSummary populates modelBreakdown from modelUsageTracker.getRawBreakdown()', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: null,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+    const modelUsageTracker = {
+      getRawBreakdown: () => ({
+        'claude-sonnet-5': {
+          requestCount: 3,
+          totalInputTokens: 900,
+          totalOutputTokens: 400,
+          totalCostUsd: 0.12,
+        },
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      modelUsageTracker: modelUsageTracker as unknown as ModelUsageTracker,
+      developer: 'alice',
+    });
+
+    expect(summary.modelBreakdown).toEqual({
+      'claude-sonnet-5': {
+        requestCount: 3,
+        totalInputTokens: 900,
+        totalOutputTokens: 400,
+        totalCostUsd: 0.12,
+      },
+    });
+  });
+
+  it('defaults modelBreakdown to {} when no modelUsageTracker is provided', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: null,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      developer: 'alice',
+    });
+    expect(summary.modelBreakdown).toEqual({});
+  });
+
+  it('round-trips modelBreakdown through JSON serialization', () => {
+    const original = makeSummary({
+      modelBreakdown: {
+        'claude-sonnet-5': {
+          requestCount: 3,
+          totalInputTokens: 900,
+          totalOutputTokens: 400,
+          totalCostUsd: 0.12,
+        },
+      },
+    });
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(JSON.stringify(original)) as Parameters<typeof deserializeFullSessionSummary>[0],
+    );
+    expect(roundTripped.modelBreakdown).toEqual(original.modelBreakdown);
+  });
+
+  it('defaults modelBreakdown to {} for legacy session files missing the field', () => {
+    const legacy = makeSummary();
+    const { modelBreakdown: _modelBreakdown, ...withoutField } = legacy;
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(JSON.stringify(withoutField)) as Parameters<
+        typeof deserializeFullSessionSummary
+      >[0],
+    );
+    expect(roundTripped.modelBreakdown).toEqual({});
+  });
+
+  it('drops malformed entries (missing numeric fields) rather than throwing', () => {
+    const raw = JSON.stringify({
+      ...makeSummary(),
+      modelBreakdown: {
+        'good-model': {
+          requestCount: 1,
+          totalInputTokens: 10,
+          totalOutputTokens: 10,
+          totalCostUsd: 0.1,
+        },
+        'bad-model': { requestCount: 1 },
+      },
+    });
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(raw) as Parameters<typeof deserializeFullSessionSummary>[0],
+    );
+    expect(roundTripped.modelBreakdown).toEqual({
+      'good-model': {
+        requestCount: 1,
+        totalInputTokens: 10,
+        totalOutputTokens: 10,
+        totalCostUsd: 0.1,
+      },
+    });
   });
 });

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -30,6 +30,7 @@ import {
   toToolSelectionSummary,
   type ToolSelectionSummary,
 } from '../metrics/tool-selection-scorer.js';
+import type { ModelUsageTracker, ModelBreakdownEntry } from '../metrics/model-usage-tracker.js';
 
 const logger = createLogger('session-store');
 
@@ -86,6 +87,14 @@ export interface FullSessionSummary extends SessionSummary {
    * for pre-fix session files and for sessions with no tool calls.
    */
   readonly toolSelectionMetrics: ToolSelectionSummary | null;
+  /**
+   * Raw per-model token/cost counters for this session, keyed by model name.
+   * Captured once at save time from ModelUsageTracker.getRawBreakdown(). Raw
+   * counters only, no derived ratios — see ModelUsageTracker.combineBreakdowns
+   * for why ratios are always recomputed at read time instead of persisted.
+   * `{}` for pre-fix session files and for sessions with no token events.
+   */
+  readonly modelBreakdown: Readonly<Record<string, ModelBreakdownEntry>>;
 }
 
 export interface SessionFileInfo {
@@ -300,6 +309,7 @@ export interface BuildSessionSummarySources {
   efficiencyScorer?: EfficiencyScorer;
   transcriptMessageTracker?: TranscriptMessageTracker;
   toolSelectionScorer?: ToolSelectionScorer;
+  modelUsageTracker?: ModelUsageTracker;
   developer: string;
   repoName?: string | null;
   /**
@@ -454,6 +464,7 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     instructionPromptHash: sources.instructionPromptHash ?? null,
     timeline: timeline.length > 0 ? timeline : undefined,
     toolSelectionMetrics: toolSelectionResult,
+    modelBreakdown: sources.modelUsageTracker?.getRawBreakdown() ?? {},
   };
 }
 
@@ -543,6 +554,7 @@ interface SerializedFullSessionSummary {
   readonly instructionPromptHash?: unknown;
   readonly timeline?: Array<Record<string, unknown>>;
   readonly toolSelectionMetrics?: unknown;
+  readonly modelBreakdown?: Record<string, unknown>;
 }
 
 /**
@@ -595,6 +607,27 @@ export function deserializeFullSessionSummary(
       unusedOutputCount: r.unusedOutputCount,
     };
   })();
+
+  const modelBreakdown: Record<string, ModelBreakdownEntry> = {};
+  if (typeof obj.modelBreakdown === 'object' && obj.modelBreakdown !== null) {
+    for (const [model, entry] of Object.entries(obj.modelBreakdown)) {
+      if (typeof entry !== 'object' || entry === null) continue;
+      const e = entry as Record<string, unknown>;
+      if (
+        typeof e.requestCount === 'number' &&
+        typeof e.totalInputTokens === 'number' &&
+        typeof e.totalOutputTokens === 'number' &&
+        typeof e.totalCostUsd === 'number'
+      ) {
+        modelBreakdown[model] = {
+          requestCount: e.requestCount,
+          totalInputTokens: e.totalInputTokens,
+          totalOutputTokens: e.totalOutputTokens,
+          totalCostUsd: e.totalCostUsd,
+        };
+      }
+    }
+  }
 
   return {
     sessionId:
@@ -666,6 +699,7 @@ export function deserializeFullSessionSummary(
           }))
       : undefined,
     toolSelectionMetrics,
+    modelBreakdown,
   };
 }
 

--- a/src/storage/weekly-summary.test.ts
+++ b/src/storage/weekly-summary.test.ts
@@ -63,6 +63,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
+    modelBreakdown: {},
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -90,6 +90,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     cacheSavingsUsd: 0,
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
+    modelBreakdown: {},
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,


### PR DESCRIPTION
## Summary
- The Today dashboard's Model Usage panel only reflected model/token/cost activity from whichever process happened to be serving the dashboard.
- Adds a raw per-model breakdown getter and a combine method that sums raw counters across sources and derives cost-per-token ratios exactly once — never by averaging per-source ratios.
- Persists that raw breakdown per session so completed/checkpointed sessions carry it to disk, with a safe default for legacy files.
- The Model Usage endpoint now combines this process's own live breakdown with every other today-persisted session's breakdown, mirroring the same pattern already used for the Tool Selection Score endpoint on this dashboard.

Fixes #327

## Test plan
- [x] `npm run build && npm test` — full suite passes
- [x] `npm run lint` — 0 errors/warnings