### PR TITLE
Fix: Quality panel reflects cross-process activity today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.17] - 2026-07-31
+
+### Fixed
+
+- **The Today dashboard's Quality panel only reflected diff-apply/test-pass/backtrack/self-correction signals from whichever process happened to be serving the dashboard, and only when that process had recorded zero signals of its own** — as soon as this process recorded even one signal, every other today session's activity was ignored outright. It's now computed from every today session's activity, the same way the other cross-process Today dashboard fixes already are. A persisted session's own detail view was also simplified to read its quality signals directly instead of re-deriving them from its recorded timeline.
+
 ## [1.14.16] - 2026-07-31
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.16",
+  "version": "1.14.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.16",
+      "version": "1.14.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.16",
+  "version": "1.14.17",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -15,6 +15,7 @@ import {
   toToolSelectionSummary,
 } from '../../metrics/tool-selection-scorer.js';
 import { ModelUsageTracker } from '../../metrics/model-usage-tracker.js';
+import { QualityProxyTracker } from '../../metrics/quality-proxy-tracker.js';
 import { localStartOfDay } from '../../lib/date.js';
 
 import type { ToolCallRecord } from '../../storage/types.js';
@@ -328,15 +329,18 @@ describe('api-handler GET /api/sessions/:id', () => {
     expect(status()).toBe(404);
   });
 
-  it('attaches qualityProxy (derived from timeline) to a persisted session with real signals', async () => {
+  it('attaches qualityProxy (derived from persisted raw counts) to a persisted session with real signals', async () => {
     const fakeSession = {
       sessionId: 'sess-quality-1',
-      testRunCount: 4,
-      testPassCount: 3,
-      timeline: [
-        { timestamp: 1, toolName: 'Edit', durationMs: 10, success: true, filePath: 'a.ts' },
-        { timestamp: 2, toolName: 'Edit', durationMs: 10, success: false, filePath: 'b.ts' },
-      ],
+      qualityProxy: {
+        totalSignals: 2,
+        diffApplyCleanCount: 1,
+        diffFailCount: 1,
+        testPassCount: 0,
+        testFailCount: 0,
+        backtrackCount: 0,
+        selfCorrectionCount: 0,
+      },
     };
     const handler = createApiHandler({
       sessionStore: {
@@ -404,6 +408,15 @@ describe('api-handler GET /api/sessions/:id', () => {
           qualityByTurnBucket: [],
           degradationDetected: false,
           events: [],
+        }),
+        getRawCounts: () => ({
+          totalSignals: 3,
+          diffApplyCleanCount: 3,
+          diffFailCount: 0,
+          testPassCount: 0,
+          testFailCount: 0,
+          backtrackCount: 0,
+          selfCorrectionCount: 0,
         }),
       },
       toolSelectionScorer: {
@@ -3774,76 +3787,131 @@ describe('api-handler GET /api/quality-proxy', () => {
     expect(JSON.parse(body())).toEqual({ error: 'unavailable', what: 'qualityProxyTracker' });
   });
 
-  it('returns the live tracker metrics directly when totalSignals > 0', async () => {
-    const liveMetrics = {
-      totalSignals: 5,
-      diffApplyRate: 0.8,
-      testPassRate: null,
-      backtrackCount: 0,
-      selfCorrectionCount: 0,
-      qualityByTurnBucket: [],
-      degradationDetected: false,
-      events: [],
-    };
-    const handler = createApiHandler({
-      qualityProxyTracker: { getMetrics: () => liveMetrics },
+  it('returns just this process live counts (as derived rates) when no persisted-today sessions exist', async () => {
+    const tracker = new QualityProxyTracker();
+    const record = (overrides: Partial<ToolCallRecord>): ToolCallRecord => ({
+      id: `id-${Math.random()}`,
+      sessionId: 'live1',
+      toolName: 'Edit',
+      toolUseId: `tu-${Math.random()}`,
+      timestamp: 1,
+      durationMs: 1,
+      success: true,
+      ...overrides,
     });
+    tracker.recordToolCall(record({ toolName: 'Edit', filePath: '/a.ts', success: true }));
+    tracker.recordToolCall(record({ toolName: 'Edit', filePath: '/b.ts', success: false }));
+    const handler = createApiHandler({ qualityProxyTracker: tracker });
     const req = { method: 'GET', url: '/api/quality-proxy' } as IncomingMessage;
     const { res, status, body } = fakeRes();
     await handler(req, res);
     expect(status()).toBe(200);
-    expect(JSON.parse(body())).toEqual(liveMetrics);
+    const parsed = JSON.parse(body());
+    expect(parsed.totalSignals).toBe(2);
+    expect(parsed.diffApplyRate).toBeCloseTo(0.5);
+    // qualityByTurnBucket/degradationDetected/events come straight from the
+    // live tracker's own getMetrics(), unchanged by aggregation.
+    expect(parsed.qualityByTurnBucket).toEqual(tracker.getMetrics().qualityByTurnBucket);
+    expect(parsed.degradationDetected).toBe(false);
   });
 
-  it('falls back to history aggregation when totalSignals is 0 and sessionStore is present', async () => {
-    const handler = createApiHandler({
-      qualityProxyTracker: {
-        getMetrics: () => ({
-          totalSignals: 0,
-          diffApplyRate: null,
-          testPassRate: null,
+  it('combines this process live counts with every other persisted-today session, excluding its own already-persisted entry', async () => {
+    const tracker = new QualityProxyTracker();
+    const record = (overrides: Partial<ToolCallRecord>): ToolCallRecord => ({
+      id: `id-${Math.random()}`,
+      sessionId: 'sess-own',
+      toolName: 'Edit',
+      toolUseId: `tu-${Math.random()}`,
+      timestamp: 1,
+      durationMs: 1,
+      success: true,
+      ...overrides,
+    });
+    // Live, not-yet-persisted: 1 applied / 1 failed = 50% apply rate.
+    tracker.recordToolCall(record({ toolName: 'Edit', filePath: '/a.ts', success: true }));
+    tracker.recordToolCall(record({ toolName: 'Edit', filePath: '/c.ts', success: false }));
+    const ownRawCounts = tracker.getRawCounts();
+    const persistedToday = [
+      {
+        // Same session as the live tracker above — must NOT be double
+        // counted on top of the live counts.
+        sessionId: 'sess-own',
+        qualityProxy: ownRawCounts,
+      },
+      {
+        sessionId: 'sess-other',
+        qualityProxy: {
+          totalSignals: 8,
+          diffApplyCleanCount: 8,
+          diffFailCount: 0,
+          testPassCount: 0,
+          testFailCount: 0,
           backtrackCount: 0,
           selfCorrectionCount: 0,
-          qualityByTurnBucket: [],
-          degradationDetected: false,
-          events: [],
-        }),
+        },
+      },
+    ] as unknown as ReturnType<
+      NonNullable<Parameters<typeof createApiHandler>[0]['sessionStore']>['loadTodaySessions']
+    >;
+    const handler = createApiHandler({
+      qualityProxyTracker: tracker,
+      sessionTracker: {
+        getMetrics: () =>
+          ({ sessionId: 'sess-own' }) as unknown as ReturnType<
+            NonNullable<Parameters<typeof createApiHandler>[0]['sessionTracker']>['getMetrics']
+          >,
       },
       sessionStore: {
-        loadTodaySessions: () => [{ testRunCount: 4, testPassCount: 3 }],
-        loadAllSessions: () => [],
+        loadTodaySessions: () => persistedToday,
         listSessions: () => [],
         loadSession: () => null,
-      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      },
     });
     const req = { method: 'GET', url: '/api/quality-proxy' } as IncomingMessage;
     const { res, status, body } = fakeRes();
     await handler(req, res);
     expect(status()).toBe(200);
-    const result = JSON.parse(body());
-    expect(result.testPassRate).toBe(0.75);
-    expect(result.totalSignals).toBe(4);
+    const parsed = JSON.parse(body());
+    // Own live (1 applied / 1 failed) is not double-counted with its own
+    // persisted entry (identical) — only sess-other's 8 applies are added on
+    // top: 1 (live applied) + 8 (other) = 9 applied, 1 failed => 10 total,
+    // diffApplyRate = 9/10 = 0.9. A naive average of 50% and 100% would give
+    // 75%, which is wrong.
+    expect(parsed.totalSignals).toBe(10);
+    expect(parsed.diffApplyRate).toBeCloseTo(0.9);
   });
 
-  it('returns the live (zero-signal) metrics as-is when totalSignals is 0 and sessionStore is absent', async () => {
-    const liveMetrics = {
-      totalSignals: 0,
-      diffApplyRate: null,
-      testPassRate: null,
-      backtrackCount: 0,
-      selfCorrectionCount: 0,
-      qualityByTurnBucket: [],
-      degradationDetected: false,
-      events: [],
-    };
+  it('ignores persisted-today sessions with no qualityProxy field (legacy files)', async () => {
+    const tracker = new QualityProxyTracker();
+    const record = (overrides: Partial<ToolCallRecord>): ToolCallRecord => ({
+      id: `id-${Math.random()}`,
+      sessionId: 'live1',
+      toolName: 'Edit',
+      toolUseId: `tu-${Math.random()}`,
+      timestamp: 1,
+      durationMs: 1,
+      success: true,
+      ...overrides,
+    });
+    tracker.recordToolCall(record({ toolName: 'Edit', filePath: '/a.ts', success: true }));
+    const persistedToday = [{ sessionId: 'sess-legacy' }] as unknown as ReturnType<
+      NonNullable<Parameters<typeof createApiHandler>[0]['sessionStore']>['loadTodaySessions']
+    >;
     const handler = createApiHandler({
-      qualityProxyTracker: { getMetrics: () => liveMetrics },
+      qualityProxyTracker: tracker,
+      sessionStore: {
+        loadTodaySessions: () => persistedToday,
+        listSessions: () => [],
+        loadSession: () => null,
+      },
     });
     const req = { method: 'GET', url: '/api/quality-proxy' } as IncomingMessage;
     const { res, status, body } = fakeRes();
     await handler(req, res);
     expect(status()).toBe(200);
-    expect(JSON.parse(body())).toEqual(liveMetrics);
+    const parsed = JSON.parse(body());
+    expect(parsed.totalSignals).toBe(1);
+    expect(parsed.diffApplyRate).toBe(1);
   });
 });
 

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -41,7 +41,14 @@ import type { BudgetStatus } from '../../metrics/budget-tracker.js';
 import type { LatencyMetrics } from '../../metrics/latency-tracker.js';
 import type { PersonalInsightsResult } from '../../metrics/personal-coach.js';
 import type { GitEfficiencyMetrics } from '../../metrics/git-efficiency-tracker.js';
-import type { QualityProxyMetrics } from '../../metrics/quality-proxy-tracker.js';
+import type {
+  QualityProxyMetrics,
+  QualityProxyRawCounts,
+} from '../../metrics/quality-proxy-tracker.js';
+import {
+  combineQualityProxyRawCounts,
+  ZERO_QUALITY_PROXY_COUNTS,
+} from '../../metrics/quality-proxy-tracker.js';
 import type {
   ToolSelectionMetrics,
   ToolSelectionSummary,
@@ -53,99 +60,6 @@ import { computeContextMetricsFromEvents } from '../../metrics/context-tracker.j
 import type { ContextReplayEvent, ContextTrackerMetrics } from '../../metrics/context-tracker.js';
 import type { AntiPattern } from '../../metrics/anti-patterns.js';
 import type { AuditRecord } from '../../security/audit-trail.js';
-// ---------------------------------------------------------------------------
-// Aggregate quality-proxy metrics from today's persisted sessions so the
-// panel isn't empty on page refresh (when the live tracker has no signals).
-// ---------------------------------------------------------------------------
-
-interface HistoricalSession {
-  readonly testRunCount?: number;
-  readonly testPassCount?: number;
-  readonly timeline?: readonly ReplayTimelineEntry[];
-}
-
-function aggregateQualityFromHistory(sessions: unknown[]): {
-  totalSignals: number;
-  diffApplyRate: number | null;
-  testPassRate: number | null;
-  backtrackCount: number;
-  selfCorrectionCount: number;
-  qualityByTurnBucket: never[];
-  degradationDetected: boolean;
-  events: never[];
-} {
-  let diffApplied = 0;
-  let diffFailed = 0;
-  let testPass = 0;
-  let testFail = 0;
-  let backtrackCount = 0;
-  let selfCorrectionCount = 0;
-
-  for (const raw of sessions) {
-    const session = raw as HistoricalSession;
-    const testRuns = session.testRunCount ?? 0;
-    const testPasses = session.testPassCount ?? 0;
-
-    // Derive diff success/failure from timeline when available
-    if (session.timeline && session.timeline.length > 0) {
-      let lastEditFile: string | null = null;
-      let lastEditIdx = -1;
-      for (let i = 0; i < session.timeline.length; i++) {
-        const entry = session.timeline[i]!;
-        if (entry.toolName === 'Edit' || entry.toolName === 'Write') {
-          if (entry.success) diffApplied++;
-          else diffFailed++;
-
-          // Detect self-correction: re-edit same file within 3 turns after a test failure
-          if (lastEditFile && entry.filePath === lastEditFile && i - lastEditIdx <= 3) {
-            const recentFail = session.timeline
-              .slice(lastEditIdx + 1, i)
-              .some((e) => e.isTestCommand && !e.success);
-            if (recentFail) selfCorrectionCount++;
-          }
-
-          lastEditFile = entry.filePath ?? null;
-          lastEditIdx = i;
-        }
-        // Detect backtrack: Read of a recently edited file
-        if (
-          entry.toolName === 'Read' &&
-          lastEditFile &&
-          entry.filePath === lastEditFile &&
-          i - lastEditIdx <= 2
-        ) {
-          backtrackCount++;
-        }
-        if (entry.isTestCommand) {
-          if (entry.success) testPass++;
-          else testFail++;
-        }
-      }
-    } else {
-      // No timeline — use summary counts for test pass/fail only.
-      // Edit/Write counts from toolBreakdown have no success/failure split,
-      // so including them would always produce 100% diffApplyRate; skip them.
-      testPass += testPasses;
-      testFail += Math.max(0, testRuns - testPasses);
-    }
-  }
-
-  const totalDiffs = diffApplied + diffFailed;
-  const totalTests = testPass + testFail;
-  const totalSignals = totalDiffs + totalTests + backtrackCount + selfCorrectionCount;
-
-  return {
-    totalSignals,
-    diffApplyRate: totalDiffs > 0 ? Math.round((diffApplied / totalDiffs) * 1000) / 1000 : null,
-    testPassRate: totalTests > 0 ? Math.round((testPass / totalTests) * 1000) / 1000 : null,
-    backtrackCount,
-    selfCorrectionCount,
-    qualityByTurnBucket: [],
-    degradationDetected: false,
-    events: [],
-  };
-}
-
 interface RawAuditRecord {
   readonly timestamp: number;
   readonly sessionId: string | null;
@@ -481,7 +395,10 @@ export interface ApiHandlerDeps {
   // Today KPI; richer per-task breakdowns ship via the existing MCP tool path.
   readonly efficiencyScorer?: { getSessionAverage: () => { score: number } | null };
   readonly gitEfficiencyTracker?: { getMetrics: () => GitEfficiencyMetrics };
-  readonly qualityProxyTracker?: { getMetrics: () => QualityProxyMetrics };
+  readonly qualityProxyTracker?: {
+    getMetrics: () => QualityProxyMetrics;
+    getRawCounts: () => QualityProxyRawCounts;
+  };
   readonly toolSelectionScorer?: {
     scoreSession: (calls: readonly ToolCallRecord[]) => ToolSelectionMetrics;
     combineSummaries: (summaries: readonly ToolSelectionSummary[]) => ToolSelectionMetrics;
@@ -1790,12 +1707,29 @@ export function createApiHandler(
 
   routes.set('GET /api/quality-proxy', (_req, res) => {
     if (!deps.qualityProxyTracker) return unavailable(res, 'qualityProxyTracker');
-    const live = deps.qualityProxyTracker.getMetrics() as { totalSignals: number };
-    if (live.totalSignals > 0 || !deps.sessionStore) {
-      jsonOk(res, live);
-      return;
-    }
-    jsonOk(res, aggregateQualityFromHistory(deps.sessionStore.loadTodaySessions()));
+    // Same own-live + persisted-today, excluding-own-already-persisted-session
+    // pattern as GET /api/model-usage: this process's live raw counts are
+    // always included, and every OTHER today session's persisted raw counts
+    // are summed on top — rates are derived exactly once from the summed
+    // totals, never averaged per-session. qualityByTurnBucket/
+    // degradationDetected/events are inherently within-session signals with
+    // no persisted cross-session equivalent, so they're sourced from the
+    // live tracker only.
+    const live = deps.qualityProxyTracker.getMetrics();
+    const ownSessionId = deps.sessionTracker?.getMetrics().sessionId;
+    const persistedCounts = (deps.sessionStore?.loadTodaySessions() ?? [])
+      .filter((s) => s.sessionId !== ownSessionId)
+      .map((s) => s.qualityProxy ?? ZERO_QUALITY_PROXY_COUNTS);
+    const combined = combineQualityProxyRawCounts([
+      deps.qualityProxyTracker.getRawCounts(),
+      ...persistedCounts,
+    ]);
+    jsonOk(res, {
+      ...combined,
+      qualityByTurnBucket: live.qualityByTurnBucket,
+      degradationDetected: live.degradationDetected,
+      events: live.events,
+    });
   });
 
   routes.set('GET /api/tool-selection-score', (_req, res) => {
@@ -2456,7 +2390,12 @@ export function createApiHandler(
         if (!deps.sessionStore) return unavailable(res, 'sessionStore');
         const session = deps.sessionStore.loadSession(sessionId);
         if (session != null) {
-          const quality = aggregateQualityFromHistory([session]);
+          // Read the session's own persisted raw counts directly and derive
+          // its rates — no more re-deriving signals from `timeline`, now that
+          // QualityProxyTracker.getRawCounts() is captured at save time.
+          const quality = combineQualityProxyRawCounts([
+            session.qualityProxy ?? ZERO_QUALITY_PROXY_COUNTS,
+          ]);
           const responseBody: Record<string, unknown> = { ...session };
           if (quality.totalSignals > 0) responseBody.qualityProxy = quality;
           jsonOk(res, responseBody);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1830,6 +1830,7 @@ async function main(): Promise<void> {
           efficiencyScorer,
           toolSelectionScorer,
           modelUsageTracker,
+          qualityProxyTracker,
           transcriptMessageTracker,
           developer: config.developer ?? 'unknown',
           repoName: currentRepoName,

--- a/src/metrics/claudemd-tracker.test.ts
+++ b/src/metrics/claudemd-tracker.test.ts
@@ -7,6 +7,7 @@ import { SessionStore } from '../storage/session-store.js';
 import type { FullSessionSummary } from '../storage/session-store.js';
 import type { ToolCallRecord } from '../storage/types.js';
 import { ClaudeMdTracker, matchesInstructionFile } from './claudemd-tracker.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from './quality-proxy-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -62,6 +63,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/collaboration-profile.test.ts
+++ b/src/metrics/collaboration-profile.test.ts
@@ -7,6 +7,7 @@ import { SessionStore } from '../storage/session-store.js';
 import type { FullSessionSummary } from '../storage/session-store.js';
 import { getWeekDateRange } from '../storage/weekly-summary.js';
 import { CollaborationProfiler } from './collaboration-profile.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from './quality-proxy-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -59,6 +60,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/prompt-feedback.test.ts
+++ b/src/metrics/prompt-feedback.test.ts
@@ -9,6 +9,7 @@ import type { ToolCallRecord } from '../storage/types.js';
 import { CollaborationProfiler } from './collaboration-profile.js';
 import { ClaudeMdTracker } from './claudemd-tracker.js';
 import { PromptFeedbackEngine } from './prompt-feedback.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from './quality-proxy-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -64,6 +65,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/quality-proxy-tracker.test.ts
+++ b/src/metrics/quality-proxy-tracker.test.ts
@@ -1,4 +1,8 @@
-import { QualityProxyTracker } from './quality-proxy-tracker.js';
+import {
+  QualityProxyTracker,
+  combineQualityProxyRawCounts,
+  ZERO_QUALITY_PROXY_COUNTS,
+} from './quality-proxy-tracker.js';
 import type { ToolCallRecord } from '../storage/types.js';
 
 const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -21,6 +25,8 @@ function makeRecord(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
 beforeEach(() => {
   idCounter = 0;
 });
+
+type QualityProxyRawCountsLike = ReturnType<QualityProxyTracker['getRawCounts']>;
 
 describe('QualityProxyTracker', () => {
   it('tracks successful edits as diff_applied_clean', () => {
@@ -190,5 +196,137 @@ describe('QualityProxyTracker', () => {
       'ai.quality.test_pass_rate',
       expect.anything(),
     );
+  });
+});
+
+describe('QualityProxyTracker.getRawCounts', () => {
+  it('returns all-zero counts for a new tracker', () => {
+    const tracker = new QualityProxyTracker();
+    expect(tracker.getRawCounts()).toEqual(ZERO_QUALITY_PROXY_COUNTS);
+  });
+
+  it('returns raw counts matching what recordToolCall derived, with no rates', () => {
+    const tracker = new QualityProxyTracker();
+    tracker.recordToolCall(makeRecord({ toolName: 'Edit', filePath: '/a.ts', success: true }));
+    tracker.recordToolCall(makeRecord({ toolName: 'Edit', filePath: '/b.ts', success: false }));
+    tracker.recordToolCall(makeRecord({ toolName: 'Bash', isTestCommand: true, success: true }));
+
+    expect(tracker.getRawCounts()).toEqual({
+      totalSignals: 3,
+      diffApplyCleanCount: 1,
+      diffFailCount: 1,
+      testPassCount: 1,
+      testFailCount: 0,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    });
+  });
+
+  it('is consistent with getMetrics(): totalSignals and backtrack/self-correction counts always match', () => {
+    const tracker = new QualityProxyTracker();
+    tracker.recordToolCall(makeRecord({ toolName: 'Edit', filePath: '/a.ts', success: false }));
+    tracker.recordToolCall(makeRecord({ toolName: 'Read', filePath: '/a.ts', success: true }));
+    tracker.recordToolCall(makeRecord({ toolName: 'Bash', isTestCommand: true, success: true }));
+
+    const raw = tracker.getRawCounts();
+    const metrics = tracker.getMetrics();
+    expect(raw.totalSignals).toBe(metrics.totalSignals);
+    expect(raw.backtrackCount).toBe(metrics.backtrackCount);
+    expect(raw.selfCorrectionCount).toBe(metrics.selfCorrectionCount);
+  });
+});
+
+describe('combineQualityProxyRawCounts', () => {
+  it('returns all-zero rates for an empty array', () => {
+    expect(combineQualityProxyRawCounts([])).toEqual({
+      totalSignals: 0,
+      diffApplyRate: null,
+      testPassRate: null,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    });
+  });
+
+  it('sums raw counts across sources before deriving rates, rather than averaging per-source rates', () => {
+    // Source A alone: 1/10 diffs applied = 10% apply rate.
+    const sourceA: QualityProxyRawCountsLike = {
+      totalSignals: 10,
+      diffApplyCleanCount: 1,
+      diffFailCount: 9,
+      testPassCount: 0,
+      testFailCount: 0,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    };
+    // Source B alone: 9/10 diffs applied = 90% apply rate.
+    const sourceB: QualityProxyRawCountsLike = {
+      totalSignals: 10,
+      diffApplyCleanCount: 9,
+      diffFailCount: 1,
+      testPassCount: 0,
+      testFailCount: 0,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    };
+    const combined = combineQualityProxyRawCounts([sourceA, sourceB]);
+    // Correct: sum first (10/20 = 50% apply rate). A naive average of the two
+    // per-source rates (10% and 90%) would also give 50% here by coincidence —
+    // use unequal-volume sources instead, checked in the next test.
+    expect(combined.totalSignals).toBe(20);
+    expect(combined.diffApplyRate).toBeCloseTo(0.5);
+  });
+
+  it('never misweights unequal-volume sources by averaging their rates', () => {
+    // Source A: 1/1 diffs applied = 100% apply rate, tiny volume.
+    const sourceA: QualityProxyRawCountsLike = {
+      totalSignals: 1,
+      diffApplyCleanCount: 1,
+      diffFailCount: 0,
+      testPassCount: 0,
+      testFailCount: 0,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    };
+    // Source B: 1/99 diffs applied ≈ 1% apply rate, huge volume.
+    const sourceB: QualityProxyRawCountsLike = {
+      totalSignals: 100,
+      diffApplyCleanCount: 1,
+      diffFailCount: 99,
+      testPassCount: 0,
+      testFailCount: 0,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    };
+    const combined = combineQualityProxyRawCounts([sourceA, sourceB]);
+    // Correct: sum first (2 applied / 100 total = 2%). A naive average of 100%
+    // and ~1% would give ~50.5%, which is wrong — it ignores that source B
+    // contributed 100x the volume of source A.
+    expect(combined.diffApplyRate).toBeCloseTo(0.02);
+  });
+
+  it('sums backtrackCount/selfCorrectionCount directly (not rate-shaped)', () => {
+    const a: QualityProxyRawCountsLike = { ...ZERO_QUALITY_PROXY_COUNTS, backtrackCount: 2 };
+    const b: QualityProxyRawCountsLike = { ...ZERO_QUALITY_PROXY_COUNTS, selfCorrectionCount: 3 };
+    const combined = combineQualityProxyRawCounts([a, b]);
+    expect(combined.backtrackCount).toBe(2);
+    expect(combined.selfCorrectionCount).toBe(3);
+  });
+
+  it('returns null rates when the relevant denominator is zero across all sources', () => {
+    const a: QualityProxyRawCountsLike = { ...ZERO_QUALITY_PROXY_COUNTS, testPassCount: 0 };
+    const combined = combineQualityProxyRawCounts([a]);
+    expect(combined.diffApplyRate).toBeNull();
+    expect(combined.testPassRate).toBeNull();
+  });
+
+  it('is consistent with a single source: combining one tracker own raw counts matches its own derived rates', () => {
+    const tracker = new QualityProxyTracker();
+    tracker.recordToolCall(makeRecord({ toolName: 'Edit', filePath: '/a.ts', success: true }));
+    tracker.recordToolCall(makeRecord({ toolName: 'Bash', isTestCommand: true, success: false }));
+    const combined = combineQualityProxyRawCounts([tracker.getRawCounts()]);
+    const metrics = tracker.getMetrics();
+    expect(combined.totalSignals).toBe(metrics.totalSignals);
+    expect(combined.diffApplyRate).toBe(metrics.diffApplyRate);
+    expect(combined.testPassRate).toBe(metrics.testPassRate);
   });
 });

--- a/src/metrics/quality-proxy-tracker.ts
+++ b/src/metrics/quality-proxy-tracker.ts
@@ -58,6 +58,77 @@ export interface QualityProxyOptions {
   readonly degradationThreshold?: number;
 }
 
+export interface QualityProxyRawCounts {
+  readonly totalSignals: number;
+  readonly diffApplyCleanCount: number;
+  readonly diffFailCount: number;
+  readonly testPassCount: number;
+  readonly testFailCount: number;
+  readonly backtrackCount: number;
+  readonly selfCorrectionCount: number;
+}
+
+export const ZERO_QUALITY_PROXY_COUNTS: QualityProxyRawCounts = {
+  totalSignals: 0,
+  diffApplyCleanCount: 0,
+  diffFailCount: 0,
+  testPassCount: 0,
+  testFailCount: 0,
+  backtrackCount: 0,
+  selfCorrectionCount: 0,
+};
+
+export interface QualityProxyRates {
+  readonly totalSignals: number;
+  readonly diffApplyRate: number | null;
+  readonly testPassRate: number | null;
+  readonly backtrackCount: number;
+  readonly selfCorrectionCount: number;
+}
+
+// Sums raw counts across multiple sources (e.g. this process's own live
+// counts plus every other today session's persisted snapshot, or a single
+// persisted session's own snapshot), then derives diffApplyRate/testPassRate
+// exactly once from the summed totals — never by averaging each source's own
+// rate, which would misweight sources with different signal volumes. Pure
+// and stateless, not a QualityProxyTracker instance method: unlike
+// ModelUsageTracker.combineBreakdowns, one of this function's two real call
+// sites (a persisted session's own detail view) has no live tracker involved
+// at all — it just re-derives that one session's own rates from its stored
+// counts.
+export function combineQualityProxyRawCounts(
+  countsList: ReadonlyArray<QualityProxyRawCounts>,
+): QualityProxyRates {
+  let diffApplied = 0;
+  let diffFailed = 0;
+  let testPass = 0;
+  let testFail = 0;
+  let backtrackCount = 0;
+  let selfCorrectionCount = 0;
+  let totalSignals = 0;
+
+  for (const counts of countsList) {
+    diffApplied += counts.diffApplyCleanCount;
+    diffFailed += counts.diffFailCount;
+    testPass += counts.testPassCount;
+    testFail += counts.testFailCount;
+    backtrackCount += counts.backtrackCount;
+    selfCorrectionCount += counts.selfCorrectionCount;
+    totalSignals += counts.totalSignals;
+  }
+
+  const totalDiffs = diffApplied + diffFailed;
+  const totalTests = testPass + testFail;
+
+  return {
+    totalSignals,
+    diffApplyRate: totalDiffs > 0 ? Math.round((diffApplied / totalDiffs) * 1000) / 1000 : null,
+    testPassRate: totalTests > 0 ? Math.round((testPass / totalTests) * 1000) / 1000 : null,
+    backtrackCount,
+    selfCorrectionCount,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
@@ -146,26 +217,38 @@ export class QualityProxyTracker {
     }
   }
 
-  getMetrics(): QualityProxyMetrics {
-    const diffApplied = this.events.filter((e) => e.signal === 'diff_applied_clean').length;
-    const diffFailed = this.events.filter((e) => e.signal === 'diff_failed').length;
-    const testPass = this.events.filter((e) => e.signal === 'test_pass').length;
-    const testFail = this.events.filter((e) => e.signal === 'test_fail').length;
-    const backtrackCount = this.events.filter((e) => e.signal === 'backtrack').length;
-    const selfCorrectionCount = this.events.filter((e) => e.signal === 'self_correction').length;
+  // Raw per-session counts only — no derived rates. This is the shape
+  // persisted onto FullSessionSummary.qualityProxy (session-store.ts) so a
+  // session file never stores a stale derived rate; rates are always
+  // recomputed at read time via getMetrics()/combineQualityProxyRawCounts().
+  getRawCounts(): QualityProxyRawCounts {
+    return {
+      totalSignals: this.events.length,
+      diffApplyCleanCount: this.countBySignal('diff_applied_clean'),
+      diffFailCount: this.countBySignal('diff_failed'),
+      testPassCount: this.countBySignal('test_pass'),
+      testFailCount: this.countBySignal('test_fail'),
+      backtrackCount: this.countBySignal('backtrack'),
+      selfCorrectionCount: this.countBySignal('self_correction'),
+    };
+  }
 
-    const totalDiffs = diffApplied + diffFailed;
-    const totalTests = testPass + testFail;
+  getMetrics(): QualityProxyMetrics {
+    const counts = this.getRawCounts();
+    const totalDiffs = counts.diffApplyCleanCount + counts.diffFailCount;
+    const totalTests = counts.testPassCount + counts.testFailCount;
 
     const buckets = this.computeTurnBuckets();
     const degradationDetected = this.detectDegradation(buckets);
 
     return {
-      totalSignals: this.events.length,
-      diffApplyRate: totalDiffs > 0 ? Math.round((diffApplied / totalDiffs) * 1000) / 1000 : null,
-      testPassRate: totalTests > 0 ? Math.round((testPass / totalTests) * 1000) / 1000 : null,
-      backtrackCount,
-      selfCorrectionCount,
+      totalSignals: counts.totalSignals,
+      diffApplyRate:
+        totalDiffs > 0 ? Math.round((counts.diffApplyCleanCount / totalDiffs) * 1000) / 1000 : null,
+      testPassRate:
+        totalTests > 0 ? Math.round((counts.testPassCount / totalTests) * 1000) / 1000 : null,
+      backtrackCount: counts.backtrackCount,
+      selfCorrectionCount: counts.selfCorrectionCount,
       qualityByTurnBucket: buckets,
       degradationDetected,
       events: this.events,
@@ -200,6 +283,10 @@ export class QualityProxyTracker {
     if (this.events.length > this.maxEvents) {
       this.events.shift();
     }
+  }
+
+  private countBySignal(signal: QualitySignal): number {
+    return this.events.filter((e) => e.signal === signal).length;
   }
 
   private computeTurnBuckets(): TurnQualityBucket[] {

--- a/src/metrics/recommendation-engine.test.ts
+++ b/src/metrics/recommendation-engine.test.ts
@@ -13,6 +13,7 @@ import { PromptFeedbackEngine } from './prompt-feedback.js';
 import { CostPerOutcomeAnalyzer } from './cost-per-outcome.js';
 import { RecommendationEngine } from './recommendation-engine.js';
 import { TaskDetector } from './task-detector.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from './quality-proxy-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -65,6 +66,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/metrics/trend-analyzer.test.ts
+++ b/src/metrics/trend-analyzer.test.ts
@@ -12,6 +12,7 @@ import {
   percentChange,
   significantChange,
 } from './trend-analyzer.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from './quality-proxy-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -64,6 +65,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -18,6 +18,8 @@ import type { TranscriptMessageTracker } from '../metrics/transcript-message-tra
 import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
 import { ToolSelectionScorer, toToolSelectionSummary } from '../metrics/tool-selection-scorer.js';
 import type { ModelUsageTracker } from '../metrics/model-usage-tracker.js';
+import type { QualityProxyTracker } from '../metrics/quality-proxy-tracker.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from '../metrics/quality-proxy-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -71,6 +73,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,
@@ -1767,5 +1770,125 @@ describe('modelBreakdown field', () => {
         totalCostUsd: 0.1,
       },
     });
+  });
+});
+
+describe('qualityProxy field', () => {
+  it('buildSessionSummary populates qualityProxy from qualityProxyTracker.getRawCounts()', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: null,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+    const qualityProxyTracker = {
+      getRawCounts: () => ({
+        totalSignals: 4,
+        diffApplyCleanCount: 2,
+        diffFailCount: 1,
+        testPassCount: 1,
+        testFailCount: 0,
+        backtrackCount: 0,
+        selfCorrectionCount: 0,
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      qualityProxyTracker: qualityProxyTracker as unknown as QualityProxyTracker,
+      developer: 'alice',
+    });
+
+    expect(summary.qualityProxy).toEqual({
+      totalSignals: 4,
+      diffApplyCleanCount: 2,
+      diffFailCount: 1,
+      testPassCount: 1,
+      testFailCount: 0,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    });
+  });
+
+  it('defaults qualityProxy to all-zero counts when no qualityProxyTracker is provided', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: null,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      developer: 'alice',
+    });
+    expect(summary.qualityProxy).toEqual(ZERO_QUALITY_PROXY_COUNTS);
+  });
+
+  it('round-trips qualityProxy through JSON serialization', () => {
+    const original = makeSummary({
+      qualityProxy: {
+        totalSignals: 4,
+        diffApplyCleanCount: 2,
+        diffFailCount: 1,
+        testPassCount: 1,
+        testFailCount: 0,
+        backtrackCount: 0,
+        selfCorrectionCount: 0,
+      },
+    });
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(JSON.stringify(original)) as Parameters<typeof deserializeFullSessionSummary>[0],
+    );
+    expect(roundTripped.qualityProxy).toEqual(original.qualityProxy);
+  });
+
+  it('defaults qualityProxy to all-zero counts for legacy session files missing the field', () => {
+    const legacy = makeSummary();
+    const { qualityProxy: _qualityProxy, ...withoutField } = legacy;
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(JSON.stringify(withoutField)) as Parameters<
+        typeof deserializeFullSessionSummary
+      >[0],
+    );
+    expect(roundTripped.qualityProxy).toEqual(ZERO_QUALITY_PROXY_COUNTS);
+  });
+
+  it('defaults qualityProxy to all-zero counts when a field is malformed (missing a numeric key)', () => {
+    const raw = JSON.stringify({
+      ...makeSummary(),
+      qualityProxy: { totalSignals: 4 }, // missing the other required numeric fields
+    });
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(raw) as Parameters<typeof deserializeFullSessionSummary>[0],
+    );
+    expect(roundTripped.qualityProxy).toEqual(ZERO_QUALITY_PROXY_COUNTS);
   });
 });

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -31,6 +31,11 @@ import {
   type ToolSelectionSummary,
 } from '../metrics/tool-selection-scorer.js';
 import type { ModelUsageTracker, ModelBreakdownEntry } from '../metrics/model-usage-tracker.js';
+import type { QualityProxyTracker } from '../metrics/quality-proxy-tracker.js';
+import {
+  type QualityProxyRawCounts,
+  ZERO_QUALITY_PROXY_COUNTS,
+} from '../metrics/quality-proxy-tracker.js';
 
 const logger = createLogger('session-store');
 
@@ -95,6 +100,17 @@ export interface FullSessionSummary extends SessionSummary {
    * `{}` for pre-fix session files and for sessions with no token events.
    */
   readonly modelBreakdown: Readonly<Record<string, ModelBreakdownEntry>>;
+  /**
+   * Raw quality-proxy signal counts for this session, captured once at save
+   * time from QualityProxyTracker.getRawCounts(). Raw counts only, no derived
+   * rates — see combineQualityProxyRawCounts for why rates are always
+   * recomputed at read time instead of persisted. All-zero
+   * (ZERO_QUALITY_PROXY_COUNTS) for pre-fix session files and for sessions
+   * with no quality signals. Nested (not top-level) specifically to avoid
+   * colliding with the unrelated top-level testPassCount/testRunCount fields
+   * above (total task test runs, not quality-proxy test signals).
+   */
+  readonly qualityProxy: QualityProxyRawCounts;
 }
 
 export interface SessionFileInfo {
@@ -310,6 +326,7 @@ export interface BuildSessionSummarySources {
   transcriptMessageTracker?: TranscriptMessageTracker;
   toolSelectionScorer?: ToolSelectionScorer;
   modelUsageTracker?: ModelUsageTracker;
+  qualityProxyTracker?: QualityProxyTracker;
   developer: string;
   repoName?: string | null;
   /**
@@ -465,6 +482,7 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     timeline: timeline.length > 0 ? timeline : undefined,
     toolSelectionMetrics: toolSelectionResult,
     modelBreakdown: sources.modelUsageTracker?.getRawBreakdown() ?? {},
+    qualityProxy: sources.qualityProxyTracker?.getRawCounts() ?? ZERO_QUALITY_PROXY_COUNTS,
   };
 }
 
@@ -555,6 +573,7 @@ interface SerializedFullSessionSummary {
   readonly timeline?: Array<Record<string, unknown>>;
   readonly toolSelectionMetrics?: unknown;
   readonly modelBreakdown?: Record<string, unknown>;
+  readonly qualityProxy?: Record<string, unknown>;
 }
 
 /**
@@ -629,6 +648,32 @@ export function deserializeFullSessionSummary(
     }
   }
 
+  const qualityProxy: QualityProxyRawCounts = (() => {
+    const q = obj.qualityProxy;
+    if (typeof q !== 'object' || q === null) return ZERO_QUALITY_PROXY_COUNTS;
+    const r = q as Record<string, unknown>;
+    if (
+      typeof r.totalSignals !== 'number' ||
+      typeof r.diffApplyCleanCount !== 'number' ||
+      typeof r.diffFailCount !== 'number' ||
+      typeof r.testPassCount !== 'number' ||
+      typeof r.testFailCount !== 'number' ||
+      typeof r.backtrackCount !== 'number' ||
+      typeof r.selfCorrectionCount !== 'number'
+    ) {
+      return ZERO_QUALITY_PROXY_COUNTS;
+    }
+    return {
+      totalSignals: r.totalSignals,
+      diffApplyCleanCount: r.diffApplyCleanCount,
+      diffFailCount: r.diffFailCount,
+      testPassCount: r.testPassCount,
+      testFailCount: r.testFailCount,
+      backtrackCount: r.backtrackCount,
+      selfCorrectionCount: r.selfCorrectionCount,
+    };
+  })();
+
   return {
     sessionId:
       typeof obj.sessionId === 'string' && obj.sessionId.length > 0 ? obj.sessionId : 'unknown',
@@ -700,6 +745,7 @@ export function deserializeFullSessionSummary(
       : undefined,
     toolSelectionMetrics,
     modelBreakdown,
+    qualityProxy,
   };
 }
 

--- a/src/storage/weekly-summary.test.ts
+++ b/src/storage/weekly-summary.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from 'node:os';
 import { SessionStore } from './session-store.js';
 import type { FullSessionSummary } from './session-store.js';
 import { WeeklySummaryGenerator, getIsoWeekId, getWeekDateRange } from './weekly-summary.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from '../metrics/quality-proxy-tracker.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -64,6 +65,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -20,6 +20,7 @@ import { TaskDetector } from '../metrics/task-detector.js';
 import { PromptFeedbackEngine } from '../metrics/prompt-feedback.js';
 import { RecommendationEngine } from '../metrics/recommendation-engine.js';
 import { PersonalCoach } from '../metrics/personal-coach.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from '../metrics/quality-proxy-tracker.js';
 import type { ToolCallRecord } from '../storage/types.js';
 import {
   handleGetSessionHistory,
@@ -91,6 +92,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,
     taskSuccessRate: 1,


### PR DESCRIPTION
## Summary

- The Today dashboard's Quality panel (`/api/quality-proxy`) only reflected diff-apply/test-pass/backtrack/self-correction signals from whichever process happened to be serving the dashboard, and only fell back to persisted history when that process had recorded **zero** signals of its own — the instant it recorded even one signal, every other today session's activity was ignored outright.
- Replaces that all-or-nothing switch with the established sum-raw-counts-then-derive-rates-once pattern (mirrors `GET /api/model-usage`, #328): `QualityProxyTracker.getRawCounts()` + a pure `combineQualityProxyRawCounts()` function, a new persisted `qualityProxy` field on `FullSessionSummary`, and a rewritten route that always sums this process's live counts with every *other* today session's persisted counts (excluding its own session).
- `GET /api/sessions/:id`'s persisted-session detail branch is simplified to read the new `qualityProxy` field directly instead of re-deriving signals from the session's `timeline` — the now-dead `aggregateQualityFromHistory()` helper and its `HistoricalSession` interface are deleted.
- Last ticket in the "Today dashboard cross-process blind spots" series.

Fixes #329

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 161/162 suites, 5269/5272 tests passing (1 pre-existing unrelated skip)
- [x] `npm run test:web` — 37/37 files, 422/422 tests passing
- [x] `npm run lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)