### PR TITLE
Fix: add cwd breadcrumb fallback to synchronous session-ID resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.18] - 2026-08-01
+
+### Fixed
+
+- **The `--stdio` MCP's synchronous session-ID resolution at startup only tried the job-dir and PPID-keyed breadcrumb, skipping the cwd-keyed breadcrumb that the async resolver already falls back to** — on setups where the PPID breadcrumb never matches (e.g. native Windows, where the hook collector's PPID is a transient shell process rather than the real parent), this meant every session started in the provisional window and paid an avoidable delay before cloud ingest wired up. Synchronous resolution now tries the cwd breadcrumb too, matching the async resolver's fallback order. Also added a one-time warning log when a tool record arrives while cloud mode is configured but ingest hasn't initialized yet, so a stuck provisional window is now visible in the logs instead of silently dropping events.
+
 ## [1.14.17] - 2026-07-31
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.17",
+  "version": "1.14.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.17",
+      "version": "1.14.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.17",
+  "version": "1.14.18",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,13 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync, utimesSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  utimesSync,
+  realpathSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve, join } from 'node:path';
 import {
@@ -798,6 +806,68 @@ describe('stdio integration', () => {
     } finally {
       rmSync(tmpJobDir, { recursive: true, force: true });
       rmSync(tmpStoragePath, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('resolves session_id synchronously from the cwd breadcrumb when no CLAUDE_JOB_DIR or PPID breadcrumb is available', async () => {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+    const { resolveFromCwd } = await import('./hooks/session-resolver.js');
+
+    const binPath = resolve(__dirname, '..', 'dist', 'index.js');
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-cwd-sync-storage-'));
+    const tmpProjectCwd = mkdtempSync(join(tmpdir(), 'nr-cwd-sync-project-'));
+    // The spawned child's process.cwd() returns the *canonicalized* path
+    // (e.g. macOS resolves /var/folders/... to /private/var/folders/...) —
+    // resolve that here too so the breadcrumb filename matches what the
+    // child's own resolveFromCwd() call derives, not the raw temp path.
+    const realProjectCwd = realpathSync(tmpProjectCwd);
+
+    // Pre-write a cwd breadcrumb (as the hook collector would, via
+    // writeCwdBreadcrumb()) for the spawned MCP's own working directory —
+    // this is the platform-independent equivalent of "native Windows, where
+    // the PPID breadcrumb never matches, but the cwd one does". Deliberately
+    // omit CLAUDE_JOB_DIR and any PPID breadcrumb so only the cwd fallback in
+    // the *synchronous* resolution chain can succeed.
+    const breadcrumbDir = resolve(tmpStoragePath, 'session-by-cwd');
+    mkdirSync(breadcrumbDir, { recursive: true });
+    const sanitizedCwd = realProjectCwd.replace(/[\\/:]/g, '-');
+    writeFileSync(resolve(breadcrumbDir, `${sanitizedCwd}.txt`), 'resolved-via-cwd-session-id');
+
+    // Sanity check against the real resolver so this test fails loudly (not
+    // mysteriously) if the sanitization scheme ever drifts between the
+    // collector's write side and resolveFromCwd()'s read side.
+    expect(resolveFromCwd(tmpStoragePath, realProjectCwd)).toBe('resolved-via-cwd-session-id');
+
+    const env = { ...process.env };
+    delete env.CLAUDE_JOB_DIR;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [binPath, '--stdio'],
+      cwd: tmpProjectCwd,
+      env: {
+        ...env,
+        NR_AI_DASHBOARD_PORT: '0',
+        NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
+      },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+
+      // If the cwd fallback resolved synchronously, the full tool set is
+      // registered immediately — no pending-tools window to poll through.
+      const tools = await client.listTools();
+      const toolNames = tools.tools.map((t) => t.name);
+      expect(toolNames).toContain('nr_observe_get_session_stats');
+
+      await client.close();
+    } finally {
+      rmSync(tmpStoragePath, { recursive: true, force: true });
+      rmSync(tmpProjectCwd, { recursive: true, force: true });
     }
   }, 30000);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ import {
   resolveSessionId,
   resolveFromJobDir,
   resolveFromBreadcrumb,
+  resolveFromCwd,
   isSyntheticSessionId,
 } from './hooks/session-resolver.js';
 import { initMcpTracer } from './tracing/mcp-tracer.js';
@@ -784,7 +785,8 @@ async function main(): Promise<void> {
 
       const synchronouslyResolved =
         resolveFromJobDir(process.env.CLAUDE_JOB_DIR ?? null) ??
-        resolveFromBreadcrumb(config.storagePath, process.ppid);
+        resolveFromBreadcrumb(config.storagePath, process.ppid) ??
+        resolveFromCwd(config.storagePath, process.cwd());
       if (synchronouslyResolved) {
         sessionTraceId = synchronouslyResolved;
         logger.info('Session ID resolved synchronously', { sessionTraceId });
@@ -1416,6 +1418,12 @@ async function main(): Promise<void> {
     }
 
     let capturedNrIngest: NrIngestManager | undefined;
+    // Set once the first tool record arrives while cloud ingest is expected but
+    // not yet wired up (still-provisional session, or the async resolver hasn't
+    // finished). Without this, a session that never leaves the provisional
+    // window sends metrics normally (a separate path) while every AiToolCall/
+    // AiMcpToolCall/etc. event is silently dropped — see issue #320.
+    let warnedMissingIngest = false;
     if (config.mode !== 'local' && !isProvisional) {
       if (!config.licenseKey || !config.accountId) {
         throw new Error(
@@ -1542,6 +1550,12 @@ async function main(): Promise<void> {
         // populates regardless of mode. NrIngestManager (when present) reuses the
         // returned AuditRecord rather than recording a second time.
         const auditRecord = auditTrail.recordToolCall(record);
+        if (!capturedNrIngest && config.mode !== 'local' && !warnedMissingIngest) {
+          warnedMissingIngest = true;
+          logger.warn(
+            'Tool record arrived with cloud ingest not yet initialized — AiToolCall/AiMcpToolCall events are being dropped until session ID resolution completes',
+          );
+        }
         capturedNrIngest?.ingestToolCall(record, auditRecord);
 
         // SSE consumers filter by sessionId for the per-session live tail.


### PR DESCRIPTION
## Summary

- Synchronous startup session-ID resolution only tried `resolveFromJobDir()` and `resolveFromBreadcrumb()` (PPID-keyed), skipping the cwd-keyed breadcrumb the async resolver already falls back to. On setups where the PPID breadcrumb never matches (e.g. native Windows, where the hook collector's PPID is a transient shell process rather than the real parent), every session paid an avoidable delay in the provisional window. Synchronous resolution now matches the async resolver's fallback order.
- Added a one-time warning log when a tool record arrives while cloud mode is configured but ingest hasn't initialized yet, so a stuck provisional window is now visible in the logs instead of silently dropping events.
- Version bump to 1.14.18 with a CHANGELOG entry.

Addresses part of #320 — see my comment there for what this PR does and doesn't cover. The issue's originally stated root cause (that cloud ingest never initializes at all) didn't hold up under a live repro: the async rescue path already recovers once the cwd breadcrumb resolves. This PR closes the one confirmed gap (missing cwd fallback in the *synchronous* path) plus a defense-in-depth log line — it does not close #320 outright, since the deeper "zero events on native Windows" symptom (if still real) likely needs a separate fix. Leaving #320 open pending confirmation from the reporter.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — full suite passing (added a new integration test: `resolves session_id synchronously from the cwd breadcrumb when no CLAUDE_JOB_DIR or PPID breadcrumb is available`, which fails without the fix)
- [x] `npm run lint` clean