### PR TITLE
Fix: parent-token cost events weren't stamped with their real timestamp for day-bucketing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.20] - 2026-08-01
+
+### Fixed
+
+- **`ParentTranscriptWatcher` (added in 1.14.19) attributed every parent-session token event to "today," regardless of the turn's real timestamp** — the day-bucketed cost total is keyed by arrival time unless an explicit timestamp is passed in, and the parent-token wiring never passed one (unlike the sibling subagent-token path, which already did). This was latent and harmless while nothing replayed history, but became a real bug the moment the watcher started backfilling up to 24h of transcript history in `--local` mode: every replayed historical turn got counted as today's spend, inflating and destabilizing the "Spend Today" figure while the backlog was being processed. Parent token events are now stamped with their actual transcript timestamp before being recorded, so historical turns land in their real day's bucket instead of today's.
+
 ## [1.14.19] - 2026-08-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1687,7 +1687,9 @@ async function main(): Promise<void> {
           cacheCreationTokens: tokenEvent.cacheCreationTokens,
           totalTokens: tokenEvent.inputTokens + tokenEvent.outputTokens,
         };
-        const breakdown = costTracker.recordTokenUsage(usage, tokenEvent.model);
+        const breakdown = costTracker.recordTokenUsage(usage, tokenEvent.model, {
+          timestampMs: tokenEvent.timestamp,
+        });
         modelUsageTracker.recordUsage(
           tokenEvent.model,
           tokenEvent.inputTokens,


### PR DESCRIPTION
Fixes #338

## Summary
- `ParentTranscriptWatcher` (added in v1.14.19) feeds parent-session token events into `CostTracker.recordTokenUsage()` without an explicit `timestampMs`, so day-bucketing falls back to arrival time instead of the turn's real transcript timestamp — the sibling subagent-token path already passes `timestampMs` correctly.
- This was latent while nothing replayed history, but became a real bug once the watcher started backfilling up to 24h of transcript history in `--local` mode: every replayed historical turn got counted as *today's* spend, inflating and destabilizing the "Spend Today" figure while the backlog was processed.
- Fix: pass `{ timestampMs: tokenEvent.timestamp }` at the parent-token call site, matching the existing subagent-token wiring.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (full suite passes)
- [x] `ctx.timestampMs`-based day-bucketing is already thoroughly covered by `cost-tracker.test.ts`; this fix corrects a wiring omission, not tracker logic

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
