### PR TITLE
Fix: self-correct a stale cwd-fallback session ID adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.21] - 2026-08-01
+
+### Fixed
+
+- **A `--stdio` MCP process could permanently adopt the wrong session identity when startup resolution fell back to the cwd-keyed breadcrumb before the precise PPID-keyed one was available** — the cwd breadcrumb is shared by every session that has ever run in that directory, so a stale value left over from an unrelated prior session could win the race and be adopted for the life of the process, with no way to self-correct once the real PPID breadcrumb appeared moments later. Every metric, checkpoint, and tool call for that session would then be misattributed to the wrong session ID. The MCP now watches for a PPID-breadcrumb resolution in the background whenever it had to fall back to the cwd breadcrumb, and re-adopts the correct session identity the moment one appears, preserving all metrics already recorded under the earlier one.
+
 ## [1.14.20] - 2026-08-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.20",
+  "version": "1.14.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.20",
+      "version": "1.14.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -2552,6 +2552,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.20",
+  "version": "1.14.21",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/session-resolver.test.ts
+++ b/src/hooks/session-resolver.test.ts
@@ -10,6 +10,7 @@ import {
   nextDelayMs,
   isSyntheticSessionId,
   isUnscopedAggregatorSessionId,
+  watchPpidBreadcrumb,
 } from './session-resolver.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -178,7 +179,7 @@ describe('session-resolver', () => {
       expect(sid).toBe('sess-immediate');
     });
 
-    it('falls back to the cwd breadcrumb when the ppid breadcrumb is missing (immediate)', async () => {
+    it('falls back to the cwd breadcrumb when the ppid breadcrumb never appears (via the poll loop, not trusted at t=0)', async () => {
       mkdirSync(resolve(tmpDir, 'session-by-cwd'), { recursive: true });
       writeFileSync(
         resolve(tmpDir, 'session-by-cwd', '-projects-winrepo.txt'),
@@ -189,8 +190,36 @@ describe('session-resolver', () => {
         ppid: 424242, // never has a matching breadcrumb
         cwd: '/projects/winrepo',
         storagePath: tmpDir,
+        suppressWarn: true,
       });
       expect(sid).toBe('sess-cwd-fallback');
+    });
+
+    it('prefers a ppid breadcrumb that appears just after startup over an already-present, possibly-stale cwd breadcrumb', async () => {
+      // A cwd breadcrumb left over from an unrelated prior session in the
+      // same directory must not win the race just because it already
+      // exists at t=0 — a ppid breadcrumb that shows up moments later (the
+      // real signal for THIS process) must still be preferred.
+      mkdirSync(resolve(tmpDir, 'session-by-cwd'), { recursive: true });
+      writeFileSync(
+        resolve(tmpDir, 'session-by-cwd', '-projects-race.txt'),
+        'sess-stale-from-other-session',
+      );
+      const ppid = 424243;
+      const breadcrumbDir = resolve(tmpDir, 'session-by-ppid');
+      mkdirSync(breadcrumbDir, { recursive: true });
+      setTimeout(() => {
+        writeFileSync(resolve(breadcrumbDir, `${ppid}.txt`), 'sess-real-for-this-process');
+      }, 10);
+
+      const sid = await resolveSessionId({
+        claudeJobDir: null,
+        ppid,
+        cwd: '/projects/race',
+        storagePath: tmpDir,
+        suppressWarn: true,
+      });
+      expect(sid).toBe('sess-real-for-this-process');
     });
 
     it('prefers the ppid breadcrumb over the cwd breadcrumb when both are present', async () => {
@@ -206,6 +235,66 @@ describe('session-resolver', () => {
         storagePath: tmpDir,
       });
       expect(sid).toBe('sess-from-ppid');
+    });
+
+    it('reports source "jobdir" via onResolutionSource when CLAUDE_JOB_DIR resolves', async () => {
+      const jobDir = resolve(tmpDir, 'job-src');
+      mkdirSync(jobDir, { recursive: true });
+      writeFileSync(
+        resolve(jobDir, 'state.json'),
+        JSON.stringify({ linkScanPath: '/whatever/job-src-uuid.jsonl' }),
+      );
+      const onResolutionSource = jest.fn();
+      const sid = await resolveSessionId({
+        claudeJobDir: jobDir,
+        ppid: 1,
+        storagePath: tmpDir,
+        onResolutionSource,
+      });
+      expect(sid).toBe('job-src-uuid');
+      expect(onResolutionSource).toHaveBeenCalledWith({
+        source: 'jobdir',
+        sessionId: 'job-src-uuid',
+      });
+    });
+
+    it('reports source "ppid" via onResolutionSource when the ppid breadcrumb resolves immediately', async () => {
+      const ppid = 99001;
+      mkdirSync(resolve(tmpDir, 'session-by-ppid'), { recursive: true });
+      writeFileSync(resolve(tmpDir, 'session-by-ppid', `${ppid}.txt`), 'sess-ppid-source');
+      const onResolutionSource = jest.fn();
+      const sid = await resolveSessionId({
+        claudeJobDir: null,
+        ppid,
+        storagePath: tmpDir,
+        onResolutionSource,
+      });
+      expect(sid).toBe('sess-ppid-source');
+      expect(onResolutionSource).toHaveBeenCalledWith({
+        source: 'ppid',
+        sessionId: 'sess-ppid-source',
+      });
+    });
+
+    it('reports source "cwd" via onResolutionSource when only the cwd fallback resolves', async () => {
+      mkdirSync(resolve(tmpDir, 'session-by-cwd'), { recursive: true });
+      writeFileSync(
+        resolve(tmpDir, 'session-by-cwd', '-projects-cwd-source.txt'),
+        'sess-cwd-source',
+      );
+      const onResolutionSource = jest.fn();
+      const sid = await resolveSessionId({
+        claudeJobDir: null,
+        ppid: 424243, // never has a matching breadcrumb
+        cwd: '/projects/cwd-source',
+        storagePath: tmpDir,
+        onResolutionSource,
+      });
+      expect(sid).toBe('sess-cwd-source');
+      expect(onResolutionSource).toHaveBeenCalledWith({
+        source: 'cwd',
+        sessionId: 'sess-cwd-source',
+      });
     });
   });
 
@@ -266,6 +355,58 @@ describe('session-resolver', () => {
         suppressWarn: true,
       });
       expect(sid).toBe('sess-win-regression');
+    });
+  });
+
+  describe('watchPpidBreadcrumb()', () => {
+    it('resolves once a ppid breadcrumb appears', async () => {
+      const ppid = 88001;
+      const breadcrumbDir = resolve(tmpDir, 'session-by-ppid');
+      mkdirSync(breadcrumbDir, { recursive: true });
+
+      setTimeout(() => {
+        writeFileSync(resolve(breadcrumbDir, `${ppid}.txt`), 'sess-ppid-correction');
+      }, 150);
+
+      const sid = await watchPpidBreadcrumb({ ppid, storagePath: tmpDir, suppressWarn: true });
+      expect(sid).toBe('sess-ppid-correction');
+    });
+
+    it('never resolves via a cwd breadcrumb, even if one appears first', async () => {
+      const ppid = 88002;
+      mkdirSync(resolve(tmpDir, 'session-by-cwd'), { recursive: true });
+      writeFileSync(
+        resolve(tmpDir, 'session-by-cwd', '-projects-watch-cwd.txt'),
+        'sess-cwd-should-be-ignored',
+      );
+
+      const ppidBreadcrumbDir = resolve(tmpDir, 'session-by-ppid');
+      mkdirSync(ppidBreadcrumbDir, { recursive: true });
+      setTimeout(() => {
+        writeFileSync(resolve(ppidBreadcrumbDir, `${ppid}.txt`), 'sess-ppid-wins');
+      }, 150);
+
+      const sid = await watchPpidBreadcrumb({
+        ppid,
+        cwd: '/projects/watch-cwd',
+        storagePath: tmpDir,
+        suppressWarn: true,
+      });
+      expect(sid).toBe('sess-ppid-wins');
+    });
+
+    it('aborts via signal', async () => {
+      const ppid = 88003;
+      const ac = new AbortController();
+      setTimeout(() => ac.abort(), 50);
+      await expect(
+        watchPpidBreadcrumb({
+          ppid,
+          storagePath: tmpDir,
+          suppressWarn: true,
+          signal: ac.signal,
+        }),
+      ).rejects.toThrow(/aborted/);
     });
   });
 });

--- a/src/hooks/session-resolver.ts
+++ b/src/hooks/session-resolver.ts
@@ -37,6 +37,9 @@ const POLL_SCHEDULE_MS = [100, 200, 500, 1000, 2000];
 const STEADY_POLL_MS = 2000;
 const WARN_AFTER_MS = 60_000;
 
+/** Which of the three sources produced a resolveSessionId() result. */
+export type SessionIdSource = 'jobdir' | 'ppid' | 'cwd';
+
 export interface SessionResolverOptions {
   /** Override the storage path used to find the breadcrumb directory. */
   readonly storagePath?: string;
@@ -48,6 +51,14 @@ export interface SessionResolverOptions {
   readonly claudeJobDir?: string | null;
   /** When true, skip the WARN log (test seam). */
   readonly suppressWarn?: boolean;
+  /**
+   * Invoked once, synchronously, right before resolveSessionId's promise
+   * settles, reporting which source produced the winning value. Purely
+   * additive — omitting it changes no behavior. Lets callers detect a
+   * cwd-sourced (lower-confidence) resolution without changing the
+   * `Promise<string>` contract existing callers rely on.
+   */
+  readonly onResolutionSource?: (info: { source: SessionIdSource; sessionId: string }) => void;
 }
 
 /** The one field `resolveFromJobDir` reads out of `CLAUDE_JOB_DIR/state.json`. */
@@ -178,23 +189,26 @@ export async function resolveSessionId(
   const fromJobDir = resolveFromJobDir(claudeJobDir);
   if (fromJobDir) {
     logger.info('Resolved session_id from CLAUDE_JOB_DIR', { sessionId: fromJobDir });
+    options.onResolutionSource?.({ source: 'jobdir', sessionId: fromJobDir });
     return fromJobDir;
   }
 
-  // Synchronous attempts before we wait — common case is a breadcrumb is
-  // already on disk because the user already typed at least one message.
-  // PPID lookup is precise and tried first; cwd is only a fallback.
+  // Synchronous attempt before we wait — common case is the ppid breadcrumb
+  // is already on disk because the user already typed at least one message.
+  // The cwd breadcrumb is NOT checked synchronously here: unlike the ppid
+  // breadcrumb (written per-process, no cross-session collision), a cwd
+  // breadcrumb can already exist at t=0 as a stale leftover from an
+  // unrelated prior session that ran in the same directory. Trusting it
+  // immediately would let that stale value win a race against THIS
+  // process's own ppid breadcrumb, which may simply not have been written
+  // yet. Routing cwd through the poll loop below — where ppid is always
+  // checked first, every tick — gives the precise signal a real chance
+  // before falling back to the collision-prone one.
   const immediate = resolveFromBreadcrumb(storagePath, ppid);
   if (immediate) {
     logger.info('Resolved session_id from breadcrumb (immediate)', { sessionId: immediate });
+    options.onResolutionSource?.({ source: 'ppid', sessionId: immediate });
     return immediate;
-  }
-  const immediateCwd = resolveFromCwd(storagePath, cwd);
-  if (immediateCwd) {
-    logger.info('Resolved session_id from cwd breadcrumb (ppid fallback, immediate)', {
-      sessionId: immediateCwd,
-    });
-    return immediateCwd;
   }
 
   const startTime = Date.now();
@@ -228,6 +242,7 @@ export async function resolveSessionId(
       if (sid) {
         const elapsed = Date.now() - startTime;
         logger.info('Resolved session_id from breadcrumb', { sessionId: sid, elapsedMs: elapsed });
+        options.onResolutionSource?.({ source: 'ppid', sessionId: sid });
         if (options.signal) options.signal.removeEventListener('abort', onAbort);
         resolvePromise(sid);
         return;
@@ -239,6 +254,7 @@ export async function resolveSessionId(
           sessionId: sidFromCwd,
           elapsedMs: elapsed,
         });
+        options.onResolutionSource?.({ source: 'cwd', sessionId: sidFromCwd });
         if (options.signal) options.signal.removeEventListener('abort', onAbort);
         resolvePromise(sidFromCwd);
         return;
@@ -255,6 +271,63 @@ export async function resolveSessionId(
       // Don't keep the event loop alive on this timer alone — Ctrl+C / stdin
       // close should be able to terminate the MCP without explicitly
       // cancelling resolution.
+      handle.unref?.();
+    };
+
+    const delay = nextDelayMs(attempt++);
+    const handle = setTimeout(tick, delay);
+    handle.unref?.();
+  });
+}
+
+/**
+ * Keep watching the PPID breadcrumb only (never cwd, never CLAUDE_JOB_DIR) —
+ * used as a corrective safety net after an initial resolution came from the
+ * cwd fallback. Same exponential-backoff schedule as resolveSessionId
+ * (reuses nextDelayMs). Resolves on the first valid ppid hit; never resolves
+ * null. The caller decides whether the resolved id differs from what's
+ * already adopted and is worth acting on — this function doesn't know or
+ * care. No 60s WARN log: a cwd-sourced session working fine while the ppid
+ * breadcrumb stays silent is expected, not alarming.
+ */
+export async function watchPpidBreadcrumb(
+  options: SessionResolverOptions & { signal?: AbortSignal } = {},
+): Promise<string> {
+  const ppid = options.ppid ?? process.ppid;
+  const storagePath = options.storagePath ?? DEFAULT_STORAGE_DIR;
+
+  let attempt = 0;
+
+  return new Promise<string>((resolvePromise, rejectPromise) => {
+    const onAbort = () => {
+      rejectPromise(new Error('session resolution aborted'));
+    };
+    if (options.signal) {
+      if (options.signal.aborted) {
+        onAbort();
+        return;
+      }
+      options.signal.addEventListener('abort', onAbort, { once: true });
+      if (options.signal.aborted) {
+        onAbort();
+        return;
+      }
+    }
+
+    const tick = () => {
+      if (options.signal?.aborted) {
+        options.signal.removeEventListener('abort', onAbort);
+        return;
+      }
+      const sid = resolveFromBreadcrumb(storagePath, ppid);
+      if (sid) {
+        logger.debug('Resolved corrected session_id from ppid breadcrumb', { sessionId: sid });
+        if (options.signal) options.signal.removeEventListener('abort', onAbort);
+        resolvePromise(sid);
+        return;
+      }
+      const delay = nextDelayMs(attempt++);
+      const handle = setTimeout(tick, delay);
       handle.unref?.();
     };
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -871,6 +871,89 @@ describe('stdio integration', () => {
     }
   }, 30000);
 
+  it('self-corrects a synchronously-resolved cwd session id once the real PPID breadcrumb appears', async () => {
+    // A stale cwd breadcrumb (leftover from an unrelated prior session in
+    // the same directory) can win the synchronous resolution race at
+    // startup; it must self-correct once the real, precise ppid breadcrumb
+    // shows up moments later.
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+    const binPath = resolve(__dirname, '..', 'dist', 'index.js');
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-cwd-correction-storage-'));
+    const tmpProjectCwd = mkdtempSync(join(tmpdir(), 'nr-cwd-correction-project-'));
+    const realProjectCwd = realpathSync(tmpProjectCwd);
+
+    // Pre-write only a cwd breadcrumb — deliberately a value that looks
+    // like it belongs to a different, unrelated session — and no
+    // CLAUDE_JOB_DIR or ppid breadcrumb, so only the synchronous cwd
+    // fallback can resolve at startup.
+    const cwdBreadcrumbDir = resolve(tmpStoragePath, 'session-by-cwd');
+    mkdirSync(cwdBreadcrumbDir, { recursive: true });
+    const sanitizedCwd = realProjectCwd.replace(/[\\/:]/g, '-');
+    writeFileSync(resolve(cwdBreadcrumbDir, `${sanitizedCwd}.txt`), 'stale-cwd-session-id');
+
+    const env = { ...process.env };
+    delete env.CLAUDE_JOB_DIR;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [binPath, '--stdio'],
+      cwd: tmpProjectCwd,
+      env: {
+        ...env,
+        NR_AI_DASHBOARD_PORT: '0',
+        NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
+      },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+
+      // Full tool set immediately — confirms this is the synchronous cwd
+      // entry point (isProvisional === false), not the pending/async one.
+      const tools = await client.listTools();
+      expect(tools.tools.map((t) => t.name)).toContain('nr_observe_get_session_stats');
+
+      const readSessionId = async (): Promise<string> => {
+        const result = await client.callTool({
+          name: 'nr_observe_get_session_stats',
+          arguments: {},
+        });
+        const content = result.content as Array<{ type: string; text: string }>;
+        const text = content[0]?.text ?? '{}';
+        return (JSON.parse(text) as { session_id: string }).session_id;
+      };
+
+      // Confirms the stale cwd value really was adopted before correction.
+      expect(await readSessionId()).toBe('stale-cwd-session-id');
+
+      // The spawned child sees this test process as its ppid, matching
+      // resolveSessionId()'s default `options.ppid ?? process.ppid` inside
+      // the child — same convention as the existing pending-tools test.
+      const ppidBreadcrumbDir = resolve(tmpStoragePath, 'session-by-ppid');
+      mkdirSync(ppidBreadcrumbDir, { recursive: true });
+      writeFileSync(resolve(ppidBreadcrumbDir, `${process.pid}.txt`), 'corrected-ppid-session-id');
+
+      let corrected = false;
+      for (let i = 0; i < 20; i++) {
+        if ((await readSessionId()) === 'corrected-ppid-session-id') {
+          corrected = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      expect(corrected).toBe(true);
+
+      await client.close();
+    } finally {
+      rmSync(tmpStoragePath, { recursive: true, force: true });
+      rmSync(tmpProjectCwd, { recursive: true, force: true });
+    }
+  }, 30000);
+
   it('serves the pending tool set immediately when session_id cannot resolve synchronously, then swaps to the full set once the breadcrumb resolves', async () => {
     const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
     const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
@@ -932,6 +1015,96 @@ describe('stdio integration', () => {
       await client.close();
     } finally {
       rmSync(tmpStoragePath, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('self-corrects when the pending path resolves via the cwd fallback and a differing PPID breadcrumb appears later', async () => {
+    // The pending -> async poller flow (not the eager synchronous one) can
+    // also resolve via cwd instead of ppid. Mirrors the provisional-path
+    // test above, but supplies only a cwd breadcrumb first — the poller can
+    // only resolve via the fallback — then a *different* ppid breadcrumb
+    // later, and expects a correction.
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+    const binPath = resolve(__dirname, '..', 'dist', 'index.js');
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-pending-cwd-correction-storage-'));
+    const tmpProjectCwd = mkdtempSync(join(tmpdir(), 'nr-pending-cwd-correction-project-'));
+    const realProjectCwd = realpathSync(tmpProjectCwd);
+
+    const env = { ...process.env };
+    delete env.CLAUDE_JOB_DIR;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [binPath, '--stdio'],
+      cwd: tmpProjectCwd,
+      env: {
+        ...env,
+        NR_AI_DASHBOARD_PORT: '0',
+        NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
+      },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+
+      // Neither CLAUDE_JOB_DIR nor any breadcrumb exists yet — the pending
+      // tool set is served immediately (isProvisional === true).
+      const pendingTools = await client.listTools();
+      expect(pendingTools.tools.map((t) => t.name)).not.toContain('nr_observe_get_session_stats');
+
+      const readSessionId = async (): Promise<string | null> => {
+        const tools = await client.listTools();
+        if (!tools.tools.map((t) => t.name).includes('nr_observe_get_session_stats')) return null;
+        const result = await client.callTool({
+          name: 'nr_observe_get_session_stats',
+          arguments: {},
+        });
+        const content = result.content as Array<{ type: string; text: string }>;
+        const text = content[0]?.text ?? '{}';
+        return (JSON.parse(text) as { session_id: string }).session_id;
+      };
+
+      // Supply only the cwd breadcrumb — the poller's ppid check keeps
+      // missing, so it must fall back to this.
+      const cwdBreadcrumbDir = resolve(tmpStoragePath, 'session-by-cwd');
+      mkdirSync(cwdBreadcrumbDir, { recursive: true });
+      const sanitizedCwd = realProjectCwd.replace(/[\\/:]/g, '-');
+      writeFileSync(resolve(cwdBreadcrumbDir, `${sanitizedCwd}.txt`), 'stale-cwd-via-pending');
+
+      let sawStale = false;
+      for (let i = 0; i < 20; i++) {
+        if ((await readSessionId()) === 'stale-cwd-via-pending') {
+          sawStale = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      expect(sawStale).toBe(true);
+
+      // Now supply a *different* ppid breadcrumb — the correction watch
+      // should pick it up and re-adopt.
+      const ppidBreadcrumbDir = resolve(tmpStoragePath, 'session-by-ppid');
+      mkdirSync(ppidBreadcrumbDir, { recursive: true });
+      writeFileSync(resolve(ppidBreadcrumbDir, `${process.pid}.txt`), 'corrected-ppid-via-pending');
+
+      let corrected = false;
+      for (let i = 0; i < 20; i++) {
+        if ((await readSessionId()) === 'corrected-ppid-via-pending') {
+          corrected = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      expect(corrected).toBe(true);
+
+      await client.close();
+    } finally {
+      rmSync(tmpStoragePath, { recursive: true, force: true });
+      rmSync(tmpProjectCwd, { recursive: true, force: true });
     }
   }, 30000);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ import {
   resolveFromBreadcrumb,
   resolveFromCwd,
   isSyntheticSessionId,
+  watchPpidBreadcrumb,
 } from './hooks/session-resolver.js';
 import { initMcpTracer } from './tracing/mcp-tracer.js';
 import { SessionSpan } from './tracing/session-span.js';
@@ -678,6 +679,10 @@ async function main(): Promise<void> {
   // Aborts the async resolveSessionId polling loop when shutdown fires so
   // the breadcrumb poll does not outlive the process.
   let sessionResolutionAbort: AbortController | undefined;
+  // Aborts the background watchPpidBreadcrumb() correction watch (armed
+  // only when the initial resolution came from the collision-prone cwd
+  // fallback — see resolvedViaCwdOnly) when shutdown fires.
+  let ppidCorrectionAbort: AbortController | undefined;
 
   let shuttingDown = false;
   const shutdown = async () => {
@@ -686,6 +691,7 @@ async function main(): Promise<void> {
     // Abort any in-progress session resolution so its polling loop exits
     // cleanly rather than continuing after process.exit() is called.
     sessionResolutionAbort?.abort();
+    ppidCorrectionAbort?.abort();
     logger.info('Shutting down...');
     try {
       persistSession?.();
@@ -759,6 +765,14 @@ async function main(): Promise<void> {
 
   if (options.stdio || options.local) {
     let sessionTraceId: string;
+    // True when the synchronous resolution chain below succeeded ONLY via
+    // the cwd fallback — the collision-prone source (shared by every
+    // session that ever ran in this directory), unlike the ppid breadcrumb
+    // (precise, keyed to this MCP's own parent process). Set inside the
+    // `options.stdio` branch below; read much later, after the eager
+    // synchronous setup completes, to decide whether to arm a background
+    // correction watch (see `startPpidCorrectionWatch` below).
+    let resolvedViaCwdOnly = false;
     if (options.stdio) {
       // Connect stdio FIRST so the MCP handshake can complete immediately.
       // Tools are registered after initialization; tool calls before that
@@ -786,10 +800,12 @@ async function main(): Promise<void> {
         process.exit(0);
       }
 
-      const synchronouslyResolved =
-        resolveFromJobDir(process.env.CLAUDE_JOB_DIR ?? null) ??
-        resolveFromBreadcrumb(config.storagePath, process.ppid) ??
-        resolveFromCwd(config.storagePath, process.cwd());
+      const fromJobDir = resolveFromJobDir(process.env.CLAUDE_JOB_DIR ?? null);
+      const fromPpid = fromJobDir ? null : resolveFromBreadcrumb(config.storagePath, process.ppid);
+      const fromCwd =
+        fromJobDir || fromPpid ? null : resolveFromCwd(config.storagePath, process.cwd());
+      const synchronouslyResolved = fromJobDir ?? fromPpid ?? fromCwd;
+      resolvedViaCwdOnly = !!fromCwd && !fromJobDir && !fromPpid;
       if (synchronouslyResolved) {
         sessionTraceId = synchronouslyResolved;
         logger.info('Session ID resolved synchronously', { sessionTraceId });
@@ -2054,6 +2070,186 @@ async function main(): Promise<void> {
       startWatchers(realSessionId);
     };
 
+    // Adopts `realId` as the live session id: swaps LocalStore, hot-swaps
+    // the event processor's store, replaces the session span/task-span-
+    // tracker, (re)constructs NrIngestManager, repoints the watchers, and
+    // re-registers the full tool set. Used both for the initial pending ->
+    // real transition and for a later correction (see
+    // startPpidCorrectionWatch below) — safe to call more than once:
+    // accumulated tracker metrics are preserved (adoptSessionId() only
+    // reassigns the id field), and any already-live NrIngestManager is
+    // stopped first so its harvest interval never leaks on a second call.
+    const adoptRealSessionId = async (realId: string): Promise<void> => {
+      sessionTraceId = realId;
+      sessionTracker!.adoptSessionId(realId);
+
+      // Replace the current LocalStore with one scoped to the real id.
+      const realLocalStore = new LocalStore(config!.storagePath, realId);
+      realLocalStore.initialize();
+      realLocalStore.writeHeartbeat();
+      localStoreForShutdown = realLocalStore;
+      try {
+        realLocalStore.migrateLegacyBuffer();
+      } catch (err) {
+        logger.warn('Legacy buffer migration failed (continuing)', { error: String(err) });
+      }
+
+      // Hot-swap the event processor to the scoped store so it only drains
+      // this session's events going forward.
+      eventProcessor!.replaceStore(realLocalStore, false);
+
+      // Replace the span with a real-ID span. End the previous one first
+      // (end() is a no-op if never started).
+      if (config!.otlp.transport !== 'nr-events-api') {
+        sessionSpan?.end(0, 0);
+        taskSpanTracker?.closeAll();
+        const detectedPlatform = createDefaultRegistry().getActive().platformName;
+        sessionSpan = new SessionSpan(realId, config!.developer, detectedPlatform);
+        taskSpanTracker = new TaskSpanTracker();
+        sessionSpan.start();
+      }
+
+      // Stop whatever NrIngestManager is already live before replacing it —
+      // load-bearing on a second (correction) call; a no-op the first time,
+      // since nrIngest is still undefined then.
+      if (nrIngest) {
+        await nrIngest.stop().catch((err) => {
+          logger.warn('Failed to stop previous NrIngestManager during session id correction', {
+            error: String(err),
+          });
+        });
+      }
+
+      if (config!.mode !== 'local') {
+        if (!config!.licenseKey || !config!.accountId) {
+          throw new Error(
+            'licenseKey and accountId must be defined for non-local mode. ' +
+              'This should have been caught by config validation.',
+          );
+        }
+        nrIngest = new NrIngestManager({
+          licenseKey: config!.licenseKey,
+          transportOptions: {
+            accountId: config!.accountId,
+            collectorHost: config!.collectorHost,
+          },
+          developer: config!.developer,
+          appName: config!.appName,
+          teamId: config!.teamId,
+          projectId: config!.projectId,
+          orgId: config!.orgId,
+          sessionTracker: sessionTracker!,
+          localStore: realLocalStore,
+          auditTrail,
+          eventHarvestIntervalMs: config!.harvestIntervalMs.events,
+          metricHarvestIntervalMs: config!.harvestIntervalMs.metrics,
+          costTracker,
+          efficiencyScorer,
+          feedbackCollector,
+          turnCostAttributor,
+          sessionTraceId: realId,
+        });
+        capturedNrIngest = nrIngest;
+        nrIngest.start();
+      }
+
+      // Re-point the subagent/workflow watchers to the real session id. See
+      // repointWatchersToRealSession's own comment above for why this is
+      // necessary; a no-op if no watcher actually started.
+      repointWatchersToRealSession(realId);
+
+      // (Re-)register the full tool set — the second (correction) call
+      // replaces the closures registered by the first, so every tool
+      // handler observes the corrected sessionTraceId/nrIngestManager going
+      // forward.
+      const configFilePath = options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
+      const configSummary: ConfigSummary = {
+        mode: config!.mode,
+        developer: config!.developer,
+        accountId: config!.accountId ?? null,
+        licenseKeyMasked: config!.licenseKey ? maskCredential(config!.licenseKey) : null,
+        nrApiKeyMasked: config!.nrApiKey ? maskCredential(config!.nrApiKey) : null,
+        region: config!.collectorHost ?? 'us',
+        storagePath: config!.storagePath,
+        dashboardUrl: `http://${config!.dashboard.host}:${config!.dashboard.port}`,
+        configFilePath,
+      };
+      registerTools(mcpServer!.server, {
+        sessionTracker: sessionTracker!,
+        costTracker,
+        budgetTracker,
+        taskDetector: taskDetector!,
+        antiPatternDetector,
+        efficiencyScorer,
+        feedbackCollector,
+        sessionStore,
+        weeklySummaryGenerator,
+        trendAnalyzer,
+        collaborationProfiler,
+        claudeMdTracker,
+        costPerOutcomeAnalyzer,
+        recommendationEngine,
+        contextWindowTracker,
+        contextTracker,
+        latencyTracker,
+        taskCompletionTracker,
+        modelUsageTracker,
+        retryDetector,
+        contextCompositionTracker,
+        latencyDecompositionTracker,
+        decisionTracker,
+        instructionDriftTracker,
+        toolSelectionScorer,
+        toolCallBuffer: toolCallBufferAccessor,
+        qualityProxyTracker,
+        apiFailureTracker,
+        turnCostAttributor,
+        turnTracker,
+        gitEfficiencyTracker,
+        genericMcpAdapter,
+        nrIngestManager: nrIngest,
+        sessionTraceId: realId,
+        sessionStartMs,
+        accountId: config!.accountId,
+        teamId: config!.teamId,
+        projectId: config!.projectId,
+        developer: config!.developer,
+        nrApiKey: config!.nrApiKey,
+        collectorHost: config!.collectorHost,
+        configFilePath,
+        configSummary,
+      });
+    };
+
+    // Arms a background watch for the ppid breadcrumb after an initial
+    // resolution came from the collision-prone cwd fallback (see
+    // resolvedViaCwdOnly). If/when the ppid breadcrumb later reports a
+    // DIFFERENT, more precise session id, corrects the adoption via the
+    // same adoptRealSessionId() used for the pending -> real transition.
+    // A no-op-forever if the ppid breadcrumb never appears or always
+    // matches — never trusts cwd itself, so it can't be fooled twice.
+    const startPpidCorrectionWatch = (staleId: string): void => {
+      ppidCorrectionAbort = new AbortController();
+      void watchPpidBreadcrumb({
+        storagePath: config!.storagePath,
+        signal: ppidCorrectionAbort.signal,
+      })
+        .then(async (ppidId) => {
+          if (ppidCorrectionAbort?.signal.aborted) return;
+          if (ppidId === staleId) return;
+          logger.info('Correcting cwd-sourced session id from PPID breadcrumb', {
+            staleId,
+            correctedId: ppidId,
+          });
+          await adoptRealSessionId(ppidId);
+        })
+        .catch((err) => {
+          if (!ppidCorrectionAbort?.signal.aborted) {
+            logger.warn('PPID correction watch failed', { error: String(err) });
+          }
+        });
+    };
+
     startWatchers(sessionTraceId);
 
     if (options.stdio) {
@@ -2085,11 +2281,15 @@ async function main(): Promise<void> {
         logger.info('Dashboard started early; awaiting session_id resolution (breadcrumb poll)');
 
         sessionResolutionAbort = new AbortController();
+        let resolvedSource: import('./hooks/session-resolver.js').SessionIdSource | undefined;
         void (async () => {
           try {
             const realId = await resolveSessionId({
               storagePath: config!.storagePath,
               signal: sessionResolutionAbort!.signal,
+              onResolutionSource: (info) => {
+                resolvedSource = info.source;
+              },
             });
 
             // Guard against a shutdown that fired while we were awaiting —
@@ -2100,148 +2300,21 @@ async function main(): Promise<void> {
               return;
             }
 
-            // Adopt the real session ID without clearing accumulated metrics.
-            sessionTraceId = realId;
-            sessionTracker!.adoptSessionId(realId);
-
-            // Replace the provisional unscoped LocalStore with the session-scoped one.
-            const realLocalStore = new LocalStore(config!.storagePath, realId);
-            realLocalStore.initialize();
-            realLocalStore.writeHeartbeat();
-            localStoreForShutdown = realLocalStore;
-            try {
-              realLocalStore.migrateLegacyBuffer();
-            } catch (err) {
-              logger.warn('Legacy buffer migration failed (continuing)', { error: String(err) });
-            }
-
-            // Hot-swap the event processor to the scoped store so it only
-            // drains this session's events going forward.
-            eventProcessor!.replaceStore(realLocalStore, false);
-
-            // Replace the provisional span with a real-ID span. End the
-            // provisional one first (end() is a no-op if never started).
-            // initMcpTracer() was already called in Phase A — skip it here.
-            if (config!.otlp.transport !== 'nr-events-api') {
-              sessionSpan?.end(0, 0);
-              // Close any task spans opened against the provisional tracker
-              // (cross-session events can open them during Phase A) before
-              // replacing it with a clean real-session instance.
-              taskSpanTracker?.closeAll();
-              const detectedPlatform = createDefaultRegistry().getActive().platformName;
-              sessionSpan = new SessionSpan(realId, config!.developer, detectedPlatform);
-              taskSpanTracker = new TaskSpanTracker();
-              sessionSpan.start();
-            }
-
-            // Complete NrIngest setup.
-            if (config!.mode !== 'local') {
-              if (!config!.licenseKey || !config!.accountId) {
-                throw new Error(
-                  'licenseKey and accountId must be defined for non-local mode. ' +
-                    'This should have been caught by config validation.',
-                );
-              }
-              nrIngest = new NrIngestManager({
-                licenseKey: config!.licenseKey,
-                transportOptions: {
-                  accountId: config!.accountId,
-                  collectorHost: config!.collectorHost,
-                },
-                developer: config!.developer,
-                appName: config!.appName,
-                teamId: config!.teamId,
-                projectId: config!.projectId,
-                orgId: config!.orgId,
-                sessionTracker: sessionTracker!,
-                localStore: realLocalStore,
-                auditTrail,
-                eventHarvestIntervalMs: config!.harvestIntervalMs.events,
-                metricHarvestIntervalMs: config!.harvestIntervalMs.metrics,
-                costTracker,
-                efficiencyScorer,
-                feedbackCollector,
-                turnCostAttributor,
-                sessionTraceId: realId,
-              });
-              capturedNrIngest = nrIngest;
-              nrIngest.start();
-            }
-
-            // Re-point the subagent/workflow watchers from the provisional
-            // `pending-<ts>` id to the resolved real session id. The watchers
-            // were constructed in the startup block with the provisional id and
-            // filter discovered transcript dirs by it; a `pending-*` id never
-            // matches a real UUID session dir, so without this re-point they
-            // capture nothing for the life of the process. Done after the
-            // NrIngest reassignment above so the rebuilt WorkflowWatcher's
-            // onRun/onHealth closures observe the live `capturedNrIngest`.
-            // Guarded inside repoint: only watchers that were actually started
-            // are stopped + reconstructed; if none ran this is a no-op.
-            repointWatchersToRealSession(realId);
-
-            // Register full tools, replacing the pending handlers.
-            const configFilePath = options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
-            const configSummary: ConfigSummary = {
-              mode: config!.mode,
-              developer: config!.developer,
-              accountId: config!.accountId ?? null,
-              licenseKeyMasked: config!.licenseKey ? maskCredential(config!.licenseKey) : null,
-              nrApiKeyMasked: config!.nrApiKey ? maskCredential(config!.nrApiKey) : null,
-              region: config!.collectorHost ?? 'us',
-              storagePath: config!.storagePath,
-              dashboardUrl: `http://${config!.dashboard.host}:${config!.dashboard.port}`,
-              configFilePath,
-            };
-            registerTools(mcpServer!.server, {
-              sessionTracker: sessionTracker!,
-              costTracker,
-              budgetTracker,
-              taskDetector: taskDetector!,
-              antiPatternDetector,
-              efficiencyScorer,
-              feedbackCollector,
-              sessionStore,
-              weeklySummaryGenerator,
-              trendAnalyzer,
-              collaborationProfiler,
-              claudeMdTracker,
-              costPerOutcomeAnalyzer,
-              recommendationEngine,
-              contextWindowTracker,
-              contextTracker,
-              latencyTracker,
-              taskCompletionTracker,
-              modelUsageTracker,
-              retryDetector,
-              contextCompositionTracker,
-              latencyDecompositionTracker,
-              decisionTracker,
-              instructionDriftTracker,
-              toolSelectionScorer,
-              toolCallBuffer: toolCallBufferAccessor,
-              qualityProxyTracker,
-              apiFailureTracker,
-              turnCostAttributor,
-              turnTracker,
-              gitEfficiencyTracker,
-              genericMcpAdapter,
-              nrIngestManager: nrIngest,
-              sessionTraceId: realId,
-              sessionStartMs,
-              accountId: config!.accountId,
-              teamId: config!.teamId,
-              projectId: config!.projectId,
-              developer: config!.developer,
-              nrApiKey: config!.nrApiKey,
-              collectorHost: config!.collectorHost,
-              configFilePath,
-              configSummary,
-            });
+            // Adopt the real session ID without clearing accumulated
+            // metrics — see adoptRealSessionId's own comment above.
+            await adoptRealSessionId(realId);
 
             logger.info('Session ID resolved, full initialization complete', {
               sessionTraceId: realId,
             });
+
+            // The ppid breadcrumb is precise (no cross-session collision);
+            // the cwd fallback is not, since it's shared by every session
+            // that ever ran in this directory. Only a cwd-sourced
+            // resolution needs the background correction watch.
+            if (resolvedSource === 'cwd') {
+              startPpidCorrectionWatch(realId);
+            }
           } catch (err) {
             // Use the signal's own aborted flag rather than matching the error
             // message string — robust against future changes to the throw site.
@@ -2317,6 +2390,15 @@ async function main(): Promise<void> {
         logger.info('Server running on stdio transport');
         // stdin 'end' and 'error' handlers are registered immediately after
         // connectStdio() above so shutdown fires even during session-ID resolution.
+
+        // resolvedViaCwdOnly means the eager setup above adopted a session
+        // id from the collision-prone cwd fallback (see its declaration).
+        // Arm the same background correction watch used on the pending
+        // path — this eager path otherwise has no correction mechanism at
+        // all once initialization completes.
+        if (resolvedViaCwdOnly) {
+          startPpidCorrectionWatch(sessionTraceId);
+        }
       }
     } else {
       logger.info('Server running in local dashboard mode (Ctrl+C to stop)');


### PR DESCRIPTION
Fixes #340

## Summary
- A `--stdio` MCP process could permanently adopt the wrong session identity when startup resolution fell back to the cwd-keyed breadcrumb before the precise PPID-keyed one was available — the cwd breadcrumb is shared by every session that has ever run in that directory, so a stale value from an unrelated prior session could win the race with no way to self-correct.
- `resolveSessionId()` now reports which source resolved it, and a new `watchPpidBreadcrumb()` keeps watching in the background whenever the initial resolution came from the cwd fallback.
- Extracted the existing pending→real adoption logic into a reusable `adoptRealSessionId()` (now safe to call a second time — stops any already-live `NrIngestManager` first) and wired the background watch from both entry points that can resolve via cwd: the synchronous startup path and the async pending-poller path.
- Accumulated metrics survive the correction; only the metrics-carrying identity changes.
- Version bump to 1.14.21 + CHANGELOG entry.

## Test plan
- [x] New unit tests in `src/hooks/session-resolver.test.ts`: `onResolutionSource` reporting for all three sources, `watchPpidBreadcrumb()` (resolves on ppid, never trusts cwd, aborts via signal), and a regression test for the race itself
- [x] New spawned-process integration tests in `src/index.test.ts` covering both trigger sites (synchronous cwd resolution, and pending→async-poller cwd resolution), each confirming the stale id is corrected once a differing PPID breadcrumb appears and metrics survive
- [x] `npm run build && npm test && npm run lint && npm run format:check` all clean
