### PR TITLE
Fix: stop stale cwd-fallback session ids from contaminating persisted data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.22] - 2026-08-01
+
+### Fixed
+
+- **A `--stdio` MCP process that briefly adopted a stale, cwd-fallback-resolved session identity before self-correcting (see 1.14.21) could still leave lasting damage from that brief window** — if the periodic 30-second checkpoint fired before the real PPID-derived identity was confirmed, it wrote a real, non-synthetic, zero-activity session file to disk under the stale identity, orphaning it; separately, any cost/token data backfilled from an unrelated old session under that stale identity rode along uncorrected into the real session's own totals once corrected, since the correction only relabeled the tracker in place. Checkpointing is now suppressed for as long as a session's identity is unconfirmed (capped at two minutes so a session that never gets a PPID breadcrumb doesn't lose checkpointing indefinitely), and a real correction now resets the affected cost/token trackers before continuing so nothing from the wrong identity carries forward.
+
 ## [1.14.21] - 2026-08-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.21",
+  "version": "1.14.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.21",
+      "version": "1.14.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.21",
+  "version": "1.14.22",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,6 +5,7 @@ import {
   writeFileSync,
   rmSync,
   existsSync,
+  readdirSync,
   utimesSync,
   realpathSync,
 } from 'node:fs';
@@ -19,6 +20,10 @@ import {
   setupDashboardPostBind,
   getDashboardRepollIntervalMs,
   DEFAULT_DASHBOARD_REPOLL_MS,
+  getSessionPersistIntervalMs,
+  DEFAULT_SESSION_PERSIST_INTERVAL_MS,
+  getPendingConfirmationCapMs,
+  DEFAULT_PENDING_CONFIRMATION_CAP_MS,
   startRetentionSweep,
   startMaintenanceGc,
 } from './index.js';
@@ -398,6 +403,70 @@ describe('getDashboardRepollIntervalMs()', () => {
     expect(getDashboardRepollIntervalMs()).toBe(DEFAULT_DASHBOARD_REPOLL_MS);
     process.env.NR_AI_DASHBOARD_REPOLL_MS = '-100';
     expect(getDashboardRepollIntervalMs()).toBe(DEFAULT_DASHBOARD_REPOLL_MS);
+  });
+});
+
+describe('getSessionPersistIntervalMs()', () => {
+  const ORIGINAL = process.env.NR_AI_SESSION_PERSIST_INTERVAL_MS;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.NR_AI_SESSION_PERSIST_INTERVAL_MS;
+    } else {
+      process.env.NR_AI_SESSION_PERSIST_INTERVAL_MS = ORIGINAL;
+    }
+  });
+
+  it('returns DEFAULT_SESSION_PERSIST_INTERVAL_MS (30s) when env is unset', () => {
+    delete process.env.NR_AI_SESSION_PERSIST_INTERVAL_MS;
+    expect(getSessionPersistIntervalMs()).toBe(DEFAULT_SESSION_PERSIST_INTERVAL_MS);
+    expect(DEFAULT_SESSION_PERSIST_INTERVAL_MS).toBe(30_000);
+  });
+
+  it('parses a numeric override from NR_AI_SESSION_PERSIST_INTERVAL_MS', () => {
+    process.env.NR_AI_SESSION_PERSIST_INTERVAL_MS = '50';
+    expect(getSessionPersistIntervalMs()).toBe(50);
+  });
+
+  it('falls back to default for non-numeric / non-positive overrides', () => {
+    process.env.NR_AI_SESSION_PERSIST_INTERVAL_MS = 'abc';
+    expect(getSessionPersistIntervalMs()).toBe(DEFAULT_SESSION_PERSIST_INTERVAL_MS);
+    process.env.NR_AI_SESSION_PERSIST_INTERVAL_MS = '0';
+    expect(getSessionPersistIntervalMs()).toBe(DEFAULT_SESSION_PERSIST_INTERVAL_MS);
+    process.env.NR_AI_SESSION_PERSIST_INTERVAL_MS = '-100';
+    expect(getSessionPersistIntervalMs()).toBe(DEFAULT_SESSION_PERSIST_INTERVAL_MS);
+  });
+});
+
+describe('getPendingConfirmationCapMs()', () => {
+  const ORIGINAL = process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS;
+    } else {
+      process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS = ORIGINAL;
+    }
+  });
+
+  it('returns DEFAULT_PENDING_CONFIRMATION_CAP_MS (2 minutes) when env is unset', () => {
+    delete process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS;
+    expect(getPendingConfirmationCapMs()).toBe(DEFAULT_PENDING_CONFIRMATION_CAP_MS);
+    expect(DEFAULT_PENDING_CONFIRMATION_CAP_MS).toBe(120_000);
+  });
+
+  it('parses a numeric override from NR_AI_PENDING_CONFIRMATION_CAP_MS', () => {
+    process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS = '50';
+    expect(getPendingConfirmationCapMs()).toBe(50);
+  });
+
+  it('falls back to default for non-numeric / non-positive overrides', () => {
+    process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS = 'abc';
+    expect(getPendingConfirmationCapMs()).toBe(DEFAULT_PENDING_CONFIRMATION_CAP_MS);
+    process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS = '0';
+    expect(getPendingConfirmationCapMs()).toBe(DEFAULT_PENDING_CONFIRMATION_CAP_MS);
+    process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS = '-100';
+    expect(getPendingConfirmationCapMs()).toBe(DEFAULT_PENDING_CONFIRMATION_CAP_MS);
   });
 });
 
@@ -1102,6 +1171,403 @@ describe('stdio integration', () => {
       expect(corrected).toBe(true);
 
       await client.close();
+    } finally {
+      rmSync(tmpStoragePath, { recursive: true, force: true });
+      rmSync(tmpProjectCwd, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('suppresses the periodic checkpoint while a cwd-resolved session id is unconfirmed', async () => {
+    // No ppid breadcrumb is ever supplied in this test, so the session stays
+    // in the "pending confirmation" state for its whole lifetime — proving
+    // the periodic checkpoint interval skips writing under the stale id.
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+    const binPath = resolve(__dirname, '..', 'dist', 'index.js');
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-pending-suppress-storage-'));
+    const tmpProjectCwd = mkdtempSync(join(tmpdir(), 'nr-pending-suppress-project-'));
+    const realProjectCwd = realpathSync(tmpProjectCwd);
+
+    const cwdBreadcrumbDir = resolve(tmpStoragePath, 'session-by-cwd');
+    mkdirSync(cwdBreadcrumbDir, { recursive: true });
+    const sanitizedCwd = realProjectCwd.replace(/[\\/:]/g, '-');
+    writeFileSync(resolve(cwdBreadcrumbDir, `${sanitizedCwd}.txt`), 'unconfirmed-cwd-session-id');
+
+    const env = { ...process.env };
+    delete env.CLAUDE_JOB_DIR;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [binPath, '--stdio'],
+      cwd: tmpProjectCwd,
+      env: {
+        ...env,
+        NR_AI_DASHBOARD_PORT: '0',
+        NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
+        NR_AI_SESSION_PERSIST_INTERVAL_MS: '200',
+      },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+      await client.listTools();
+
+      // Let several 200ms persist ticks elapse while unconfirmed.
+      await new Promise((r) => setTimeout(r, 900));
+
+      const sessionsDir = resolve(tmpStoragePath, 'sessions');
+      const files = existsSync(sessionsDir) ? readdirSync(sessionsDir) : [];
+      expect(files.some((f) => f.includes('unconfirmed-cwd-session-id'))).toBe(false);
+
+      await client.close();
+    } finally {
+      rmSync(tmpStoragePath, { recursive: true, force: true });
+      rmSync(tmpProjectCwd, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('resumes periodic checkpointing after the pending-confirmation cap elapses with no correction', async () => {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+    const binPath = resolve(__dirname, '..', 'dist', 'index.js');
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-cap-timeout-storage-'));
+    const tmpProjectCwd = mkdtempSync(join(tmpdir(), 'nr-cap-timeout-project-'));
+    const realProjectCwd = realpathSync(tmpProjectCwd);
+
+    const cwdBreadcrumbDir = resolve(tmpStoragePath, 'session-by-cwd');
+    mkdirSync(cwdBreadcrumbDir, { recursive: true });
+    const sanitizedCwd = realProjectCwd.replace(/[\\/:]/g, '-');
+    writeFileSync(resolve(cwdBreadcrumbDir, `${sanitizedCwd}.txt`), 'cap-timeout-session-id');
+
+    const env = { ...process.env };
+    delete env.CLAUDE_JOB_DIR;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [binPath, '--stdio'],
+      cwd: tmpProjectCwd,
+      env: {
+        ...env,
+        NR_AI_DASHBOARD_PORT: '0',
+        NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
+        NR_AI_SESSION_PERSIST_INTERVAL_MS: '200',
+        NR_AI_PENDING_CONFIRMATION_CAP_MS: '500',
+      },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+      await client.listTools();
+
+      const dateStr = new Date().toISOString().slice(0, 10);
+      const expectedFile = resolve(
+        tmpStoragePath,
+        'sessions',
+        `${dateStr}_cap-timeout-session-id.json`,
+      );
+
+      let appeared = false;
+      for (let i = 0; i < 20; i++) {
+        if (existsSync(expectedFile)) {
+          appeared = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      expect(appeared).toBe(true);
+
+      await client.close();
+    } finally {
+      rmSync(tmpStoragePath, { recursive: true, force: true });
+      rmSync(tmpProjectCwd, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('clears pending confirmation immediately when the PPID breadcrumb confirms the same id as the cwd guess', async () => {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+    const binPath = resolve(__dirname, '..', 'dist', 'index.js');
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-confirmed-same-storage-'));
+    const tmpProjectCwd = mkdtempSync(join(tmpdir(), 'nr-confirmed-same-project-'));
+    const realProjectCwd = realpathSync(tmpProjectCwd);
+
+    const cwdBreadcrumbDir = resolve(tmpStoragePath, 'session-by-cwd');
+    mkdirSync(cwdBreadcrumbDir, { recursive: true });
+    const sanitizedCwd = realProjectCwd.replace(/[\\/:]/g, '-');
+    writeFileSync(resolve(cwdBreadcrumbDir, `${sanitizedCwd}.txt`), 'confirmed-same-session-id');
+
+    const env = { ...process.env };
+    delete env.CLAUDE_JOB_DIR;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [binPath, '--stdio'],
+      cwd: tmpProjectCwd,
+      env: {
+        ...env,
+        NR_AI_DASHBOARD_PORT: '0',
+        NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
+        NR_AI_SESSION_PERSIST_INTERVAL_MS: '200',
+        // Deliberately left at the (2-minute) default: if pendingConfirmation
+        // only cleared via the cap, the checkpoint below could not appear
+        // within this test's short poll window.
+      },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+      await client.listTools();
+
+      // The spawned child sees this test process as its ppid — same
+      // convention as the existing correction tests.
+      const ppidBreadcrumbDir = resolve(tmpStoragePath, 'session-by-ppid');
+      mkdirSync(ppidBreadcrumbDir, { recursive: true });
+      writeFileSync(resolve(ppidBreadcrumbDir, `${process.pid}.txt`), 'confirmed-same-session-id');
+
+      const dateStr = new Date().toISOString().slice(0, 10);
+      const expectedFile = resolve(
+        tmpStoragePath,
+        'sessions',
+        `${dateStr}_confirmed-same-session-id.json`,
+      );
+
+      let appeared = false;
+      for (let i = 0; i < 20; i++) {
+        if (existsSync(expectedFile)) {
+          appeared = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      expect(appeared).toBe(true);
+
+      await client.close();
+    } finally {
+      rmSync(tmpStoragePath, { recursive: true, force: true });
+      rmSync(tmpProjectCwd, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('resets accumulated cost when the PPID breadcrumb corrects to a different session id', async () => {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+    const binPath = resolve(__dirname, '..', 'dist', 'index.js');
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-cost-reset-storage-'));
+    const tmpProjectCwd = mkdtempSync(join(tmpdir(), 'nr-cost-reset-project-'));
+    const realProjectCwd = realpathSync(tmpProjectCwd);
+
+    const cwdBreadcrumbDir = resolve(tmpStoragePath, 'session-by-cwd');
+    mkdirSync(cwdBreadcrumbDir, { recursive: true });
+    const sanitizedCwd = realProjectCwd.replace(/[\\/:]/g, '-');
+    writeFileSync(resolve(cwdBreadcrumbDir, `${sanitizedCwd}.txt`), 'stale-cost-session-id');
+
+    const env = { ...process.env };
+    delete env.CLAUDE_JOB_DIR;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [binPath, '--stdio'],
+      cwd: tmpProjectCwd,
+      env: {
+        ...env,
+        NR_AI_DASHBOARD_PORT: '0',
+        NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
+      },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+      await client.listTools();
+
+      // Simulate the wrong-identity backfill: while still on the stale cwd
+      // id, real cost gets recorded through the same shared CostTracker the
+      // parent-transcript watcher would feed.
+      await client.callTool({
+        name: 'nr_observe_report_tokens',
+        arguments: { input_tokens: 10000, output_tokens: 2000, model: 'claude-sonnet-5' },
+      });
+
+      const readTotalUsd = async (): Promise<number> => {
+        const result = await client.callTool({
+          name: 'nr_observe_get_cost_breakdown',
+          arguments: {},
+        });
+        const content = result.content as Array<{ type: string; text: string }>;
+        const text = content[0]?.text ?? '{}';
+        return (JSON.parse(text) as { total_usd: number }).total_usd;
+      };
+
+      expect(await readTotalUsd()).toBeGreaterThan(0);
+
+      // Now correct to a different ppid-derived id.
+      const ppidBreadcrumbDir = resolve(tmpStoragePath, 'session-by-ppid');
+      mkdirSync(ppidBreadcrumbDir, { recursive: true });
+      writeFileSync(resolve(ppidBreadcrumbDir, `${process.pid}.txt`), 'corrected-cost-session-id');
+
+      const readSessionId = async (): Promise<string> => {
+        const result = await client.callTool({
+          name: 'nr_observe_get_session_stats',
+          arguments: {},
+        });
+        const content = result.content as Array<{ type: string; text: string }>;
+        const text = content[0]?.text ?? '{}';
+        return (JSON.parse(text) as { session_id: string }).session_id;
+      };
+
+      let corrected = false;
+      for (let i = 0; i < 20; i++) {
+        if ((await readSessionId()) === 'corrected-cost-session-id') {
+          corrected = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      expect(corrected).toBe(true);
+      expect(await readTotalUsd()).toBe(0);
+
+      await client.close();
+    } finally {
+      rmSync(tmpStoragePath, { recursive: true, force: true });
+      rmSync(tmpProjectCwd, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('resumes checkpointing promptly after a real correction, not after the full pending-confirmation cap', async () => {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+    const binPath = resolve(__dirname, '..', 'dist', 'index.js');
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-correction-resume-storage-'));
+    const tmpProjectCwd = mkdtempSync(join(tmpdir(), 'nr-correction-resume-project-'));
+    const realProjectCwd = realpathSync(tmpProjectCwd);
+
+    const cwdBreadcrumbDir = resolve(tmpStoragePath, 'session-by-cwd');
+    mkdirSync(cwdBreadcrumbDir, { recursive: true });
+    const sanitizedCwd = realProjectCwd.replace(/[\\/:]/g, '-');
+    writeFileSync(resolve(cwdBreadcrumbDir, `${sanitizedCwd}.txt`), 'stale-resume-session-id');
+
+    const env = { ...process.env };
+    delete env.CLAUDE_JOB_DIR;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [binPath, '--stdio'],
+      cwd: tmpProjectCwd,
+      env: {
+        ...env,
+        NR_AI_DASHBOARD_PORT: '0',
+        NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
+        NR_AI_SESSION_PERSIST_INTERVAL_MS: '200',
+        // Left at the 2-minute default deliberately — see the sibling
+        // "confirmed same id" test's identical rationale.
+      },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+      await client.listTools();
+
+      const ppidBreadcrumbDir = resolve(tmpStoragePath, 'session-by-ppid');
+      mkdirSync(ppidBreadcrumbDir, { recursive: true });
+      writeFileSync(
+        resolve(ppidBreadcrumbDir, `${process.pid}.txt`),
+        'corrected-resume-session-id',
+      );
+
+      const dateStr = new Date().toISOString().slice(0, 10);
+      const expectedFile = resolve(
+        tmpStoragePath,
+        'sessions',
+        `${dateStr}_corrected-resume-session-id.json`,
+      );
+
+      let appeared = false;
+      for (let i = 0; i < 20; i++) {
+        if (existsSync(expectedFile)) {
+          appeared = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      expect(appeared).toBe(true);
+
+      await client.close();
+    } finally {
+      rmSync(tmpStoragePath, { recursive: true, force: true });
+      rmSync(tmpProjectCwd, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('still writes the terminal session save on shutdown even while pending confirmation', async () => {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+    const binPath = resolve(__dirname, '..', 'dist', 'index.js');
+    const tmpStoragePath = mkdtempSync(join(tmpdir(), 'nr-shutdown-pending-storage-'));
+    const tmpProjectCwd = mkdtempSync(join(tmpdir(), 'nr-shutdown-pending-project-'));
+    const realProjectCwd = realpathSync(tmpProjectCwd);
+
+    const cwdBreadcrumbDir = resolve(tmpStoragePath, 'session-by-cwd');
+    mkdirSync(cwdBreadcrumbDir, { recursive: true });
+    const sanitizedCwd = realProjectCwd.replace(/[\\/:]/g, '-');
+    writeFileSync(resolve(cwdBreadcrumbDir, `${sanitizedCwd}.txt`), 'shutdown-pending-session-id');
+
+    const env = { ...process.env };
+    delete env.CLAUDE_JOB_DIR;
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [binPath, '--stdio'],
+      cwd: tmpProjectCwd,
+      env: {
+        ...env,
+        NR_AI_DASHBOARD_PORT: '0',
+        NR_AI_MODE: 'local',
+        NEW_RELIC_AI_MCP_STORAGE_PATH: tmpStoragePath,
+        // No ppid breadcrumb is ever supplied, and the cap is left at its
+        // 2-minute default, so the session is still pendingConfirmation when
+        // we close the client below (which ends the child's stdin and
+        // triggers its shutdown handler).
+      },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+      await client.listTools();
+
+      await client.close();
+
+      const dateStr = new Date().toISOString().slice(0, 10);
+      const expectedFile = resolve(
+        tmpStoragePath,
+        'sessions',
+        `${dateStr}_shutdown-pending-session-id.json`,
+      );
+
+      let appeared = false;
+      for (let i = 0; i < 20; i++) {
+        if (existsSync(expectedFile)) {
+          appeared = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      expect(appeared).toBe(true);
     } finally {
       rmSync(tmpStoragePath, { recursive: true, force: true });
       rmSync(tmpProjectCwd, { recursive: true, force: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,6 +249,38 @@ export function getDashboardRepollIntervalMs(): number {
   return parsed;
 }
 
+/**
+ * Interval (ms) between periodic session-JSON checkpoints. Overridable via
+ * NR_AI_SESSION_PERSIST_INTERVAL_MS — kept simple to avoid threading a new
+ * config field through the loader for what is essentially a knob for tests.
+ */
+export const DEFAULT_SESSION_PERSIST_INTERVAL_MS = 30_000;
+
+export function getSessionPersistIntervalMs(): number {
+  const raw = process.env.NR_AI_SESSION_PERSIST_INTERVAL_MS;
+  if (raw === undefined || raw === '') return DEFAULT_SESSION_PERSIST_INTERVAL_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SESSION_PERSIST_INTERVAL_MS;
+  return parsed;
+}
+
+/**
+ * Cap (ms) on how long a cwd-fallback-resolved session id is treated as
+ * "pending confirmation" before periodic checkpointing resumes
+ * unconditionally. Overridable via NR_AI_PENDING_CONFIRMATION_CAP_MS — kept
+ * simple to avoid threading a new config field through the loader for what
+ * is essentially a knob for tests.
+ */
+export const DEFAULT_PENDING_CONFIRMATION_CAP_MS = 120_000;
+
+export function getPendingConfirmationCapMs(): number {
+  const raw = process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS;
+  if (raw === undefined || raw === '') return DEFAULT_PENDING_CONFIRMATION_CAP_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_PENDING_CONFIRMATION_CAP_MS;
+  return parsed;
+}
+
 const RETENTION_SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 export interface RetentionSweepDeps {
@@ -684,6 +716,34 @@ async function main(): Promise<void> {
   // fallback — see resolvedViaCwdOnly) when shutdown fires.
   let ppidCorrectionAbort: AbortController | undefined;
 
+  // True whenever the live sessionTraceId came from the collision-prone cwd
+  // fallback and hasn't yet been ppid-confirmed. While true, the periodic
+  // session-JSON checkpoint below is suppressed so a stale identity never
+  // gets written to disk as an orphaned, zero-activity session file. Cleared
+  // either by a real ppid confirmation/correction or by the cap timer in
+  // armPendingConfirmation below.
+  let pendingConfirmation = false;
+  let pendingConfirmationCapTimer: NodeJS.Timeout | undefined;
+
+  const clearPendingConfirmation = (): void => {
+    pendingConfirmation = false;
+    if (pendingConfirmationCapTimer) {
+      clearTimeout(pendingConfirmationCapTimer);
+      pendingConfirmationCapTimer = undefined;
+    }
+  };
+
+  const armPendingConfirmation = (): void => {
+    pendingConfirmation = true;
+    pendingConfirmationCapTimer = setTimeout(() => {
+      logger.warn(
+        'Session id confirmation cap elapsed with no PPID correction; resuming periodic checkpointing',
+      );
+      clearPendingConfirmation();
+    }, getPendingConfirmationCapMs());
+    pendingConfirmationCapTimer.unref?.();
+  };
+
   let shuttingDown = false;
   const shutdown = async () => {
     if (shuttingDown) return;
@@ -711,6 +771,7 @@ async function main(): Promise<void> {
       if (retentionInterval) clearInterval(retentionInterval);
       if (dashboardRepollInterval) clearInterval(dashboardRepollInterval);
       if (sessionPersistInterval) clearInterval(sessionPersistInterval);
+      if (pendingConfirmationCapTimer) clearTimeout(pendingConfirmationCapTimer);
       // Remove this MCP's heartbeat so the next dashboard-owner GC pass
       // doesn't have to mtime-archive our buffer file.
       localStoreForShutdown?.removeHeartbeat();
@@ -1920,8 +1981,13 @@ async function main(): Promise<void> {
     // exit (crash / SIGKILL) loses at most ~30s of data instead of the whole
     // session. persistSession() no-ops for synthetic / provisional ids, so this
     // is safe to arm immediately. unref'd so it never keeps the process alive.
-    const SESSION_PERSIST_INTERVAL_MS = 30_000;
+    const SESSION_PERSIST_INTERVAL_MS = getSessionPersistIntervalMs();
     sessionPersistInterval = setInterval(() => {
+      // Skip while the live session id is an unconfirmed cwd-fallback guess —
+      // see armPendingConfirmation's own comment. Persisting here would write
+      // a real, non-synthetic checkpoint file under an identity that might
+      // be corrected away moments later, orphaning the file on disk.
+      if (pendingConfirmation) return;
       try {
         persistSession?.({ periodic: true });
       } catch (err) {
@@ -2079,7 +2145,25 @@ async function main(): Promise<void> {
     // accumulated tracker metrics are preserved (adoptSessionId() only
     // reassigns the id field), and any already-live NrIngestManager is
     // stopped first so its harvest interval never leaks on a second call.
-    const adoptRealSessionId = async (realId: string): Promise<void> => {
+    const adoptRealSessionId = async (
+      realId: string,
+      opts?: { isCorrection?: boolean },
+    ): Promise<void> => {
+      if (opts?.isCorrection) {
+        // A real correction means the previously-adopted id was wrong, and
+        // anything these four trackers accumulated since startWatchers()
+        // scoped them to that wrong id (chiefly ParentTranscriptWatcher
+        // backfill from an unrelated old transcript) belongs to nobody.
+        // SessionTracker itself needs no reset here: real tool-call events
+        // only ever reach it via the per-session LocalStore/HookEventProcessor
+        // path, which is keyed by whatever id the hook collector script
+        // wrote — never the wrong guess — so toolCallCount/timeline stay
+        // clean through the whole unconfirmed window regardless.
+        costTracker.reset(realId);
+        modelUsageTracker.reset(realId);
+        contextCompositionTracker.reset(realId);
+        turnCostAttributor.reset(realId);
+      }
       sessionTraceId = realId;
       sessionTracker!.adoptSessionId(realId);
 
@@ -2229,6 +2313,7 @@ async function main(): Promise<void> {
     // A no-op-forever if the ppid breadcrumb never appears or always
     // matches — never trusts cwd itself, so it can't be fooled twice.
     const startPpidCorrectionWatch = (staleId: string): void => {
+      armPendingConfirmation();
       ppidCorrectionAbort = new AbortController();
       void watchPpidBreadcrumb({
         storagePath: config!.storagePath,
@@ -2236,17 +2321,25 @@ async function main(): Promise<void> {
       })
         .then(async (ppidId) => {
           if (ppidCorrectionAbort?.signal.aborted) return;
-          if (ppidId === staleId) return;
+          if (ppidId === staleId) {
+            // The cwd guess turned out to be correct — no correction needed,
+            // so no reason to keep suppressing checkpoints for the rest of
+            // the cap window.
+            clearPendingConfirmation();
+            return;
+          }
           logger.info('Correcting cwd-sourced session id from PPID breadcrumb', {
             staleId,
             correctedId: ppidId,
           });
-          await adoptRealSessionId(ppidId);
+          await adoptRealSessionId(ppidId, { isCorrection: true });
+          clearPendingConfirmation();
         })
         .catch((err) => {
           if (!ppidCorrectionAbort?.signal.aborted) {
             logger.warn('PPID correction watch failed', { error: String(err) });
           }
+          clearPendingConfirmation();
         });
     };
 


### PR DESCRIPTION
Fixes #342

## Summary

- When a `--stdio` MCP process resolved its session identity via the collision-prone cwd fallback before the precise PPID breadcrumb confirmed it, the brief unconfirmed window could cause lasting damage even after the existing self-correction landed: the periodic 30-second checkpoint could write a real, non-synthetic, zero-activity session file to disk under the stale identity, orphaning it, and any cost/token data backfilled from an unrelated old session under that stale identity rode along uncorrected into the real session's own totals once corrected, since the correction only relabeled the tracker in place.
- Checkpointing is now suppressed for as long as a session's identity is unconfirmed (capped at two minutes so a session that never gets a PPID breadcrumb doesn't lose checkpointing indefinitely), and a real correction now resets the affected cost/token trackers before continuing so nothing from the wrong identity carries forward.
- Version bump to 1.14.22 + CHANGELOG entry.

## Test plan

- [x] `npm run build && npm test` — full suite green
- [x] `npm run lint` — 0 errors/warnings
- [x] 6 new integration tests covering: checkpoint suppression while unconfirmed, cap-timeout fallback, immediate-clear on confirmed-same-id, tracker reset on a real correction, prompt checkpoint resume after a real correction, and shutdown still persisting the terminal save mid-pending
