### PR TITLE
Add explanatory tooltips to Today page panel headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.23] - 2026-08-02
+
+### Added
+
+- **Each panel on the Today dashboard now has an info icon next to its header explaining what it measures** — hover or keyboard-focus the icon for a short explanation of what's shown and how it's computed (covers Quality, Tool Selection, Latency, Model Usage, Cache Health, Session Live Tail, Recent Alerts, Activity Today, and the End-of-Day forecast). The tooltip always renders in full, even next to a panel with its own scrollable area.
+
 ## [1.14.22] - 2026-08-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.22",
+  "version": "1.14.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.22",
+      "version": "1.14.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.22",
+  "version": "1.14.23",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/web/components/ui/InfoTooltip.test.tsx
+++ b/src/web/components/ui/InfoTooltip.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { InfoTooltip } from './InfoTooltip';
+
+describe('InfoTooltip', () => {
+  it('renders an info button wired to the tooltip text via aria-describedby once hovered', () => {
+    render(<InfoTooltip text="Explains the panel." />);
+    const button = screen.getByRole('button', { name: 'What is this?' });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    fireEvent.mouseEnter(button);
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Explains the panel.');
+    expect(button.getAttribute('aria-describedby')).toBe(tooltip.getAttribute('id'));
+  });
+
+  it('hides the tooltip again after the mouse leaves the button', () => {
+    render(<InfoTooltip text="Explains the panel." />);
+    const button = screen.getByRole('button', { name: 'What is this?' });
+
+    fireEvent.mouseEnter(button);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(button);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('portals the tooltip outside the rendered container instead of nesting it inline', () => {
+    const { container } = render(<InfoTooltip text="Explains the panel." />);
+    const button = screen.getByRole('button', { name: 'What is this?' });
+
+    fireEvent.mouseEnter(button);
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(container).not.toContainElement(tooltip);
+    expect(document.body).toContainElement(tooltip);
+  });
+
+  it('shows the tooltip on focus and hides it again on blur', () => {
+    render(<InfoTooltip text="Explains the panel." />);
+    const button = screen.getByRole('button', { name: 'What is this?' });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    fireEvent.focus(button);
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Explains the panel.');
+    expect(button.getAttribute('aria-describedby')).toBe(tooltip.getAttribute('id'));
+
+    fireEvent.blur(button);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+});

--- a/src/web/components/ui/InfoTooltip.tsx
+++ b/src/web/components/ui/InfoTooltip.tsx
@@ -1,0 +1,61 @@
+import { useId, useRef, useState, type JSX } from 'react';
+import { createPortal } from 'react-dom';
+import { Info } from 'lucide-react';
+
+export interface InfoTooltipProps {
+  readonly text: string;
+}
+
+interface TooltipPosition {
+  readonly top: number;
+  readonly left: number;
+}
+
+export function InfoTooltip({ text }: InfoTooltipProps): JSX.Element {
+  const tooltipId = useId();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState<TooltipPosition>({ top: 0, left: 0 });
+
+  const openTooltip = (): void => {
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (rect) {
+      setPosition({ top: rect.bottom + 4, left: rect.left });
+    }
+    setIsOpen(true);
+  };
+
+  const closeTooltip = (): void => {
+    setIsOpen(false);
+  };
+
+  return (
+    <span className="relative inline-flex">
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-label="What is this?"
+        aria-describedby={tooltipId}
+        onMouseEnter={openTooltip}
+        onFocus={openTooltip}
+        onMouseLeave={closeTooltip}
+        onBlur={closeTooltip}
+        className="text-ink-muted hover:text-ink-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/40 focus-visible:ring-offset-1 focus-visible:ring-offset-bg-deep rounded-full"
+      >
+        <Info size={12} aria-hidden="true" focusable="false" />
+      </button>
+      {isOpen &&
+        createPortal(
+          <span
+            id={tooltipId}
+            role="tooltip"
+            className="fixed z-50 w-60 max-w-[240px] rounded-md glass-card glass-card-static p-2 text-[10px] leading-snug text-ink-subtle"
+            style={{ top: position.top, left: position.left }}
+          >
+            {text}
+          </span>,
+          document.body,
+        )}
+    </span>
+  );
+}

--- a/src/web/components/ui/index.ts
+++ b/src/web/components/ui/index.ts
@@ -18,3 +18,6 @@ export type { EyebrowProps, EyebrowAs } from './Eyebrow';
 
 export { SectionHeader } from './SectionHeader';
 export type { SectionHeaderProps } from './SectionHeader';
+
+export { InfoTooltip } from './InfoTooltip';
+export type { InfoTooltipProps } from './InfoTooltip';

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -19,7 +19,7 @@ import { ConcurrencyIndicator, type ConcurrencyData } from '../components/Concur
 import { ActivityHeatmap } from '../components/ActivityHeatmap';
 import { GeoBanner } from '../components/GeoBanner';
 import { ContextBar } from '../components/ContextBar';
-import { Card, Eyebrow, LiveBadge, Pill } from '../components/ui';
+import { Card, Eyebrow, InfoTooltip, LiveBadge, Pill } from '../components/ui';
 import {
   fetchRecentAlerts,
   fetchCacheHealth,
@@ -481,7 +481,10 @@ export function Today(): JSX.Element {
           {todayHeatmap && todayHeatmap.buckets?.length > 0 && (
             <AnimatedCard index={5} className="mb-3">
               <Card padding="sm">
-                <Eyebrow className="mb-2">Activity Today</Eyebrow>
+                <div className="flex items-center gap-1.5 mb-2">
+                  <Eyebrow>Activity Today</Eyebrow>
+                  <InfoTooltip text="Tool-call activity in 15-minute blocks across today. Darker blocks mean more calls in that window." />
+                </div>
                 <ActivityHeatmap
                   variant="strip"
                   buckets={todayHeatmap.buckets}
@@ -512,7 +515,10 @@ function QualityProxyPanel(): JSX.Element {
 
   return (
     <Card padding="sm" className="h-full">
-      <Eyebrow className="mb-2">Quality</Eyebrow>
+      <div className="flex items-center gap-1.5 mb-2">
+        <Eyebrow>Quality</Eyebrow>
+        <InfoTooltip text="Diff apply rate and test pass rate across today's sessions, plus how often you backtracked or self-corrected. Watch for the degrading flag if quality drops mid-session." />
+      </div>
       {!data || data.totalSignals === 0 ? (
         <EmptyState
           icon="checkmark"
@@ -563,7 +569,10 @@ function ToolSelectionPanel(): JSX.Element {
 
   return (
     <Card padding="sm" className="h-full">
-      <Eyebrow className="mb-2">Tool Selection</Eyebrow>
+      <div className="flex items-center gap-1.5 mb-2">
+        <Eyebrow>Tool Selection</Eyebrow>
+        <InfoTooltip text="Scores how efficiently tools were chosen today: penalizes re-reading a file without editing it, retrying a failing call, or fetching output that's never used." />
+      </div>
       {!data || Array.isArray(data) || data.totalCalls === 0 ? (
         <EmptyState
           icon="radar"
@@ -633,7 +642,10 @@ function LatencyPanel({
 
   return (
     <Card padding="sm" className="h-full">
-      <Eyebrow className="mb-2">Latency (ms)</Eyebrow>
+      <div className="flex items-center gap-1.5 mb-2">
+        <Eyebrow>Latency (ms)</Eyebrow>
+        <InfoTooltip text="How long tool calls took today — p50/p95/p99 across all calls, plus the slowest tools by p95." />
+      </div>
       {!data || !data.overall ? (
         <EmptyState
           icon="clock"
@@ -707,7 +719,10 @@ function ModelUsagePanel(): JSX.Element {
 
   return (
     <Card padding="sm" className="h-full">
-      <Eyebrow className="mb-2">Model Usage</Eyebrow>
+      <div className="flex items-center gap-1.5 mb-2">
+        <Eyebrow>Model Usage</Eyebrow>
+        <InfoTooltip text="Cost and request volume per model used today, combining this server's live usage with every other session's saved totals. The live slice resets if the server process restarts." />
+      </div>
       {!data || models.length === 0 ? (
         <EmptyState
           icon="radar"
@@ -773,7 +788,10 @@ function CacheHealthPanel({
 
   return (
     <Card padding="sm" className="h-full">
-      <Eyebrow className="mb-2">Cache Health</Eyebrow>
+      <div className="flex items-center gap-1.5 mb-2">
+        <Eyebrow>Cache Health</Eyebrow>
+        <InfoTooltip text="Prompt cache hit rate today, with a suggestion for improving it — usually by moving stable context earlier in the prompt." />
+      </div>
       {noActivity ? (
         <EmptyState
           icon="radar"
@@ -1059,53 +1077,58 @@ function LiveSessionPane({
         style={{ height: '320px' }}
       >
         {/* Session list */}
-        <div className="border-r border-border-subtle overflow-auto">
-          <Eyebrow className="p-2 border-b border-border-subtle">Session Live Tail</Eyebrow>
-          {todaySessions.map((s) => {
-            const isSessionLive = liveSessionIds.has(s.sessionId);
-            return (
-              <button
-                key={s.sessionId}
-                type="button"
-                onClick={() => setSelectedId(s.sessionId)}
-                className={
-                  'block w-full text-left p-2 border-b border-border-subtle text-xs transition-colors duration-150 hover:bg-surface-5 ' +
-                  (activeId === s.sessionId ? 'bg-surface-5' : '')
-                }
-              >
-                <div className="flex items-center gap-1.5">
-                  <span className="font-mono text-ink-base">
-                    {s.sessionName || s.sessionId.slice(0, 8)}
-                  </span>
-                  {isSessionLive ? (
-                    <LiveBadge label="live" size="sm" />
-                  ) : (
-                    <span
-                      className="text-[10px] text-ink-muted"
-                      title={s.startTime ? `Started ${fmtTimeOfDay(s.startTime)}` : undefined}
-                    >
-                      {s.startTime ? fmtTimeOfDay(s.startTime + (s.durationMs ?? 0)) : ''}
+        <div className="border-r border-border-subtle flex flex-col overflow-hidden">
+          <div className="flex items-center justify-between gap-1.5 p-2 border-b border-border-subtle shrink-0">
+            <Eyebrow>Session Live Tail</Eyebrow>
+            <InfoTooltip text="Today's sessions on the left; select one to stream its live tool-call trace on the right." />
+          </div>
+          <div className="overflow-auto flex-1">
+            {todaySessions.map((s) => {
+              const isSessionLive = liveSessionIds.has(s.sessionId);
+              return (
+                <button
+                  key={s.sessionId}
+                  type="button"
+                  onClick={() => setSelectedId(s.sessionId)}
+                  className={
+                    'block w-full text-left p-2 border-b border-border-subtle text-xs transition-colors duration-150 hover:bg-surface-5 ' +
+                    (activeId === s.sessionId ? 'bg-surface-5' : '')
+                  }
+                >
+                  <div className="flex items-center gap-1.5">
+                    <span className="font-mono text-ink-base">
+                      {s.sessionName || s.sessionId.slice(0, 8)}
                     </span>
-                  )}
-                </div>
-                <div className="flex gap-2 mt-0.5 text-[10px] text-ink-subtle">
-                  <span>{s.toolCallCount ?? 0} calls</span>
-                  {s.estimatedCostUsd != null && s.estimatedCostUsd > 0 ? (
-                    <span>{formatUsd(s.estimatedCostUsd)}</span>
-                  ) : (
-                    <span>—</span>
-                  )}
-                </div>
-              </button>
-            );
-          })}
-          {liveSessionIds.size === 0 && todaySessions.length === 0 && (
-            <EmptyState
-              icon="code"
-              title="No sessions today"
-              subtitle="Start coding with Claude to see sessions here."
-            />
-          )}
+                    {isSessionLive ? (
+                      <LiveBadge label="live" size="sm" />
+                    ) : (
+                      <span
+                        className="text-[10px] text-ink-muted"
+                        title={s.startTime ? `Started ${fmtTimeOfDay(s.startTime)}` : undefined}
+                      >
+                        {s.startTime ? fmtTimeOfDay(s.startTime + (s.durationMs ?? 0)) : ''}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex gap-2 mt-0.5 text-[10px] text-ink-subtle">
+                    <span>{s.toolCallCount ?? 0} calls</span>
+                    {s.estimatedCostUsd != null && s.estimatedCostUsd > 0 ? (
+                      <span>{formatUsd(s.estimatedCostUsd)}</span>
+                    ) : (
+                      <span>—</span>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+            {liveSessionIds.size === 0 && todaySessions.length === 0 && (
+              <EmptyState
+                icon="code"
+                title="No sessions today"
+                subtitle="Start coding with Claude to see sessions here."
+              />
+            )}
+          </div>
         </div>
 
         {/* Live tail */}
@@ -1224,7 +1247,10 @@ function RecentAlertsPanel(): JSX.Element | null {
 
   return (
     <Card padding="sm">
-      <Eyebrow className="mb-2">Recent Alerts</Eyebrow>
+      <div className="flex items-center gap-1.5 mb-2">
+        <Eyebrow>Recent Alerts</Eyebrow>
+        <InfoTooltip text="The most recent alert firings and resolutions from your configured alert rules, newest first." />
+      </div>
       {isLoading && <EmptyState variant="loading" title="Loading..." />}
       {error && <div className="text-accent-red text-xs">Error loading recent alerts.</div>}
       {!isLoading && !error && sortedEntries.length === 0 && (
@@ -1394,7 +1420,10 @@ function ForecastEodCard({
 
   return (
     <Card padding="sm" className="mb-3 h-full">
-      <Eyebrow className="mb-1.5">Forecast · End of Day</Eyebrow>
+      <div className="flex items-center gap-1.5 mb-1.5">
+        <Eyebrow>Forecast · End of Day</Eyebrow>
+        <InfoTooltip text="Projects today's total spend by midnight, based on the spending trend so far this hour-by-hour." />
+      </div>
       {hasForecast ? (
         <>
           <div className="flex items-baseline gap-3">


### PR DESCRIPTION
Fixes #344

## Summary
- Add a reusable `InfoTooltip` component (info icon + hover/focus tooltip, rendered via a React portal to `document.body` so it isn't clipped by any panel's own scroll area)
- Wire it into all 9 panel headers on the Today dashboard: Activity Today, Quality, Tool Selection, Latency, Model Usage, Cache Health, Session Live Tail, Recent Alerts, and Forecast · End of Day
- Bump version to 1.14.23 with a matching CHANGELOG entry

## Test plan
- [x] `npm run test:web` — 426/426 passing (includes `InfoTooltip.test.tsx`: hover, keyboard focus/blur, and portal-escape coverage)
- [x] `npm run build` — clean
- [x] Manual verification in a running dashboard: all 9 icons render at the correct headers, tooltip text correct on hover and keyboard-focus, no clipping in any panel (including one with its own scrollable area)