### PR TITLE
Feat: surface RetryDetector detail on Today's thrashing anti-pattern banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.24] - 2026-08-02
+
+### Added
+
+- **The Today dashboard's thrashing anti-pattern banner now shows an estimated wasted-token count when one is available** — when the retry detector has flagged the same repeated tool call behind the banner's alert, the banner appends a rough token-waste estimate next to the existing pattern type and file/command target, rather than requiring a separate lookup.
+
 ## [1.14.23] - 2026-08-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.23",
+  "version": "1.14.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.23",
+      "version": "1.14.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.23",
+  "version": "1.14.24",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -791,6 +791,44 @@ describe('api-handler GET /api/anti-patterns', () => {
   });
 });
 
+describe('api-handler GET /api/retry-alerts', () => {
+  it('returns 503 when retryDetector is missing', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/retry-alerts' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns retry detector metrics as JSON', async () => {
+    const fakeMetrics = {
+      alerts: [
+        {
+          toolName: 'Read',
+          occurrences: 4,
+          windowSize: 5,
+          similarity: 0.9,
+          tokensWastedEstimate: 750,
+          timestamp: 1700000000000,
+        },
+      ],
+      totalTokensWasted: 750,
+      totalAlertsEmitted: 1,
+    };
+    const handler = createApiHandler({
+      retryDetector: { getMetrics: () => fakeMetrics } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['retryDetector'],
+    });
+    const req = { method: 'GET', url: '/api/retry-alerts' } as IncomingMessage;
+    const { res, status, body, headers } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(headers()['content-type']).toMatch(/application\/json/);
+    expect(JSON.parse(body())).toEqual(fakeMetrics);
+  });
+});
+
 describe('api-handler GET /api/audit', () => {
   it('returns audit log mapped to SPA AuditEntry shape', async () => {
     const ts1 = Date.now() - 5000;

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -59,6 +59,7 @@ import { DEFAULT_STALE_THRESHOLD_MS } from '../../metrics/live-session-registry.
 import { computeContextMetricsFromEvents } from '../../metrics/context-tracker.js';
 import type { ContextReplayEvent, ContextTrackerMetrics } from '../../metrics/context-tracker.js';
 import type { AntiPattern } from '../../metrics/anti-patterns.js';
+import type { RetryDetectorMetrics } from '../../metrics/retry-detector.js';
 import type { AuditRecord } from '../../security/audit-trail.js';
 interface RawAuditRecord {
   readonly timestamp: number;
@@ -376,6 +377,7 @@ export interface ApiHandlerDeps {
   };
   readonly costForecast?: () => CostForecast;
   readonly antiPatternDetector?: { getCurrentPatterns: () => readonly AntiPattern[] };
+  readonly retryDetector?: { getMetrics: () => RetryDetectorMetrics };
   readonly auditTrailManager?: { getAuditLog: () => readonly AuditRecord[] };
   readonly weeklySummaryGenerator?: WeeklySummaryGenerator;
   readonly budgetTracker?: { getStatus: () => BudgetStatus };
@@ -1569,6 +1571,11 @@ export function createApiHandler(
   routes.set('GET /api/anti-patterns', (_req, res) => {
     if (!deps.antiPatternDetector) return unavailable(res, 'antiPatternDetector');
     jsonOk(res, deps.antiPatternDetector.getCurrentPatterns());
+  });
+
+  routes.set('GET /api/retry-alerts', (_req, res) => {
+    if (!deps.retryDetector) return unavailable(res, 'retryDetector');
+    jsonOk(res, deps.retryDetector.getMetrics());
   });
 
   routes.set('GET /api/audit', (_req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1337,6 +1337,7 @@ async function main(): Promise<void> {
             });
           },
           antiPatternDetector,
+          retryDetector,
           weeklySummaryGenerator,
           budgetTracker,
           latencyTracker,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -280,6 +280,25 @@ export const fetchSessionDetail = (id: string): Promise<SessionDetail> =>
 export const fetchCost = (): Promise<CostResponse> => getJson<CostResponse>('/api/cost');
 export const fetchAntiPatterns = (): Promise<AntiPattern[]> =>
   getJson<AntiPattern[]>('/api/anti-patterns');
+
+export interface ThrashingAlertEntry {
+  readonly toolName: string;
+  readonly occurrences: number;
+  readonly windowSize: number;
+  readonly similarity: number;
+  readonly tokensWastedEstimate: number;
+  readonly timestamp: number;
+}
+
+export interface RetryAlertsResponse {
+  readonly alerts: readonly ThrashingAlertEntry[];
+  readonly totalTokensWasted: number;
+  readonly totalAlertsEmitted: number;
+}
+
+export const fetchRetryAlerts = (): Promise<RetryAlertsResponse> =>
+  getJson<RetryAlertsResponse>('/api/retry-alerts');
+
 export interface QualityEvent {
   readonly signal:
     | 'diff_applied_clean'

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -79,6 +79,37 @@ describe('Today view', () => {
     expect(screen.queryByText(/thrashing/i)).toBeNull();
   });
 
+  it('shows retry-detector detail on the thrashing banner when a matching alert exists', async () => {
+    useLiveStore.setState({ antiPatterns: [{ type: 'thrashing', target: 'Read', count: 4 }] });
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (url === '/api/retry-alerts') {
+        return new Response(
+          JSON.stringify({
+            alerts: [
+              {
+                toolName: 'Read',
+                occurrences: 4,
+                windowSize: 5,
+                similarity: 0.9,
+                tokensWastedEstimate: 750,
+                timestamp: Date.now(),
+              },
+            ],
+            totalTokensWasted: 750,
+            totalAlertsEmitted: 1,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    renderToday();
+    expect(await screen.findByText(/~750 tokens wasted/i)).toBeInTheDocument();
+  });
+
   it('renders a real count for stuck_loop via the API-fallback path, not "?"', async () => {
     useLiveStore.setState({ antiPatterns: [] });
     globalThis.fetch = vi.fn(async (url: string) => {

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -30,6 +30,8 @@ import {
   fetchSessionSubagents,
   fetchWorkflows,
   fetchAntiPatterns,
+  fetchRetryAlerts,
+  type RetryAlertsResponse,
   fetchQualityProxy,
   fetchToolSelectionScore,
   fetchConcurrency,
@@ -162,6 +164,11 @@ export function Today(): JSX.Element {
   const { data: apiAntiPatterns, isPending: antiPatternsPending } = useQuery<SessionAntiPattern[]>({
     queryKey: qk.antiPatterns,
     queryFn: fetchAntiPatterns,
+  });
+  const { data: retryAlerts } = useQuery<RetryAlertsResponse>({
+    queryKey: ['retry-alerts'],
+    queryFn: fetchRetryAlerts,
+    refetchInterval: 10_000,
   });
   const { data: concurrency, isPending: concurrencyPending } = useQuery<ConcurrencyData>({
     queryKey: qk.concurrency,
@@ -418,6 +425,18 @@ export function Today(): JSX.Element {
                           Session: {sessionPillLabel(antiPatterns[0].sessionId, liveSessions ?? [])}
                         </Pill>
                       )}
+                      {antiPatterns[0].type === 'thrashing' &&
+                        retryAlerts?.alerts?.find((a) => a.toolName === antiPatterns[0].target)
+                          ?.tokensWastedEstimate !== undefined && (
+                          <span className="text-ink-muted ml-2">
+                            ~
+                            {
+                              retryAlerts.alerts.find((a) => a.toolName === antiPatterns[0].target)!
+                                .tokensWastedEstimate
+                            }{' '}
+                            tokens wasted
+                          </span>
+                        )}
                     </>
                   ) : apiAntiPatterns && apiAntiPatterns.length > 0 ? (
                     <>


### PR DESCRIPTION
Closes #292

## Summary

- Adds `GET /api/retry-alerts`, wiring the existing `RetryDetector` tracker into the dashboard's API — previously only reachable via its MCP tool.
- Enriches the Today dashboard's existing thrashing anti-pattern banner with `RetryDetector`'s streak/tokens-wasted detail, rather than adding a separate competing panel for the same underlying signal.
- Bumps to `1.14.24` with the matching CHANGELOG entry.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — full suite passing
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] Manually verified against a dashboard instance with fixture data: the banner shows `~N tokens wasted` next to the existing pattern type and target when a matching retry alert exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)