### PR TITLE
Add instruction-drift verdict card to History view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.25] - 2026-08-02
+
+### Added
+
+- **The History dashboard now shows how your last instruction file change affected your sessions** — a new "Instruction Drift" panel compares session outcomes before and after your most recent edit to CLAUDE.md (or the active platform's equivalent, e.g. Cursor's `.cursorrules`), showing an improved/degraded/neutral verdict alongside the success-rate, token-usage, and thrashing deltas behind it.
+
 ## [1.14.24] - 2026-08-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -829,6 +829,47 @@ describe('api-handler GET /api/retry-alerts', () => {
   });
 });
 
+describe('api-handler GET /api/instruction-drift', () => {
+  it('returns 503 when instructionDriftTracker is missing', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/instruction-drift' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns instruction drift metrics as JSON', async () => {
+    const fakeMetrics = {
+      currentPromptHash: 'abc123',
+      uniquePromptVariants: 2,
+      variantStats: [],
+      recentCorrelations: [
+        {
+          fromHash: 'aaa',
+          toHash: 'bbb',
+          successRateDelta: -0.15,
+          tokensDelta: 6000,
+          thrashingDelta: 0.6,
+          efficiencyDelta: -0.1,
+          verdict: 'degraded',
+        },
+      ],
+      currentVariantSessionCount: 3,
+    };
+    const handler = createApiHandler({
+      instructionDriftTracker: { getMetrics: () => fakeMetrics } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['instructionDriftTracker'],
+    });
+    const req = { method: 'GET', url: '/api/instruction-drift' } as IncomingMessage;
+    const { res, status, body, headers } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(headers()['content-type']).toMatch(/application\/json/);
+    expect(JSON.parse(body())).toEqual(fakeMetrics);
+  });
+});
+
 describe('api-handler GET /api/audit', () => {
   it('returns audit log mapped to SPA AuditEntry shape', async () => {
     const ts1 = Date.now() - 5000;

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -60,6 +60,7 @@ import { computeContextMetricsFromEvents } from '../../metrics/context-tracker.j
 import type { ContextReplayEvent, ContextTrackerMetrics } from '../../metrics/context-tracker.js';
 import type { AntiPattern } from '../../metrics/anti-patterns.js';
 import type { RetryDetectorMetrics } from '../../metrics/retry-detector.js';
+import type { InstructionDriftMetrics } from '../../metrics/instruction-drift-tracker.js';
 import type { AuditRecord } from '../../security/audit-trail.js';
 interface RawAuditRecord {
   readonly timestamp: number;
@@ -378,6 +379,7 @@ export interface ApiHandlerDeps {
   readonly costForecast?: () => CostForecast;
   readonly antiPatternDetector?: { getCurrentPatterns: () => readonly AntiPattern[] };
   readonly retryDetector?: { getMetrics: () => RetryDetectorMetrics };
+  readonly instructionDriftTracker?: { getMetrics: () => InstructionDriftMetrics };
   readonly auditTrailManager?: { getAuditLog: () => readonly AuditRecord[] };
   readonly weeklySummaryGenerator?: WeeklySummaryGenerator;
   readonly budgetTracker?: { getStatus: () => BudgetStatus };
@@ -1576,6 +1578,11 @@ export function createApiHandler(
   routes.set('GET /api/retry-alerts', (_req, res) => {
     if (!deps.retryDetector) return unavailable(res, 'retryDetector');
     jsonOk(res, deps.retryDetector.getMetrics());
+  });
+
+  routes.set('GET /api/instruction-drift', (_req, res) => {
+    if (!deps.instructionDriftTracker) return unavailable(res, 'instructionDriftTracker');
+    jsonOk(res, deps.instructionDriftTracker.getMetrics());
   });
 
   routes.set('GET /api/audit', (_req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1338,6 +1338,7 @@ async function main(): Promise<void> {
           },
           antiPatternDetector,
           retryDetector,
+          instructionDriftTracker,
           weeklySummaryGenerator,
           budgetTracker,
           latencyTracker,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -933,6 +933,38 @@ export const fetchWorkflows = (): Promise<ReadonlyArray<WorkflowRunInfo>> =>
 export const fetchWorkflowDetail = (runId: string): Promise<WorkflowRunDetailResponse> =>
   getJson<WorkflowRunDetailResponse>(`/api/workflows/${encodeURIComponent(runId)}`);
 
+export interface DriftCorrelationEntry {
+  readonly fromHash: string;
+  readonly toHash: string;
+  readonly successRateDelta: number | null;
+  readonly tokensDelta: number;
+  readonly thrashingDelta: number;
+  readonly efficiencyDelta: number | null;
+  readonly verdict: 'improved' | 'degraded' | 'neutral' | 'insufficient_data';
+}
+
+export interface PromptVariantStatsEntry {
+  readonly promptHash: string;
+  readonly sessionCount: number;
+  readonly avgSuccessRate: number | null;
+  readonly avgTokensPerSession: number;
+  readonly avgThrashingIncidents: number;
+  readonly avgEfficiency: number | null;
+  readonly firstSeen: number;
+  readonly lastSeen: number;
+}
+
+export interface InstructionDriftResponse {
+  readonly currentPromptHash: string | null;
+  readonly uniquePromptVariants: number;
+  readonly variantStats: readonly PromptVariantStatsEntry[];
+  readonly recentCorrelations: readonly DriftCorrelationEntry[];
+  readonly currentVariantSessionCount: number;
+}
+
+export const fetchInstructionDrift = (): Promise<InstructionDriftResponse> =>
+  getJson<InstructionDriftResponse>('/api/instruction-drift');
+
 export const qk = {
   sessionCurrent: ['session', 'current'] as const,
   sessionsList: (limit: number) => ['sessions', 'list', limit] as const,
@@ -945,6 +977,7 @@ export const qk = {
   latency: ['latency'] as const,
   costPerOutcome: (days: number) => ['cost-per-outcome', days] as const,
   personalCoach: ['personal-coach'] as const,
+  instructionDrift: ['instruction-drift'] as const,
   alertsRecent: ['alerts', 'recent'] as const,
   sessionReplay: (id: string) => ['session', id, 'replay'] as const,
   sessionSubagents: (id: string) => ['session', id, 'subagents'] as const,

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -343,6 +343,167 @@ describe('History view', () => {
       expect(screen.getAllByText(/no anti-patterns detected/i).length).toBeGreaterThanOrEqual(1),
     );
   });
+
+  it('shows the most recent drift verdict with deltas', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = ((url: string) => {
+      if (url.startsWith('/api/instruction-drift')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              currentPromptHash: 'abc123',
+              uniquePromptVariants: 2,
+              variantStats: [],
+              recentCorrelations: [
+                {
+                  fromHash: 'aaa',
+                  toHash: 'bbb',
+                  successRateDelta: -0.15,
+                  tokensDelta: 6000,
+                  thrashingDelta: 0.6,
+                  efficiencyDelta: -0.1,
+                  verdict: 'degraded',
+                },
+              ],
+              currentVariantSessionCount: 3,
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        );
+      }
+      if (url.startsWith('/api/weekly')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_WEEKLY), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/cost-per-outcome')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_OUTCOME), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/personal-coach')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_COACH_OK), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/sessions')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_SESSIONS), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/activity-heatmap')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ days: [{ date: '2026-05-26', count: 3 }], maxCount: 3 }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/concurrency')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ dailyPeaks: [{ date: '2026-05-26', peak: 2 }] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('null', { status: 200 }));
+    }) as typeof globalThis.fetch;
+    render(
+      <QueryClientProvider client={qc}>
+        <History />
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByText(/degraded/i)).toBeInTheDocument();
+    expect(screen.getByText(/-15%/)).toBeInTheDocument();
+  });
+
+  it('shows a neutral empty state with no correlations yet', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = ((url: string) => {
+      if (url.startsWith('/api/instruction-drift')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              currentPromptHash: null,
+              uniquePromptVariants: 0,
+              variantStats: [],
+              recentCorrelations: [],
+              currentVariantSessionCount: 0,
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        );
+      }
+      if (url.startsWith('/api/weekly')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_WEEKLY), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/cost-per-outcome')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_OUTCOME), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/personal-coach')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_COACH_OK), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/sessions')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_SESSIONS), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/activity-heatmap')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ days: [{ date: '2026-05-26', count: 3 }], maxCount: 3 }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/concurrency')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ dailyPeaks: [{ date: '2026-05-26', peak: 2 }] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('null', { status: 200 }));
+    }) as typeof globalThis.fetch;
+    render(
+      <QueryClientProvider client={qc}>
+        <History />
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByText(/no instruction file changes tracked yet/i)).toBeInTheDocument();
+  });
 });
 
 describe('History — error handling', () => {

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -18,7 +18,7 @@ import { EmptyState } from '../components/EmptyState';
 import { ActivityHeatmap } from '../components/ActivityHeatmap';
 import { GeoBanner } from '../components/GeoBanner';
 import { DiscreteBlockChart, type DiscreteBlockChartItem } from '../components/DiscreteBlockChart';
-import { Card, Eyebrow } from '../components/ui';
+import { Card, Eyebrow, InfoTooltip, Pill, type PillTone } from '../components/ui';
 import {
   fetchWeekly,
   fetchSessionsList,
@@ -26,12 +26,15 @@ import {
   fetchPersonalCoach,
   fetchActivityHeatmap,
   fetchConcurrencyHistory,
+  fetchInstructionDrift,
   qk,
   type WeeklyRow,
   type CostPerOutcomeResponse,
   type PersonalCoachResult,
   type ConcurrencyHistoryResponse,
   type ActivityHeatmapHistoryResponse,
+  type InstructionDriftResponse,
+  type DriftCorrelationEntry,
 } from '../api/client';
 import { formatUsdOrDash, shortToolName } from '../lib/format';
 
@@ -90,6 +93,72 @@ function shortMonthDay(value: string): string {
   return typeof value === 'string' && value.length >= 10 ? value.slice(5, 10) : value;
 }
 
+const INSTRUCTION_DRIFT_TOOLTIP =
+  "Compares session outcomes before and after your most recent change to an instruction file (CLAUDE.md, or the active platform's equivalent) — success rate, token usage, and thrashing incidents. A degraded verdict means sessions got worse after the edit, not better.";
+
+function DriftStat({ label, value }: { label: string; value: string }): JSX.Element {
+  return (
+    <div>
+      <div className="text-[10px] text-ink-muted uppercase tracking-wider">{label}</div>
+      <div className="text-sm font-bold tabular-nums mt-0.5">{value}</div>
+    </div>
+  );
+}
+
+function InstructionDriftCard({
+  data,
+}: {
+  data: InstructionDriftResponse | undefined;
+}): JSX.Element {
+  if (!data) {
+    return (
+      <Panel title="Instruction Drift" tooltip={INSTRUCTION_DRIFT_TOOLTIP}>
+        <EmptyState variant="loading" title="Loading drift data…" />
+      </Panel>
+    );
+  }
+  const latest = data.recentCorrelations[data.recentCorrelations.length - 1];
+  if (!latest) {
+    return (
+      <Panel title="Instruction Drift" tooltip={INSTRUCTION_DRIFT_TOOLTIP}>
+        <div className="text-ink-muted text-xs">No instruction file changes tracked yet.</div>
+      </Panel>
+    );
+  }
+  const verdictTone: Record<DriftCorrelationEntry['verdict'], PillTone> = {
+    improved: 'success',
+    degraded: 'danger',
+    neutral: 'neutral',
+    insufficient_data: 'neutral',
+  };
+  return (
+    <Panel
+      title="Instruction Drift — most recent instruction file change"
+      tooltip={INSTRUCTION_DRIFT_TOOLTIP}
+    >
+      <div className="flex items-center gap-6">
+        <Pill tone={verdictTone[latest.verdict]}>{latest.verdict}</Pill>
+        <DriftStat
+          label="Success"
+          value={
+            latest.successRateDelta !== null
+              ? `${latest.successRateDelta > 0 ? '+' : ''}${Math.round(latest.successRateDelta * 100)}%`
+              : '—'
+          }
+        />
+        <DriftStat
+          label="Tokens"
+          value={`${latest.tokensDelta > 0 ? '+' : ''}${latest.tokensDelta}`}
+        />
+        <DriftStat
+          label="Thrashing"
+          value={`${latest.thrashingDelta > 0 ? '+' : ''}${latest.thrashingDelta}`}
+        />
+      </div>
+    </Panel>
+  );
+}
+
 export function History(): JSX.Element {
   const weekly = useQuery<WeeklyRow[]>({
     queryKey: qk.weekly,
@@ -119,6 +188,11 @@ export function History(): JSX.Element {
   const concurrencyHistory = useQuery<ConcurrencyHistoryResponse>({
     queryKey: qk.concurrencyHistory(30),
     queryFn: () => fetchConcurrencyHistory(30),
+  });
+
+  const drift = useQuery<InstructionDriftResponse>({
+    queryKey: qk.instructionDrift,
+    queryFn: fetchInstructionDrift,
   });
 
   const hasLoadError =
@@ -425,16 +499,31 @@ export function History(): JSX.Element {
       </div>
 
       <div className="mt-3">
+        <InstructionDriftCard data={drift.data} />
+      </div>
+
+      <div className="mt-3">
         <CoachCard data={coach.data} />
       </div>
     </section>
   );
 }
 
-function Panel({ title, children }: { title: string; children: React.ReactNode }): JSX.Element {
+function Panel({
+  title,
+  tooltip,
+  children,
+}: {
+  title: string;
+  tooltip?: string;
+  children: React.ReactNode;
+}): JSX.Element {
   return (
     <Card padding="md">
-      <Eyebrow>{title}</Eyebrow>
+      <div className="flex items-center gap-1.5">
+        <Eyebrow>{title}</Eyebrow>
+        {tooltip && <InfoTooltip text={tooltip} />}
+      </div>
       <div className="mt-3">{children}</div>
     </Card>
   );


### PR DESCRIPTION
Closes #293

## Summary
- Wires the already-computed `InstructionDriftTracker` into the dashboard via a new `GET /api/instruction-drift` route
- Adds an "Instruction Drift" card to the History view showing the most recent verdict (improved/degraded/neutral/insufficient_data) with success-rate, token, and thrashing deltas
- Works for any harness whose active platform adapter reports `Read` tool calls — not just Claude Code (tracks CLAUDE.md, `.cursorrules`, `AGENTS.md`, `GEMINI.md`, etc. depending on the detected platform)

## Test plan
- [x] `npm run build && npm test && npm run lint` — clean, 5301 passed / 3 skipped, 0 lint errors
- [x] Backend route tests: 503 when tracker missing, 200 + JSON metrics otherwise
- [x] Frontend tests: verdict + deltas rendered for a populated correlation, empty state rendered with no correlations yet