### PR TITLE
Feat: decision-tree and per-turn cost detail on live session pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.26] - 2026-08-03
+
+### Added
+
+- **The Today dashboard's live session pane now shows decision-tree and per-turn cost detail** — a "session detail" link opens a drawer with the current session's longest failure streak, success rate, and recovery reasoning, alongside a full breakdown of recent turns by cost, tokens, and model.
+
 ## [1.14.25] - 2026-08-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.25",
+  "version": "1.14.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.25",
+      "version": "1.14.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.25",
+  "version": "1.14.26",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -870,6 +870,82 @@ describe('api-handler GET /api/instruction-drift', () => {
   });
 });
 
+describe('api-handler GET /api/decision-tree', () => {
+  it('returns 503 when decisionTracker is missing', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/decision-tree' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns decision tree metrics as JSON', async () => {
+    const fakeMetrics = {
+      totalBranches: 4,
+      successRate: 0.5,
+      failurePoints: [],
+      longestFailureStreak: 2,
+      firstFailureIndex: 1,
+      note: '',
+    };
+    const handler = createApiHandler({
+      decisionTracker: { getMetrics: () => fakeMetrics } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['decisionTracker'],
+    });
+    const req = { method: 'GET', url: '/api/decision-tree' } as IncomingMessage;
+    const { res, status, body, headers } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(headers()['content-type']).toMatch(/application\/json/);
+    expect(JSON.parse(body())).toEqual(fakeMetrics);
+  });
+});
+
+describe('api-handler GET /api/turn-costs', () => {
+  it('returns 503 when turnCostAttributor is missing', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/turn-costs' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns turn cost metrics as JSON', async () => {
+    const fakeMetrics = {
+      turns: [
+        {
+          turnId: 't1',
+          startTime: 1,
+          endTime: 2,
+          toolCalls: ['toolu_001', 'toolu_002'],
+          toolNames: ['Read', 'Edit'],
+          inputTokens: 500,
+          outputTokens: 200,
+          cacheReadTokens: 0,
+          model: 'claude-sonnet-5',
+          estimatedCostUsd: 0.02,
+          costPerToolCall: 0.01,
+        },
+      ],
+      costByToolType: {},
+      totalAttributedCost: 0.02,
+      attributionRate: 1,
+    };
+    const handler = createApiHandler({
+      turnCostAttributor: { getMetrics: () => fakeMetrics } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['turnCostAttributor'],
+    });
+    const req = { method: 'GET', url: '/api/turn-costs' } as IncomingMessage;
+    const { res, status, body, headers } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(headers()['content-type']).toMatch(/application\/json/);
+    expect(JSON.parse(body())).toEqual(fakeMetrics);
+  });
+});
+
 describe('api-handler GET /api/audit', () => {
   it('returns audit log mapped to SPA AuditEntry shape', async () => {
     const ts1 = Date.now() - 5000;

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -61,6 +61,8 @@ import type { ContextReplayEvent, ContextTrackerMetrics } from '../../metrics/co
 import type { AntiPattern } from '../../metrics/anti-patterns.js';
 import type { RetryDetectorMetrics } from '../../metrics/retry-detector.js';
 import type { InstructionDriftMetrics } from '../../metrics/instruction-drift-tracker.js';
+import type { DecisionTreeMetrics } from '../../metrics/decision-tracker.js';
+import type { CostAttributionMetrics } from '../../metrics/turn-cost-attributor.js';
 import type { AuditRecord } from '../../security/audit-trail.js';
 interface RawAuditRecord {
   readonly timestamp: number;
@@ -380,6 +382,8 @@ export interface ApiHandlerDeps {
   readonly antiPatternDetector?: { getCurrentPatterns: () => readonly AntiPattern[] };
   readonly retryDetector?: { getMetrics: () => RetryDetectorMetrics };
   readonly instructionDriftTracker?: { getMetrics: () => InstructionDriftMetrics };
+  readonly decisionTracker?: { getMetrics: () => DecisionTreeMetrics };
+  readonly turnCostAttributor?: { getMetrics: () => CostAttributionMetrics };
   readonly auditTrailManager?: { getAuditLog: () => readonly AuditRecord[] };
   readonly weeklySummaryGenerator?: WeeklySummaryGenerator;
   readonly budgetTracker?: { getStatus: () => BudgetStatus };
@@ -1583,6 +1587,16 @@ export function createApiHandler(
   routes.set('GET /api/instruction-drift', (_req, res) => {
     if (!deps.instructionDriftTracker) return unavailable(res, 'instructionDriftTracker');
     jsonOk(res, deps.instructionDriftTracker.getMetrics());
+  });
+
+  routes.set('GET /api/decision-tree', (_req, res) => {
+    if (!deps.decisionTracker) return unavailable(res, 'decisionTracker');
+    jsonOk(res, deps.decisionTracker.getMetrics());
+  });
+
+  routes.set('GET /api/turn-costs', (_req, res) => {
+    if (!deps.turnCostAttributor) return unavailable(res, 'turnCostAttributor');
+    jsonOk(res, deps.turnCostAttributor.getMetrics());
   });
 
   routes.set('GET /api/audit', (_req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1339,6 +1339,8 @@ async function main(): Promise<void> {
           antiPatternDetector,
           retryDetector,
           instructionDriftTracker,
+          decisionTracker,
+          turnCostAttributor,
           weeklySummaryGenerator,
           budgetTracker,
           latencyTracker,

--- a/src/metrics/turn-cost-attributor.test.ts
+++ b/src/metrics/turn-cost-attributor.test.ts
@@ -57,6 +57,7 @@ describe('TurnCostAttributor', () => {
       const metrics = attributor.getMetrics();
       expect(metrics.turns).toHaveLength(1);
       expect(metrics.turns[0].toolCalls).toEqual(['toolu_001']);
+      expect(metrics.turns[0].toolNames).toEqual(['Read']);
       expect(metrics.turns[0].estimatedCostUsd).toBeGreaterThan(0);
       expect(metrics.turns[0].costPerToolCall).toBe(metrics.turns[0].estimatedCostUsd);
     });
@@ -73,6 +74,7 @@ describe('TurnCostAttributor', () => {
       const metrics = attributor.getMetrics();
       expect(metrics.turns).toHaveLength(1);
       expect(metrics.turns[0].toolCalls).toEqual(['toolu_001', 'toolu_002']);
+      expect(metrics.turns[0].toolNames).toEqual(['Read', 'Edit']);
       expect(metrics.turns[0].costPerToolCall).toBeCloseTo(
         metrics.turns[0].estimatedCostUsd / 2,
         10,
@@ -90,7 +92,9 @@ describe('TurnCostAttributor', () => {
       const metrics = attributor.getMetrics();
       expect(metrics.turns).toHaveLength(2);
       expect(metrics.turns[0].toolCalls).toEqual(['toolu_001']);
+      expect(metrics.turns[0].toolNames).toEqual(['Read']);
       expect(metrics.turns[1].toolCalls).toEqual(['toolu_002']);
+      expect(metrics.turns[1].toolNames).toEqual(['Read']);
     });
 
     it('ignores token events that arrive too late (>5s after turn end)', () => {

--- a/src/metrics/turn-cost-attributor.ts
+++ b/src/metrics/turn-cost-attributor.ts
@@ -13,6 +13,7 @@ export interface TurnCostAttribution {
   readonly startTime: number;
   readonly endTime: number;
   readonly toolCalls: string[];
+  readonly toolNames: string[];
   readonly inputTokens: number;
   readonly outputTokens: number;
   readonly cacheReadTokens: number;
@@ -123,6 +124,7 @@ export class TurnCostAttributor {
       startTime: this.pendingTurn.startTime,
       endTime: this.pendingTurn.endTime,
       toolCalls: this.pendingTurn.toolCalls.map((tc) => tc.toolUseId),
+      toolNames: this.pendingTurn.toolCalls.map((tc) => tc.toolName),
       inputTokens: event.inputTokens,
       outputTokens: event.outputTokens,
       cacheReadTokens: event.cacheReadTokens,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -299,6 +299,55 @@ export interface RetryAlertsResponse {
 export const fetchRetryAlerts = (): Promise<RetryAlertsResponse> =>
   getJson<RetryAlertsResponse>('/api/retry-alerts');
 
+export interface DecisionBranchEntry {
+  readonly turnNumber: number;
+  readonly timestamp: number;
+  readonly reasoning: string;
+  readonly chosenAction: string;
+  readonly toolName: string | null;
+  readonly outcome: 'unknown' | 'success' | 'failure';
+  readonly nextToolSuccess: boolean | null;
+  readonly sessionSucceeded: boolean | null;
+}
+
+export interface DecisionTreeResponse {
+  readonly totalBranches: number;
+  readonly successRate: number | null;
+  readonly failurePoints: readonly DecisionBranchEntry[];
+  readonly longestFailureStreak: number;
+  readonly firstFailureIndex: number | null;
+  readonly note: string;
+}
+
+export interface TurnCostEntry {
+  readonly turnId: string;
+  readonly startTime: number;
+  readonly endTime: number;
+  readonly toolCalls: readonly string[];
+  readonly toolNames: readonly string[];
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly model: string;
+  readonly estimatedCostUsd: number;
+  readonly costPerToolCall: number;
+}
+
+export interface TurnCostsResponse {
+  readonly turns: readonly TurnCostEntry[];
+  readonly costByToolType: Record<
+    string,
+    { totalCost: number; callCount: number; avgCost: number }
+  >;
+  readonly totalAttributedCost: number;
+  readonly attributionRate: number;
+}
+
+export const fetchDecisionTree = (): Promise<DecisionTreeResponse> =>
+  getJson<DecisionTreeResponse>('/api/decision-tree');
+export const fetchTurnCosts = (): Promise<TurnCostsResponse> =>
+  getJson<TurnCostsResponse>('/api/turn-costs');
+
 export interface QualityEvent {
   readonly signal:
     | 'diff_applied_clean'

--- a/src/web/components/SessionDetailDialog.test.tsx
+++ b/src/web/components/SessionDetailDialog.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SessionDetailDialog } from './SessionDetailDialog';
+import type { DecisionTreeResponse, TurnCostsResponse } from '../api/client';
+
+function makeDecisionTree(overrides: Partial<DecisionTreeResponse> = {}): DecisionTreeResponse {
+  return {
+    totalBranches: 4,
+    successRate: 0.75,
+    failurePoints: [],
+    longestFailureStreak: 2,
+    firstFailureIndex: 1,
+    note: 'reasoning fields are the model’s own thinking/text output for that turn',
+    ...overrides,
+  };
+}
+
+function makeTurnCosts(overrides: Partial<TurnCostsResponse> = {}): TurnCostsResponse {
+  return {
+    turns: [
+      {
+        turnId: 't1',
+        startTime: 1,
+        endTime: 2,
+        toolCalls: ['toolu_001'],
+        toolNames: ['Read'],
+        inputTokens: 500,
+        outputTokens: 100,
+        cacheReadTokens: 0,
+        model: 'claude-sonnet-5',
+        estimatedCostUsd: 0.01,
+        costPerToolCall: 0.01,
+      },
+    ],
+    costByToolType: {},
+    totalAttributedCost: 0.01,
+    attributionRate: 1,
+    ...overrides,
+  };
+}
+
+function makeSixTurns(): TurnCostsResponse['turns'] {
+  return Array.from({ length: 6 }, (_, i) => ({
+    turnId: `t${i + 1}`,
+    startTime: i,
+    endTime: i + 1,
+    toolCalls: [`toolu_00${i + 1}`],
+    toolNames: [i === 5 ? 'Bash' : 'Read'],
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheReadTokens: 0,
+    model: 'claude-sonnet-5',
+    estimatedCostUsd: (i + 1) / 100,
+    costPerToolCall: (i + 1) / 100,
+  }));
+}
+
+describe('SessionDetailDialog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders decision-tree stats and every turn row, not just the last 5', () => {
+    render(
+      <SessionDetailDialog
+        decisionTree={makeDecisionTree()}
+        turnCosts={makeTurnCosts({ turns: makeSixTurns(), totalAttributedCost: 0.21 })}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText(/longest failure streak/i)).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('75%')).toBeInTheDocument();
+    // The 6th turn would have been sliced off by the old `.slice(-5)` — assert
+    // it's visible here since the dialog has room to show every turn.
+    expect(screen.getByText('$0.06')).toBeInTheDocument();
+    expect(screen.getByText('$0.21')).toBeInTheDocument();
+  });
+
+  it('shows a "No data yet" fallback for an empty/undefined decision tree', () => {
+    render(
+      <SessionDetailDialog
+        decisionTree={undefined}
+        turnCosts={makeTurnCosts()}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText(/no decision-tree data yet/i)).toBeInTheDocument();
+  });
+
+  it('shows a "No data yet" fallback for an empty/undefined turn-cost list', () => {
+    render(
+      <SessionDetailDialog
+        decisionTree={makeDecisionTree()}
+        turnCosts={makeTurnCosts({ turns: [] })}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText(/no turn-cost data yet/i)).toBeInTheDocument();
+  });
+
+  it('calls onClose on Escape', () => {
+    const onClose = vi.fn();
+    render(
+      <SessionDetailDialog
+        decisionTree={makeDecisionTree()}
+        turnCosts={makeTurnCosts()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <SessionDetailDialog
+        decisionTree={makeDecisionTree()}
+        turnCosts={makeTurnCosts()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /close session detail/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('focuses the close button on mount', () => {
+    render(
+      <SessionDetailDialog
+        decisionTree={makeDecisionTree()}
+        turnCosts={makeTurnCosts()}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /close session detail/i })).toHaveFocus();
+  });
+});

--- a/src/web/components/SessionDetailDialog.tsx
+++ b/src/web/components/SessionDetailDialog.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useRef } from 'react';
+import type { JSX } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+
+import type { DecisionTreeResponse, TurnCostsResponse } from '../api/client';
+import { Card, Eyebrow, Pill, type PillTone } from './ui';
+import { formatTokensCompact } from '../lib/format.js';
+
+export interface SessionDetailDialogProps {
+  readonly decisionTree: DecisionTreeResponse | undefined;
+  readonly turnCosts: TurnCostsResponse | undefined;
+  readonly onClose: () => void;
+}
+
+const OUTCOME_TONE: Record<'unknown' | 'success' | 'failure', PillTone> = {
+  success: 'success',
+  failure: 'danger',
+  unknown: 'neutral',
+};
+
+// Same drawer/backdrop/focus-trap pattern as WorkflowRunDetail — kept in
+// lockstep with that component so the two dialogs behave identically.
+export function SessionDetailDialog({
+  decisionTree,
+  turnCosts,
+  onClose,
+}: SessionDetailDialogProps): JSX.Element {
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent): void {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab' && drawerRef.current) {
+        const focusable = drawerRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        } else if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        }
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    closeButtonRef.current?.focus();
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const hasDecisionData = decisionTree != null && decisionTree.totalBranches > 0;
+  const hasTurnData = turnCosts?.turns != null && turnCosts.turns.length > 0;
+
+  // Portaled to document.body: LiveSessionPane's `.animate-card-enter`
+  // ancestor keeps a non-`none` `transform` after its entrance animation
+  // settles (animation-fill-mode: both), which makes it a containing block
+  // for `position: fixed` descendants — without the portal this drawer
+  // renders clipped to that 320px card instead of the viewport.
+  return createPortal(
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+
+      {/* Drawer panel */}
+      <div
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Session decision-tree and turn-cost detail"
+        className="fixed right-0 top-0 bottom-0 z-50 w-[640px] max-w-full flex flex-col bg-bg-panel border-l border-border-medium shadow-2xl overflow-hidden"
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-border-subtle shrink-0">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-sm font-semibold text-ink-base">Session Detail</h2>
+            <p className="mt-1 text-[10px] text-ink-muted">
+              Live, current-process-only — reflects this dashboard process&rsquo;s own current
+              session.
+            </p>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            aria-label="Close session detail"
+            onClick={onClose}
+            className="shrink-0 p-1.5 rounded-md text-ink-muted hover:text-ink-base hover:bg-surface-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/40"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+          <section aria-label="Decision tree">
+            <Eyebrow className="mb-3">Decision Tree</Eyebrow>
+            <Card tone="static" padding="sm">
+              {!hasDecisionData ? (
+                <div className="py-2 text-center text-xs text-ink-muted">
+                  No decision-tree data yet.
+                </div>
+              ) : (
+                <>
+                  <div className="grid grid-cols-3 gap-3">
+                    <Stat
+                      label="Longest failure streak"
+                      value={String(decisionTree.longestFailureStreak)}
+                    />
+                    <Stat
+                      label="Success rate"
+                      value={
+                        decisionTree.successRate !== null
+                          ? `${Math.round(decisionTree.successRate * 100)}%`
+                          : '—'
+                      }
+                    />
+                    <Stat label="Total branches" value={String(decisionTree.totalBranches)} />
+                  </div>
+                  {decisionTree.failurePoints.length > 0 && (
+                    <div className="mt-3 pt-3 border-t border-border-subtle space-y-2">
+                      {decisionTree.failurePoints.map((branch, i) => (
+                        <div
+                          key={`${branch.turnNumber}-${i}`}
+                          className="flex items-start justify-between gap-2 text-xs"
+                        >
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-1.5 flex-wrap">
+                              <span className="text-ink-muted">Turn {branch.turnNumber}</span>
+                              {branch.toolName && (
+                                <code className="text-[10px] bg-surface-5 px-1 rounded">
+                                  {branch.toolName}
+                                </code>
+                              )}
+                              <Pill tone={OUTCOME_TONE[branch.outcome]} size="sm">
+                                {branch.outcome}
+                              </Pill>
+                            </div>
+                            <p className="mt-0.5 text-ink-subtle break-words">{branch.reasoning}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {decisionTree.note && (
+                    <p className="mt-3 pt-3 border-t border-border-subtle text-[10px] text-ink-muted">
+                      {decisionTree.note}
+                    </p>
+                  )}
+                </>
+              )}
+            </Card>
+          </section>
+
+          <section aria-label="Turn costs">
+            <Eyebrow className="mb-3">Turn Costs</Eyebrow>
+            <Card tone="static" padding="sm">
+              {!hasTurnData ? (
+                <div className="py-2 text-center text-xs text-ink-muted">
+                  No turn-cost data yet.
+                </div>
+              ) : (
+                <>
+                  <div className="grid grid-cols-2 gap-3 mb-3 pb-3 border-b border-border-subtle">
+                    <Stat
+                      label="Total attributed cost"
+                      value={`$${turnCosts.totalAttributedCost.toFixed(2)}`}
+                    />
+                    <Stat
+                      label="Attribution rate"
+                      value={`${Math.round(turnCosts.attributionRate * 100)}%`}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    {turnCosts.turns.map((t) => (
+                      <div
+                        key={t.turnId}
+                        className="flex items-center justify-between gap-2 text-xs"
+                      >
+                        <div className="min-w-0">
+                          <div className="text-ink-base">{t.toolNames.join(', ')}</div>
+                          <div className="text-[10px] text-ink-muted font-mono">
+                            {t.model} · {formatTokensCompact(t.inputTokens)} in /{' '}
+                            {formatTokensCompact(t.outputTokens)} out /{' '}
+                            {formatTokensCompact(t.cacheReadTokens)} cache
+                          </div>
+                        </div>
+                        <span className="shrink-0 tabular-nums text-ink-base">
+                          ${t.estimatedCostUsd.toFixed(2)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
+            </Card>
+          </section>
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }): JSX.Element {
+  return (
+    <div>
+      <div className="text-[10px] text-ink-muted uppercase tracking-wider">{label}</div>
+      <div className="text-sm font-bold tabular-nums text-ink-base mt-0.5">{value}</div>
+    </div>
+  );
+}

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Today } from './Today';
 import { useLiveStore } from '../store/liveStore';
@@ -108,6 +108,97 @@ describe('Today view', () => {
     }) as typeof fetch;
     renderToday();
     expect(await screen.findByText(/~750 tokens wasted/i)).toBeInTheDocument();
+  });
+
+  function stubTurnCostsAndDecisionTree(turnCount = 1): void {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.startsWith('/api/turn-costs')) {
+        return new Response(
+          JSON.stringify({
+            turns: Array.from({ length: turnCount }, (_, i) => ({
+              turnId: `t${i + 1}`,
+              startTime: i,
+              endTime: i + 1,
+              toolCalls: [`toolu_00${i + 1}`],
+              toolNames: [i === turnCount - 1 ? 'Bash' : 'Read'],
+              inputTokens: 500,
+              outputTokens: 200,
+              cacheReadTokens: 0,
+              model: 'claude-sonnet-5',
+              estimatedCostUsd: (i + 1) / 100,
+              costPerToolCall: (i + 1) / 100,
+            })),
+            costByToolType: {},
+            totalAttributedCost: (turnCount * (turnCount + 1)) / 2 / 100,
+            attributionRate: 1,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.startsWith('/api/decision-tree')) {
+        return new Response(
+          JSON.stringify({
+            totalBranches: 4,
+            successRate: 0.5,
+            failurePoints: [],
+            longestFailureStreak: 2,
+            firstFailureIndex: 1,
+            note: '',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response('null', { status: 200 });
+    }) as typeof globalThis.fetch;
+  }
+
+  it('shows a one-line trigger (not the full detail) in LiveSessionPane when data exists', async () => {
+    stubTurnCostsAndDecisionTree(1);
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <Today />
+      </QueryClientProvider>,
+    );
+    expect(
+      await screen.findByText(/2 failure streak.*1 turns.*\$0\.01.*session detail/i),
+    ).toBeInTheDocument();
+    // The full breakdown must NOT be inline — that's the whole point of the dialog.
+    expect(screen.queryByText('Recent turns')).toBeNull();
+  });
+
+  it('opens the session detail dialog with every turn (not sliced to the last 5) on click', async () => {
+    stubTurnCostsAndDecisionTree(6);
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <Today />
+      </QueryClientProvider>,
+    );
+    const trigger = await screen.findByText(/session detail/i);
+    fireEvent.click(trigger);
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    // 6th turn's cost ($0.06) would have been sliced off by the old `.slice(-5)`.
+    expect(screen.getByText('$0.06')).toBeInTheDocument();
+    expect(screen.getByText(/longest failure streak/i)).toBeInTheDocument();
+  });
+
+  it('hides the trigger when neither tracker has data', async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ) as typeof fetch;
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <Today />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(screen.queryByText(/session detail/i)).toBeNull());
   });
 
   it('renders a real count for stuck_loop via the API-fallback path, not "?"', async () => {

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -14,6 +14,7 @@ import { HourlyCostBlocks, type HourlyCostEntry } from '../components/HourlyCost
 import { EmptyState } from '../components/EmptyState';
 import { SessionTrace } from '../components/SessionTrace';
 import { WorkflowRunDetail } from '../components/WorkflowRunDetail';
+import { SessionDetailDialog } from '../components/SessionDetailDialog';
 import type { AgentSpan } from '../components/AgentSwimlanes';
 import { ConcurrencyIndicator, type ConcurrencyData } from '../components/ConcurrencyIndicator';
 import { ActivityHeatmap } from '../components/ActivityHeatmap';
@@ -32,6 +33,10 @@ import {
   fetchAntiPatterns,
   fetchRetryAlerts,
   type RetryAlertsResponse,
+  fetchTurnCosts,
+  type TurnCostsResponse,
+  fetchDecisionTree,
+  type DecisionTreeResponse,
   fetchQualityProxy,
   fetchToolSelectionScore,
   fetchConcurrency,
@@ -897,6 +902,10 @@ function LiveSessionPane({
   // In-place workflow-run drawer (same pattern as the Sessions view) — opening
   // a run from the trace overlays the detail rather than navigating away.
   const [openRunId, setOpenRunId] = useState<string | null>(null);
+  // Decision-tree + turn-cost detail drawer — kept out of the fixed-height
+  // trace pane itself so a busy session's failure/turn count never eats into
+  // the trace's available vertical space.
+  const [showDetail, setShowDetail] = useState(false);
   const [, navigate] = useLocation();
   const setActiveSession = useLiveStore((s) => s.setActiveSession);
 
@@ -970,6 +979,21 @@ function LiveSessionPane({
     queryKey: qk.workflows,
     queryFn: fetchWorkflows,
     refetchInterval: isLive ? 10_000 : false,
+  });
+
+  // Decision-tree + per-turn cost detail — both trackers are live,
+  // in-memory, current-process-only accumulators (no persistence), so this
+  // always reflects this dashboard process's own current session, not
+  // necessarily the session selected in the list on the left.
+  const { data: turnCosts } = useQuery<TurnCostsResponse>({
+    queryKey: ['turn-costs'],
+    queryFn: fetchTurnCosts,
+    refetchInterval: 10_000,
+  });
+  const { data: decisionTree } = useQuery<DecisionTreeResponse>({
+    queryKey: ['decision-tree'],
+    queryFn: fetchDecisionTree,
+    refetchInterval: 10_000,
   });
 
   const tailRef = useRef<HTMLDivElement>(null);
@@ -1215,10 +1239,39 @@ function LiveSessionPane({
               <ContextBar sessionId={activeId} />
             </div>
           )}
+          {/* `turnCosts?.turns?.length` (not `turnCosts && turnCosts.turns.length`)
+            because unrelated tests' default fetch mocks resolve every
+            unmatched endpoint (including this one) to `[]`, which has no
+            `.turns` field — the plain-object shape only holds under the
+            dedicated /api/turn-costs mock. */}
+          {((decisionTree?.totalBranches ?? 0) > 0 || (turnCosts?.turns?.length ?? 0) > 0) && (
+            <div className="border-t border-bg-line px-3 py-2 shrink-0">
+              <button
+                type="button"
+                onClick={() => setShowDetail(true)}
+                className="text-[10px] text-accent-cyan hover:underline transition-colors duration-150 text-left"
+              >
+                {decisionTree && decisionTree.totalBranches > 0
+                  ? `${decisionTree.longestFailureStreak} failure streak`
+                  : null}
+                {turnCosts?.turns && turnCosts.turns.length > 0
+                  ? ` · ${turnCosts.turns.length} turns · $${turnCosts.totalAttributedCost.toFixed(2)}`
+                  : null}
+                {' — session detail →'}
+              </button>
+            </div>
+          )}
         </div>
       </div>
       {openRunId != null && (
         <WorkflowRunDetail runId={openRunId} onClose={() => setOpenRunId(null)} />
+      )}
+      {showDetail && (
+        <SessionDetailDialog
+          decisionTree={decisionTree}
+          turnCosts={turnCosts}
+          onClose={() => setShowDetail(false)}
+        />
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- Adds `GET /api/decision-tree` and `GET /api/turn-costs`, backed by the existing `DecisionTracker` and `TurnCostAttributor` (previously reachable only via their MCP tools, not the dashboard).
- Adds a "session detail" link in the Today dashboard's live session pane that opens a drawer showing the current session's longest failure streak, success rate, and recovery reasoning, alongside a full per-turn breakdown of cost, tokens, and model.
- Both trackers are live, in-memory, current-process-only — the drawer reflects the dashboard process's own current session, with no historical/persisted-session support.
- Progress on #304 (decision-tree and turn-cost-attribution are now surfaced; context-efficiency and context-composition from that issue are still MCP-tool-only).

## Test plan
- [x] `npm run build && npm test && npm run lint` clean
- [x] `npm run test:web` — full frontend suite passing, including new coverage for the trigger/dialog behavior and the dialog component itself