### PR TITLE
Feat: context window pressure timeline in ContextBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.27] - 2026-08-04
+
+### Added
+
+- **The Today dashboard's live session pane now shows a context-window fill timeline** — the "session detail" drawer gains a stacked-area chart of context fill per turn, so you can see how the context window filled up over the course of a session, not just its current snapshot. On the full Sessions page, the same chart still expands inline from the context bar's own chevron, unchanged.
+
 ## [1.14.26] - 2026-08-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.26",
+  "version": "1.14.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.26",
+      "version": "1.14.27",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.26",
+  "version": "1.14.27",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/web/components/ContextBar.test.tsx
+++ b/src/web/components/ContextBar.test.tsx
@@ -1,16 +1,21 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ContextBar } from './ContextBar';
+import { ContextBar, type ContextBarProps } from './ContextBar';
 import type { ContextResponse } from '../api/client';
+import { useLiveStore } from '../store/liveStore';
 
-function renderContextBar(data: ContextResponse) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
-  return render(
-    <QueryClientProvider client={client}>
-      <ContextBar data={data} />
-    </QueryClientProvider>,
-  );
+function makeHistory(count: number): ContextResponse['history'] {
+  return Array.from({ length: count }, (_, i) => ({
+    turnNumber: i + 1,
+    timestamp: 0,
+    inputTokens: (i + 1) * 10_000,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    fillPercent: (((i + 1) * 10_000) / 200_000) * 100,
+    breakdown: { system: 5_000, tools: 3_000, user: 1_500, assistant: 500 },
+  }));
 }
 
 function makeContext(overrides: Partial<ContextResponse> = {}): ContextResponse {
@@ -26,9 +31,98 @@ function makeContext(overrides: Partial<ContextResponse> = {}): ContextResponse 
   };
 }
 
+function renderContextBar(props: ContextBarProps): ReturnType<typeof render> {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ContextBar {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+function resetStore(): void {
+  useLiveStore.setState({ contextBySession: new Map() });
+}
+
+describe('ContextBar — timeline expand/collapse', () => {
+  beforeEach(resetStore);
+  afterEach(resetStore);
+
+  it('hides the chevron toggle when history is empty', () => {
+    renderContextBar({ data: makeContext({ history: [] }) });
+    expect(screen.queryByRole('button', { name: 'Toggle context timeline' })).toBeNull();
+  });
+
+  it('hides the chevron toggle when history has exactly 1 turn', () => {
+    renderContextBar({ data: makeContext({ history: makeHistory(1) }) });
+    expect(screen.queryByRole('button', { name: 'Toggle context timeline' })).toBeNull();
+  });
+
+  it('shows the chevron toggle when history has 2 or more turns', () => {
+    renderContextBar({ data: makeContext({ history: makeHistory(2) }) });
+    expect(screen.getByRole('button', { name: 'Toggle context timeline' })).toBeInTheDocument();
+  });
+
+  it('timeline is collapsed by default (aria-expanded=false)', () => {
+    renderContextBar({ data: makeContext({ history: makeHistory(3) }) });
+    const btn = screen.getByRole('button', { name: 'Toggle context timeline' });
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('expands the timeline on click (aria-expanded becomes true)', () => {
+    renderContextBar({ data: makeContext({ history: makeHistory(3) }) });
+    const btn = screen.getByRole('button', { name: 'Toggle context timeline' });
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('collapses the timeline on second click', () => {
+    renderContextBar({ data: makeContext({ history: makeHistory(3) }) });
+    const btn = screen.getByRole('button', { name: 'Toggle context timeline' });
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('resets the timeline to collapsed when sessionId changes', () => {
+    const data = makeContext({ history: makeHistory(3) });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    const { rerender } = render(
+      <QueryClientProvider client={qc}>
+        <ContextBar data={data} sessionId="s1" />
+      </QueryClientProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle context timeline' }));
+    expect(screen.getByRole('button', { name: 'Toggle context timeline' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+
+    rerender(
+      <QueryClientProvider client={qc}>
+        <ContextBar data={data} sessionId="s2" />
+      </QueryClientProvider>,
+    );
+    expect(screen.getByRole('button', { name: 'Toggle context timeline' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('omits the chevron toggle when expandable is false, even with 2+ turns', () => {
+    renderContextBar({ data: makeContext({ history: makeHistory(3) }), expandable: false });
+    expect(screen.queryByRole('button', { name: 'Toggle context timeline' })).toBeNull();
+  });
+
+  it('still shows the chevron toggle when expandable is true (explicit, not just default)', () => {
+    renderContextBar({ data: makeContext({ history: makeHistory(3) }), expandable: true });
+    expect(screen.getByRole('button', { name: 'Toggle context timeline' })).toBeInTheDocument();
+  });
+});
+
 describe('ContextBar', () => {
   it('flags the compacting state when currentTokens drops more than 30% from the previous render', () => {
-    const { container, rerender } = renderContextBar(makeContext());
+    const { container, rerender } = renderContextBar({ data: makeContext() });
     const client = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
     rerender(
       <QueryClientProvider client={client}>
@@ -44,7 +138,7 @@ describe('ContextBar', () => {
   });
 
   it('does not flag compacting on a small drop (< 30%)', () => {
-    const { container, rerender } = renderContextBar(makeContext());
+    const { container, rerender } = renderContextBar({ data: makeContext() });
     const client = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
     rerender(
       <QueryClientProvider client={client}>
@@ -60,12 +154,12 @@ describe('ContextBar', () => {
   });
 
   it('renders the "at capacity" pill only when fillPercent is at least 100', () => {
-    renderContextBar(makeContext({ fillPercent: 100 }));
+    renderContextBar({ data: makeContext({ fillPercent: 100 }) });
     expect(screen.getByText('at capacity')).toBeInTheDocument();
   });
 
   it('does not render the "at capacity" pill when fillPercent is below 100', () => {
-    renderContextBar(makeContext({ fillPercent: 99 }));
+    renderContextBar({ data: makeContext({ fillPercent: 99 }) });
     expect(screen.queryByText('at capacity')).not.toBeInTheDocument();
   });
 });

--- a/src/web/components/ContextBar.tsx
+++ b/src/web/components/ContextBar.tsx
@@ -1,6 +1,16 @@
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState, useId } from 'react';
 import type { JSX } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ReferenceArea,
+  ResponsiveContainer,
+} from 'recharts';
 
 import { fetchContext, qk, type ContextResponse } from '../api/client';
 import { useLiveStore, type ContextUpdateEvent } from '../store/liveStore';
@@ -9,6 +19,7 @@ import { Eyebrow, Pill } from './ui';
 export interface ContextBarProps {
   readonly data?: ContextResponse | null;
   readonly sessionId?: string | null;
+  readonly expandable?: boolean;
 }
 
 const CATEGORIES = ['system', 'tools', 'user', 'assistant'] as const;
@@ -41,6 +52,81 @@ const CATEGORY_LABELS: Record<string, string> = {
   assistant: 'Assistant',
 };
 
+const CHART_COLORS: Record<string, string> = {
+  system: '#6366f1',
+  tools: '#ffb224',
+  user: '#0095ff',
+  assistant: '#1ce783',
+};
+
+const CHART_TICK_STYLE = { fontSize: 10, fill: '#6b7280' } as const;
+const CHART_GRID_STROKE = '#2a2a3a';
+
+export interface ContextTimelineProps {
+  readonly history: ContextResponse['history'];
+  readonly contextWindow: number;
+}
+
+export function ContextTimeline({
+  history,
+  contextWindow,
+}: ContextTimelineProps): JSX.Element | null {
+  const gradientId = useId();
+  if (history.length < 2) return null;
+
+  const chartData = history.map((snap) => ({
+    turn: snap.turnNumber,
+    system: contextWindow > 0 ? (snap.breakdown.system / contextWindow) * 100 : 0,
+    tools: contextWindow > 0 ? (snap.breakdown.tools / contextWindow) * 100 : 0,
+    user: contextWindow > 0 ? (snap.breakdown.user / contextWindow) * 100 : 0,
+    assistant: contextWindow > 0 ? (snap.breakdown.assistant / contextWindow) * 100 : 0,
+  }));
+
+  return (
+    <div className="mt-2 pt-2 border-t border-surface-3">
+      <ResponsiveContainer width="100%" height={120}>
+        <AreaChart data={chartData} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="1" x2="0" y2="0">
+              <stop offset="0%" stopColor="#f59e0b" stopOpacity={0.15} />
+              <stop offset="100%" stopColor="#ef4444" stopOpacity={0.25} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
+          <XAxis dataKey="turn" tick={CHART_TICK_STYLE} stroke={CHART_GRID_STROKE} />
+          <YAxis domain={[0, 100]} unit="%" tick={CHART_TICK_STYLE} stroke={CHART_GRID_STROKE} />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1a1a2e',
+              border: '1px solid #2a2a3a',
+              fontSize: 11,
+            }}
+            formatter={(value: unknown, name: unknown) => [
+              `${(value as number).toFixed(1)}%`,
+              name as string,
+            ]}
+            labelFormatter={(label: unknown) => `Turn ${label as number}`}
+          />
+          <ReferenceArea y1={80} y2={100} fill={`url(#${gradientId})`} ifOverflow="visible" />
+          {CATEGORIES.map((cat) => (
+            <Area
+              key={cat}
+              type="monotone"
+              dataKey={cat}
+              stackId="context"
+              stroke={CHART_COLORS[cat]}
+              fill={CHART_COLORS[cat]}
+              fillOpacity={0.4}
+              strokeWidth={1}
+              dot={false}
+            />
+          ))}
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
@@ -67,13 +153,22 @@ function toContextEvent(api: ContextResponse, sessionId = ''): ContextUpdateEven
   };
 }
 
-export function ContextBar({ data, sessionId }: ContextBarProps): JSX.Element | null {
+export function ContextBar({
+  data,
+  sessionId,
+  expandable = true,
+}: ContextBarProps): JSX.Element | null {
   const contextBySession = useLiveStore((s) => s.contextBySession);
   const liveContext = sessionId ? (contextBySession.get(sessionId) ?? null) : null;
   const [hoveredCat, setHoveredCat] = useState<string | null>(null);
   const [compacting, setCompacting] = useState(false);
+  const [showTimeline, setShowTimeline] = useState(false);
   const prevFillRef = useRef(0);
   const prevTokensRef = useRef(0);
+
+  useEffect(() => {
+    setShowTimeline(false);
+  }, [sessionId]);
 
   const { data: apiContext } = useQuery<ContextResponse>({
     queryKey: sessionId ? ['context', sessionId] : qk.context,
@@ -118,6 +213,9 @@ export function ContextBar({ data, sessionId }: ContextBarProps): JSX.Element | 
   // bar like "250K / 200K" with a 25% legend.
   const contextWindow = ctx.contextWindow;
 
+  const timelineHistory =
+    showTimeline && source?.history && source.history.length >= 2 ? source.history : null;
+
   return (
     <div className="group">
       {/* Header */}
@@ -135,7 +233,7 @@ export function ContextBar({ data, sessionId }: ContextBarProps): JSX.Element | 
             </Pill>
           )}
         </div>
-        <div className="text-[11px] text-ink-subtle tabular-nums">
+        <div className="flex items-center gap-1 text-[11px] text-ink-subtle tabular-nums">
           {formatTokens(growth.currentTokens)}
           {contextWindow && contextWindow > 0 && (
             <span className="text-ink-muted">{` / ${formatTokens(contextWindow)}`}</span>
@@ -144,6 +242,16 @@ export function ContextBar({ data, sessionId }: ContextBarProps): JSX.Element | 
             <span className="text-accent-amber ml-1">+{formatTokens(growth.delta)}</span>
           )}
           {growth.delta < 0 && <span className="text-accent-cyan ml-1">compacted</span>}
+          {expandable && (source?.history?.length ?? 0) >= 2 && (
+            <button
+              onClick={() => setShowTimeline((v) => !v)}
+              className="ml-1 text-ink-muted hover:text-ink-base transition-colors"
+              aria-label="Toggle context timeline"
+              aria-expanded={showTimeline}
+            >
+              {showTimeline ? '▾' : '▸'}
+            </button>
+          )}
         </div>
       </div>
 
@@ -202,6 +310,16 @@ export function ContextBar({ data, sessionId }: ContextBarProps): JSX.Element | 
           {cappedFill.toFixed(0)}%
         </span>
       </div>
+
+      {expandable && (
+        <div
+          className={`overflow-hidden transition-all duration-300 ${showTimeline ? 'max-h-40' : 'max-h-0'}`}
+        >
+          {timelineHistory && (
+            <ContextTimeline history={timelineHistory} contextWindow={contextWindow} />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/web/components/SessionDetailDialog.test.tsx
+++ b/src/web/components/SessionDetailDialog.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { SessionDetailDialog } from './SessionDetailDialog';
-import type { DecisionTreeResponse, TurnCostsResponse } from '../api/client';
+import type { DecisionTreeResponse, TurnCostsResponse, ContextResponse } from '../api/client';
 
 function makeDecisionTree(overrides: Partial<DecisionTreeResponse> = {}): DecisionTreeResponse {
   return {
@@ -52,6 +52,19 @@ function makeSixTurns(): TurnCostsResponse['turns'] {
     model: 'claude-sonnet-5',
     estimatedCostUsd: (i + 1) / 100,
     costPerToolCall: (i + 1) / 100,
+  }));
+}
+
+function makeContextHistory(count: number): ContextResponse['history'] {
+  return Array.from({ length: count }, (_, i) => ({
+    turnNumber: i + 1,
+    timestamp: i,
+    inputTokens: (i + 1) * 10_000,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    fillPercent: (((i + 1) * 10_000) / 200_000) * 100,
+    breakdown: { system: 5_000, tools: 3_000, user: 1_500, assistant: 500 },
   }));
 }
 
@@ -134,5 +147,49 @@ describe('SessionDetailDialog', () => {
       />,
     );
     expect(screen.getByRole('button', { name: /close session detail/i })).toHaveFocus();
+  });
+});
+
+describe('SessionDetailDialog — context timeline section', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the empty state when contextHistory has fewer than 2 turns', () => {
+    render(
+      <SessionDetailDialog
+        decisionTree={makeDecisionTree()}
+        turnCosts={makeTurnCosts()}
+        contextHistory={makeContextHistory(1)}
+        contextWindow={200_000}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('No context timeline data yet.')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when contextHistory is undefined', () => {
+    render(
+      <SessionDetailDialog
+        decisionTree={makeDecisionTree()}
+        turnCosts={makeTurnCosts()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('No context timeline data yet.')).toBeInTheDocument();
+  });
+
+  it('renders the Context Timeline section label when 2+ turns are present', () => {
+    render(
+      <SessionDetailDialog
+        decisionTree={makeDecisionTree()}
+        turnCosts={makeTurnCosts()}
+        contextHistory={makeContextHistory(3)}
+        contextWindow={200_000}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Context Timeline')).toBeInTheDocument();
+    expect(screen.queryByText('No context timeline data yet.')).toBeNull();
   });
 });

--- a/src/web/components/SessionDetailDialog.tsx
+++ b/src/web/components/SessionDetailDialog.tsx
@@ -3,13 +3,16 @@ import type { JSX } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 
-import type { DecisionTreeResponse, TurnCostsResponse } from '../api/client';
+import type { DecisionTreeResponse, TurnCostsResponse, ContextResponse } from '../api/client';
 import { Card, Eyebrow, Pill, type PillTone } from './ui';
 import { formatTokensCompact } from '../lib/format.js';
+import { ContextTimeline } from './ContextBar';
 
 export interface SessionDetailDialogProps {
   readonly decisionTree: DecisionTreeResponse | undefined;
   readonly turnCosts: TurnCostsResponse | undefined;
+  readonly contextHistory?: ContextResponse['history'];
+  readonly contextWindow?: number;
   readonly onClose: () => void;
 }
 
@@ -24,6 +27,8 @@ const OUTCOME_TONE: Record<'unknown' | 'success' | 'failure', PillTone> = {
 export function SessionDetailDialog({
   decisionTree,
   turnCosts,
+  contextHistory,
+  contextWindow,
   onClose,
 }: SessionDetailDialogProps): JSX.Element {
   const drawerRef = useRef<HTMLDivElement>(null);
@@ -57,6 +62,7 @@ export function SessionDetailDialog({
 
   const hasDecisionData = decisionTree != null && decisionTree.totalBranches > 0;
   const hasTurnData = turnCosts?.turns != null && turnCosts.turns.length > 0;
+  const hasContextTimeline = (contextHistory?.length ?? 0) >= 2;
 
   // Portaled to document.body: LiveSessionPane's `.animate-card-enter`
   // ancestor keeps a non-`none` `transform` after its entrance animation
@@ -201,6 +207,22 @@ export function SessionDetailDialog({
                     ))}
                   </div>
                 </>
+              )}
+            </Card>
+          </section>
+
+          <section aria-label="Context timeline">
+            <Eyebrow className="mb-3">Context Timeline</Eyebrow>
+            <Card tone="static" padding="sm">
+              {hasContextTimeline ? (
+                <ContextTimeline
+                  history={contextHistory ?? []}
+                  contextWindow={contextWindow ?? 0}
+                />
+              ) : (
+                <div className="py-2 text-center text-xs text-ink-muted">
+                  No context timeline data yet.
+                </div>
               )}
             </Card>
           </section>

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -201,6 +201,96 @@ describe('Today view', () => {
     await waitFor(() => expect(screen.queryByText(/session detail/i)).toBeNull());
   });
 
+  it('shows the session detail trigger from context-history data alone, with no decision/cost data', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.startsWith('/api/context')) {
+        return new Response(
+          JSON.stringify({
+            turnCount: 3,
+            growth: { startTokens: 10_000, currentTokens: 30_000, deltaTokens: 20_000 },
+            currentBreakdown: { system: 10_000, tools: 10_000, user: 5_000, assistant: 5_000 },
+            fillPercent: 15,
+            contextWindow: 200_000,
+            toolContributions: [],
+            history: [
+              {
+                turnNumber: 1,
+                timestamp: 0,
+                inputTokens: 10_000,
+                outputTokens: 0,
+                cacheReadTokens: 0,
+                cacheCreationTokens: 0,
+                fillPercent: 5,
+                breakdown: { system: 5_000, tools: 3_000, user: 1_500, assistant: 500 },
+              },
+              {
+                turnNumber: 2,
+                timestamp: 1,
+                inputTokens: 20_000,
+                outputTokens: 0,
+                cacheReadTokens: 0,
+                cacheCreationTokens: 0,
+                fillPercent: 10,
+                breakdown: { system: 5_000, tools: 6_000, user: 3_000, assistant: 1_000 },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      // Exact match (not `startsWith`) — the session id below starts with
+      // "live", so a prefix match would also swallow its own
+      // `/api/sessions/live-context-only/replay` request.
+      if (url === '/api/sessions/live') {
+        return new Response(
+          JSON.stringify([
+            {
+              sessionId: 'live-context-only',
+              sessionName: 'live-context-only',
+              startTime: 1,
+              lastActivity: 1_000,
+            },
+          ]),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      // Selecting the live session re-keys the liveStore's cost/antiPatterns
+      // (liveStore.ts's setActiveSession filters out entries whose sessionId
+      // doesn't match), zeroing the `resetStore()`-seeded values. Stub a
+      // nonzero aggregate — as the other live-session tests in this file do
+      // (e.g. 'defaults to most-recently-active live session') — so
+      // `noActivityToday` stays false and the pane actually renders.
+      if (url.startsWith('/api/sessions/today/aggregate')) {
+        return new Response(
+          JSON.stringify({
+            toolCallCount: 1,
+            totalCostUsd: 0,
+            antiPatternCount: 0,
+            avgDurationMs: 0,
+            sessionCount: 1,
+            sparkline: { startTimestamp: 0, bucketSizeMs: 60_000, points: [] },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      // decision-tree/turn-costs deliberately absent (resolve to `null`) so the
+      // trigger can only be showing because of context-history data.
+      return new Response('null', { status: 200 });
+    }) as typeof globalThis.fetch;
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <Today />
+      </QueryClientProvider>,
+    );
+    const trigger = await screen.findByText(/session detail/i);
+    // Neither decision-tree nor turn-costs data is present, so there's no
+    // fragment for the em-dash separator to attach to — the button text
+    // must not start with an orphaned " — ".
+    expect(trigger.textContent).toBe('session detail →');
+  });
+
   it('renders a real count for stuck_loop via the API-fallback path, not "?"', async () => {
     useLiveStore.setState({ antiPatterns: [] });
     globalThis.fetch = vi.fn(async (url: string) => {

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -37,6 +37,8 @@ import {
   type TurnCostsResponse,
   fetchDecisionTree,
   type DecisionTreeResponse,
+  fetchContext,
+  type ContextResponse,
   fetchQualityProxy,
   fetchToolSelectionScore,
   fetchConcurrency,
@@ -995,6 +997,15 @@ function LiveSessionPane({
     queryFn: fetchDecisionTree,
     refetchInterval: 10_000,
   });
+  // Mirrors ContextBar's own internal query for the same sessionId — using
+  // the identical key (`['context', activeId]`) means TanStack Query dedupes
+  // this to a single network request/shared cache entry, not a second fetch.
+  const { data: contextData } = useQuery<ContextResponse>({
+    queryKey: activeId ? ['context', activeId] : qk.context,
+    queryFn: () => fetchContext(activeId ?? undefined),
+    refetchInterval: 10_000,
+    enabled: isLive && Boolean(activeId),
+  });
 
   const tailRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -1236,7 +1247,7 @@ function LiveSessionPane({
             numbers would be stale and the SSE feed won't be updating). */}
           {isLive && activeId && (
             <div className="border-t border-bg-line px-3 py-2 shrink-0">
-              <ContextBar sessionId={activeId} />
+              <ContextBar sessionId={activeId} expandable={false} />
             </div>
           )}
           {/* `turnCosts?.turns?.length` (not `turnCosts && turnCosts.turns.length`)
@@ -1244,20 +1255,29 @@ function LiveSessionPane({
             unmatched endpoint (including this one) to `[]`, which has no
             `.turns` field — the plain-object shape only holds under the
             dedicated /api/turn-costs mock. */}
-          {((decisionTree?.totalBranches ?? 0) > 0 || (turnCosts?.turns?.length ?? 0) > 0) && (
+          {((decisionTree?.totalBranches ?? 0) > 0 ||
+            (turnCosts?.turns?.length ?? 0) > 0 ||
+            (contextData?.history?.length ?? 0) >= 2) && (
             <div className="border-t border-bg-line px-3 py-2 shrink-0">
               <button
                 type="button"
                 onClick={() => setShowDetail(true)}
                 className="text-[10px] text-accent-cyan hover:underline transition-colors duration-150 text-left"
               >
-                {decisionTree && decisionTree.totalBranches > 0
-                  ? `${decisionTree.longestFailureStreak} failure streak`
-                  : null}
-                {turnCosts?.turns && turnCosts.turns.length > 0
-                  ? ` · ${turnCosts.turns.length} turns · $${turnCosts.totalAttributedCost.toFixed(2)}`
-                  : null}
-                {' — session detail →'}
+                {(() => {
+                  const parts: string[] = [];
+                  if (decisionTree && decisionTree.totalBranches > 0) {
+                    parts.push(`${decisionTree.longestFailureStreak} failure streak`);
+                  }
+                  if (turnCosts?.turns && turnCosts.turns.length > 0) {
+                    parts.push(
+                      `${turnCosts.turns.length} turns · $${turnCosts.totalAttributedCost.toFixed(2)}`,
+                    );
+                  }
+                  return parts.length > 0
+                    ? `${parts.join(' · ')} — session detail →`
+                    : 'session detail →';
+                })()}
               </button>
             </div>
           )}
@@ -1270,6 +1290,8 @@ function LiveSessionPane({
         <SessionDetailDialog
           decisionTree={decisionTree}
           turnCosts={turnCosts}
+          contextHistory={contextData?.history}
+          contextWindow={contextData?.contextWindow}
           onClose={() => setShowDetail(false)}
         />
       )}


### PR DESCRIPTION
## Summary

- Adds `ContextTimeline` sub-component inside `ContextBar.tsx` — a Recharts stacked area chart (system / tools / user / assistant) showing fill % per turn, sourced from `ContextResponse.history` (already present on `main`)
- Adds a chevron toggle button to the `ContextBar` header; only shown when `history.length >= 2`
- Amber-to-red `ReferenceArea` warning band shades the top 20% (80–100% fill) of the chart
- `useId()` generates a unique per-instance SVG gradient ID — no DOM collision when multiple `ContextBar` instances render in the same document

## Dialog placement redesign

`ContextBar` gained an `expandable?: boolean` prop (default `true`). On `Sessions.tsx` (full-width page), behavior is unchanged — chevron + inline chart. On `Today.tsx`'s narrow live-session pane, the chevron is gone entirely; the chart now lives in a new "Context Timeline" section inside `SessionDetailDialog`, reachable via the pane's existing "… session detail →" link, whose visibility condition now also fires from context-history data alone. Also fixes an orphaned em-dash in that opener's text when it's showing purely from context data.

`ContextTimeline` is exported from `ContextBar.tsx` so `SessionDetailDialog` can reuse it without duplicating chart JSX.

## Test plan

- [x] `npx vitest run` — full web suite passes (451/451)
- [x] `npm test` — 5302/5305 pass (3 pre-existing skips)
- [x] `npm run lint` && `npm run format:check` — clean
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
