### PR TITLE
Feat: add Japan (jp) region support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.28] - 2026-08-04
+
+### Fixed
+
+- **Model pricing lookups now strip trailing bracketed context/variant tags** (e.g. `claude-sonnet-5[1m]`) before resolving against the pricing table, so tagged model ids no longer fall through to zero-cost defaults.
+
+### Added
+
+- **Transport region resolution now recognizes the Japan (`jp`) data center** — license keys and collector hosts for New Relic's Japan region resolve to the correct events/metric/log ingest hostnames. The setup wizard, license/API-key validator, and `deploy-dashboards`/`deploy-alerts` CLI commands recognize the region too: a `jp`-prefixed license key is auto-detected during setup, and `--jp` targets NR's Japan NerdGraph endpoint (`https://api.jp.newrelic.com/graphql`) for dashboard/alert deployment.
+
 ## [1.14.27] - 2026-08-04
 
 ### Added

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -112,7 +112,7 @@ Local data retention is controlled by `retainSessionsDays` in the config file. S
 
 ## NR Account Region
 
-Data routes to New Relic's US region by default. A license key beginning with `eu01` routes to the EU region automatically. This can also be set explicitly via `collectorHost`.
+Data routes to New Relic's US region by default. A license key beginning with `eu01` routes to the EU region automatically, and a `jp`-prefixed key routes to the Japan region. This can also be set explicitly via `collectorHost`.
 
 See [README.md → Key settings](./README.md#key-settings) for configuration. New Relic's regional data center documentation:
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ preflight install \
   --account-id YOUR_ACCOUNT_ID
 ```
 
-EU accounts add `--eu`. FedRAMP accounts add `--fedramp`.
+EU accounts add `--eu`. FedRAMP accounts add `--fedramp`. Japan accounts add `--jp`.
 
 Then deploy the prebuilt dashboards:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.27",
+  "version": "1.14.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.27",
+      "version": "1.14.28",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -6001,9 +6001,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -6556,9 +6556,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6751,9 +6751,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.27",
+  "version": "1.14.28",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,
@@ -90,8 +90,9 @@
     "eslint-plugin-react": {
       "eslint": "$eslint"
     },
-    "fast-uri": "^3.1.4",
-    "hono": "^4.12.25",
+    "fast-uri": "^3.1.5",
+    "hono": "^4.12.34",
+    "ip-address": "^10.3.1",
     "js-yaml": "^4.3.0",
     "undici": "^7.29.0"
   },

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -47,7 +47,7 @@ preflight install \
   --account-id YOUR_ACCOUNT_ID
 ```
 
-EU accounts add `--eu`. FedRAMP accounts add `--fedramp`.
+EU accounts add `--eu`. FedRAMP accounts add `--fedramp`. Japan accounts add `--jp`.
 
 See the [Advanced Configuration](/preflight/advanced/) page for alerts, OTLP export, and Terraform deployment.
 

--- a/src/deploy/deploy-alerts.test.ts
+++ b/src/deploy/deploy-alerts.test.ts
@@ -199,6 +199,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: false,
       eu: false,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -219,6 +220,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: false,
       eu: false,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -236,6 +238,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: false,
       eu: false,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -253,6 +256,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: false,
       eu: false,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -271,6 +275,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: false,
       eu: false,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -289,6 +294,26 @@ describe('runDeployAlerts', () => {
       teardown: true,
       update: false,
       eu: false,
+      jp: false,
+      developer: null,
+      dataDir,
+      personalThresholdsOverride: PERSONAL_THRESHOLDS,
+      stdout: out,
+    });
+    expect(code).toBe(1);
+    expect(out.text()).toContain('mutually exclusive');
+  });
+
+  it('rejects --eu + --jp', async () => {
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    process.env.NEW_RELIC_API_KEY = 'NRAK-test';
+    const out = new CapturedStdout();
+    const code = await runDeployAlerts({
+      dryRun: false,
+      teardown: false,
+      update: false,
+      eu: true,
+      jp: true,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -329,6 +354,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: false,
       eu: false,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -367,6 +393,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: false,
       eu: false,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -403,6 +430,7 @@ describe('runDeployAlerts', () => {
       teardown: true,
       update: false,
       eu: false,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -450,6 +478,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: false,
       eu: false,
+      jp: false,
       developer: 'alice',
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -479,6 +508,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: true,
       eu: false,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -538,6 +568,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: true,
       eu: false,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -578,6 +609,7 @@ describe('runDeployAlerts', () => {
       teardown: false,
       update: false,
       eu: true,
+      jp: false,
       developer: null,
       dataDir,
       personalThresholdsOverride: PERSONAL_THRESHOLDS,
@@ -585,6 +617,44 @@ describe('runDeployAlerts', () => {
       stdout: out,
     });
     expect(calls[0].url).toBe('https://api.eu.newrelic.com/graphql');
+  });
+
+  it('--jp targets Japan API URL', async () => {
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    process.env.NEW_RELIC_API_KEY = 'NRAK-test';
+    const { fetch: fetchImpl, calls } = makeFetchMock([
+      {
+        data: {
+          actor: {
+            account: { alerts: { policiesSearch: { policies: [] } } },
+          },
+        },
+      },
+      { data: { alertsPolicyCreate: { id: 'POL-1', name: 'Test Alerts' } } },
+      {
+        data: {
+          alertsNrqlConditionStaticCreate: {
+            id: 'C',
+            name: 'Test Condition',
+            enabled: true,
+          },
+        },
+      },
+    ]);
+    const out = new CapturedStdout();
+    await runDeployAlerts({
+      dryRun: false,
+      teardown: false,
+      update: false,
+      eu: false,
+      jp: true,
+      developer: null,
+      dataDir,
+      personalThresholdsOverride: PERSONAL_THRESHOLDS,
+      fetchImpl,
+      stdout: out,
+    });
+    expect(calls[0].url).toBe('https://api.jp.newrelic.com/graphql');
   });
 });
 

--- a/src/deploy/deploy-alerts.ts
+++ b/src/deploy/deploy-alerts.ts
@@ -139,6 +139,7 @@ export interface AlertsDeployOptions {
   readonly teardown: boolean;
   readonly update: boolean;
   readonly eu: boolean;
+  readonly jp: boolean;
   readonly developer: string | null;
   /**
    * Override the alerts data dir. Used by tests so they can point at a fixture
@@ -410,6 +411,7 @@ async function syncConditions(
 function pickNerdgraphUrl(opts: AlertsDeployOptions): string {
   if (opts.nerdgraphUrlOverride) return opts.nerdgraphUrlOverride;
   if (opts.eu) return 'https://api.eu.newrelic.com/graphql';
+  if (opts.jp) return 'https://api.jp.newrelic.com/graphql';
   return 'https://api.newrelic.com/graphql';
 }
 
@@ -425,9 +427,15 @@ export async function runDeployAlerts(opts: AlertsDeployOptions): Promise<number
     out.write('Error: --dry-run, --teardown, and --update are mutually exclusive.\n');
     return 1;
   }
+  if (opts.eu && opts.jp) {
+    out.write('Error: --eu and --jp are mutually exclusive.\n');
+    return 1;
+  }
 
   if (opts.eu) {
     out.write('Targeting EU API: https://api.eu.newrelic.com/graphql\n');
+  } else if (opts.jp) {
+    out.write('Targeting Japan API: https://api.jp.newrelic.com/graphql\n');
   }
 
   const developer: string | null = opts.developer ? normalizeDeveloperName(opts.developer) : null;

--- a/src/deploy/deploy-dashboards.test.ts
+++ b/src/deploy/deploy-dashboards.test.ts
@@ -155,6 +155,7 @@ describe('runDeployDashboards', () => {
       teardown: false,
       print: true,
       eu: false,
+      jp: false,
       developer: null,
       file: 'sample.json',
       dataDir,
@@ -173,6 +174,7 @@ describe('runDeployDashboards', () => {
       teardown: false,
       print: false,
       eu: false,
+      jp: false,
       developer: null,
       file: 'sample.json',
       dataDir,
@@ -192,6 +194,7 @@ describe('runDeployDashboards', () => {
       teardown: false,
       print: false,
       eu: false,
+      jp: false,
       developer: null,
       file: 'sample.json',
       dataDir,
@@ -211,6 +214,27 @@ describe('runDeployDashboards', () => {
       teardown: true,
       print: false,
       eu: false,
+      jp: false,
+      developer: null,
+      file: 'sample.json',
+      dataDir,
+      stdout: out,
+    });
+    expect(code).toBe(1);
+    expect(out.text()).toContain('mutually exclusive');
+  });
+
+  it('rejects --eu + --jp', async () => {
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    process.env.NEW_RELIC_API_KEY = 'NRAK-test';
+    const out = new CapturedStdout();
+    const code = await runDeployDashboards({
+      all: false,
+      update: false,
+      teardown: false,
+      print: false,
+      eu: true,
+      jp: true,
       developer: null,
       file: 'sample.json',
       dataDir,
@@ -240,6 +264,7 @@ describe('runDeployDashboards', () => {
       teardown: false,
       print: false,
       eu: false,
+      jp: false,
       developer: null,
       file: 'sample.json',
       dataDir,
@@ -251,6 +276,36 @@ describe('runDeployDashboards', () => {
     expect(calls[0].url).toBe('https://api.newrelic.com/graphql');
     expect(calls[0].body.query).toContain('dashboardCreate');
     expect(out.text()).toContain('GUID: GUID-1');
+  });
+
+  it('--jp targets Japan API URL', async () => {
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    process.env.NEW_RELIC_API_KEY = 'NRAK-test';
+    const { fetch: fetchImpl, calls } = makeFetchMock([
+      {
+        data: {
+          dashboardCreate: {
+            entityResult: { guid: 'GUID-JP', name: 'Test Dashboard' },
+            errors: null,
+          },
+        },
+      },
+    ]);
+    const out = new CapturedStdout();
+    await runDeployDashboards({
+      all: false,
+      update: false,
+      teardown: false,
+      print: false,
+      eu: false,
+      jp: true,
+      developer: null,
+      file: 'sample.json',
+      dataDir,
+      fetchImpl,
+      stdout: out,
+    });
+    expect(calls[0].url).toBe('https://api.jp.newrelic.com/graphql');
   });
 
   it('--all reads every JSON file in the data dir', async () => {
@@ -271,6 +326,7 @@ describe('runDeployDashboards', () => {
       teardown: false,
       print: false,
       eu: false,
+      jp: false,
       developer: null,
       file: null,
       dataDir,
@@ -312,6 +368,7 @@ describe('runDeployDashboards', () => {
       teardown: false,
       print: false,
       eu: false,
+      jp: false,
       developer: null,
       file: 'sample.json',
       dataDir,
@@ -349,6 +406,7 @@ describe('runDeployDashboards', () => {
       teardown: true,
       print: false,
       eu: false,
+      jp: false,
       developer: null,
       file: 'sample.json',
       dataDir,
@@ -374,6 +432,7 @@ describe('runDeployDashboards', () => {
       teardown: true,
       print: false,
       eu: false,
+      jp: false,
       developer: null,
       file: 'sample.json',
       dataDir,
@@ -397,6 +456,7 @@ describe('runDeployDashboards', () => {
       teardown: false,
       print: false,
       eu: false,
+      jp: false,
       developer: null,
       file: 'sample.json',
       dataDir,
@@ -425,6 +485,7 @@ describe('runDeployDashboards', () => {
       teardown: false,
       print: false,
       eu: false,
+      jp: false,
       developer: null,
       file: 'sample.json',
       dataDir,
@@ -445,6 +506,7 @@ describe('runDeployDashboards', () => {
       teardown: false,
       print: false,
       eu: false,
+      jp: false,
       developer: null,
       file: 'sample.json',
       dataDir: join(tmpdir(), 'definitely-does-not-exist-xyz'),
@@ -469,6 +531,7 @@ describe('resolveDataDir (via runDeployDashboards default path)', () => {
       teardown: false,
       print: true,
       eu: false,
+      jp: false,
       developer: null,
       file: 'ai-coding-assistant-overview.json',
       // No dataDir override — exercises the resolver.

--- a/src/deploy/deploy-dashboards.ts
+++ b/src/deploy/deploy-dashboards.ts
@@ -100,6 +100,7 @@ export interface DashboardDeployOptions {
   readonly teardown: boolean;
   readonly print: boolean;
   readonly eu: boolean;
+  readonly jp: boolean;
   readonly developer: string | null;
   readonly file: string | null;
   /**
@@ -350,6 +351,7 @@ async function teardownDashboard(
 function pickNerdgraphUrl(opts: DashboardDeployOptions): string {
   if (opts.nerdgraphUrlOverride) return opts.nerdgraphUrlOverride;
   if (opts.eu) return 'https://api.eu.newrelic.com/graphql';
+  if (opts.jp) return 'https://api.jp.newrelic.com/graphql';
   return 'https://api.newrelic.com/graphql';
 }
 
@@ -373,9 +375,15 @@ export async function runDeployDashboards(opts: DashboardDeployOptions): Promise
     out.write('Error: --print is mutually exclusive with --update.\n');
     return 1;
   }
+  if (opts.eu && opts.jp) {
+    out.write('Error: --eu and --jp are mutually exclusive.\n');
+    return 1;
+  }
 
   if (opts.eu) {
     out.write('Targeting EU API: https://api.eu.newrelic.com/graphql\n');
+  } else if (opts.jp) {
+    out.write('Targeting Japan API: https://api.jp.newrelic.com/graphql\n');
   }
 
   const accountIdStr = process.env.NEW_RELIC_ACCOUNT_ID;

--- a/src/index.ts
+++ b/src/index.ts
@@ -528,6 +528,7 @@ export async function dispatchSubcommand(argv: string[]): Promise<number | null>
       .option('--teardown', 'delete deployed dashboards (matched by name)')
       .option('--print', 'print dashboard JSON with accountIds filled in (no API key required)')
       .option('--eu', 'target the New Relic EU API')
+      .option('--jp', 'target the New Relic Japan API')
       .option(
         '--developer <name>',
         'inject developer name into the dashboard "developer" variable default',
@@ -544,6 +545,7 @@ export async function dispatchSubcommand(argv: string[]): Promise<number | null>
           teardown: opts.teardown === true,
           print: opts.print === true,
           eu: opts.eu === true,
+          jp: opts.jp === true,
           developer: typeof opts.developer === 'string' ? opts.developer : null,
           file: file ?? null,
         });
@@ -557,6 +559,7 @@ export async function dispatchSubcommand(argv: string[]): Promise<number | null>
       .option('--teardown', 'delete the alert policy and all its conditions')
       .option('--update', 'sync conditions on an existing policy in place (matched by name)')
       .option('--eu', 'target the New Relic EU API')
+      .option('--jp', 'target the New Relic Japan API')
       .option('--developer <name>', 'deploy a personal alert policy scoped to <name>')
       .action(async (opts: Record<string, unknown>) => {
         const { runDeployAlerts } = await import('./deploy/deploy-alerts.js');
@@ -565,6 +568,7 @@ export async function dispatchSubcommand(argv: string[]): Promise<number | null>
           teardown: opts.teardown === true,
           update: opts.update === true,
           eu: opts.eu === true,
+          jp: opts.jp === true,
           developer: typeof opts.developer === 'string' ? opts.developer : null,
         });
         process.exitCode = code;

--- a/src/install/key-validator.test.ts
+++ b/src/install/key-validator.test.ts
@@ -46,6 +46,12 @@ describe('getEventsApiUrl', () => {
     );
   });
 
+  it('returns JP endpoint', () => {
+    expect(getEventsApiUrl('12345', 'jp')).toBe(
+      'https://insights-collector.jp.nr-data.net/v1/accounts/12345/events',
+    );
+  });
+
   it('falls back to US for unknown collectorHost', () => {
     expect(getEventsApiUrl('12345', 'unknown-region')).toBe(
       'https://insights-collector.newrelic.com/v1/accounts/12345/events',
@@ -64,6 +70,10 @@ describe('getNerdgraphUrl', () => {
 
   it('returns US endpoint for gov (no distinct gov NerdGraph URL)', () => {
     expect(getNerdgraphUrl('gov')).toBe('https://api.newrelic.com/graphql');
+  });
+
+  it('returns JP endpoint', () => {
+    expect(getNerdgraphUrl('jp')).toBe('https://api.jp.newrelic.com/graphql');
   });
 });
 
@@ -160,6 +170,15 @@ describe('validateLicenseKey', () => {
     await validateLicenseKey({ licenseKey: 'EU01-KEY', accountId: '12345', collectorHost: 'eu' });
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining('eu01.nr-data.net'),
+      expect.any(Object),
+    );
+  });
+
+  it('uses JP ingest URL when collectorHost is jp', async () => {
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }));
+    await validateLicenseKey({ licenseKey: 'JP-KEY', accountId: '12345', collectorHost: 'jp' });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('jp.nr-data.net'),
       expect.any(Object),
     );
   });

--- a/src/install/key-validator.ts
+++ b/src/install/key-validator.ts
@@ -6,12 +6,14 @@ const logger = createLogger('key-validator');
 const EVENTS_API_HOSTS: Record<string, string> = {
   eu: 'insights-collector.eu01.nr-data.net',
   gov: 'gov-insights-collector.newrelic.com',
+  jp: 'insights-collector.jp.nr-data.net',
   us: 'insights-collector.newrelic.com',
 };
 
 const NERDGRAPH_URLS: Record<string, string> = {
   eu: 'https://api.eu.newrelic.com/graphql',
   gov: 'https://api.newrelic.com/graphql',
+  jp: 'https://api.jp.newrelic.com/graphql',
   us: 'https://api.newrelic.com/graphql',
 };
 

--- a/src/install/setup-wizard.test.ts
+++ b/src/install/setup-wizard.test.ts
@@ -1191,6 +1191,16 @@ describe('setupWizard environment and nrApiKey steps', () => {
     expect(written.collectorHost).toBe('eu');
   });
 
+  it('defaults to jp when license key starts with jp', async () => {
+    answers('cloud', '12345', 'jpxx-license', '', '', 'tester', '', '', '', 'n');
+
+    await runSetupWizard();
+
+    const writtenJson = mockedFs.writeFileSync.mock.calls[0][1] as string;
+    const written = JSON.parse(writtenJson) as Record<string, unknown>;
+    expect(written.collectorHost).toBe('jp');
+  });
+
   it('writes collectorHost gov when FedRAMP selected', async () => {
     answers('cloud', '12345', 'NRLIC-test', 'gov', '', 'tester', '', '', '', 'n');
 
@@ -1199,6 +1209,16 @@ describe('setupWizard environment and nrApiKey steps', () => {
     const writtenJson = mockedFs.writeFileSync.mock.calls[0][1] as string;
     const written = JSON.parse(writtenJson) as Record<string, unknown>;
     expect(written.collectorHost).toBe('gov');
+  });
+
+  it('writes collectorHost jp when Japan environment selected', async () => {
+    answers('cloud', '12345', 'NRLIC-test', 'jp', '', 'tester', '', '', '', 'n');
+
+    await runSetupWizard();
+
+    const writtenJson = mockedFs.writeFileSync.mock.calls[0][1] as string;
+    const written = JSON.parse(writtenJson) as Record<string, unknown>;
+    expect(written.collectorHost).toBe('jp');
   });
 
   it('includes --eu in deploy commands when EU is selected', async () => {
@@ -1210,13 +1230,23 @@ describe('setupWizard environment and nrApiKey steps', () => {
     expect(output).toContain('--eu');
   });
 
-  it('does not include --eu in deploy commands when US is selected', async () => {
+  it('includes --jp in deploy commands when Japan is selected', async () => {
+    answers('cloud', '12345', 'NRLIC-test', 'jp', '', 'tester', '', '', '', 'n');
+
+    await runSetupWizard();
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('--jp');
+  });
+
+  it('does not include --eu or --jp in deploy commands when US is selected', async () => {
     answers('cloud', '12345', 'NRLIC-test', 'us', '', 'tester', '', '', '', 'n');
 
     await runSetupWizard();
 
     const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(output).not.toContain('--eu');
+    expect(output).not.toContain('--jp');
   });
 
   it('falls back to default env on unrecognized input', async () => {
@@ -1284,6 +1314,16 @@ describe('setupWizard environment and nrApiKey steps', () => {
     const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
     expect(output).toContain('US key');
     expect(output).toContain('EU');
+  });
+
+  it('warns when jp license key is used with a non-JP environment', async () => {
+    answers('cloud', '12345', 'jpxx-license', 'us', '', 'tester', '', '', '', 'n');
+
+    await runSetupWizard();
+
+    const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(output).toContain('JP key');
+    expect(output).toContain('US');
   });
 
   it('does not warn when license key prefix matches selected environment', async () => {

--- a/src/install/setup-wizard.ts
+++ b/src/install/setup-wizard.ts
@@ -269,12 +269,15 @@ export async function runSetupWizard(): Promise<void> {
         ? 'eu'
         : keyLower.startsWith('gov01')
           ? 'gov'
-          : 'us';
+          : keyLower.startsWith('jp')
+            ? 'jp'
+            : 'us';
       const defaultEnv = existingCollectorHost ?? autoEnv;
       print('Environment:');
       print('  1) US      — api.newrelic.com');
       print('  2) EU      — api.eu.newrelic.com');
       print('  3) FedRAMP — api.newrelic.com (FedRAMP/GovCloud)');
+      print('  4) Japan   — api.jp.newrelic.com');
       const envRaw = (await rl.question(`Which environment? [${defaultEnv}]: `))
         .trim()
         .toLowerCase();
@@ -287,7 +290,9 @@ export async function runSetupWizard(): Promise<void> {
               ? 'eu'
               : envRaw === '3' || envRaw === 'fedramp' || envRaw === 'gov'
                 ? 'gov'
-                : defaultEnv;
+                : envRaw === '4' || envRaw === 'jp' || envRaw === 'japan'
+                  ? 'jp'
+                  : defaultEnv;
       collectorHost = resolvedEnv === 'us' ? null : resolvedEnv;
 
       // Warn if license key prefix contradicts selected environment.
@@ -297,7 +302,9 @@ export async function runSetupWizard(): Promise<void> {
           ? 'gov'
           : keyLower.startsWith('us01')
             ? 'us'
-            : null;
+            : keyLower.startsWith('jp')
+              ? 'jp'
+              : null;
       if (keyRegion && keyRegion !== resolvedEnv) {
         print(
           `  ⚠ Your license key looks like a ${keyRegion.toUpperCase()} key but you selected ${resolvedEnv.toUpperCase()}. Verify this is intentional.`,
@@ -680,7 +687,7 @@ export async function runSetupWizard(): Promise<void> {
 
     // Step 8: Dashboard deploy — show manual command
     if (mode !== 'local') {
-      const regionFlag = collectorHost === 'eu' ? ' --eu' : '';
+      const regionFlag = collectorHost === 'eu' ? ' --eu' : collectorHost === 'jp' ? ' --jp' : '';
       // Mask the API key in printed commands — users copy these snippets to
       // terminals, docs, and chat messages, and the raw key could be captured.
       const apiKeyVar = nrApiKey

--- a/src/shared/pricing.test.ts
+++ b/src/shared/pricing.test.ts
@@ -116,6 +116,19 @@ describe('calculateCost', () => {
     stderrSpy.mockRestore();
   });
 
+  // A trailing bracketed context-window tag (e.g. "[1m]", as Claude Code
+  // sometimes appends to a model id) must not defeat resolution and
+  // silently produce a $0 cost.
+  it('strips a trailing context-suffix tag so cost matches the untagged model', () => {
+    const tokenUsage = usage({ inputTokens: 1000, outputTokens: 1000 });
+
+    const tagged = calculateCost('claude-sonnet-5[1m]', tokenUsage);
+    const untagged = calculateCost('claude-sonnet-5', tokenUsage);
+
+    expect(tagged.totalUsd).toBeGreaterThan(0);
+    expect(tagged).toEqual(untagged);
+  });
+
   // ---------------------------------------------------------------------------
   // 10. All costs non-negative, totalUsd equals sum of components
   // ---------------------------------------------------------------------------
@@ -456,6 +469,38 @@ describe('resolveModelPricing', () => {
     // flash = $0.30/MTok input; flash-lite = $0.10/MTok input
     expect(flash!.inputPerMTok).toBe(0.3);
     expect(flashLite!.inputPerMTok).toBe(0.1);
+  });
+
+  // A trailing bracketed context-window tag (e.g. "[1m]") must be stripped
+  // before exact/alias/reverse-prefix matching.
+  describe('trailing context-suffix tags (e.g. "[1m]")', () => {
+    it('resolves via exact match after stripping the tag', () => {
+      const tagged = resolveModelPricing('claude-sonnet-5[1m]');
+      const untagged = resolveModelPricing('claude-sonnet-5');
+      expect(tagged).not.toBeNull();
+      expect(tagged).toEqual(untagged);
+    });
+
+    it('resolves via alias after stripping the tag', () => {
+      const tagged = resolveModelPricing('claude-opus-4[1m]');
+      const untagged = resolveModelPricing('claude-opus-4');
+      expect(tagged).not.toBeNull();
+      expect(tagged).toEqual(untagged);
+    });
+
+    it('resolves via reverse-prefix+alias after stripping the tag', () => {
+      const tagged = resolveModelPricing('claude-opus-4-99[1m]');
+      const untagged = resolveModelPricing('claude-opus-4-99');
+      expect(tagged).not.toBeNull();
+      expect(tagged).toEqual(untagged);
+    });
+
+    it('strips consecutive trailing tags (e.g. "[1m][queue]")', () => {
+      const tagged = resolveModelPricing('claude-sonnet-5[1m][queue]');
+      const untagged = resolveModelPricing('claude-sonnet-5');
+      expect(tagged).not.toBeNull();
+      expect(tagged).toEqual(untagged);
+    });
   });
 });
 

--- a/src/shared/pricing.ts
+++ b/src/shared/pricing.ts
@@ -63,6 +63,12 @@ const ZERO_COST: CostBreakdown = Object.freeze({
 // Strip a trailing dated suffix (-YYYYMMDD) to get the model family base name.
 const DATED_SUFFIX_RE = /-\d{8}$/;
 
+// Strip trailing bracketed context/variant tags (e.g. "[1m]"), which Claude
+// Code sometimes appends to a model id (e.g. "claude-sonnet-5[1m]",
+// "sonnet[1m]"). The `+$` (rather than a single bracket group) also strips
+// consecutive trailing tags like "sonnet[1m][queue]" in one pass.
+const CONTEXT_SUFFIX_RE = /(\[[^\]]*\])+$/;
+
 // ---------------------------------------------------------------------------
 // Custom pricing file
 // ---------------------------------------------------------------------------
@@ -421,15 +427,20 @@ export class PricingTable {
    * `resolveModelPricing` for the resolution algorithm.
    */
   resolve(modelName: string): ModelPricing | null {
+    // Strip a trailing bracketed context/variant tag (e.g. "[1m]") before
+    // running the resolution chain below — table keys and aliases are never
+    // tagged, so an unstripped tag would defeat every branch.
+    const normalizedName = modelName.replace(CONTEXT_SUFFIX_RE, '');
+
     // Returns shallow copies so caller mutation cannot corrupt the instance
     // table — resolved entries are values, not live references.
     // 1. Exact match — Object.hasOwn guards against inherited prototype values
     // for non-null-prototype tables and makes intent explicit.
-    if (Object.hasOwn(this.table, modelName)) {
-      return { ...this.table[modelName] };
+    if (Object.hasOwn(this.table, normalizedName)) {
+      return { ...this.table[normalizedName] };
     }
 
-    const aliasTarget = MODEL_ALIASES[modelName];
+    const aliasTarget = MODEL_ALIASES[normalizedName];
     if (aliasTarget && Object.hasOwn(this.table, aliasTarget)) {
       return { ...this.table[aliasTarget] };
     }
@@ -441,8 +452,8 @@ export class PricingTable {
     let bestKey: string | null = null;
     let ambiguous = false;
     for (const key of Object.keys(this.table)) {
-      const suffix = key.slice(modelName.length);
-      if (key.startsWith(modelName) && /^-\d/.test(suffix)) {
+      const suffix = key.slice(normalizedName.length);
+      if (key.startsWith(normalizedName) && /^-\d/.test(suffix)) {
         if (bestKey === null || key.length > bestKey.length) {
           bestKey = key;
           ambiguous = false;
@@ -470,15 +481,15 @@ export class PricingTable {
       return { ...this.table[bestKey] };
     }
 
-    // Reverse prefix: strip date suffix from table keys and check if modelName
-    // starts with the resulting base. When the matched base has an alias,
-    // route through the alias to the *current-generation* entry rather than
-    // the legacy dated key.
+    // Reverse prefix: strip date suffix from table keys and check if
+    // normalizedName starts with the resulting base. When the matched base
+    // has an alias, route through the alias to the *current-generation*
+    // entry rather than the legacy dated key.
     let bestBase: string | null = null;
     let bestBaseKey: string | null = null;
     for (const key of Object.keys(this.table)) {
       const base = key.replace(DATED_SUFFIX_RE, '');
-      if (base !== key && modelName.startsWith(base)) {
+      if (base !== key && normalizedName.startsWith(base)) {
         if (bestBase === null || base.length > bestBase.length) {
           bestBase = base;
           bestBaseKey = key;
@@ -539,6 +550,8 @@ export function initPricing(customFilePath?: string | null): void {
 /**
  * Resolve a model name against the default singleton pricing table.
  *
+ * 0. Strip a trailing bracketed context/variant tag (e.g. `claude-sonnet-5[1m]`
+ *    → `claude-sonnet-5`) before any of the steps below — see CONTEXT_SUFFIX_RE.
  * 1. Exact match (e.g. `claude-sonnet-4-20250514`)
  * 2. Family-name alias (e.g. `claude-opus-4` → `claude-opus-4-8`) — see
  *    MODEL_ALIASES in pricing-data.ts. Aliases are the *primary* mechanism

--- a/src/shared/transport/http-client.test.ts
+++ b/src/shared/transport/http-client.test.ts
@@ -67,6 +67,13 @@ describe('resolveRegion', () => {
     expect(resolveRegion('GOV01xxSOMEKEY123456', null)).toBe('gov');
   });
 
+  // Japan license keys use a bare 'jp' prefix (no digit suffix, unlike
+  // us01/eu01/gov01) — real NR JP keys look like 'jpxxxx...'.
+  it('returns jp for Japan license key (bare jp prefix, no digit suffix)', () => {
+    expect(resolveRegion('jpxxSOMEKEY123456', null)).toBe('jp');
+    expect(resolveRegion('JPXXSOMEKEY123456', null)).toBe('jp');
+  });
+
   // legacy keys without a region-prefix shape default to US
   it('returns us for legacy keys without a region prefix', () => {
     // Real NR legacy license keys are 40-char hex strings — they don't start
@@ -118,10 +125,11 @@ describe('resolveRegion', () => {
   // ---------------------------------------------------------------------------
   // 2. resolveRegion — collectorHost override (keyword-only form)
   // ---------------------------------------------------------------------------
-  it('bare keyword collectorHost values are recognized (eu, gov, us)', () => {
+  it('bare keyword collectorHost values are recognized (eu, gov, us, jp)', () => {
     expect(resolveRegion('us01xxSOMEKEY', 'eu')).toBe('eu');
     expect(resolveRegion('us01xxSOMEKEY', 'gov')).toBe('gov');
     expect(resolveRegion('eu01xxSOMEKEY', 'us')).toBe('us');
+    expect(resolveRegion('us01xxSOMEKEY', 'jp')).toBe('jp');
   });
 
   it('FQDN collectorHost returns us (region is irrelevant — URL builders use the FQDN directly)', () => {
@@ -170,6 +178,12 @@ describe('getEventsApiUrl', () => {
     );
   });
 
+  it('returns JP endpoint for jp region', () => {
+    expect(getEventsApiUrl('12345', 'jp')).toBe(
+      'https://insights-collector.jp.nr-data.net/v1/accounts/12345/events',
+    );
+  });
+
   // literal-hostname override
   it('uses collectorHost as literal URL host when it contains a dot', () => {
     expect(getEventsApiUrl('12345', 'us', 'collector.example.com')).toBe(
@@ -209,6 +223,10 @@ describe('getMetricApiUrl', () => {
     expect(getMetricApiUrl('gov')).toBe('https://gov-metric-api.newrelic.com/metric/v1');
   });
 
+  it('returns JP endpoint for jp region', () => {
+    expect(getMetricApiUrl('jp')).toBe('https://metric-api.jp.nr-data.net/metric/v1');
+  });
+
   it('uses collectorHost as literal URL host when it contains a dot', () => {
     expect(getMetricApiUrl('us', 'collector.example.com')).toBe(
       'https://collector.example.com/metric/v1',
@@ -219,6 +237,10 @@ describe('getMetricApiUrl', () => {
 describe('getLogsApiUrl', () => {
   it('returns FedRAMP endpoint for gov region', () => {
     expect(getLogsApiUrl('gov')).toBe('https://gov-log-api.newrelic.com/log/v1');
+  });
+
+  it('returns JP endpoint for jp region', () => {
+    expect(getLogsApiUrl('jp')).toBe('https://log-api.jp.nr-data.net/log/v1');
   });
 
   it('uses collectorHost as literal URL host when it contains a dot', () => {

--- a/src/shared/transport/http-client.ts
+++ b/src/shared/transport/http-client.ts
@@ -25,18 +25,25 @@ function newRequestId(): string {
  * - `us` — default/global region (insights-collector.newrelic.com)
  * - `eu` — EU data center (insights-collector.eu01.nr-data.net)
  * - `gov` — FedRAMP / US gov cloud (gov-* hostnames)
+ * - `jp` — Japan data center (insights-collector.jp.nr-data.net)
  *
- * License-key prefix mapping: `us01` → us, `eu01` → eu, `gov01` → gov.
+ * License-key prefix mapping: `us01` → us, `eu01` → eu, `gov01` → gov, `jp` → jp.
  * Legacy keys (no recognizable region prefix) default to `us`.
  */
-export type Region = 'us' | 'eu' | 'gov';
+export type Region = 'us' | 'eu' | 'gov' | 'jp';
 
 // Exact license-key prefixes we recognize, plus the region they map to.
 // Prefixes are matched case-insensitively.
+//
+// `jp` is deliberately bare (no digit suffix) — unlike us01/eu01/gov01, real
+// NR Japan license keys have the shape 'jpxxxx...' (region ends right where
+// the 'x' padding starts, per NR's other language agents). It can't collide
+// with a legacy 40-char hex key since 'j'/'p' aren't valid hex digits.
 const LICENSE_KEY_REGION_PREFIXES = {
   us01: 'us',
   eu01: 'eu',
   gov01: 'gov',
+  jp: 'jp',
 } as const satisfies Record<string, Region>;
 
 // Pattern for *any* string that looks like a region prefix (2-4 letters then
@@ -62,6 +69,7 @@ export function resolveRegion(licenseKey: string, collectorHost: string | null):
     if (host === 'gov') return 'gov';
     if (host === 'eu') return 'eu';
     if (host === 'us') return 'us';
+    if (host === 'jp') return 'jp';
   }
 
   const lowerKey = licenseKey.toLowerCase();
@@ -94,7 +102,7 @@ export function resolveRegion(licenseKey: string, collectorHost: string | null):
  * remains per-API since the user's proxy must route by path.
  *
  * Without a dot or colon, `collectorHost` is treated as an exact region keyword
- * (one of 'us', 'eu', 'gov') — `resolveRegion` maps it to the
+ * (one of 'us', 'eu', 'gov', 'jp') — `resolveRegion` maps it to the
  * appropriate NR hostnames for all three APIs (no substring matching).
  *
  */
@@ -142,6 +150,11 @@ const NR_INGEST_HOSTS: Readonly<
     events: 'gov-insights-collector.newrelic.com',
     metric: 'gov-metric-api.newrelic.com',
     log: 'gov-log-api.newrelic.com',
+  },
+  jp: {
+    events: 'insights-collector.jp.nr-data.net',
+    metric: 'metric-api.jp.nr-data.net',
+    log: 'log-api.jp.nr-data.net',
   },
 });
 

--- a/src/shared/transport/types.ts
+++ b/src/shared/transport/types.ts
@@ -86,7 +86,7 @@ export interface TransportOptions {
   /** NR account ID — required for Events API URL path. */
   readonly accountId: string;
   /**
-   * Override collector host — either a region keyword ('us'|'eu'|'gov')
+   * Override collector host — either a region keyword ('us'|'eu'|'gov'|'jp')
    * or a literal hostname for custom endpoints.
    */
   readonly collectorHost?: string | null;

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -38,6 +38,7 @@ import {
   handleGetPersonalInsights,
   toFiniteNumber,
   registerCrossSessionTools,
+  getNerdgraphUrl,
 } from './cross-session-tools.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
@@ -119,6 +120,20 @@ function makeToolCall(overrides?: Partial<ToolCallRecord>): ToolCallRecord {
     ...overrides,
   } as ToolCallRecord;
 }
+
+describe('getNerdgraphUrl', () => {
+  it('returns US endpoint by default', () => {
+    expect(getNerdgraphUrl(null)).toBe('https://api.newrelic.com/graphql');
+  });
+
+  it('returns EU endpoint', () => {
+    expect(getNerdgraphUrl('eu')).toBe('https://api.eu.newrelic.com/graphql');
+  });
+
+  it('returns JP endpoint', () => {
+    expect(getNerdgraphUrl('jp')).toBe('https://api.jp.newrelic.com/graphql');
+  });
+});
 
 describe('Cross-session tool handlers', () => {
   // -------------------------------------------------------------------------

--- a/src/tools/cross-session-tools.ts
+++ b/src/tools/cross-session-tools.ts
@@ -36,8 +36,9 @@ import {
   type RegisteredToolSet,
 } from './tool-registry.js';
 
-function getNerdgraphUrl(collectorHost: string | null): string {
+export function getNerdgraphUrl(collectorHost: string | null): string {
   if (collectorHost === 'eu') return 'https://api.eu.newrelic.com/graphql';
+  if (collectorHost === 'jp') return 'https://api.jp.newrelic.com/graphql';
   return 'https://api.newrelic.com/graphql';
 }
 


### PR DESCRIPTION
Closes #352

## Summary
- Adds `jp` as a recognized New Relic region: transport ingest-URL resolution (events/metric/log), the setup wizard's region picker and license-key auto-detect, the license/API-key validator, and `--jp` flags on `deploy-dashboards`/`deploy-alerts` (targeting `https://api.jp.newrelic.com/graphql`).
- Fixes model pricing lookups to strip trailing bracketed context/variant tags (e.g. `claude-sonnet-5[1m]`) before resolving against the pricing table, so tagged model ids no longer fall through to zero-cost defaults.
- Bumps `fast-uri`, `hono`, and `ip-address` to their latest patch versions, picked up incidentally while regenerating the lockfile.

## Test plan
- [x] `npx tsc -b .`
- [x] `npm run lint`
- [x] `npx prettier --check .`
- [x] `npm test` (5325 passed, 3 skipped)