### PR TITLE
Feat: context composition/efficiency drill-down in ContextBar and SessionDetailDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.29] - 2026-08-04
+
+### Added
+
+- **The context bar and session detail drawer now show what's driving context usage** — expanding a session's context bar (Sessions page) or opening the "session detail" drawer (Today's live pane) surfaces the dominant content category for the current turn and the files being re-read most often, alongside the existing token breakdown.
+
 ## [1.14.28] - 2026-08-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.28",
+  "version": "1.14.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.28",
+      "version": "1.14.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.28",
+  "version": "1.14.29",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -4879,6 +4879,76 @@ describe('api-handler GET /api/context', () => {
   });
 });
 
+describe('api-handler GET /api/context-composition', () => {
+  it('returns 503 when contextCompositionTracker is missing', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/context-composition' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns context composition metrics as JSON', async () => {
+    const fakeMetrics = {
+      currentFillPercent: 62,
+      currentBreakdown: {
+        system_prompt: 1000,
+        conversation_history: 3000,
+        tool_results: 5000,
+        injected_file_content: 500,
+        other: 100,
+      },
+      turnCount: 5,
+      thresholdAlerts: [],
+      dominanceAlerts: [],
+      history: [],
+      note: '',
+    };
+    const handler = createApiHandler({
+      contextCompositionTracker: { getMetrics: () => fakeMetrics } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['contextCompositionTracker'],
+    });
+    const req = { method: 'GET', url: '/api/context-composition' } as IncomingMessage;
+    const { res, status, body, headers } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(headers()['content-type']).toMatch(/application\/json/);
+    expect(JSON.parse(body())).toEqual(fakeMetrics);
+  });
+});
+
+describe('api-handler GET /api/context-efficiency', () => {
+  it('returns 503 when contextEfficiencyTracker is missing', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/context-efficiency' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns context efficiency metrics as JSON', async () => {
+    const fakeMetrics = {
+      uniqueFilesRead: 12,
+      totalReadOperations: 20,
+      repeatedReadCount: 8,
+      repeatedReadRatio: 0.4,
+      topRepeatedFiles: [{ file: 'src/index.ts', readCount: 4 }],
+    };
+    const handler = createApiHandler({
+      contextEfficiencyTracker: { getMetrics: () => fakeMetrics } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['contextEfficiencyTracker'],
+    });
+    const req = { method: 'GET', url: '/api/context-efficiency' } as IncomingMessage;
+    const { res, status, body, headers } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(headers()['content-type']).toMatch(/application\/json/);
+    expect(JSON.parse(body())).toEqual(fakeMetrics);
+  });
+});
+
 describe('buildContextReplayEvents', () => {
   it('maps a post event to a tool replay event using tool/outputSize fields', () => {
     const events = buildContextReplayEvents(

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -58,6 +58,8 @@ import type { ModelUsageMetrics, ModelBreakdownEntry } from '../../metrics/model
 import { DEFAULT_STALE_THRESHOLD_MS } from '../../metrics/live-session-registry.js';
 import { computeContextMetricsFromEvents } from '../../metrics/context-tracker.js';
 import type { ContextReplayEvent, ContextTrackerMetrics } from '../../metrics/context-tracker.js';
+import type { ContextCompositionMetrics } from '../../metrics/context-composition-tracker.js';
+import type { ContextWindowMetrics } from '../../metrics/context-window-tracker.js';
 import type { AntiPattern } from '../../metrics/anti-patterns.js';
 import type { RetryDetectorMetrics } from '../../metrics/retry-detector.js';
 import type { InstructionDriftMetrics } from '../../metrics/instruction-drift-tracker.js';
@@ -433,6 +435,8 @@ export interface ApiHandlerDeps {
     getConcurrencyTimeSeries: () => readonly { timestamp: number; count: number }[];
   };
   readonly contextTracker?: { getMetrics: (sessionId?: string) => ContextTrackerMetrics };
+  readonly contextCompositionTracker?: { getMetrics: () => ContextCompositionMetrics };
+  readonly contextEfficiencyTracker?: { getMetrics: () => ContextWindowMetrics };
   readonly config?: McpServerConfig;
   readonly configFilePath?: string;
   // Resolved lazily (not captured as a plain value) because the platform
@@ -1828,6 +1832,16 @@ export function createApiHandler(
       }
     }
     jsonOk(res, local);
+  });
+
+  routes.set('GET /api/context-composition', (_req, res) => {
+    if (!deps.contextCompositionTracker) return unavailable(res, 'contextCompositionTracker');
+    jsonOk(res, deps.contextCompositionTracker.getMetrics());
+  });
+
+  routes.set('GET /api/context-efficiency', (_req, res) => {
+    if (!deps.contextEfficiencyTracker) return unavailable(res, 'contextEfficiencyTracker');
+    jsonOk(res, deps.contextEfficiencyTracker.getMetrics());
   });
 
   routes.set('GET /api/concurrency', (req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1361,6 +1361,8 @@ async function main(): Promise<void> {
           gitEfficiencyTracker,
           concurrencyTracker: liveSessionRegistry,
           contextTracker,
+          contextCompositionTracker,
+          contextEfficiencyTracker: contextWindowTracker,
           config,
           configFilePath: options.config ?? resolve(DEFAULT_STORAGE_PATH, 'config.json'),
           // eventProcessor isn't assigned until after this object is built —

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -804,6 +804,51 @@ export const fetchContext = (sessionId?: string): Promise<ContextResponse> =>
     sessionId ? `/api/context?sessionId=${encodeURIComponent(sessionId)}` : '/api/context',
   );
 
+export type ContextCategory =
+  'system_prompt' | 'conversation_history' | 'tool_results' | 'injected_file_content' | 'other';
+
+export interface ContextCompositionResponse {
+  readonly currentFillPercent: number;
+  readonly currentBreakdown: Record<ContextCategory, number>;
+  readonly turnCount: number;
+  readonly thresholdAlerts: ReadonlyArray<{
+    readonly threshold: number;
+    readonly fillPercent: number;
+    readonly timestamp: number;
+    readonly turnNumber: number;
+    readonly dominantCategory: ContextCategory;
+    readonly dominantPercent: number;
+  }>;
+  readonly dominanceAlerts: ReadonlyArray<{
+    readonly category: ContextCategory;
+    readonly percent: number;
+    readonly timestamp: number;
+    readonly turnNumber: number;
+  }>;
+  readonly history: ReadonlyArray<{
+    readonly turnNumber: number;
+    readonly timestamp: number;
+    readonly totalTokens: number;
+    readonly breakdown: Record<ContextCategory, number>;
+    readonly fillPercent: number;
+    readonly dominantCategory: ContextCategory | null;
+  }>;
+  readonly note: string;
+}
+
+export interface ContextEfficiencyResponse {
+  readonly uniqueFilesRead: number;
+  readonly totalReadOperations: number;
+  readonly repeatedReadCount: number;
+  readonly repeatedReadRatio: number | null;
+  readonly topRepeatedFiles: ReadonlyArray<{ readonly file: string; readonly readCount: number }>;
+}
+
+export const fetchContextComposition = (): Promise<ContextCompositionResponse> =>
+  getJson<ContextCompositionResponse>('/api/context-composition');
+export const fetchContextEfficiency = (): Promise<ContextEfficiencyResponse> =>
+  getJson<ContextEfficiencyResponse>('/api/context-efficiency');
+
 export interface SettingsPatch {
   developer?: string;
   teamId?: string | null;

--- a/src/web/components/ContextBar.test.tsx
+++ b/src/web/components/ContextBar.test.tsx
@@ -120,6 +120,57 @@ describe('ContextBar — timeline expand/collapse', () => {
   });
 });
 
+describe('ContextBar — composition/efficiency drill-down', () => {
+  beforeEach(resetStore);
+  afterEach(resetStore);
+
+  it('shows the top re-read file and dominant category once expanded', async () => {
+    globalThis.fetch = ((url: string) => {
+      if (url.startsWith('/api/context-efficiency')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              uniqueFilesRead: 12,
+              totalReadOperations: 20,
+              repeatedReadCount: 8,
+              repeatedReadRatio: 0.4,
+              topRepeatedFiles: [{ file: 'src/index.ts', readCount: 4 }],
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        );
+      }
+      if (url.startsWith('/api/context-composition')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              currentFillPercent: 62,
+              currentBreakdown: {
+                system_prompt: 1000,
+                conversation_history: 3000,
+                tool_results: 5000,
+                injected_file_content: 500,
+                other: 100,
+              },
+              turnCount: 5,
+              thresholdAlerts: [],
+              dominanceAlerts: [],
+              history: [],
+              note: '',
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response('null', { status: 200 }));
+    }) as typeof globalThis.fetch;
+    renderContextBar({ data: makeContext({ history: makeHistory(3) }) });
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle context timeline' }));
+    expect(await screen.findByText(/src\/index\.ts/)).toBeInTheDocument();
+    expect(screen.getByText(/40%/)).toBeInTheDocument();
+  });
+});
+
 describe('ContextBar', () => {
   it('flags the compacting state when currentTokens drops more than 30% from the previous render', () => {
     const { container, rerender } = renderContextBar({ data: makeContext() });

--- a/src/web/components/ContextBar.tsx
+++ b/src/web/components/ContextBar.tsx
@@ -12,7 +12,15 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 
-import { fetchContext, qk, type ContextResponse } from '../api/client';
+import {
+  fetchContext,
+  fetchContextComposition,
+  fetchContextEfficiency,
+  qk,
+  type ContextResponse,
+  type ContextCompositionResponse,
+  type ContextEfficiencyResponse,
+} from '../api/client';
 import { useLiveStore, type ContextUpdateEvent } from '../store/liveStore';
 import { Eyebrow, Pill } from './ui';
 
@@ -177,6 +185,17 @@ export function ContextBar({
     enabled: !data,
   });
 
+  const { data: composition } = useQuery<ContextCompositionResponse>({
+    queryKey: ['context-composition', sessionId],
+    queryFn: fetchContextComposition,
+    enabled: showTimeline,
+  });
+  const { data: efficiency } = useQuery<ContextEfficiencyResponse>({
+    queryKey: ['context-efficiency', sessionId],
+    queryFn: fetchContextEfficiency,
+    enabled: showTimeline,
+  });
+
   const source = data ?? apiContext;
   const sid = sessionId ?? '';
   const ctx: ContextUpdateEvent | null = data
@@ -313,10 +332,30 @@ export function ContextBar({
 
       {expandable && (
         <div
-          className={`overflow-hidden transition-all duration-300 ${showTimeline ? 'max-h-40' : 'max-h-0'}`}
+          className={`overflow-hidden transition-all duration-300 ${showTimeline ? 'max-h-56' : 'max-h-0'}`}
         >
           {timelineHistory && (
             <ContextTimeline history={timelineHistory} contextWindow={contextWindow} />
+          )}
+          {showTimeline && efficiency && efficiency.repeatedReadRatio !== null && (
+            <div className="mt-2 text-xs text-ink-muted">
+              <span>Repeated reads: {Math.round(efficiency.repeatedReadRatio * 100)}%</span>
+              {efficiency.topRepeatedFiles[0] && (
+                <span className="ml-2">
+                  top:{' '}
+                  <code className="bg-surface-5 px-1 rounded">
+                    {efficiency.topRepeatedFiles[0].file}
+                  </code>{' '}
+                  ({efficiency.topRepeatedFiles[0].readCount}x)
+                </span>
+              )}
+            </div>
+          )}
+          {showTimeline && composition && (
+            <div className="mt-1 text-xs text-ink-muted">
+              Dominant this turn:{' '}
+              {Object.entries(composition.currentBreakdown).sort((a, b) => b[1] - a[1])[0]?.[0]}
+            </div>
           )}
         </div>
       )}

--- a/src/web/components/SessionDetailDialog.test.tsx
+++ b/src/web/components/SessionDetailDialog.test.tsx
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { SessionDetailDialog } from './SessionDetailDialog';
-import type { DecisionTreeResponse, TurnCostsResponse, ContextResponse } from '../api/client';
+import type {
+  DecisionTreeResponse,
+  TurnCostsResponse,
+  ContextResponse,
+  ContextCompositionResponse,
+  ContextEfficiencyResponse,
+} from '../api/client';
 
 function makeDecisionTree(overrides: Partial<DecisionTreeResponse> = {}): DecisionTreeResponse {
   return {
@@ -53,6 +59,40 @@ function makeSixTurns(): TurnCostsResponse['turns'] {
     estimatedCostUsd: (i + 1) / 100,
     costPerToolCall: (i + 1) / 100,
   }));
+}
+
+function makeContextComposition(
+  overrides: Partial<ContextCompositionResponse> = {},
+): ContextCompositionResponse {
+  return {
+    currentFillPercent: 62,
+    currentBreakdown: {
+      system_prompt: 1000,
+      conversation_history: 3000,
+      tool_results: 5000,
+      injected_file_content: 500,
+      other: 100,
+    },
+    turnCount: 5,
+    thresholdAlerts: [],
+    dominanceAlerts: [],
+    history: [],
+    note: '',
+    ...overrides,
+  };
+}
+
+function makeContextEfficiency(
+  overrides: Partial<ContextEfficiencyResponse> = {},
+): ContextEfficiencyResponse {
+  return {
+    uniqueFilesRead: 12,
+    totalReadOperations: 20,
+    repeatedReadCount: 8,
+    repeatedReadRatio: 0.4,
+    topRepeatedFiles: [{ file: 'src/index.ts', readCount: 4 }],
+    ...overrides,
+  };
 }
 
 function makeContextHistory(count: number): ContextResponse['history'] {
@@ -191,5 +231,38 @@ describe('SessionDetailDialog — context timeline section', () => {
     );
     expect(screen.getByText('Context Timeline')).toBeInTheDocument();
     expect(screen.queryByText('No context timeline data yet.')).toBeNull();
+  });
+});
+
+describe('SessionDetailDialog — context composition/efficiency section', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the dominant category and repeated-read percentage', () => {
+    render(
+      <SessionDetailDialog
+        decisionTree={makeDecisionTree()}
+        turnCosts={makeTurnCosts()}
+        contextComposition={makeContextComposition()}
+        contextEfficiency={makeContextEfficiency()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('tool_results')).toBeInTheDocument();
+    expect(screen.getByText(/40%/)).toBeInTheDocument();
+    expect(screen.getByText(/src\/index\.ts/)).toBeInTheDocument();
+    expect(screen.getByText(/4x/)).toBeInTheDocument();
+  });
+
+  it('shows the empty state when both props are omitted', () => {
+    render(
+      <SessionDetailDialog
+        decisionTree={makeDecisionTree()}
+        turnCosts={makeTurnCosts()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('No composition/efficiency data yet.')).toBeInTheDocument();
   });
 });

--- a/src/web/components/SessionDetailDialog.tsx
+++ b/src/web/components/SessionDetailDialog.tsx
@@ -3,7 +3,13 @@ import type { JSX } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 
-import type { DecisionTreeResponse, TurnCostsResponse, ContextResponse } from '../api/client';
+import type {
+  DecisionTreeResponse,
+  TurnCostsResponse,
+  ContextResponse,
+  ContextCompositionResponse,
+  ContextEfficiencyResponse,
+} from '../api/client';
 import { Card, Eyebrow, Pill, type PillTone } from './ui';
 import { formatTokensCompact } from '../lib/format.js';
 import { ContextTimeline } from './ContextBar';
@@ -13,6 +19,8 @@ export interface SessionDetailDialogProps {
   readonly turnCosts: TurnCostsResponse | undefined;
   readonly contextHistory?: ContextResponse['history'];
   readonly contextWindow?: number;
+  readonly contextComposition?: ContextCompositionResponse;
+  readonly contextEfficiency?: ContextEfficiencyResponse;
   readonly onClose: () => void;
 }
 
@@ -29,6 +37,8 @@ export function SessionDetailDialog({
   turnCosts,
   contextHistory,
   contextWindow,
+  contextComposition,
+  contextEfficiency,
   onClose,
 }: SessionDetailDialogProps): JSX.Element {
   const drawerRef = useRef<HTMLDivElement>(null);
@@ -222,6 +232,50 @@ export function SessionDetailDialog({
               ) : (
                 <div className="py-2 text-center text-xs text-ink-muted">
                   No context timeline data yet.
+                </div>
+              )}
+            </Card>
+          </section>
+
+          <section aria-label="Context composition and efficiency">
+            <Eyebrow className="mb-3">Context Composition &amp; Efficiency</Eyebrow>
+            <Card tone="static" padding="sm">
+              {!contextComposition && !contextEfficiency ? (
+                <div className="py-2 text-center text-xs text-ink-muted">
+                  No composition/efficiency data yet.
+                </div>
+              ) : (
+                <div className="space-y-2 text-xs">
+                  {contextComposition && (
+                    <div className="text-ink-muted">
+                      Dominant this turn:{' '}
+                      <span className="text-ink-base">
+                        {
+                          Object.entries(contextComposition.currentBreakdown).sort(
+                            (a, b) => b[1] - a[1],
+                          )[0]?.[0]
+                        }
+                      </span>
+                    </div>
+                  )}
+                  {contextEfficiency && contextEfficiency.repeatedReadRatio !== null && (
+                    <div className="text-ink-muted">
+                      Repeated reads:{' '}
+                      <span className="text-ink-base">
+                        {Math.round(contextEfficiency.repeatedReadRatio * 100)}%
+                      </span>
+                      {contextEfficiency.topRepeatedFiles[0] && (
+                        <>
+                          {' '}
+                          — top:{' '}
+                          <code className="bg-surface-5 px-1 rounded">
+                            {contextEfficiency.topRepeatedFiles[0].file}
+                          </code>{' '}
+                          ({contextEfficiency.topRepeatedFiles[0].readCount}x)
+                        </>
+                      )}
+                    </div>
+                  )}
                 </div>
               )}
             </Card>

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -149,6 +149,38 @@ describe('Today view', () => {
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
+      if (url.startsWith('/api/context-composition')) {
+        return new Response(
+          JSON.stringify({
+            currentFillPercent: 62,
+            currentBreakdown: {
+              system_prompt: 1000,
+              conversation_history: 3000,
+              tool_results: 5000,
+              injected_file_content: 500,
+              other: 100,
+            },
+            turnCount: 5,
+            thresholdAlerts: [],
+            dominanceAlerts: [],
+            history: [],
+            note: '',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.startsWith('/api/context-efficiency')) {
+        return new Response(
+          JSON.stringify({
+            uniqueFilesRead: 12,
+            totalReadOperations: 20,
+            repeatedReadCount: 8,
+            repeatedReadRatio: 0.4,
+            topRepeatedFiles: [{ file: 'src/index.ts', readCount: 4 }],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
       return new Response('null', { status: 200 });
     }) as typeof globalThis.fetch;
   }
@@ -182,6 +214,7 @@ describe('Today view', () => {
     // 6th turn's cost ($0.06) would have been sliced off by the old `.slice(-5)`.
     expect(screen.getByText('$0.06')).toBeInTheDocument();
     expect(screen.getByText(/longest failure streak/i)).toBeInTheDocument();
+    expect(await screen.findByText('tool_results')).toBeInTheDocument();
   });
 
   it('hides the trigger when neither tracker has data', async () => {

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -39,6 +39,10 @@ import {
   type DecisionTreeResponse,
   fetchContext,
   type ContextResponse,
+  fetchContextComposition,
+  type ContextCompositionResponse,
+  fetchContextEfficiency,
+  type ContextEfficiencyResponse,
   fetchQualityProxy,
   fetchToolSelectionScore,
   fetchConcurrency,
@@ -1006,6 +1010,16 @@ function LiveSessionPane({
     refetchInterval: 10_000,
     enabled: isLive && Boolean(activeId),
   });
+  const { data: contextComposition } = useQuery<ContextCompositionResponse>({
+    queryKey: ['context-composition'],
+    queryFn: fetchContextComposition,
+    refetchInterval: 10_000,
+  });
+  const { data: contextEfficiency } = useQuery<ContextEfficiencyResponse>({
+    queryKey: ['context-efficiency'],
+    queryFn: fetchContextEfficiency,
+    refetchInterval: 10_000,
+  });
 
   const tailRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -1292,6 +1306,8 @@ function LiveSessionPane({
           turnCosts={turnCosts}
           contextHistory={contextData?.history}
           contextWindow={contextData?.contextWindow}
+          contextComposition={contextComposition}
+          contextEfficiency={contextEfficiency}
           onClose={() => setShowDetail(false)}
         />
       )}


### PR DESCRIPTION
## Summary
- Add `GET /api/context-composition` and `GET /api/context-efficiency` routes.
- Add a drill-down inside `ContextBar`'s expanded state (Sessions page): dominant content category for the current turn, plus the most frequently re-read files.
- Add the same detail as a new section in `SessionDetailDialog` (Today's live session pane), alongside the existing Decision Tree, Turn Costs, and Context Timeline sections.
- Bump to v1.14.29.

Fixes #304. Fixes #323.

## Test plan
- [x] `npm run build && npm test` — 162/163 suites, 5329/5332 tests passing (3 pre-existing skips)
- [x] `npx vitest run` — 39/39 files, 454/454 tests passing
- [x] `npm run lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>