### PR TITLE
Feat: personal coach metrics table in History panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.30] - 2026-08-04
+
+### Added
+
+- **The History dashboard's Personal Coach panel now shows the numbers behind its recommendations** — a compact table of this week's efficiency, cost per session, anti-pattern rate, and session count sits above the existing highlights and top recommendation, each metric paired with a delta badge against your rolling baseline.
+
 ## [1.14.29] - 2026-08-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.29",
+  "version": "1.14.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.29",
+      "version": "1.14.30",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.29",
+  "version": "1.14.30",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1452,6 +1452,42 @@ describe('api-handler GET /api/personal-coach', () => {
     await handler(req, res);
     expect(status()).toBe(503);
   });
+
+  it('regenerates the current week summary before reading, so "this week" is never stale', async () => {
+    const generatedWeekIds: string[] = [];
+    const handler = createApiHandler({
+      personalCoach: { generate: () => ({ status: 'insufficient_data' }) } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['personalCoach'],
+      weeklySummaryGenerator: {
+        generate: (weekId: string) => generatedWeekIds.push(weekId),
+      } as unknown as Parameters<typeof createApiHandler>[0]['weeklySummaryGenerator'],
+    });
+    const req = { method: 'GET', url: '/api/personal-coach' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(generatedWeekIds).toEqual([getIsoWeekId(new Date())]);
+  });
+
+  it('still returns personalCoach.generate() when the regeneration throws', async () => {
+    const fake = { status: 'insufficient_data' };
+    const handler = createApiHandler({
+      personalCoach: { generate: () => fake } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['personalCoach'],
+      weeklySummaryGenerator: {
+        generate: () => {
+          throw new Error('disk full');
+        },
+      } as unknown as Parameters<typeof createApiHandler>[0]['weeklySummaryGenerator'],
+    });
+    const req = { method: 'GET', url: '/api/personal-coach' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(JSON.parse(body())).toEqual(fake);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1711,6 +1711,12 @@ export function createApiHandler(
 
   routes.set('GET /api/personal-coach', (_req, res) => {
     if (!deps.personalCoach) return unavailable(res, 'personalCoach');
+    try {
+      deps.weeklySummaryGenerator?.generate(getIsoWeekId(new Date()));
+    } catch (err) {
+      // best-effort — failure here means "this week" reflects a stale cache, not a 500
+      console.error('Weekly summary generation failed', err);
+    }
     jsonOk(res, deps.personalCoach.generate());
   });
 

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -470,6 +470,15 @@ export interface CostPerOutcomeResponse {
 export const fetchCostPerOutcome = (days = 30): Promise<CostPerOutcomeResponse> =>
   getJson<CostPerOutcomeResponse>(`/api/cost-per-outcome?days=${days}`);
 
+// Mirrors the subset of PersonalWeekMetrics (src/metrics/personal-coach.ts,
+// not importable) actually rendered by CoachMetricsTable.
+export interface PersonalWeekMetrics {
+  readonly avgEfficiencyScore: number | null;
+  readonly avgCostPerSession: number;
+  readonly antiPatternRate: number;
+  readonly sessionsCount: number;
+}
+
 // Mirrors the 'ok'/'insufficient_data' union returned by PersonalCoach.generate()
 // in src/metrics/personal-coach.ts (not importable).
 export interface PersonalCoachReport {
@@ -478,6 +487,9 @@ export interface PersonalCoachReport {
   readonly regressions: readonly string[];
   readonly streaks: readonly string[];
   readonly topRecommendation: string;
+  readonly thisWeek: PersonalWeekMetrics;
+  readonly baseline: PersonalWeekMetrics;
+  readonly weeksAnalyzed: number;
 }
 
 export interface PersonalCoachInsufficientData {

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -104,9 +104,21 @@ const SAMPLE_COACH_OK = {
   regressions: [],
   streaks: ['Cost per session has decreased for 3 consecutive weeks.'],
   topRecommendation: 'Strong week — document what worked in CLAUDE.md.',
-  thisWeek: { weekId: '2026-W22' },
+  thisWeek: {
+    weekId: '2026-W22',
+    avgEfficiencyScore: 0.72,
+    avgCostPerSession: 0.42,
+    antiPatternRate: 0.042,
+    sessionsCount: 5,
+  },
   lastWeek: { weekId: '2026-W21' },
-  baseline: { weekId: 'baseline' },
+  baseline: {
+    weekId: 'baseline',
+    avgEfficiencyScore: 0.64,
+    avgCostPerSession: 0.5,
+    antiPatternRate: 0.035,
+    sessionsCount: 4,
+  },
 };
 
 const SAMPLE_COACH_INSUFFICIENT = {
@@ -1124,5 +1136,43 @@ describe('aggregateToolUsage', () => {
 
   it('returns empty array for empty input', () => {
     expect(aggregateToolUsage([])).toEqual([]);
+  });
+});
+
+describe('CoachMetricsTable', () => {
+  it('renders all four metric row labels and the efficiency delta badge', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText(/personal coach/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/strong week/i)).toBeInTheDocument());
+    // Check for the four row labels (exact match with word boundaries)
+    expect(screen.getByText('Efficiency')).toBeInTheDocument();
+    expect(screen.getByText('Cost / session')).toBeInTheDocument();
+    expect(screen.getByText('Anti-pattern rate')).toBeInTheDocument();
+    expect(screen.getAllByText('Sessions').length).toBeGreaterThanOrEqual(1);
+    // Now check for the metrics table values
+    expect(screen.getByText('72')).toBeInTheDocument(); // effValue = 0.72 * 100 = 72
+    expect(screen.getByText('$0.42')).toBeInTheDocument(); // thisWeek cost
+    expect(screen.getByText('4.2%')).toBeInTheDocument(); // antiPatternRate as percentage
+    // SAMPLE_COACH_OK has efficiency 0.72 vs baseline 0.64 → delta = +8pts
+    expect(screen.getByText('↑8pts')).toBeInTheDocument();
+  });
+
+  it('renders zero deltas correctly when baseline values are null or zero', async () => {
+    const coachNullBaseline = {
+      ...SAMPLE_COACH_OK,
+      status: 'ok' as const,
+      baseline: {
+        ...SAMPLE_COACH_OK.baseline,
+        avgEfficiencyScore: null,
+        avgCostPerSession: 0,
+        antiPatternRate: 0,
+      },
+    };
+    renderHistory({ coach: coachNullBaseline });
+    await waitFor(() => expect(screen.getByText(/personal coach/i)).toBeInTheDocument());
+    // Verify the coach card renders with the null/zero baseline without crashing
+    // The component should handle null efficiency and zero-valued baseline metrics gracefully
+    expect(screen.getByText(/personal coach/i)).toBeInTheDocument();
+    expect(screen.getByText(/Efficiency/i)).toBeInTheDocument();
   });
 });

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -31,6 +31,7 @@ import {
   type WeeklyRow,
   type CostPerOutcomeResponse,
   type PersonalCoachResult,
+  type PersonalWeekMetrics,
   type ConcurrencyHistoryResponse,
   type ActivityHeatmapHistoryResponse,
   type InstructionDriftResponse,
@@ -529,6 +530,98 @@ function Panel({
   );
 }
 
+function CoachMetricsTable({
+  thisWeek,
+  baseline,
+}: {
+  thisWeek: PersonalWeekMetrics;
+  baseline: PersonalWeekMetrics;
+}): JSX.Element {
+  const effDelta =
+    thisWeek.avgEfficiencyScore !== null && baseline.avgEfficiencyScore !== null
+      ? Math.round((thisWeek.avgEfficiencyScore - baseline.avgEfficiencyScore) * 100)
+      : null;
+
+  const costDelta =
+    baseline.avgCostPerSession > 0
+      ? (thisWeek.avgCostPerSession - baseline.avgCostPerSession) / baseline.avgCostPerSession
+      : null;
+
+  const apDelta =
+    baseline.antiPatternRate > 0
+      ? (thisWeek.antiPatternRate - baseline.antiPatternRate) / baseline.antiPatternRate
+      : null;
+
+  const sessionsDelta = Math.round(thisWeek.sessionsCount - baseline.sessionsCount);
+
+  function effColor(delta: number | null): string {
+    if (delta === null) return 'text-ink-muted';
+    if (delta >= 5) return 'text-accent-green';
+    if (delta <= -5) return 'text-accent-amber';
+    return 'text-ink-muted';
+  }
+
+  function costColor(delta: number | null): string {
+    if (delta === null) return 'text-ink-muted';
+    if (delta <= -0.15) return 'text-accent-green';
+    if (delta >= 0.25) return 'text-accent-amber';
+    return 'text-ink-muted';
+  }
+
+  function apColor(delta: number | null): string {
+    if (delta === null) return 'text-ink-muted';
+    if (delta <= -0.2) return 'text-accent-green';
+    if (delta >= 0.25) return 'text-accent-amber';
+    return 'text-ink-muted';
+  }
+
+  function effDeltaText(delta: number | null): string {
+    if (delta === null) return '—';
+    if (delta === 0) return '0pts';
+    return `${delta > 0 ? '↑' : '↓'}${Math.abs(delta)}pts`;
+  }
+
+  function pctDeltaText(delta: number | null): string {
+    if (delta === null) return '—';
+    if (delta === 0) return '0%';
+    return `${delta > 0 ? '↑' : '↓'}${Math.abs(Math.round(delta * 100))}%`;
+  }
+
+  function sessionsDeltaText(delta: number): string {
+    if (delta === 0) return '0';
+    return delta > 0 ? `+${delta}` : `${delta}`;
+  }
+
+  const effValue =
+    thisWeek.avgEfficiencyScore !== null
+      ? Math.round(thisWeek.avgEfficiencyScore * 100).toString()
+      : '—';
+
+  return (
+    <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-xs mb-3">
+      <span className="text-ink-muted" />
+      <span className="text-ink-muted">This wk</span>
+      <span className="text-ink-muted">vs baseline</span>
+
+      <span className="text-ink-muted">Efficiency</span>
+      <span className="font-mono">{effValue}</span>
+      <span className={effColor(effDelta)}>{effDeltaText(effDelta)}</span>
+
+      <span className="text-ink-muted">Cost / session</span>
+      <span className="font-mono">${thisWeek.avgCostPerSession.toFixed(2)}</span>
+      <span className={costColor(costDelta)}>{pctDeltaText(costDelta)}</span>
+
+      <span className="text-ink-muted">Anti-pattern rate</span>
+      <span className="font-mono">{(thisWeek.antiPatternRate * 100).toFixed(1)}%</span>
+      <span className={apColor(apDelta)}>{pctDeltaText(apDelta)}</span>
+
+      <span className="text-ink-muted">Sessions</span>
+      <span className="font-mono">{Math.round(thisWeek.sessionsCount)}</span>
+      <span className="text-ink-muted">{sessionsDeltaText(sessionsDelta)}</span>
+    </div>
+  );
+}
+
 function CoachCard({ data }: { data: PersonalCoachResult | undefined }): JSX.Element {
   if (!data) {
     return (
@@ -547,6 +640,7 @@ function CoachCard({ data }: { data: PersonalCoachResult | undefined }): JSX.Ele
   return (
     <Panel title="Personal coach">
       <div className="text-xs space-y-2">
+        <CoachMetricsTable thisWeek={data.thisWeek} baseline={data.baseline} />
         <div>
           <span className="text-accent-cyan font-semibold">Top recommendation: </span>
           {data.topRecommendation}


### PR DESCRIPTION
Closes #35

## Summary

- Adds a compact delta table to the History dashboard's existing Personal Coach panel — this week's efficiency, cost per session, anti-pattern rate, and session count, each paired with a delta badge against your rolling baseline — above the existing narrative highlights and top recommendation.
- Fixes `/api/personal-coach` to regenerate the current week's cached summary before reading it, matching the same best-effort refresh `/api/weekly` already does, so "this week" data is never stale.
- Version bump to 1.14.30 with matching CHANGELOG entry.

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 5331/5334 passing (3 skipped)
- [x] `npx vitest run src/web/views/History.test.tsx` — 61/61 passing
- [x] `npm run lint` — 0 errors/warnings
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)