### PR TITLE
Fix: --mode option missing from preflight install command 

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,9 @@ import { resolveRecordContent } from './record-content-gate.js';
 
 const logger = createLogger('mcp-config');
 
+export const VALID_MODES = ['cloud', 'local', 'both'] as const;
+export type Mode = (typeof VALID_MODES)[number];
+
 export interface McpServerConfig {
   readonly licenseKey?: string;
   readonly accountId?: string;
@@ -45,7 +48,7 @@ export interface McpServerConfig {
   /** Default: 90. `null` disables retention (only reachable via an explicit `null` in config.json). */
   readonly retainSessionsDays: number | null;
   readonly personalAlertThresholds: PersonalAlertThresholds;
-  readonly mode: 'cloud' | 'local' | 'both';
+  readonly mode: Mode;
   readonly platformTarget?: PlatformTarget;
   /**
    * OTLP-related config, grouped to match the `dashboard`/`alerts` nesting
@@ -153,7 +156,7 @@ export const ConfigFileSchema = z
     otlpReceiverBindAddress: z.string().optional(),
     otlpForwardEndpoint: z.string().nullable().optional(),
     otlpForwardHeaders: z.record(z.string(), z.string()).optional(),
-    mode: z.enum(['cloud', 'local', 'both']).optional(),
+    mode: z.enum(VALID_MODES).optional(),
     platformTarget: z.enum(['native', 'wsl-windows-cc', 'wsl-linux-cc']).optional(),
     otlp: z
       .object({
@@ -591,8 +594,6 @@ export function loadMcpConfig(cliOptions?: Partial<CliOptions>): Readonly<McpSer
 
   // --- Resolve mode early so we can gate licenseKey/accountId requirements ---
   // File mode is already validated by the zod schema in loadConfigFile.
-  const VALID_MODES = ['cloud', 'local', 'both'] as const;
-  type Mode = (typeof VALID_MODES)[number];
   const isValidMode = (v: string | undefined): v is Mode =>
     v !== undefined && (VALID_MODES as readonly string[]).includes(v);
   const envMode = process.env.NR_AI_MODE;

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -10,7 +10,7 @@ import { existsSync, copyFileSync, realpathSync, readFileSync } from 'node:fs';
 import { createInterface } from 'node:readline/promises';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 
 import { createLogger } from '../shared/index.js';
 import {
@@ -24,6 +24,7 @@ import {
 } from './install-helper.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
 import { validateConfigFile, DEFAULT_STORAGE_PATH, ConfigFileSchema } from '../config.js';
+import { VALID_MODES, type Mode } from '../config.js';
 import type { PlatformTarget } from '../config.js';
 import { migrateStoragePath } from './migrate.js';
 import {
@@ -582,6 +583,7 @@ function handleSchedule(options: { time?: string; disable?: boolean }): void {
 function handleInstall(options: {
   licenseKey?: string;
   accountId?: string;
+  mode?: Mode;
   project?: boolean;
   windowsCc?: boolean;
   linuxCc?: boolean;
@@ -658,6 +660,9 @@ function handleInstall(options: {
           nrConfig,
           generateNrConfig(options.licenseKey as string, options.accountId as string),
         );
+      }
+      if (options.mode) {
+        nrConfig.mode = options.mode;
       }
       writeJsonFile(NR_CONFIG_PATH, nrConfig, DEFAULT_STORAGE_PATH);
       nrConfigWritten = credentialsProvided;
@@ -1227,6 +1232,11 @@ export function createInstallProgram(): Command {
     .description('Configure Claude Code hooks and MCP server for AI observability')
     .option('--license-key <key>', 'New Relic license key')
     .option('--account-id <id>', 'New Relic account ID')
+    .addOption(
+      new Option('--mode <mode>', 'Telemetry mode: cloud, local, or both (default: local)').choices(
+        [...VALID_MODES],
+      ),
+    )
     .option('--project', 'Write to project-level .claude/settings.json instead of user-level')
     .option('--windows-cc', 'Target Windows Claude Code (desktop app) when running inside WSL')
     .option('--linux-cc', 'Target Linux Claude Code (npm in WSL) when running inside WSL')

--- a/src/install/setup-wizard.ts
+++ b/src/install/setup-wizard.ts
@@ -11,6 +11,7 @@ import { resolve, dirname } from 'node:path';
 import { z } from 'zod';
 
 import { normalizeDeveloperName, ConfigFileSchema, DEFAULT_STORAGE_PATH } from '../config.js';
+import type { Mode } from '../config.js';
 import { migrateStoragePath } from './migrate.js';
 import { runInstallCli, verifyBinaryOnPath, findRepoRoot } from './cli.js';
 import { writeJsonFile } from './json-utils.js';
@@ -138,7 +139,7 @@ function loadExisting(): Partial<z.infer<typeof ConfigFileSchema>> {
   return filtered;
 }
 
-export type WizardMode = 'cloud' | 'local' | 'both';
+export type WizardMode = Mode;
 
 export function buildConfig(
   existing: Partial<z.infer<typeof ConfigFileSchema>>,


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                     
  - The README non-interactive install example includes `--mode cloud` but the `install` command did not implement this option — running the example as-written produced `error: unknown option '--mode'`                                            
  - Add `--mode <mode>` option to `preflight install` with runtime validation via Commander `.choices()`                                                                                                                                             
  - Write `mode` to `~/.newrelic-preflight/config.json` when provided alongside credentials                                                                                                                                                          
  - Centralize mode values: extract `VALID_MODES` and `Mode` type in `config.ts` as single source of truth; use `z.enum(VALID_MODES)` in Zod schema and `WizardMode` as alias for `Mode`                                                             
                                                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                     
  - [x] `preflight install --mode invalid` → `error: option '--mode <mode>' argument 'invalid' is invalid. Allowed choices are cloud, local, both.`                                                                                                  
  - [x] `preflight install --mode cloud --license-key ... --account-id ...` → `config.json` contains `"mode": "cloud"`                                                                                                                             
  - [ ] `npm test` passes                                                                                                                                                                                                                            
  - [x] `npm run build` passes   