### PR TITLE
Feat: Recommendations panel in History view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.31] - 2026-08-05
+
+### Added
+
+- **The History dashboard now surfaces personalized optimization recommendations** — a new panel synthesizes cost, prompt-engineering, and model-selection signals into a prioritized list, with high-priority items expanded and the rest shown as a compact list.
+
 ## [1.14.30] - 2026-08-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.30",
+  "version": "1.14.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.30",
+      "version": "1.14.31",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.30",
+  "version": "1.14.31",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -40,6 +40,7 @@ import type { AlertEvent } from '../live-event-bus.js';
 import type { BudgetStatus } from '../../metrics/budget-tracker.js';
 import type { LatencyMetrics } from '../../metrics/latency-tracker.js';
 import type { PersonalInsightsResult } from '../../metrics/personal-coach.js';
+import type { Recommendation } from '../../metrics/recommendation-engine.js';
 import type { GitEfficiencyMetrics } from '../../metrics/git-efficiency-tracker.js';
 import type {
   QualityProxyMetrics,
@@ -395,6 +396,9 @@ export interface ApiHandlerDeps {
     computeTrends: () => {
       weeklyCacheHitRateTrend: ReadonlyArray<{ readonly week: string; readonly value: number }>;
     };
+  };
+  readonly recommendationEngine?: {
+    generateAllRecommendations: (developer: string) => readonly Recommendation[];
   };
   readonly alertLog?: { readRecent: (limit: number) => Promise<AlertEvent[]> };
   readonly taskDetector?: {
@@ -1718,6 +1722,31 @@ export function createApiHandler(
       console.error('Weekly summary generation failed', err);
     }
     jsonOk(res, deps.personalCoach.generate());
+  });
+
+  routes.set('GET /api/recommendations', (_req, res) => {
+    if (!deps.recommendationEngine) return unavailable(res, 'recommendationEngine');
+    const developer = deps.config?.developer ?? 'unknown';
+    const recs = deps.recommendationEngine
+      .generateAllRecommendations(developer)
+      // The History dashboard already renders 'efficiency' (CoachCard's
+      // regressions, vs. a multi-week baseline) and 'claudemd' (InstructionDriftCard,
+      // a differently-computed before/after verdict) via their own panels —
+      // surfacing them again here would just restate the same signal with
+      // different numbers. 'claudemd_impact' is a prompt_engineering
+      // sub-category (see PROMPT_RECOMMENDATION_TITLES) that restates the
+      // same "instruction-file change hurt metrics" signal as 'claudemd' under a
+      // different top-level category, so it's excluded too. All exclusions
+      // are for this dashboard route only; the nr_observe_get_recommendations
+      // MCP tool still returns every category, since it has no adjacent
+      // panels to duplicate.
+      .filter(
+        (rec) =>
+          rec.category !== 'efficiency' &&
+          rec.category !== 'claudemd' &&
+          rec.subCategory !== 'claudemd_impact',
+      );
+    jsonOk(res, { recommendations: recs, count: recs.length });
   });
 
   routes.set('GET /api/alerts/recent', async (_req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1350,6 +1350,7 @@ async function main(): Promise<void> {
           latencyTracker,
           personalCoach,
           trendAnalyzer,
+          recommendationEngine,
           alertLog,
           taskDetector,
           efficiencyScorer,

--- a/src/metrics/recommendation-engine.ts
+++ b/src/metrics/recommendation-engine.ts
@@ -35,6 +35,12 @@ export interface Recommendation {
   readonly detail: string;
   readonly evidence: string;
   readonly estimatedSavings?: string;
+  // Only set for 'prompt_engineering' recommendations — identifies which of
+  // PromptFeedbackEngine's own sub-categories (prompt_context/plan_mode/
+  // file_paths/claudemd_impact) produced this item. Lets callers dedupe
+  // against other categories (e.g. 'claudemd_impact' restates the same
+  // signal as the top-level 'claudemd' category) without parsing title text.
+  readonly subCategory?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -42,6 +48,16 @@ export interface Recommendation {
 // ---------------------------------------------------------------------------
 
 const PRIORITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
+
+// Human-readable titles for PromptFeedbackEngine's sub-categories — its
+// `category` field is a slug (e.g. 'plan_mode'), not display text. Falls
+// back to the raw slug for any future category this map hasn't caught up to.
+const PROMPT_RECOMMENDATION_TITLES: Record<string, string> = {
+  prompt_context: 'High correction rate',
+  plan_mode: 'Low autonomy on complex tasks',
+  file_paths: 'Frequent file re-reads',
+  claudemd_impact: 'Negative instruction-file impact',
+};
 
 // ---------------------------------------------------------------------------
 // RecommendationEngine
@@ -271,10 +287,11 @@ export class RecommendationEngine {
       makeRec(
         'prompt_engineering',
         pr.priority,
-        pr.category,
+        PROMPT_RECOMMENDATION_TITLES[pr.category] ?? pr.category,
         pr.message,
         pr.evidence,
         pr.estimatedImpact,
+        pr.category,
       ),
     );
   }
@@ -367,6 +384,7 @@ function makeRec(
   detail: string,
   evidence: string,
   estimatedSavings?: string,
+  subCategory?: string,
 ): Recommendation {
   const hash = createHash('sha256').update(`${category}:${title}`).digest('hex').slice(0, 12);
 
@@ -378,6 +396,7 @@ function makeRec(
     detail,
     evidence,
     ...(estimatedSavings != null && { estimatedSavings }),
+    ...(subCategory != null && { subCategory }),
   };
 }
 

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -501,6 +501,26 @@ export type PersonalCoachResult = PersonalCoachReport | PersonalCoachInsufficien
 
 export const fetchPersonalCoach = (): Promise<PersonalCoachResult> =>
   getJson<PersonalCoachResult>('/api/personal-coach');
+
+// Mirrors Recommendation in src/metrics/recommendation-engine.ts (not importable).
+export interface RecommendationItem {
+  readonly id: string;
+  readonly category: string;
+  readonly priority: 'high' | 'medium' | 'low';
+  readonly title: string;
+  readonly detail: string;
+  readonly evidence: string;
+  readonly estimatedSavings?: string;
+}
+
+export interface RecommendationsApiResponse {
+  readonly recommendations: readonly RecommendationItem[];
+  readonly count: number;
+}
+
+export const fetchRecommendations = (): Promise<RecommendationsApiResponse> =>
+  getJson<RecommendationsApiResponse>('/api/recommendations');
+
 export const fetchRecentAlerts = (): Promise<AlertEvent[]> =>
   getJson<AlertEvent[]>('/api/alerts/recent');
 export const fetchSessionReplay = (id: string): Promise<SessionReplayResponse> =>
@@ -1084,6 +1104,7 @@ export const qk = {
   costPerOutcome: (days: number) => ['cost-per-outcome', days] as const,
   personalCoach: ['personal-coach'] as const,
   instructionDrift: ['instruction-drift'] as const,
+  recommendations: ['recommendations'] as const,
   alertsRecent: ['alerts', 'recent'] as const,
   sessionReplay: (id: string) => ['session', id, 'replay'] as const,
   sessionSubagents: (id: string) => ['session', id, 'subagents'] as const,

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -129,9 +129,29 @@ const SAMPLE_COACH_INSUFFICIENT = {
   message: 'Need at least 2 weeks of session history.',
 };
 
+const SAMPLE_RECOMMENDATIONS_OK = {
+  recommendations: [
+    {
+      id: 'r1',
+      category: 'cost_optimization',
+      priority: 'high',
+      title: 'High failed attempt ratio',
+      detail: 'Failed attempts represent a significant portion of spend.',
+      evidence: 'Failed attempts: 32% of total cost',
+    },
+  ],
+  count: 1,
+};
+
+const SAMPLE_RECOMMENDATIONS_EMPTY = {
+  recommendations: [],
+  count: 0,
+};
+
 interface FetchOverrides {
   outcome?: unknown;
   coach?: unknown;
+  recommendations?: unknown;
 }
 
 function renderHistory(overrides: FetchOverrides = {}) {
@@ -156,6 +176,14 @@ function renderHistory(overrides: FetchOverrides = {}) {
     if (url.startsWith('/api/personal-coach')) {
       return Promise.resolve(
         new Response(JSON.stringify(overrides.coach ?? SAMPLE_COACH_OK), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }
+    if (url.startsWith('/api/recommendations')) {
+      return Promise.resolve(
+        new Response(JSON.stringify(overrides.recommendations ?? SAMPLE_RECOMMENDATIONS_OK), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         }),
@@ -295,6 +323,74 @@ describe('History view', () => {
     }
     const svgs = container.querySelectorAll('svg');
     expect(svgs.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('renders RecommendationsPanel with a high-priority item title and detail', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText('High failed attempt ratio')).toBeInTheDocument());
+    expect(
+      screen.getByText('Failed attempts represent a significant portion of spend.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders no recommendations empty state when list is empty', async () => {
+    renderHistory({ recommendations: SAMPLE_RECOMMENDATIONS_EMPTY });
+    await waitFor(() => expect(screen.getByText('No recommendations yet')).toBeInTheDocument());
+  });
+
+  it('renders unavailable state when /api/recommendations returns 503', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = ((url: string) => {
+      if (url.startsWith('/api/weekly')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_WEEKLY), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/cost-per-outcome')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_OUTCOME), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/personal-coach')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_COACH_OK), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/recommendations')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'unavailable' }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/sessions')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_SESSIONS), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('null', { status: 200 }));
+    }) as typeof globalThis.fetch;
+    render(
+      <QueryClientProvider client={qc}>
+        <History />
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Recommendations unavailable')).toBeInTheDocument(),
+    );
   });
 
   it('skips the anti-pattern panel chart when no weeks have anti-patterns', async () => {

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -24,6 +24,7 @@ import {
   fetchSessionsList,
   fetchCostPerOutcome,
   fetchPersonalCoach,
+  fetchRecommendations,
   fetchActivityHeatmap,
   fetchConcurrencyHistory,
   fetchInstructionDrift,
@@ -36,6 +37,7 @@ import {
   type ActivityHeatmapHistoryResponse,
   type InstructionDriftResponse,
   type DriftCorrelationEntry,
+  type RecommendationsApiResponse,
 } from '../api/client';
 import { formatUsdOrDash, shortToolName } from '../lib/format';
 
@@ -179,6 +181,12 @@ export function History(): JSX.Element {
   const coach = useQuery<PersonalCoachResult>({
     queryKey: qk.personalCoach,
     queryFn: fetchPersonalCoach,
+  });
+
+  const recommendations = useQuery<RecommendationsApiResponse>({
+    queryKey: qk.recommendations,
+    queryFn: fetchRecommendations,
+    retry: false,
   });
 
   const activityGrid = useQuery<ActivityHeatmapHistoryResponse>({
@@ -506,6 +514,10 @@ export function History(): JSX.Element {
       <div className="mt-3">
         <CoachCard data={coach.data} />
       </div>
+
+      <div className="mt-3">
+        <RecommendationsPanel data={recommendations.data} isError={recommendations.isError} />
+      </div>
     </section>
   );
 }
@@ -619,6 +631,107 @@ function CoachMetricsTable({
       <span className="font-mono">{Math.round(thisWeek.sessionsCount)}</span>
       <span className="text-ink-muted">{sessionsDeltaText(sessionsDelta)}</span>
     </div>
+  );
+}
+
+function categoryBorderColor(category: string): string {
+  if (category === 'cost_optimization') return 'var(--color-accent-amber)';
+  if (category === 'efficiency') return 'var(--color-accent-red)';
+  if (category === 'prompt_engineering') return 'var(--color-accent-blue)';
+  if (category === 'claudemd') return 'var(--color-accent-purple)';
+  if (category === 'model_selection') return 'var(--color-accent-teal)';
+  return 'var(--color-ink-muted)';
+}
+
+function priorityDotColor(priority: 'high' | 'medium' | 'low'): string {
+  if (priority === 'high') return 'var(--color-accent-amber)';
+  if (priority === 'medium') return 'var(--color-accent-blue)';
+  return 'var(--color-ink-muted)';
+}
+
+function RecommendationsPanel({
+  data,
+  isError,
+}: {
+  data: RecommendationsApiResponse | undefined;
+  isError: boolean;
+}): JSX.Element {
+  if (isError) {
+    return (
+      <Panel title="Recommendations">
+        <EmptyState
+          icon="radar"
+          title="Recommendations unavailable"
+          subtitle="Connect a full Preflight session to enable recommendations."
+        />
+      </Panel>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Panel title="Recommendations">
+        <EmptyState variant="loading" title="Loading recommendations…" />
+      </Panel>
+    );
+  }
+
+  if (data.recommendations.length === 0) {
+    return (
+      <Panel title="Recommendations">
+        <EmptyState
+          icon="radar"
+          title="No recommendations yet"
+          subtitle="Keep using Preflight — recommendations appear after a few sessions of data."
+        />
+      </Panel>
+    );
+  }
+
+  const highItems = data.recommendations.filter((r) => r.priority === 'high');
+  const otherItems = data.recommendations.filter((r) => r.priority !== 'high');
+
+  return (
+    <Panel title="Recommendations">
+      <div className="space-y-3">
+        {highItems.map((rec) => (
+          <div
+            key={rec.id}
+            className="border-l-2 pl-3"
+            style={{ borderColor: categoryBorderColor(rec.category) }}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <span className="text-sm font-medium text-ink-base">{rec.title}</span>
+              {rec.estimatedSavings && (
+                <span className="text-[10px] text-accent-green shrink-0">
+                  {rec.estimatedSavings}
+                </span>
+              )}
+            </div>
+            <div className="text-xs text-ink-muted mt-0.5">{rec.detail}</div>
+            <div className="text-[10px] text-ink-muted italic mt-0.5">{rec.evidence}</div>
+          </div>
+        ))}
+        {otherItems.length > 0 && (
+          <div className={highItems.length > 0 ? 'border-t border-border-subtle pt-3' : ''}>
+            <div className="space-y-2">
+              {otherItems.map((rec) => (
+                <div key={rec.id} className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="w-1.5 h-1.5 rounded-full shrink-0"
+                      style={{ backgroundColor: priorityDotColor(rec.priority) }}
+                    />
+                    <span className="text-xs text-ink-base">{rec.title}</span>
+                  </div>
+                  <div className="text-[10px] text-ink-muted mt-0.5 pl-3.5">{rec.detail}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </Panel>
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/recommendations` and wires `RecommendationEngine` into the dashboard
- Adds a `RecommendationsPanel` to the History view, synthesizing cost, prompt-engineering, and model-selection signals into a prioritized list

Closes #33

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npx vitest run`