### PR TITLE
Fix: preflight install --mode now actually defaults to local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.32] - 2026-08-05
+
+### Added
+
+- **`preflight install` now accepts `--mode <cloud|local|both>`** — sets the telemetry mode non-interactively, matching what the interactive setup wizard already offers. Defaults to `local` for fresh installs; an install that already has a saved mode is never overwritten by omitting the flag.
+
+### Fixed
+
+- **`preflight install --mode`'s "default: local" help text is now accurate** — omitting `--mode` previously left the mode unresolved until the server's own fallback resolved it to `cloud`. Installs without a saved mode now get `local` written explicitly.
+
 ## [1.14.31] - 2026-08-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.31",
+  "version": "1.14.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.31",
+      "version": "1.14.32",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.31",
+  "version": "1.14.32",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -1227,6 +1227,58 @@ describe('platform transition matrix', () => {
     expect(stderr).toContain('invalid JSON');
     stderrSpy.mockRestore();
   });
+
+  // The --mode option's help text claims "default: local", but nothing
+  // enforced that — omitting --mode meant no mode was written, and
+  // loadMcpConfig's own fallback resolves that to 'cloud'. Defaulting to
+  // 'local' only when no mode is already saved makes the help text true
+  // without disturbing existing users.
+  it('bare install with no existing config and no --mode defaults mode to local', async () => {
+    mFs.readFileSync.mockReturnValue('{}');
+
+    await runInstallCli(['install']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.mode).toBe('local');
+  });
+
+  it('install without --mode preserves an existing saved mode (no silent overwrite)', async () => {
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ mode: 'cloud' }));
+
+    await runInstallCli(['install', '--windows-cc']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.mode).toBe('cloud');
+  });
+
+  it('install --mode local overrides an existing saved cloud mode', async () => {
+    mFs.readFileSync.mockReturnValue(JSON.stringify({ mode: 'cloud' }));
+
+    await runInstallCli(['install', '--mode', 'local']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.mode).toBe('local');
+  });
+
+  it('install --mode both persists mode both on a fresh config', async () => {
+    mFs.readFileSync.mockReturnValue('{}');
+
+    await runInstallCli(['install', '--mode', 'both']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.mode).toBe('both');
+  });
+
+  it('install without --mode on an existing credentialed config with no mode key does not write one (protects pre-existing cloud users)', async () => {
+    mFs.readFileSync.mockReturnValue(
+      JSON.stringify({ licenseKey: 'NRLIC-existing', accountId: '12345' }),
+    );
+
+    await runInstallCli(['install']);
+
+    const written = findConfigWrite(mFs);
+    expect(written?.mode).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -663,6 +663,8 @@ function handleInstall(options: {
       }
       if (options.mode) {
         nrConfig.mode = options.mode;
+      } else if (nrConfig.mode === undefined && existingNrConfig.licenseKey === undefined) {
+        nrConfig.mode = 'local';
       }
       writeJsonFile(NR_CONFIG_PATH, nrConfig, DEFAULT_STORAGE_PATH);
       nrConfigWritten = credentialsProvided;


### PR DESCRIPTION
## Summary

Follow-up to #355: that PR's `--mode` option help text claimed a default of `local`, but nothing enforced it — omitting `--mode` never wrote a `mode` key to `config.json`, so the server's own fallback resolved the absence to `cloud` instead.

- `preflight install` now defaults to `mode: 'local'` when `--mode` is omitted and no mode is already saved — and only when there's no cloud credentials already saved either, so an existing non-interactive cloud install is never silently flipped to local the next time `install` runs for any other reason.
- 5 new tests covering the fresh-install default, preserving an existing saved mode, explicit `--mode` overriding existing state, and the regression case (existing credentials + no mode key + bare re-install leaves the mode untouched).
- CHANGELOG now documents `--mode` itself under `### Added` (this is the first release to ship it), alongside the `### Fixed` entry for the default-text fix.
- Version bumped 1.14.31 → 1.14.32 (patch).

## Test plan

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`


Fixes #359
