### PR TITLE
Fix small bugs: BudgetTracker UTC, event-send visibility, Node-version guard, cloud-mode docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.33] - 2026-08-05
+
+### Added
+
+- **`nr_observe_health` now reports whether telemetry event sends are succeeding** — new `event_send_status` (`ok`/`failing`) and `consecutive_event_send_failures` fields surface consecutive failures sending events to New Relic (for example, from a misconfigured or cross-account license key), which previously had no visible signal — metrics could keep flowing successfully over a different transport while events silently failed. Both fields are omitted when event-send health tracking isn't wired up for the current server mode.
+- **The MCP server now checks the running Node.js version at startup** and exits with a clear diagnostic instead of failing deep in the stack when a too-old Node binary is resolved — most commonly seen when an MCP client resolves a stale `nvm` default.
+
+### Fixed
+
+- **`BudgetTracker`'s daily and weekly period keys now use UTC consistently** — both previously read local-time date components before computing their period identifier, so in UTC+ timezones a budget threshold could re-arm a full day (or, for the weekly key, a full ISO week) early.
+
+### Changed
+
+- **README now explains what happens after enabling cloud mode** — cloud mode ships telemetry immediately, but no dashboard exists until `deploy-dashboards` is run separately with a different credential (a user API key, not the license key). The README now calls this out explicitly and shows how to query the raw data via NRQL in the meantime.
+
 ## [1.14.32] - 2026-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ NEW_RELIC_API_KEY=NRAK-... NEW_RELIC_ACCOUNT_ID=12345 \
 
 You'll need a **license key** (telemetry ingest) and your **account ID**, plus a **user API key** (`NRAK-…`) to deploy dashboards and alerts. See [ADVANCED.md](docs/ADVANCED.md) for alerts, OTLP export to other backends, and Terraform.
 
+> **No dashboard until you run `deploy-dashboards`.** Cloud mode ships telemetry to New Relic as soon as it's configured, but nothing creates a dashboard automatically — that's the separate step above, and it needs a **different** credential (a user API key, not your license key). Until you run it, there's no UI to look at. In the meantime, query the raw events directly in New Relic's **Query Builder**, e.g.:
+>
+> ```sql
+> SELECT * FROM AiToolCall SINCE 1 hour ago
+> ```
+>
+> Once `deploy-dashboards` succeeds, find the dashboards under your New Relic account's **Dashboards** section.
+
 > **Data ingest note:** Telemetry sent to New Relic counts against your account's data ingest. On paid plans, standard ingest rates apply. Monitor your usage under **NR One → Data Management → Data Ingestion**.
 
 ---

--- a/docs/COMMANDS_TABLE.md
+++ b/docs/COMMANDS_TABLE.md
@@ -30,13 +30,15 @@ Check server health and connection status.
   "connected_at": "2026-06-03T10:00:00.000Z",
   "uptime_seconds": 3600,
   "hooks_installed": true,
-  "setup_required": false
+  "setup_required": false,
+  "event_send_status": "ok",
+  "consecutive_event_send_failures": 0
 }
 ```
 
 **Data source:** Server startup metadata
 
-**How it works:** Returns the current server version, the resolved developer name, how long the server has been running (`uptime_seconds`), the current session ID, and the ISO timestamp of when the MCP connection was established. Use this to confirm the MCP server is responsive and to verify the expected developer identity is being used. When a hook-detection function is available (e.g. in a Claude Code environment), also reports `hooks_installed` and `setup_required` so the caller can detect an incomplete setup — for example, right after a Smithery-driven install that only wired up the MCP server — and prompt to call `nr_observe_install_hooks`. Both fields are omitted when hook detection isn't wired up for the current server mode.
+**How it works:** Returns the current server version, the resolved developer name, how long the server has been running (`uptime_seconds`), the current session ID, and the ISO timestamp of when the MCP connection was established. Use this to confirm the MCP server is responsive and to verify the expected developer identity is being used. When a hook-detection function is available (e.g. in a Claude Code environment), also reports `hooks_installed` and `setup_required` so the caller can detect an incomplete setup — for example, right after a Smithery-driven install that only wired up the MCP server — and prompt to call `nr_observe_install_hooks`. Both fields are omitted when hook detection isn't wired up for the current server mode. When event-send health tracking is available, also reports `event_send_status` (`'ok'` or `'failing'`) and `consecutive_event_send_failures` — the number of consecutive failed attempts to send telemetry events to New Relic — so the caller can detect a broken ingest path. Both fields are omitted when event-send health tracking isn't wired up for the current server mode.
 
 **Requires:** Always available
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.32",
+  "version": "1.14.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.32",
+      "version": "1.14.33",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.32",
+  "version": "1.14.33",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_PENDING_CONFIRMATION_CAP_MS,
   startRetentionSweep,
   startMaintenanceGc,
+  checkNodeVersion,
 } from './index.js';
 import type { DashboardServer } from './dashboard/dashboard-server.js';
 import type { LocalStore } from './storage/index.js';
@@ -467,6 +468,26 @@ describe('getPendingConfirmationCapMs()', () => {
     expect(getPendingConfirmationCapMs()).toBe(DEFAULT_PENDING_CONFIRMATION_CAP_MS);
     process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS = '-100';
     expect(getPendingConfirmationCapMs()).toBe(DEFAULT_PENDING_CONFIRMATION_CAP_MS);
+  });
+});
+
+describe('checkNodeVersion()', () => {
+  it('returns null when the running Node version meets the floor', () => {
+    expect(checkNodeVersion('v22.0.0')).toBeNull();
+    expect(checkNodeVersion('v24.18.0')).toBeNull();
+  });
+
+  it('returns a diagnostic message when Node is below the floor', () => {
+    const message = checkNodeVersion('v16.20.0');
+    expect(message).not.toBeNull();
+    expect(message).toContain('v16.20.0');
+    expect(message).toContain('v22');
+    expect(message).toContain('TROUBLESHOOTING.md');
+  });
+
+  it('defaults to process.version when no argument is given', () => {
+    // The test runner itself must satisfy engines.node (>=22), so this is null.
+    expect(checkNodeVersion()).toBeNull();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -626,7 +626,44 @@ export function parseArgs(argv: string[]): CliOptions {
   };
 }
 
+// Must track package.json's `engines.node` floor.
+export const MIN_SUPPORTED_NODE_MAJOR = 22;
+
+/**
+ * Returns a diagnostic message when the running Node major version is below
+ * MIN_SUPPORTED_NODE_MAJOR, or null when it's fine. Checked at the very start
+ * of main() so an MCP client resolving a stale/unintended Node binary (e.g.
+ * via nvm — see docs/TROUBLESHOOTING.md) fails with a clear message instead
+ * of an opaque deep-in-the-stack error or silent connection failure.
+ *
+ * This only actually catches Node 20-21: on those versions the static import
+ * graph still loads fine, so this check's own code gets a chance to run
+ * before failing on the version floor. On Node 16-19 the process crashes
+ * earlier, during ESM's evaluation of the whole static import graph — before
+ * main() (and this check) ever runs — with a less clear error, e.g.
+ * `ReferenceError: structuredClone is not defined` (Node 16, from
+ * src/shared/pricing.ts) or `ReferenceError: File is not defined` (Node 18,
+ * from undici). Still valuable for the most common real-world case: a stale
+ * nvm default resolving to a merely-slightly-old Node.
+ */
+export function checkNodeVersion(nodeVersion: string = process.version): string | null {
+  const major = parseInt(nodeVersion.replace(/^v/, '').split('.')[0], 10);
+  if (!Number.isFinite(major) || major >= MIN_SUPPORTED_NODE_MAJOR) return null;
+  return (
+    `preflight requires Node.js v${MIN_SUPPORTED_NODE_MAJOR}+, but is running under ${nodeVersion}. ` +
+    'This usually means your MCP client resolved a stale or unintended Node binary (e.g. via nvm). ' +
+    'See docs/TROUBLESHOOTING.md, "MCP server won\'t start (wrong Node version)", for how to pin the ' +
+    'exact Node path in ~/.mcp.json.'
+  );
+}
+
 async function main(): Promise<void> {
+  const nodeVersionError = checkNodeVersion();
+  if (nodeVersionError) {
+    process.stderr.write(`${nodeVersionError}\n`);
+    process.exit(1);
+  }
+
   // Subcommand dispatch (e.g. `preflight deploy-dashboards --all`)
   // happens before flag parsing — they don't share the option schema with the
   // server modes (--stdio / --local / --validate / proxy), and they exit

--- a/src/metrics/budget-tracker.ts
+++ b/src/metrics/budget-tracker.ts
@@ -82,15 +82,15 @@ export class BudgetTracker {
       return 'session:infinite';
     }
     if (period === 'daily') {
-      const year = now.getFullYear();
-      const month = String(now.getMonth() + 1).padStart(2, '0');
-      const day = String(now.getDate()).padStart(2, '0');
+      const year = now.getUTCFullYear();
+      const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+      const day = String(now.getUTCDate()).padStart(2, '0');
       return `day:${year}-${month}-${day}`;
     }
     if (period === 'weekly') {
       // ISO 8601 week number — correct across year boundaries.
       // The ISO week year can differ from the calendar year in early Jan / late Dec.
-      const d = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+      const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
       const dayOfWeek = d.getUTCDay() || 7; // 1=Mon … 7=Sun
       d.setUTCDate(d.getUTCDate() + 4 - dayOfWeek); // nearest Thursday
       const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));

--- a/src/tools/session-stats.test.ts
+++ b/src/tools/session-stats.test.ts
@@ -266,6 +266,31 @@ describe('handleHealth()', () => {
     expect(data.hooks_installed).toBe(false);
     expect(data.setup_required).toBe(true);
   });
+
+  it('omits event_send_status when eventSendHealth is not provided', () => {
+    const result = handleHealth({});
+    const data = JSON.parse(result.content[0].text);
+    expect('event_send_status' in data).toBe(false);
+    expect('consecutive_event_send_failures' in data).toBe(false);
+  });
+
+  it('reports event_send_status "ok" when there are no consecutive failures', () => {
+    const result = handleHealth({
+      eventSendHealth: { consecutiveFailures: 0, lastFailureAt: null, lastSuccessAt: Date.now() },
+    });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.event_send_status).toBe('ok');
+    expect(data.consecutive_event_send_failures).toBe(0);
+  });
+
+  it('reports event_send_status "failing" when there are consecutive failures', () => {
+    const result = handleHealth({
+      eventSendHealth: { consecutiveFailures: 3, lastFailureAt: Date.now(), lastSuccessAt: null },
+    });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.event_send_status).toBe('failing');
+    expect(data.consecutive_event_send_failures).toBe(3);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tools/session-stats.ts
+++ b/src/tools/session-stats.ts
@@ -82,7 +82,7 @@ const SESSION_STATS_TOOL = {
 const HEALTH_TOOL = {
   name: 'nr_observe_health',
   description:
-    'Check server health: version, uptime, session ID, and connection timestamp. Use when the MCP connection feels stale or tools are behaving unexpectedly.',
+    'Check server health: version, uptime, session ID, and connection timestamp. Also reports whether telemetry event sends are succeeding. Use when the MCP connection feels stale or tools are behaving unexpectedly.',
   inputSchema: {
     type: 'object' as const,
     properties: {},
@@ -211,6 +211,11 @@ export function handleHealth(options: {
   developer?: string;
   sessionId?: string;
   hooksInstalledFn?: () => boolean;
+  eventSendHealth?: {
+    consecutiveFailures: number;
+    lastFailureAt: number | null;
+    lastSuccessAt: number | null;
+  };
 }): { content: [{ type: 'text'; text: string }] } {
   const nowMs = Date.now();
   const startMs = options.sessionStartMs ?? nowMs;
@@ -230,6 +235,11 @@ export function handleHealth(options: {
   if (hooksInstalled !== undefined) {
     payload.hooks_installed = hooksInstalled;
     payload.setup_required = !hooksInstalled;
+  }
+
+  if (options.eventSendHealth !== undefined) {
+    payload.event_send_status = options.eventSendHealth.consecutiveFailures > 0 ? 'failing' : 'ok';
+    payload.consecutive_event_send_failures = options.eventSendHealth.consecutiveFailures;
   }
 
   return {
@@ -387,7 +397,14 @@ export interface ToolRegistrationOptions {
   turnTracker?: TurnTracker;
   gitEfficiencyTracker?: GitEfficiencyTracker;
   genericMcpAdapter?: GenericMcpAdapter;
-  nrIngestManager?: { ingestToolCall(record: import('../storage/types.js').ToolCallRecord): void };
+  nrIngestManager?: {
+    ingestToolCall(record: import('../storage/types.js').ToolCallRecord): void;
+    getEventSendHealth?(): {
+      consecutiveFailures: number;
+      lastFailureAt: number | null;
+      lastSuccessAt: number | null;
+    };
+  };
   sessionTraceId?: string;
   sessionStartMs?: number;
   accountId?: string;
@@ -418,6 +435,7 @@ function registerCoreTools(deps: ToolRegistrationOptions): RegisteredToolSet {
           developer: deps.developer,
           sessionId: deps.sessionTracker?.getMetrics().sessionId,
           hooksInstalledFn: deps.hooksInstalledFn,
+          eventSendHealth: deps.nrIngestManager?.getEventSendHealth?.(),
         }),
     },
     {

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -983,6 +983,98 @@ describe('NrIngestManager', () => {
   });
 });
 
+describe('getEventSendHealth()', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('starts with zero failures and no timestamps', () => {
+    const manager = new NrIngestManager(makeIngestOptions());
+    expect(manager.getEventSendHealth()).toEqual({
+      consecutiveFailures: 0,
+      lastFailureAt: null,
+      lastSuccessAt: null,
+    });
+  });
+
+  it('resets to 0 and stamps lastSuccessAt after a successful send', async () => {
+    const localSendEvents = jest
+      .fn<() => Promise<{ success: boolean; statusCode: number; retryCount: number }>>()
+      .mockResolvedValue({ success: true, statusCode: 200, retryCount: 0 });
+
+    const manager = new NrIngestManager(
+      makeIngestOptions({
+        sendEventsFn: localSendEvents,
+        eventHarvestIntervalMs: 5_000,
+        logHarvestIntervalMs: 100_000,
+      }),
+    );
+    manager.ingestToolCall(makeRecord());
+    manager.start();
+
+    await jest.advanceTimersByTimeAsync(5_000);
+
+    const health = manager.getEventSendHealth();
+    expect(health.consecutiveFailures).toBe(0);
+    expect(health.lastSuccessAt).not.toBeNull();
+
+    await manager.stop();
+  });
+
+  it('increments consecutiveFailures on a retryable failure (e.g. 503)', async () => {
+    const localSendEvents = jest
+      .fn<() => Promise<{ success: boolean; statusCode: number; retryCount: number }>>()
+      .mockResolvedValueOnce({ success: false, statusCode: 503, retryCount: 3 })
+      .mockResolvedValue({ success: true, statusCode: 200, retryCount: 0 });
+
+    const manager = new NrIngestManager(
+      makeIngestOptions({
+        sendEventsFn: localSendEvents,
+        eventHarvestIntervalMs: 5_000,
+        logHarvestIntervalMs: 100_000,
+      }),
+    );
+    manager.ingestToolCall(makeRecord());
+    manager.start();
+
+    await jest.advanceTimersByTimeAsync(5_000);
+    const health = manager.getEventSendHealth();
+    expect(health.consecutiveFailures).toBe(1);
+    expect(health.lastFailureAt).not.toBeNull();
+
+    await manager.stop();
+  });
+
+  it('increments consecutiveFailures on a masked non-retryable failure (e.g. 403 cross-account mismatch)', async () => {
+    const localSendEvents = jest
+      .fn<() => Promise<{ success: boolean; statusCode: number; retryCount: number }>>()
+      .mockResolvedValue({ success: false, statusCode: 403, retryCount: 0 });
+
+    const manager = new NrIngestManager(
+      makeIngestOptions({
+        sendEventsFn: localSendEvents,
+        eventHarvestIntervalMs: 5_000,
+        logHarvestIntervalMs: 100_000,
+      }),
+    );
+    manager.ingestToolCall(makeRecord());
+    manager.start();
+
+    // HarvestScheduler itself sees success=true (masked) and does NOT re-queue —
+    // but getEventSendHealth() must still reflect the real underlying failure.
+    await jest.advanceTimersByTimeAsync(5_000);
+    const health = manager.getEventSendHealth();
+    expect(health.consecutiveFailures).toBe(1);
+    expect(health.lastFailureAt).not.toBeNull();
+
+    await manager.stop();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // codingTaskToNrEvent()
 // ---------------------------------------------------------------------------

--- a/src/transport/nr-ingest.ts
+++ b/src/transport/nr-ingest.ts
@@ -808,6 +808,9 @@ export class NrIngestManager {
   private readonly trackSessionGauges: boolean;
   private sessionGaugeIntervalId: ReturnType<typeof setInterval> | null = null;
   private running = false;
+  private consecutiveEventSendFailures = 0;
+  private lastEventSendFailureAt: number | null = null;
+  private lastEventSendSuccessAt: number | null = null;
 
   constructor(options: NrIngestOptions) {
     this.developer = options.developer;
@@ -861,6 +864,13 @@ export class NrIngestManager {
     const rawSendEventsFn = options.sendEventsFn ?? sendEvents;
     const classifyingEventsFn: SendEventsFn = async (events, licenseKey, opts) => {
       const result = await rawSendEventsFn(events, licenseKey, opts);
+      if (result.success) {
+        this.consecutiveEventSendFailures = 0;
+        this.lastEventSendSuccessAt = Date.now();
+      } else {
+        this.consecutiveEventSendFailures += 1;
+        this.lastEventSendFailureAt = Date.now();
+      }
       if (!result.success && result.statusCode !== null && isNonRetryable4xx(result.statusCode)) {
         logger.warn('Dropping non-retryable event batch', {
           statusCode: result.statusCode,
@@ -911,6 +921,18 @@ export class NrIngestManager {
       logHarvestIntervalMs: options.logHarvestIntervalMs,
       sendLogsFn: options.sendLogsFn,
     });
+  }
+
+  getEventSendHealth(): {
+    consecutiveFailures: number;
+    lastFailureAt: number | null;
+    lastSuccessAt: number | null;
+  } {
+    return {
+      consecutiveFailures: this.consecutiveEventSendFailures,
+      lastFailureAt: this.lastEventSendFailureAt,
+      lastSuccessAt: this.lastEventSendSuccessAt,
+    };
   }
 
   ingestProxyRequest(record: ProxyRequestRecord): void {


### PR DESCRIPTION
## Summary

- **Fixed** `BudgetTracker`'s daily and weekly period keys — both previously read local-time date components before computing their period identifier, so a threshold could re-arm a day (or ISO week) early in UTC+ timezones. Fixes #356.
- **Added** `event_send_status`/`consecutive_event_send_failures` to the `nr_observe_health` MCP tool, so a cross-account or misconfigured license key (events silently rejected while metrics keep flowing via a different transport) now has a visible signal.
- **Added** a runtime Node.js version check at MCP startup, so a too-old Node binary (most commonly a stale `nvm` default resolved by an MCP client) fails with a clear diagnostic instead of an opaque deep-stack error.
- **Documentation**: README now explains that cloud mode ships no dashboard until `deploy-dashboards` is run separately with a different credential, and shows the NRQL fallback for querying raw data in the meantime. Fixes #324.

Ships as v1.14.33 — see `CHANGELOG.md`.

## Test plan

- [x] `npm run build && npm test` — 162 suites passed, 5346 tests passed, 3 skipped (pre-existing, unrelated), 0 failed
- [x] `npm run lint` — 0 errors, 0 warnings