### PR TITLE
Feat: coaching additions — CLAUDE.md impact + collaboration profile panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.34] - 2026-08-06
+
+### Added
+
+- **History dashboard now shows a Collaboration Profile panel and an Instruction File Impact panel** — a developer-collaboration-style classification (specificity, autonomy, correction rate, task complexity vs. team baseline) and a before/after comparison for the most recent instruction-file change (CLAUDE.md, or your platform's equivalent), both previously available only through MCP tools.
+
 ## [1.14.33] - 2026-08-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.33",
+  "version": "1.14.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.33",
+      "version": "1.14.34",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.33",
+  "version": "1.14.34",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -400,6 +400,56 @@ export interface ApiHandlerDeps {
   readonly recommendationEngine?: {
     generateAllRecommendations: (developer: string) => readonly Recommendation[];
   };
+  readonly claudeMdTracker?: {
+    getChanges: () => readonly {
+      timestamp: number;
+      filePath: string;
+      changeType: 'created' | 'modified' | 'deleted';
+      linesAdded: number;
+      linesRemoved: number;
+    }[];
+    computeImpact: (timestamp: number) => {
+      beforeMetrics: {
+        avgEfficiencyScore: number | null;
+        avgCostUsd: number;
+        avgCorrectionRate: number;
+        sessionCount: number;
+      };
+      afterMetrics: {
+        avgEfficiencyScore: number | null;
+        avgCostUsd: number;
+        avgCorrectionRate: number;
+        sessionCount: number;
+      };
+      deltas: {
+        efficiencyScore: { value: number; percentChange: number | null; improved: boolean } | null;
+        cost: { value: number; percentChange: number | null; improved: boolean };
+        correctionRate: { value: number; percentChange: number | null; improved: boolean };
+      };
+      contextTokensForClaudeMd: number | null;
+      verdict: string;
+    };
+  };
+  readonly collaborationProfiler?: {
+    computeProfile: (developer: string) => {
+      classification: string;
+      dimensions: {
+        specificity: number;
+        autonomy: number;
+        correctionRate: number;
+        taskComplexity: number;
+      };
+      sessionCount: number;
+    };
+    compareToTeam: (developer: string) => {
+      deltas: {
+        specificity: number;
+        autonomy: number;
+        correctionRate: number;
+        taskComplexity: number;
+      };
+    };
+  };
   readonly alertLog?: { readRecent: (limit: number) => Promise<AlertEvent[]> };
   readonly taskDetector?: {
     getCompletedTasks: () => readonly { toolCalls: readonly ToolCallRecord[] }[];
@@ -1747,6 +1797,44 @@ export function createApiHandler(
           rec.subCategory !== 'claudemd_impact',
       );
     jsonOk(res, { recommendations: recs, count: recs.length });
+  });
+
+  routes.set('GET /api/claudemd-impact', (_req, res) => {
+    if (!deps.claudeMdTracker) return unavailable(res, 'claudeMdTracker');
+    const changes = deps.claudeMdTracker.getChanges();
+    if (changes.length === 0) {
+      jsonOk(res, { message: 'No instruction-file changes detected' });
+      return;
+    }
+    const latest = changes[changes.length - 1]!;
+    const impact = deps.claudeMdTracker.computeImpact(latest.timestamp);
+    jsonOk(res, {
+      change: {
+        filePath: latest.filePath,
+        changeType: latest.changeType,
+        timestamp: latest.timestamp,
+        linesAdded: latest.linesAdded,
+        linesRemoved: latest.linesRemoved,
+      },
+      before: impact.beforeMetrics,
+      after: impact.afterMetrics,
+      deltas: impact.deltas,
+      contextTokensForClaudeMd: impact.contextTokensForClaudeMd,
+      verdict: impact.verdict,
+    });
+  });
+
+  routes.set('GET /api/collaboration-profile', (_req, res) => {
+    if (!deps.collaborationProfiler) return unavailable(res, 'collaborationProfiler');
+    const developer = (deps.config?.developer as string | undefined) ?? 'unknown';
+    const profile = deps.collaborationProfiler.computeProfile(developer);
+    const comparison = deps.collaborationProfiler.compareToTeam(developer);
+    jsonOk(res, {
+      classification: profile.classification,
+      dimensions: profile.dimensions,
+      sessionCount: profile.sessionCount,
+      teamDeltas: comparison.deltas,
+    });
   });
 
   routes.set('GET /api/alerts/recent', async (_req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1388,6 +1388,8 @@ async function main(): Promise<void> {
           personalCoach,
           trendAnalyzer,
           recommendationEngine,
+          claudeMdTracker,
+          collaborationProfiler,
           alertLog,
           taskDetector,
           efficiencyScorer,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -521,6 +521,66 @@ export interface RecommendationsApiResponse {
 export const fetchRecommendations = (): Promise<RecommendationsApiResponse> =>
   getJson<RecommendationsApiResponse>('/api/recommendations');
 
+// Mirrors the subset of AggregateMetrics (src/metrics/claudemd-tracker.ts, not
+// importable) actually rendered by ClaudeMdImpactPanel.
+export interface AggregateMetricsSubset {
+  readonly avgEfficiencyScore: number | null;
+  readonly avgCostUsd: number;
+  readonly avgCorrectionRate: number;
+  readonly sessionCount: number;
+}
+
+export interface MetricDelta {
+  readonly value: number;
+  readonly percentChange: number | null;
+  readonly improved: boolean;
+}
+
+// Mirrors the shape built by GET /api/claudemd-impact in api-handler.ts.
+export interface ClaudeMdImpactApiResponse {
+  readonly message?: string;
+  readonly change?: {
+    readonly filePath: string;
+    readonly changeType: 'created' | 'modified' | 'deleted';
+    readonly timestamp: number;
+    readonly linesAdded: number;
+    readonly linesRemoved: number;
+  };
+  readonly before?: AggregateMetricsSubset;
+  readonly after?: AggregateMetricsSubset;
+  readonly deltas?: {
+    readonly efficiencyScore: MetricDelta | null;
+    readonly cost: MetricDelta;
+    readonly correctionRate: MetricDelta;
+  };
+  readonly contextTokensForClaudeMd?: number | null;
+  readonly verdict?: string;
+}
+
+export const fetchClaudeMdImpact = (): Promise<ClaudeMdImpactApiResponse> =>
+  getJson<ClaudeMdImpactApiResponse>('/api/claudemd-impact');
+
+// Mirrors the shape built by GET /api/collaboration-profile in api-handler.ts.
+export interface CollaborationProfileApiResponse {
+  readonly classification: string;
+  readonly dimensions: {
+    readonly specificity: number;
+    readonly autonomy: number;
+    readonly correctionRate: number;
+    readonly taskComplexity: number;
+  };
+  readonly sessionCount: number;
+  readonly teamDeltas: {
+    readonly specificity: number;
+    readonly autonomy: number;
+    readonly correctionRate: number;
+    readonly taskComplexity: number;
+  };
+}
+
+export const fetchCollaborationProfile = (): Promise<CollaborationProfileApiResponse> =>
+  getJson<CollaborationProfileApiResponse>('/api/collaboration-profile');
+
 export const fetchRecentAlerts = (): Promise<AlertEvent[]> =>
   getJson<AlertEvent[]>('/api/alerts/recent');
 export const fetchSessionReplay = (id: string): Promise<SessionReplayResponse> =>
@@ -1105,6 +1165,8 @@ export const qk = {
   personalCoach: ['personal-coach'] as const,
   instructionDrift: ['instruction-drift'] as const,
   recommendations: ['recommendations'] as const,
+  claudeMdImpact: ['claudemd-impact'] as const,
+  collaborationProfile: ['collaboration-profile'] as const,
   alertsRecent: ['alerts', 'recent'] as const,
   sessionReplay: (id: string) => ['session', id, 'replay'] as const,
   sessionSubagents: (id: string) => ['session', id, 'subagents'] as const,

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   History,
@@ -148,10 +148,49 @@ const SAMPLE_RECOMMENDATIONS_EMPTY = {
   count: 0,
 };
 
+const SAMPLE_CLAUDEMD_IMPACT = {
+  change: {
+    filePath: '/Users/alice/.claude/CLAUDE.md',
+    changeType: 'modified',
+    timestamp: new Date(2026, 5, 29, 12, 0, 0).getTime(),
+    linesAdded: 5,
+    linesRemoved: 2,
+  },
+  before: { avgEfficiencyScore: 0.64, avgCostUsd: 0.52, avgCorrectionRate: 0.18, sessionCount: 8 },
+  after: { avgEfficiencyScore: 0.71, avgCostUsd: 0.44, avgCorrectionRate: 0.12, sessionCount: 6 },
+  deltas: {
+    efficiencyScore: { value: 0.07, percentChange: 10.9, improved: true },
+    cost: { value: -0.08, percentChange: -15.4, improved: true },
+    correctionRate: { value: -0.06, percentChange: -33.3, improved: true },
+  },
+  contextTokensForClaudeMd: 1240,
+  verdict: 'Positive impact: efficiency +7pts, cost -15%',
+};
+
+const SAMPLE_CLAUDEMD_NO_CHANGES = {
+  message: 'No instruction-file changes detected',
+};
+
+const SAMPLE_COLLAB_PROFILE = {
+  classification: 'Explorer',
+  dimensions: { specificity: 0.78, autonomy: 0.61, correctionRate: 0.42, taskComplexity: 0.73 },
+  sessionCount: 47,
+  teamDeltas: { specificity: 0.12, autonomy: 0.03, correctionRate: -0.08, taskComplexity: 0.05 },
+};
+
+const SAMPLE_COLLAB_EMPTY = {
+  classification: 'Unknown',
+  dimensions: { specificity: 0, autonomy: 0, correctionRate: 0, taskComplexity: 0 },
+  sessionCount: 0,
+  teamDeltas: { specificity: 0, autonomy: 0, correctionRate: 0, taskComplexity: 0 },
+};
+
 interface FetchOverrides {
   outcome?: unknown;
   coach?: unknown;
   recommendations?: unknown;
+  claudemdImpact?: unknown;
+  collabProfile?: unknown;
 }
 
 function renderHistory(overrides: FetchOverrides = {}) {
@@ -184,6 +223,22 @@ function renderHistory(overrides: FetchOverrides = {}) {
     if (url.startsWith('/api/recommendations')) {
       return Promise.resolve(
         new Response(JSON.stringify(overrides.recommendations ?? SAMPLE_RECOMMENDATIONS_OK), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }
+    if (url.startsWith('/api/claudemd-impact')) {
+      return Promise.resolve(
+        new Response(JSON.stringify(overrides.claudemdImpact ?? SAMPLE_CLAUDEMD_IMPACT), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }
+    if (url.startsWith('/api/collaboration-profile')) {
+      return Promise.resolve(
+        new Response(JSON.stringify(overrides.collabProfile ?? SAMPLE_COLLAB_PROFILE), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         }),
@@ -391,6 +446,34 @@ describe('History view', () => {
     await waitFor(() =>
       expect(screen.getByText('Recommendations unavailable')).toBeInTheDocument(),
     );
+  });
+
+  it('renders ClaudeMdImpactPanel with verdict and metric rows', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText(/instruction file impact/i)).toBeInTheDocument());
+    const panel = screen
+      .getByText(/instruction file impact/i)
+      .closest('.glass-card') as HTMLElement;
+    expect(within(panel).getByText(/Positive impact/)).toBeInTheDocument();
+    expect(within(panel).getByText('Efficiency')).toBeInTheDocument();
+  });
+
+  it('renders no-changes state for ClaudeMdImpactPanel', async () => {
+    renderHistory({ claudemdImpact: SAMPLE_CLAUDEMD_NO_CHANGES });
+    await waitFor(() =>
+      expect(screen.getByText('No instruction file changes yet')).toBeInTheDocument(),
+    );
+  });
+
+  it('renders CollaborationProfilePanel with classification and dimension labels', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText(/collaboration profile/i)).toBeInTheDocument());
+    expect(screen.getByText('Explorer')).toBeInTheDocument();
+  });
+
+  it('renders no-data state for CollaborationProfilePanel', async () => {
+    renderHistory({ collabProfile: SAMPLE_COLLAB_EMPTY });
+    await waitFor(() => expect(screen.getByText('No collaboration data yet')).toBeInTheDocument());
   });
 
   it('skips the anti-pattern panel chart when no weeks have anti-patterns', async () => {
@@ -1240,17 +1323,18 @@ describe('CoachMetricsTable', () => {
     renderHistory();
     await waitFor(() => expect(screen.getByText(/personal coach/i)).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText(/strong week/i)).toBeInTheDocument());
+    const panel = screen.getByText(/personal coach/i).closest('.glass-card') as HTMLElement;
     // Check for the four row labels (exact match with word boundaries)
-    expect(screen.getByText('Efficiency')).toBeInTheDocument();
-    expect(screen.getByText('Cost / session')).toBeInTheDocument();
-    expect(screen.getByText('Anti-pattern rate')).toBeInTheDocument();
-    expect(screen.getAllByText('Sessions').length).toBeGreaterThanOrEqual(1);
+    expect(within(panel).getByText('Efficiency')).toBeInTheDocument();
+    expect(within(panel).getByText('Cost / session')).toBeInTheDocument();
+    expect(within(panel).getByText('Anti-pattern rate')).toBeInTheDocument();
+    expect(within(panel).getAllByText('Sessions').length).toBeGreaterThanOrEqual(1);
     // Now check for the metrics table values
-    expect(screen.getByText('72')).toBeInTheDocument(); // effValue = 0.72 * 100 = 72
-    expect(screen.getByText('$0.42')).toBeInTheDocument(); // thisWeek cost
-    expect(screen.getByText('4.2%')).toBeInTheDocument(); // antiPatternRate as percentage
+    expect(within(panel).getByText('72')).toBeInTheDocument(); // effValue = 0.72 * 100 = 72
+    expect(within(panel).getByText('$0.42')).toBeInTheDocument(); // thisWeek cost
+    expect(within(panel).getByText('4.2%')).toBeInTheDocument(); // antiPatternRate as percentage
     // SAMPLE_COACH_OK has efficiency 0.72 vs baseline 0.64 → delta = +8pts
-    expect(screen.getByText('↑8pts')).toBeInTheDocument();
+    expect(within(panel).getByText('↑8pts')).toBeInTheDocument();
   });
 
   it('renders zero deltas correctly when baseline values are null or zero', async () => {

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -25,6 +25,8 @@ import {
   fetchCostPerOutcome,
   fetchPersonalCoach,
   fetchRecommendations,
+  fetchClaudeMdImpact,
+  fetchCollaborationProfile,
   fetchActivityHeatmap,
   fetchConcurrencyHistory,
   fetchInstructionDrift,
@@ -38,6 +40,9 @@ import {
   type InstructionDriftResponse,
   type DriftCorrelationEntry,
   type RecommendationsApiResponse,
+  type ClaudeMdImpactApiResponse,
+  type CollaborationProfileApiResponse,
+  type MetricDelta,
 } from '../api/client';
 import { formatUsdOrDash, shortToolName } from '../lib/format';
 
@@ -186,6 +191,18 @@ export function History(): JSX.Element {
   const recommendations = useQuery<RecommendationsApiResponse>({
     queryKey: qk.recommendations,
     queryFn: fetchRecommendations,
+    retry: false,
+  });
+
+  const claudeMdImpact = useQuery<ClaudeMdImpactApiResponse>({
+    queryKey: qk.claudeMdImpact,
+    queryFn: fetchClaudeMdImpact,
+    retry: false,
+  });
+
+  const collabProfile = useQuery<CollaborationProfileApiResponse>({
+    queryKey: qk.collaborationProfile,
+    queryFn: fetchCollaborationProfile,
     retry: false,
   });
 
@@ -507,6 +524,11 @@ export function History(): JSX.Element {
         </Card>
       </div>
 
+      <div className="mt-3 space-y-3">
+        <CollaborationProfilePanel data={collabProfile.data} isError={collabProfile.isError} />
+        <ClaudeMdImpactPanel data={claudeMdImpact.data} isError={claudeMdImpact.isError} />
+      </div>
+
       <div className="mt-3">
         <InstructionDriftCard data={drift.data} />
       </div>
@@ -730,6 +752,250 @@ function RecommendationsPanel({
             </div>
           </div>
         )}
+      </div>
+    </Panel>
+  );
+}
+
+function verdictColor(verdict: string): string {
+  if (verdict.startsWith('Positive')) return 'text-accent-green';
+  if (verdict.startsWith('Negative')) return 'text-accent-red';
+  return 'text-accent-amber';
+}
+
+function ptsDeltaText(delta: MetricDelta | null | undefined): string {
+  if (!delta) return '—';
+  if (delta.value === 0) return '0pts';
+  const pts = Math.round(Math.abs(delta.value) * 100);
+  return `${delta.value > 0 ? '↑' : '↓'}${pts}pts`;
+}
+
+function pctDeltaText(delta: MetricDelta | undefined): string {
+  if (!delta) return '—';
+  if (delta.percentChange == null) return '—';
+  if (delta.value === 0) return '0%';
+  const pct = Math.round(Math.abs(delta.percentChange));
+  return `${delta.value > 0 ? '↑' : '↓'}${pct}%`;
+}
+
+function ClaudeMdImpactPanel({
+  data,
+  isError,
+}: {
+  data: ClaudeMdImpactApiResponse | undefined;
+  isError: boolean;
+}): JSX.Element {
+  if (isError) {
+    return (
+      <Panel title="Instruction File Impact">
+        <EmptyState icon="radar" title="Instruction file impact unavailable" />
+      </Panel>
+    );
+  }
+  if (!data) {
+    return (
+      <Panel title="Instruction File Impact">
+        <EmptyState variant="loading" title="Loading instruction file impact…" />
+      </Panel>
+    );
+  }
+  if (
+    data.message ||
+    !data.change ||
+    !data.before ||
+    !data.after ||
+    !data.deltas ||
+    !data.verdict
+  ) {
+    return (
+      <Panel title="Instruction File Impact">
+        <EmptyState
+          icon="radar"
+          title="No instruction file changes yet"
+          subtitle="Edit your instruction file (CLAUDE.md, or your platform's equivalent) to start tracking impact."
+        />
+      </Panel>
+    );
+  }
+  const changeDate = new Date(data.change.timestamp).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+  const beforeEff =
+    data.before.avgEfficiencyScore !== null
+      ? Math.round(data.before.avgEfficiencyScore * 100)
+      : null;
+  const afterEff =
+    data.after.avgEfficiencyScore !== null ? Math.round(data.after.avgEfficiencyScore * 100) : null;
+  return (
+    <Panel title="Instruction File Impact">
+      <div className="text-xs mb-3">
+        <span className={`font-medium ${verdictColor(data.verdict)}`}>{data.verdict}</span>
+        <span className="text-[10px] text-ink-muted">
+          {' · '}
+          {data.change.changeType} {data.change.filePath.split('/').pop()} · {changeDate}
+        </span>
+      </div>
+      <div className="grid grid-cols-4 gap-x-4 gap-y-1 text-xs">
+        <span className="text-ink-muted" />
+        <span className="text-ink-muted">Before</span>
+        <span className="text-ink-muted">After</span>
+        <span className="text-ink-muted">Δ</span>
+
+        <span className="text-ink-muted">Efficiency</span>
+        <span className="font-mono">{beforeEff ?? '—'}</span>
+        <span className="font-mono">{afterEff ?? '—'}</span>
+        <span
+          className={
+            data.deltas.efficiencyScore == null
+              ? 'text-ink-muted'
+              : data.deltas.efficiencyScore.improved
+                ? 'text-accent-green'
+                : 'text-accent-amber'
+          }
+        >
+          {ptsDeltaText(data.deltas.efficiencyScore)}
+        </span>
+
+        <span className="text-ink-muted">Cost/session</span>
+        <span className="font-mono">${data.before.avgCostUsd.toFixed(2)}</span>
+        <span className="font-mono">${data.after.avgCostUsd.toFixed(2)}</span>
+        <span className={data.deltas.cost.improved ? 'text-accent-green' : 'text-accent-amber'}>
+          {pctDeltaText(data.deltas.cost)}
+        </span>
+
+        <span className="text-ink-muted">Correction rate</span>
+        <span className="font-mono">{Math.round(data.before.avgCorrectionRate * 100)}%</span>
+        <span className="font-mono">{Math.round(data.after.avgCorrectionRate * 100)}%</span>
+        <span
+          className={
+            data.deltas.correctionRate.improved ? 'text-accent-green' : 'text-accent-amber'
+          }
+        >
+          {pctDeltaText(data.deltas.correctionRate)}
+        </span>
+      </div>
+      {data.contextTokensForClaudeMd != null && data.contextTokensForClaudeMd > 0 && (
+        <div className="text-[10px] text-ink-muted italic mt-2">
+          Instruction file adds ~{data.contextTokensForClaudeMd.toLocaleString()} tokens/turn
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+function CollaborationProfilePanel({
+  data,
+  isError,
+}: {
+  data: CollaborationProfileApiResponse | undefined;
+  isError: boolean;
+}): JSX.Element {
+  if (isError) {
+    return (
+      <Panel title="Collaboration Profile">
+        <EmptyState icon="radar" title="Collaboration profile unavailable" />
+      </Panel>
+    );
+  }
+  if (!data) {
+    return (
+      <Panel title="Collaboration Profile">
+        <EmptyState variant="loading" title="Loading collaboration profile…" />
+      </Panel>
+    );
+  }
+  if (data.sessionCount === 0) {
+    return (
+      <Panel title="Collaboration Profile">
+        <EmptyState
+          icon="radar"
+          title="No collaboration data yet"
+          subtitle="Profile appears after a few sessions."
+        />
+      </Panel>
+    );
+  }
+  const dims = [
+    {
+      name: 'Specificity',
+      key: 'specificity',
+      value: Math.round(data.dimensions.specificity * 100),
+      delta: data.teamDeltas.specificity,
+      lowerIsBetter: false,
+    },
+    {
+      name: 'Autonomy',
+      key: 'autonomy',
+      value: Math.round(data.dimensions.autonomy * 100),
+      delta: data.teamDeltas.autonomy,
+      lowerIsBetter: false,
+    },
+    {
+      name: 'Correction rate',
+      key: 'correctionRate',
+      value: Math.round(data.dimensions.correctionRate * 100),
+      delta: data.teamDeltas.correctionRate,
+      lowerIsBetter: true,
+    },
+    {
+      name: 'Task complexity',
+      key: 'taskComplexity',
+      value: Math.round(data.dimensions.taskComplexity * 100),
+      delta: data.teamDeltas.taskComplexity,
+      lowerIsBetter: false,
+    },
+  ];
+  return (
+    <Panel title="Collaboration Profile">
+      <div className="text-xs mb-3">
+        <span className="text-sm font-medium text-ink-base">{data.classification}</span>
+        <span className="text-ink-muted"> · {data.sessionCount} sessions</span>
+      </div>
+      <div className="min-w-0" style={{ height: `${dims.length * 28 + 40}px` }}>
+        <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
+          <BarChart data={dims} layout="vertical">
+            <CartesianGrid stroke={GRID_STROKE} strokeDasharray="3 3" />
+            <XAxis
+              type="number"
+              domain={[0, 100]}
+              tick={TICK_STYLE}
+              stroke={GRID_STROKE}
+              tickFormatter={(v: number) => `${v}%`}
+            />
+            <YAxis
+              type="category"
+              dataKey="name"
+              tick={TICK_STYLE}
+              stroke={GRID_STROKE}
+              width={110}
+            />
+            <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(v: number) => [`${v}%`]} />
+            <Bar dataKey="value" fill={ACCENT_TEAL} fillOpacity={0.8} radius={[0, 3, 3, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="space-y-1 mt-2">
+        {dims.map((d) => {
+          const pct = Math.round(Math.abs(d.delta) * 100);
+          const positive = d.lowerIsBetter ? d.delta < 0 : d.delta > 0;
+          const color =
+            d.delta === 0 ? 'text-ink-muted' : positive ? 'text-accent-green' : 'text-accent-amber';
+          const sign = d.delta > 0 ? '+' : d.delta < 0 ? '-' : '';
+          const note = d.lowerIsBetter ? ' (lower = better)' : '';
+          return (
+            <div key={d.key} className="flex items-center justify-between text-[10px]">
+              <span className="text-ink-muted">
+                {d.name}
+                {note}
+              </span>
+              <span className={color}>
+                {sign}
+                {pct}% vs team
+              </span>
+            </div>
+          );
+        })}
       </div>
     </Panel>
   );


### PR DESCRIPTION
## Summary

- Adds a **Collaboration Profile** panel to the History dashboard — a developer-collaboration classification (Power User / Delegator / Learning / Collaborative) with specificity, autonomy, correction rate, and task complexity, each compared against the team baseline.
- Adds an **Instruction File Impact** panel — a before/after comparison (efficiency, cost/session, correction rate) around the most recent change to your instruction file (`CLAUDE.md`, or your platform's equivalent), with a verdict and an estimated context-token cost.
- Both metrics were previously available only through MCP tools (`nr_observe_get_collaboration_profile`, `nr_observe_get_claudemd_impact`); this brings them into the local dashboard's History view.

## Test plan

- [x] `npm run build && npm test && npm run lint` — clean
- [x] Full Vitest frontend suite — clean
- [x] Manually verified both panels render correctly against mocked API responses (loading, empty, and populated states)

---

Closes #32