### PR TITLE
Feat: compute waste metric — token waste panel + MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.35] - 2026-08-06
+
+### Added
+
+- **Compute waste is now a unified metric** — `AntiPatternDetector` annotates every detected anti-pattern (thrashing, re-reading, stuck loops, blind editing, over-delegation) with an estimated `tokensWasted`, combined with `RetryDetector`'s existing waste tracking into one total. Surfaced via a new "Compute Waste" panel in the Today dashboard view (headline token count, status pill, per-source breakdown, top offender, and a recommendation), a new `GET /api/compute-waste` dashboard route, and a new `nr_observe_get_compute_waste` MCP tool.
+
 ## [1.14.34] - 2026-08-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.34",
+  "version": "1.14.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.34",
+      "version": "1.14.35",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.34",
+  "version": "1.14.35",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -946,6 +946,102 @@ describe('api-handler GET /api/turn-costs', () => {
   });
 });
 
+describe('api-handler GET /api/compute-waste', () => {
+  it('returns clean status with correct totals when waste is low', async () => {
+    const handler = createApiHandler({
+      retryDetector: { getMetrics: () => ({ totalTokensWasted: 100 }) } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['retryDetector'],
+      antiPatternDetector: {
+        getCurrentPatterns: () => [
+          { type: 'stuck_loop', tokensWasted: 200, command: 'npm test', suggestion: '' },
+        ],
+        getTotalAntiPatternWaste: () => 200,
+      } as unknown as Parameters<typeof createApiHandler>[0]['antiPatternDetector'],
+    });
+    const req = { method: 'GET', url: '/api/compute-waste' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const json = JSON.parse(body()) as Record<string, unknown>;
+    expect(json.total_tokens_wasted).toBe(300);
+    expect(json.retry_tokens_wasted).toBe(100);
+    expect(json.anti_pattern_tokens_wasted).toBe(200);
+    expect(json.status).toBe('clean');
+    expect((json.breakdown as unknown[]).length).toBe(1);
+  });
+
+  it('returns needs_attention when totalTokensWasted >= 2000', async () => {
+    const handler = createApiHandler({
+      retryDetector: { getMetrics: () => ({ totalTokensWasted: 1500 }) } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['retryDetector'],
+      antiPatternDetector: {
+        getCurrentPatterns: () => [
+          { type: 're_reading', tokensWasted: 600, file: '/a.ts', suggestion: '' },
+        ],
+        getTotalAntiPatternWaste: () => 600,
+      } as unknown as Parameters<typeof createApiHandler>[0]['antiPatternDetector'],
+    });
+    const req = { method: 'GET', url: '/api/compute-waste' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const json = JSON.parse(body()) as Record<string, unknown>;
+    expect(json.total_tokens_wasted).toBe(2100);
+    expect(json.status).toBe('needs_attention');
+    expect((json.breakdown as Array<Record<string, unknown>>).length).toBe(1);
+    expect((json.breakdown as Array<Record<string, unknown>>)[0].type).toBe('re_reading');
+    expect((json.breakdown as Array<Record<string, unknown>>)[0].tokens_wasted).toBe(600);
+  });
+
+  it('returns 503 when retryDetector is missing', async () => {
+    const handler = createApiHandler({
+      antiPatternDetector: {
+        getCurrentPatterns: () => [],
+        getTotalAntiPatternWaste: () => 0,
+      } as unknown as Parameters<typeof createApiHandler>[0]['antiPatternDetector'],
+    });
+    const req = { method: 'GET', url: '/api/compute-waste' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns 503 when antiPatternDetector is missing', async () => {
+    const handler = createApiHandler({
+      retryDetector: { getMetrics: () => ({ totalTokensWasted: 0 }) } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['retryDetector'],
+    });
+    const req = { method: 'GET', url: '/api/compute-waste' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns moderate status when totalTokensWasted is in 500-1999 range', async () => {
+    const handler = createApiHandler({
+      retryDetector: { getMetrics: () => ({ totalTokensWasted: 400 }) } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['retryDetector'],
+      antiPatternDetector: {
+        getCurrentPatterns: () => [
+          { type: 're_reading', tokensWasted: 200, file: '/a.ts', suggestion: '' },
+        ],
+        getTotalAntiPatternWaste: () => 200,
+      } as unknown as Parameters<typeof createApiHandler>[0]['antiPatternDetector'],
+    });
+    const req = { method: 'GET', url: '/api/compute-waste' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const json = JSON.parse(body()) as Record<string, unknown>;
+    expect(json.total_tokens_wasted).toBe(600);
+    expect(json.status).toBe('moderate');
+  });
+});
+
 describe('api-handler GET /api/audit', () => {
   it('returns audit log mapped to SPA AuditEntry shape', async () => {
     const ts1 = Date.now() - 5000;

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -382,7 +382,10 @@ export interface ApiHandlerDeps {
     getSnapshot: () => ObservabilityHealthSnapshot;
   };
   readonly costForecast?: () => CostForecast;
-  readonly antiPatternDetector?: { getCurrentPatterns: () => readonly AntiPattern[] };
+  readonly antiPatternDetector?: {
+    getCurrentPatterns: () => readonly AntiPattern[];
+    getTotalAntiPatternWaste: () => number;
+  };
   readonly retryDetector?: { getMetrics: () => RetryDetectorMetrics };
   readonly instructionDriftTracker?: { getMetrics: () => InstructionDriftMetrics };
   readonly decisionTracker?: { getMetrics: () => DecisionTreeMetrics };
@@ -1655,6 +1658,46 @@ export function createApiHandler(
   routes.set('GET /api/turn-costs', (_req, res) => {
     if (!deps.turnCostAttributor) return unavailable(res, 'turnCostAttributor');
     jsonOk(res, deps.turnCostAttributor.getMetrics());
+  });
+
+  routes.set('GET /api/compute-waste', (_req, res) => {
+    if (!deps.retryDetector) return unavailable(res, 'retryDetector');
+    if (!deps.antiPatternDetector) return unavailable(res, 'antiPatternDetector');
+
+    const retryTokensWasted = deps.retryDetector.getMetrics().totalTokensWasted;
+    const antiPatternTokensWasted = deps.antiPatternDetector.getTotalAntiPatternWaste();
+    const totalTokensWasted = retryTokensWasted + antiPatternTokensWasted;
+
+    const patterns = deps.antiPatternDetector.getCurrentPatterns();
+    const breakdownMap = patterns
+      .filter((p) => p.tokensWasted > 0)
+      .reduce<Map<string, { tokens_wasted: number; instances: number }>>((acc, p) => {
+        const existing = acc.get(p.type) ?? { tokens_wasted: 0, instances: 0 };
+        acc.set(p.type, {
+          tokens_wasted: existing.tokens_wasted + p.tokensWasted,
+          instances: existing.instances + 1,
+        });
+        return acc;
+      }, new Map());
+
+    const breakdown = [...breakdownMap.entries()]
+      .map(([type, v]) => ({ type, ...v }))
+      .sort((a, b) => b.tokens_wasted - a.tokens_wasted);
+
+    const status =
+      totalTokensWasted >= 2000
+        ? 'needs_attention'
+        : totalTokensWasted >= 500
+          ? 'moderate'
+          : 'clean';
+
+    jsonOk(res, {
+      total_tokens_wasted: totalTokensWasted,
+      retry_tokens_wasted: retryTokensWasted,
+      anti_pattern_tokens_wasted: antiPatternTokensWasted,
+      breakdown,
+      status,
+    });
   });
 
   routes.set('GET /api/audit', (_req, res) => {

--- a/src/metrics/anti-patterns.test.ts
+++ b/src/metrics/anti-patterns.test.ts
@@ -839,3 +839,52 @@ describe('Edge cases', () => {
     expect(detector.getCurrentPatterns()).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Token waste annotation
+// ---------------------------------------------------------------------------
+
+describe('Token waste annotation', () => {
+  it('estimates tokensWasted for stuck_loop (skips first occurrence)', () => {
+    const detector = new AntiPatternDetector({ stuckLoopThreshold: 3 });
+    const calls = [
+      makeRecord({ toolName: 'Bash', command: 'npm test', inputTokens: 100, outputTokens: 50 }),
+      makeRecord({ toolName: 'Bash', command: 'npm test', inputTokens: 110, outputTokens: 60 }),
+      makeRecord({ toolName: 'Bash', command: 'npm test', inputTokens: 120, outputTokens: 70 }),
+    ];
+    const { patterns } = detector.analyze(calls);
+    expect(patterns).toHaveLength(1);
+    expect(patterns[0].type).toBe('stuck_loop');
+    // calls[0] is the first occurrence (not waste); calls[1] + calls[2] are waste
+    expect(patterns[0].tokensWasted).toBe(110 + 60 + (120 + 70)); // 360
+  });
+
+  it('estimates tokensWasted for re_reading (skips first read)', () => {
+    const detector = new AntiPatternDetector({ reReadThreshold: 3 });
+    const calls = [
+      makeRecord({ toolName: 'Read', filePath: '/src/foo.ts', inputTokens: 200, outputTokens: 0 }),
+      makeRecord({ toolName: 'Read', filePath: '/src/foo.ts', inputTokens: 210, outputTokens: 0 }),
+      makeRecord({ toolName: 'Read', filePath: '/src/foo.ts', inputTokens: 220, outputTokens: 0 }),
+      makeRecord({ toolName: 'Read', filePath: '/src/foo.ts', inputTokens: 230, outputTokens: 0 }),
+    ];
+    const { patterns } = detector.analyze(calls);
+    expect(patterns).toHaveLength(1);
+    expect(patterns[0].type).toBe('re_reading');
+    // calls[0] is the first (necessary) read; calls[1-3] are waste
+    expect(patterns[0].tokensWasted).toBe(210 + 220 + 230); // 660
+  });
+
+  it('getTotalAntiPatternWaste() sums tokensWasted across all patterns', () => {
+    const detector = new AntiPatternDetector({ stuckLoopThreshold: 2, reReadThreshold: 2 });
+    const calls = [
+      // stuck_loop on 'npm test' — calls[0] necessary, calls[1] waste (80 + 40 = 120)
+      makeRecord({ toolName: 'Bash', command: 'npm test', inputTokens: 50, outputTokens: 30 }),
+      makeRecord({ toolName: 'Bash', command: 'npm test', inputTokens: 80, outputTokens: 40 }),
+      // re_reading on '/a.ts' — calls[2] necessary, calls[3] waste (200 + 0 = 200)
+      makeRecord({ toolName: 'Read', filePath: '/a.ts', inputTokens: 150, outputTokens: 0 }),
+      makeRecord({ toolName: 'Read', filePath: '/a.ts', inputTokens: 200, outputTokens: 0 }),
+    ];
+    detector.analyze(calls);
+    expect(detector.getTotalAntiPatternWaste()).toBe(120 + 200); // 320
+  });
+});

--- a/src/metrics/anti-patterns.ts
+++ b/src/metrics/anti-patterns.ts
@@ -37,6 +37,7 @@ export interface AntiPattern {
   readonly repeatCount?: number;
   readonly editCount?: number;
   readonly agentCount?: number;
+  readonly tokensWasted: number;
   readonly suggestion: string;
 }
 
@@ -109,13 +110,15 @@ export class AntiPatternDetector implements Resettable {
   }
 
   analyze(toolCalls: ToolCallRecord[]): AntiPatternMetrics {
-    const patterns: AntiPattern[] = [];
+    const rawPatterns: AntiPattern[] = [];
 
-    patterns.push(...this.detectThrashing(toolCalls));
-    patterns.push(...this.detectReReading(toolCalls));
-    patterns.push(...this.detectStuckLoop(toolCalls));
-    patterns.push(...this.detectBlindEditing(toolCalls));
-    patterns.push(...this.detectOverDelegation(toolCalls));
+    rawPatterns.push(...this.detectThrashing(toolCalls));
+    rawPatterns.push(...this.detectReReading(toolCalls));
+    rawPatterns.push(...this.detectStuckLoop(toolCalls));
+    rawPatterns.push(...this.detectBlindEditing(toolCalls));
+    rawPatterns.push(...this.detectOverDelegation(toolCalls));
+
+    const patterns = this.annotateTokenWaste(rawPatterns, toolCalls);
 
     const metrics = {
       readEfficiency: this.computeReadEfficiency(toolCalls),
@@ -133,6 +136,10 @@ export class AntiPatternDetector implements Resettable {
 
   reset(_sessionId: string): void {
     this.lastMetrics = null;
+  }
+
+  getTotalAntiPatternWaste(): number {
+    return (this.lastMetrics?.patterns ?? []).reduce((sum, p) => sum + p.tokensWasted, 0);
   }
 
   emitMetrics(aggregator: MetricAggregator, patterns: AntiPattern[]): void {
@@ -184,6 +191,7 @@ export class AntiPatternDetector implements Resettable {
         type: 'thrashing',
         file,
         iterations,
+        tokensWasted: 0,
         suggestion:
           'Consider reading the test output more carefully or reading the test framework docs',
       });
@@ -220,6 +228,7 @@ export class AntiPatternDetector implements Resettable {
           type: 're_reading',
           file,
           readCount: count,
+          tokensWasted: 0,
           suggestion:
             'Context may have been compressed — consider breaking the task into smaller pieces',
         });
@@ -268,6 +277,7 @@ export class AntiPatternDetector implements Resettable {
         command,
         repeatCount,
         bashCategory,
+        tokensWasted: 0,
         suggestion: stuckLoopSuggestion(bashCategory),
       });
     }
@@ -319,6 +329,7 @@ export class AntiPatternDetector implements Resettable {
         type: 'blind_editing',
         file,
         editCount,
+        tokensWasted: 0,
         suggestion: 'Verify changes with tests between edits',
       });
     }
@@ -344,12 +355,74 @@ export class AntiPatternDetector implements Resettable {
         {
           type: 'over_delegation',
           agentCount,
+          tokensWasted: 0,
           suggestion: 'Too many sub-agents spawned — consider handling more work directly',
         },
       ];
     }
 
     return [];
+  }
+
+  private annotateTokenWaste(patterns: AntiPattern[], toolCalls: ToolCallRecord[]): AntiPattern[] {
+    const tokenSum = (records: ToolCallRecord[]): number =>
+      records.reduce(
+        (sum, r) => sum + (((r.inputTokens as number) || 0) + ((r.outputTokens as number) || 0)),
+        0,
+      );
+
+    return patterns.map((p): AntiPattern => {
+      switch (p.type) {
+        case 'stuck_loop': {
+          if (!p.command) return p;
+          const matching = toolCalls.filter(
+            (r) => r.toolName === 'Bash' && r.command === p.command,
+          );
+          return { ...p, tokensWasted: tokenSum(matching.slice(1)) };
+        }
+        case 're_reading': {
+          if (!p.file) return p;
+          const matching = toolCalls.filter(
+            (r) =>
+              (r.toolName === 'Read' ||
+                r.toolName === 'NotebookRead' ||
+                r.toolName.toLowerCase().includes('read')) &&
+              r.filePath === p.file,
+          );
+          return { ...p, tokensWasted: tokenSum(matching.slice(1)) };
+        }
+        case 'thrashing': {
+          if (!p.file) return p;
+          let sawEdit = false;
+          const wastedCalls: ToolCallRecord[] = [];
+          for (const r of toolCalls) {
+            if (r.toolName === 'Edit' || r.toolName === 'Write') {
+              sawEdit = r.filePath === p.file;
+            } else if (r.toolName === 'Bash' && r.isTestCommand) {
+              if (sawEdit && !r.success) {
+                wastedCalls.push(r);
+              } else if (r.success) {
+                sawEdit = false;
+              }
+            }
+          }
+          return { ...p, tokensWasted: tokenSum(wastedCalls) };
+        }
+        case 'blind_editing': {
+          if (!p.file) return p;
+          const matching = toolCalls.filter(
+            (r) => (r.toolName === 'Edit' || r.toolName === 'Write') && r.filePath === p.file,
+          );
+          return { ...p, tokensWasted: tokenSum(matching.slice(this.blindEditThreshold)) };
+        }
+        case 'over_delegation': {
+          const matching = toolCalls.filter((r) => r.toolName === 'Agent');
+          return { ...p, tokensWasted: tokenSum(matching.slice(this.overDelegationThreshold)) };
+        }
+        default:
+          return p;
+      }
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/metrics/efficiency-score.test.ts
+++ b/src/metrics/efficiency-score.test.ts
@@ -88,6 +88,7 @@ describe('Poor task', () => {
         type: 'thrashing',
         file: '/a.ts',
         iterations: 5,
+        tokensWasted: 0,
         suggestion: 'Consider reading the test output more carefully',
       },
     ];
@@ -145,6 +146,7 @@ describe('Thrash iterations', () => {
         type: 'thrashing',
         file: '/a.ts',
         iterations: 3,
+        tokensWasted: 0,
         suggestion: '',
       },
     ];
@@ -162,6 +164,7 @@ describe('Thrash iterations', () => {
         type: 'thrashing',
         file: '/a.ts',
         iterations: 1,
+        tokensWasted: 0,
         suggestion: '',
       },
     ];
@@ -175,9 +178,9 @@ describe('Thrash iterations', () => {
     const scorer = new EfficiencyScorer();
 
     const antiPatterns: AntiPattern[] = [
-      { type: 'thrashing', file: '/a.ts', iterations: 1, suggestion: '' },
-      { type: 'thrashing', file: '/b.ts', iterations: 4, suggestion: '' },
-      { type: 'thrashing', file: '/c.ts', iterations: 2, suggestion: '' },
+      { type: 'thrashing', file: '/a.ts', iterations: 1, tokensWasted: 0, suggestion: '' },
+      { type: 'thrashing', file: '/b.ts', iterations: 4, tokensWasted: 0, suggestion: '' },
+      { type: 'thrashing', file: '/c.ts', iterations: 2, tokensWasted: 0, suggestion: '' },
     ];
 
     const result = scorer.computeScore(makeTask(), antiPatterns);
@@ -190,8 +193,8 @@ describe('Thrash iterations', () => {
     const scorer = new EfficiencyScorer();
 
     const antiPatterns: AntiPattern[] = [
-      { type: 're_reading', file: '/a.ts', readCount: 10, suggestion: '' },
-      { type: 'stuck_loop', command: 'npm test', repeatCount: 5, suggestion: '' },
+      { type: 're_reading', file: '/a.ts', readCount: 10, tokensWasted: 0, suggestion: '' },
+      { type: 'stuck_loop', command: 'npm test', repeatCount: 5, tokensWasted: 0, suggestion: '' },
     ];
 
     const result = scorer.computeScore(makeTask(), antiPatterns);

--- a/src/tools/extended-analytics-tools.test.ts
+++ b/src/tools/extended-analytics-tools.test.ts
@@ -7,6 +7,7 @@ import { ToolSelectionScorer } from '../metrics/tool-selection-scorer.js';
 import { QualityProxyTracker } from '../metrics/quality-proxy-tracker.js';
 import { ApiFailureTracker } from '../metrics/api-failure-tracker.js';
 import type { ToolCallRecord } from '../storage/types.js';
+import type { AntiPatternDetector } from '../metrics/anti-patterns.js';
 import {
   handleGetRetryAlerts,
   handleGetContextComposition,
@@ -17,6 +18,7 @@ import {
   handleGetQualityProxy,
   handleGetApiFailures,
   registerExtendedAnalyticsTools,
+  handleGetComputeWaste,
 } from './extended-analytics-tools.js';
 
 jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -112,6 +114,7 @@ describe('registerExtendedAnalyticsTools()', () => {
     expect(tools).toEqual([]);
     expect(Object.keys(handlers).sort()).toEqual([
       'nr_observe_get_api_failures',
+      'nr_observe_get_compute_waste',
       'nr_observe_get_context_composition',
       'nr_observe_get_decision_tree',
       'nr_observe_get_instruction_drift',
@@ -189,5 +192,43 @@ describe('registerExtendedAnalyticsTools()', () => {
       'nr_observe_get_retry_alerts',
       'nr_observe_get_tool_selection_score',
     ]);
+  });
+});
+
+describe('handleGetComputeWaste', () => {
+  it('returns correct totals, breakdown, and clean status', () => {
+    const retryDetector = {
+      getMetrics: () => ({ totalTokensWasted: 100, alerts: [], totalAlertsEmitted: 0 }),
+    } as unknown as RetryDetector;
+    const antiPatternDetector = {
+      getTotalAntiPatternWaste: () => 200,
+      getCurrentPatterns: () => [
+        { type: 'stuck_loop', tokensWasted: 200, command: 'npm test', suggestion: '' },
+      ],
+    } as unknown as AntiPatternDetector;
+    const result = handleGetComputeWaste(retryDetector, antiPatternDetector);
+    const data = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    expect(data.total_tokens_wasted).toBe(300);
+    expect(data.retry_tokens_wasted).toBe(100);
+    expect(data.anti_pattern_tokens_wasted).toBe(200);
+    expect(data.status).toBe('clean');
+    expect((data.breakdown as unknown[]).length).toBe(1);
+  });
+
+  it('excludes zero-waste patterns from breakdown', () => {
+    const retryDetector = {
+      getMetrics: () => ({ totalTokensWasted: 0, alerts: [], totalAlertsEmitted: 0 }),
+    } as unknown as RetryDetector;
+    const antiPatternDetector = {
+      getTotalAntiPatternWaste: () => 0,
+      getCurrentPatterns: () => [
+        { type: 'stuck_loop', tokensWasted: 0, command: 'npm test', suggestion: '' },
+        { type: 're_reading', tokensWasted: 0, file: '/a.ts', suggestion: '' },
+      ],
+    } as unknown as AntiPatternDetector;
+    const result = handleGetComputeWaste(retryDetector, antiPatternDetector);
+    const data = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    expect(data.total_tokens_wasted).toBe(0);
+    expect((data.breakdown as unknown[]).length).toBe(0);
   });
 });

--- a/src/tools/extended-analytics-tools.ts
+++ b/src/tools/extended-analytics-tools.ts
@@ -22,6 +22,7 @@ import type { InstructionDriftTracker } from '../metrics/instruction-drift-track
 import type { ToolSelectionScorer } from '../metrics/tool-selection-scorer.js';
 import type { QualityProxyTracker } from '../metrics/quality-proxy-tracker.js';
 import type { ApiFailureTracker } from '../metrics/api-failure-tracker.js';
+import type { AntiPatternDetector } from '../metrics/anti-patterns.js';
 import {
   requireTracker,
   requireAvailable,
@@ -103,6 +104,14 @@ export const API_FAILURES_TOOL = {
   name: 'nr_observe_get_api_failures',
   description:
     "Get API failure tracking: per-model reliability scorecards, tokens lost, cost impact, throttle alerts, and mean time to recovery. LIMITATION: model-API-level failure data is not observable in Preflight's current architecture (see the note field in the response) — this tool currently always returns empty/zero metrics.",
+  inputSchema: { type: 'object' as const, properties: {} },
+  annotations: { readOnlyHint: true },
+};
+
+export const COMPUTE_WASTE_TOOL = {
+  name: 'nr_observe_get_compute_waste',
+  description:
+    'Get compute waste summary: total tokens wasted on retried tool calls and anti-pattern activity (stuck loops, redundant reads, thrashing). Includes per-pattern breakdown and a status assessment (clean / moderate / needs_attention).',
   inputSchema: { type: 'object' as const, properties: {} },
   annotations: { readOnlyHint: true },
 };
@@ -205,6 +214,7 @@ export interface ExtendedAnalyticsToolsDeps {
   toolCallBuffer?: { getRecords(): readonly ToolCallRecord[] };
   qualityProxyTracker?: QualityProxyTracker;
   apiFailureTracker?: ApiFailureTracker;
+  antiPatternDetector?: AntiPatternDetector;
 }
 
 export function registerExtendedAnalyticsTools(
@@ -308,5 +318,65 @@ export function registerExtendedAnalyticsTools(
         return handleGetApiFailures(check.value);
       },
     },
+    {
+      definition: COMPUTE_WASTE_TOOL,
+      available: !!deps.retryDetector && !!deps.antiPatternDetector,
+      handle: () => {
+        const missing = requireAvailable(
+          !!deps.retryDetector && !!deps.antiPatternDetector,
+          'RetryDetector or AntiPatternDetector not available',
+        );
+        if (missing) return missing;
+        return handleGetComputeWaste(deps.retryDetector!, deps.antiPatternDetector!);
+      },
+    },
   ]);
+}
+
+export function handleGetComputeWaste(
+  retryDetector: RetryDetector,
+  antiPatternDetector: AntiPatternDetector,
+): { content: Array<{ type: 'text'; text: string }> } {
+  const retryTokensWasted = retryDetector.getMetrics().totalTokensWasted;
+  const antiPatternTokensWasted = antiPatternDetector.getTotalAntiPatternWaste();
+  const totalTokensWasted = retryTokensWasted + antiPatternTokensWasted;
+
+  const patterns = antiPatternDetector.getCurrentPatterns();
+  const breakdown = [
+    ...patterns
+      .filter((p) => p.tokensWasted > 0)
+      .reduce<Map<string, { tokens_wasted: number; instances: number }>>((acc, p) => {
+        const existing = acc.get(p.type) ?? { tokens_wasted: 0, instances: 0 };
+        acc.set(p.type, {
+          tokens_wasted: existing.tokens_wasted + p.tokensWasted,
+          instances: existing.instances + 1,
+        });
+        return acc;
+      }, new Map())
+      .entries(),
+  ]
+    .map(([type, v]) => ({ type, ...v }))
+    .sort((a, b) => b.tokens_wasted - a.tokens_wasted);
+
+  const status =
+    totalTokensWasted >= 2000 ? 'needs_attention' : totalTokensWasted >= 500 ? 'moderate' : 'clean';
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          {
+            total_tokens_wasted: totalTokensWasted,
+            retry_tokens_wasted: retryTokensWasted,
+            anti_pattern_tokens_wasted: antiPatternTokensWasted,
+            breakdown,
+            status,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
 }

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -95,6 +95,7 @@ function makeToolContribution(
 function makePattern(overrides?: Partial<AntiPattern>): AntiPattern {
   return {
     type: 'thrashing',
+    tokensWasted: 0,
     suggestion: 'Consider reviewing your approach before retrying',
     ...overrides,
   };

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -281,6 +281,21 @@ export const fetchCost = (): Promise<CostResponse> => getJson<CostResponse>('/ap
 export const fetchAntiPatterns = (): Promise<AntiPattern[]> =>
   getJson<AntiPattern[]>('/api/anti-patterns');
 
+export interface ComputeWasteResponse {
+  readonly total_tokens_wasted: number;
+  readonly retry_tokens_wasted: number;
+  readonly anti_pattern_tokens_wasted: number;
+  readonly breakdown: ReadonlyArray<{
+    readonly type: string;
+    readonly tokens_wasted: number;
+    readonly instances: number;
+  }>;
+  readonly status: 'clean' | 'moderate' | 'needs_attention';
+}
+
+export const fetchComputeWaste = (): Promise<ComputeWasteResponse> =>
+  getJson<ComputeWasteResponse>('/api/compute-waste');
+
 export interface ThrashingAlertEntry {
   readonly toolName: string;
   readonly occurrences: number;
@@ -1157,6 +1172,7 @@ export const qk = {
   sessionDetail: (id: string) => ['session', id] as const,
   cost: ['cost'] as const,
   antiPatterns: ['anti-patterns'] as const,
+  computeWaste: ['compute-waste'] as const,
   audit: ['audit'] as const,
   weekly: ['weekly'] as const,
   budget: ['budget'] as const,

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -1413,3 +1413,100 @@ describe('Today view — Recent alerts panel', () => {
     expect(titles.map((el) => el.textContent)).toEqual(['New alert', 'Middle alert', 'Old alert']);
   });
 });
+
+describe('Today view — Compute Waste panel', () => {
+  beforeEach(() => {
+    useLiveStore.setState({
+      connected: true,
+      recentToolCalls: [],
+      cost: { sessionTotalUsd: 1, todayTotalUsd: 1, forecastEodUsd: null },
+      antiPatterns: [],
+      firingAlerts: new Map(),
+      dismissedAlerts: new Set(),
+    });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows clean status when total_tokens_wasted is 0', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/compute-waste')) {
+        return new Response(
+          JSON.stringify({
+            total_tokens_wasted: 0,
+            retry_tokens_wasted: 0,
+            anti_pattern_tokens_wasted: 0,
+            breakdown: [],
+            status: 'clean',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+    expect(await screen.findByText(/~0 wasted tokens/)).toBeInTheDocument();
+    expect(screen.getByText('clean')).toBeInTheDocument();
+    expect(screen.getByText('No compute waste detected this session.')).toBeInTheDocument();
+  });
+
+  it('shows needs_attention status with top offender chip', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/compute-waste')) {
+        return new Response(
+          JSON.stringify({
+            total_tokens_wasted: 2400,
+            retry_tokens_wasted: 800,
+            anti_pattern_tokens_wasted: 1600,
+            breakdown: [{ type: 'stuck_loop', tokens_wasted: 1600, instances: 2 }],
+            status: 'needs_attention',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+    expect(await screen.findByText(/~2,400 wasted tokens/)).toBeInTheDocument();
+    expect(screen.getByText('needs attention')).toBeInTheDocument();
+    expect(screen.getByText(/stuck loop/i)).toBeInTheDocument();
+    expect(screen.getByText(/~1,600 tokens/)).toBeInTheDocument();
+  });
+
+  it('shows per-source breakdown sub-line', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/compute-waste')) {
+        return new Response(
+          JSON.stringify({
+            total_tokens_wasted: 600,
+            retry_tokens_wasted: 200,
+            anti_pattern_tokens_wasted: 400,
+            breakdown: [{ type: 're_reading', tokens_wasted: 400, instances: 1 }],
+            status: 'moderate',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+    expect(await screen.findByText(/retry: ~200/)).toBeInTheDocument();
+    expect(screen.getByText(/anti-pattern: ~400/)).toBeInTheDocument();
+  });
+});

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -43,6 +43,7 @@ import {
   type ContextCompositionResponse,
   fetchContextEfficiency,
   type ContextEfficiencyResponse,
+  fetchComputeWaste,
   fetchQualityProxy,
   fetchToolSelectionScore,
   fetchConcurrency,
@@ -104,6 +105,36 @@ interface SessionAntiPattern {
   readonly repeatCount?: number;
   readonly editCount?: number;
   readonly agentCount?: number;
+}
+
+interface ComputeWasteApiResponse {
+  readonly total_tokens_wasted: number;
+  readonly retry_tokens_wasted: number;
+  readonly anti_pattern_tokens_wasted: number;
+  readonly breakdown: ReadonlyArray<{
+    readonly type: string;
+    readonly tokens_wasted: number;
+    readonly instances: number;
+  }>;
+  readonly status: 'clean' | 'moderate' | 'needs_attention';
+}
+
+function computeWasteRecommendationText(
+  status: ComputeWasteApiResponse['status'],
+  topPatternType: string | null,
+): string {
+  if (status === 'clean') return 'No compute waste detected this session.';
+
+  const patternAdvice: Record<string, string> = {
+    stuck_loop: 'Address the command output before re-running the same command.',
+    re_reading: 'Read each file once and keep relevant sections in mind.',
+    thrashing: 'Read the test failure output carefully before editing again.',
+    blind_editing: 'Verify changes with tests between edit batches.',
+    over_delegation: 'Handle more work directly instead of spawning sub-agents.',
+  };
+
+  const advice = topPatternType !== null ? (patternAdvice[topPatternType] ?? null) : null;
+  return advice ?? 'Review anti-patterns to reduce repeated tool calls.';
 }
 
 interface SessionSummary {
@@ -502,6 +533,7 @@ export function Today(): JSX.Element {
             <LatencyPanel aggregate={aggregate} />
             <ModelUsagePanel />
             <CacheHealthPanel aggregate={aggregate} />
+            <ComputeWastePanel />
           </AnimatedCard>
 
           <AnimatedCard index={4}>
@@ -867,6 +899,62 @@ function CacheHealthPanel({
           </div>
         </>
       )}
+    </Card>
+  );
+}
+
+function ComputeWastePanel(): JSX.Element | null {
+  const { data, isPending } = useQuery<ComputeWasteApiResponse>({
+    queryKey: qk.computeWaste,
+    queryFn: fetchComputeWaste as () => Promise<ComputeWasteApiResponse>,
+    retry: false,
+  });
+
+  if (isPending || !data || typeof data.total_tokens_wasted !== 'number') return null;
+
+  const statusColor =
+    data.status === 'clean'
+      ? 'text-accent-green'
+      : data.status === 'moderate'
+        ? 'text-accent-amber'
+        : 'text-accent-red';
+
+  const statusLabel =
+    data.status === 'clean' ? 'clean' : data.status === 'moderate' ? 'moderate' : 'needs attention';
+
+  const topOffender = data.breakdown[0] ?? null;
+
+  return (
+    <Card padding="sm" className="h-full">
+      <div className="flex items-center gap-1.5 mb-2">
+        <Eyebrow>Compute Waste</Eyebrow>
+        <InfoTooltip text="Tokens wasted today on retried tool calls and anti-pattern activity (stuck loops, redundant reads, thrashing)." />
+      </div>
+      <div className={`text-lg font-semibold tabular-nums ${statusColor}`}>
+        ~{data.total_tokens_wasted.toLocaleString()} wasted tokens
+      </div>
+      <Pill
+        tone={
+          data.status === 'clean' ? 'success' : data.status === 'moderate' ? 'warning' : 'danger'
+        }
+        size="sm"
+        className="mt-1"
+      >
+        {statusLabel}
+      </Pill>
+      <div className="text-xs text-ink-muted mt-1">
+        retry: ~{data.retry_tokens_wasted.toLocaleString()} · anti-pattern: ~
+        {data.anti_pattern_tokens_wasted.toLocaleString()}
+      </div>
+      {topOffender !== null && (
+        <div className="text-[10px] font-medium text-accent-amber mb-1">
+          {topOffender.type.replace(/_/g, ' ')} · ~{topOffender.tokens_wasted.toLocaleString()}{' '}
+          tokens
+        </div>
+      )}
+      <div className="text-[10px] text-ink-subtle/70 leading-snug">
+        {computeWasteRecommendationText(data.status, topOffender?.type ?? null)}
+      </div>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

- `AntiPatternDetector` now annotates every detected anti-pattern (thrashing, re-reading, stuck loops, blind editing, over-delegation) with an estimated `tokensWasted`, combined with `RetryDetector`'s existing waste tracking into one total.
- New "Compute Waste" panel in the Today dashboard grid (sized to match its neighbors, sitting next to Cache Health): headline token count, status pill, per-source breakdown, top offender, and a recommendation.
- New `GET /api/compute-waste` dashboard route returning `{ total_tokens_wasted, retry_tokens_wasted, anti_pattern_tokens_wasted, breakdown, status }` (clean / moderate / needs_attention).
- New `nr_observe_get_compute_waste` MCP tool exposing the same shape.

Closes #31

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 5356 passed
- [x] `npx vitest run src/web/views/Today.test.tsx` — 47 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)