### PR TITLE
Fix: day-boundary handling, sort-order, attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.36] - 2026-08-09
+
+### Fixed
+
+- **The Today and History dashboards now handle local-day boundaries consistently.** Day-window math across the concurrency, activity-heatmap, and cost/tool-call/anti-pattern-flag routes now uses local (not UTC) midnight everywhere, is DST-safe, and is anchored the same way as the sibling charts it's meant to agree with — previously a developer's evening session could land on the wrong calendar day, and a "last N days" window could quietly disagree with an adjacent chart labeled the same way.
+- **A session that spans local midnight now contributes its correct proportional share to today's tool-call count, flag count, and hourly spend**, instead of either being skipped entirely or counted at its full lifetime total.
+- **Several timeline/history arrays (session activity, audit log, git commit/conflict history) are now sorted by timestamp before being sliced or windowed**, fixing cases where an out-of-order array could show a negative duration or silently drop the true most-recent entries.
+- **Session-, repo-, and process-scoped data is now attributed to the right owner** — a live in-progress session's real model is no longer bucketed as "unknown," a different repo's git activity earlier in the day no longer counts against the currently active repo, and per-session decision-tree/turn-cost data no longer blends across concurrently-live sessions.
+- **`GET /api/audit` and the underlying audit-log reader now cap how much history is read from disk per request**, bounding both the response size and the amount of work a single request can trigger.
+
 ## [1.14.35] - 2026-08-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.35",
+  "version": "1.14.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.35",
+      "version": "1.14.36",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.35",
+  "version": "1.14.36",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../../metrics/tool-selection-scorer.js';
 import { ModelUsageTracker } from '../../metrics/model-usage-tracker.js';
 import { QualityProxyTracker } from '../../metrics/quality-proxy-tracker.js';
-import { localStartOfDay } from '../../lib/date.js';
+import { localStartOfDay, localDateKey } from '../../lib/date.js';
 
 import type { ToolCallRecord } from '../../storage/types.js';
 
@@ -266,6 +266,81 @@ describe('api-handler GET /api/sessions', () => {
     expect(status()).toBe(200);
     expect(loadAllSessionsSpy).toHaveBeenCalled();
     expect(listSessionsSpy).not.toHaveBeenCalled();
+  });
+
+  // The live-session stub appended for the current process's own
+  // in-progress session (not yet persisted to disk) must carry its real
+  // model, sourced from costTracker.getMetrics().model, so
+  // aggregateModelPerformance (History.tsx) doesn't bucket it under
+  // "unknown" while the session is still running.
+  it('carries the real model on the live-session stub', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadAllSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({
+          sessionId: 'live-session-with-model',
+          sessionName: null,
+          sessionStartTime: 1000,
+          sessionDurationMs: 500,
+          toolCallCount: 3,
+          toolCallCountByTool: { Read: 3 },
+          uniqueFilesRead: 1,
+          uniqueFilesWritten: 0,
+          toolCallTimeline: [],
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+      costTracker: {
+        getMetrics: () => ({
+          sessionTotalCostUsd: 0.42,
+          model: 'claude-sonnet-4-20250514',
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['costTracker'],
+    });
+    const req = { method: 'GET', url: '/api/sessions' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body()) as Array<{ sessionId: string; model: string | null }>;
+    const live = result.find((s) => s.sessionId === 'live-session-with-model');
+    expect(live).toBeDefined();
+    expect(live?.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('defaults model to null on the live-session stub when costTracker has none', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadAllSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({
+          sessionId: 'live-session-no-model',
+          sessionName: null,
+          sessionStartTime: 1000,
+          sessionDurationMs: 500,
+          toolCallCount: 3,
+          toolCallCountByTool: { Read: 3 },
+          uniqueFilesRead: 1,
+          uniqueFilesWritten: 0,
+          toolCallTimeline: [],
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+    });
+    const req = { method: 'GET', url: '/api/sessions' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body()) as Array<{ sessionId: string; model: string | null }>;
+    const live = result.find((s) => s.sessionId === 'live-session-no-model');
+    expect(live).toBeDefined();
+    expect(live?.model ?? null).toBeNull();
   });
 });
 
@@ -562,6 +637,70 @@ describe('api-handler GET /api/sessions/:id', () => {
     };
     expect(parsed.qualityProxy).toBeUndefined();
     expect(parsed.toolSelectionScore?.repeatedFailureCount).toBe(1);
+  });
+
+  // session.timeline is append-only in processing order, not timestamp
+  // order — parallel tool calls can complete (and be pushed) in a different
+  // order than they started. SessionActivityStrip reads timeline[0]/[-1] as
+  // start/end assuming ascending order, so an unsorted response can produce
+  // a negative durationMs and collapse the activity-density bucket count.
+  it('sorts an out-of-order persisted session.timeline chronologically before returning it', async () => {
+    const outOfOrderTimeline = [
+      { timestamp: 300, toolName: 'Read', durationMs: 10, success: true },
+      { timestamp: 100, toolName: 'Edit', durationMs: 20, success: true },
+      { timestamp: 200, toolName: 'Bash', durationMs: 30, success: true },
+    ];
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: (id: string) =>
+          id === 'sess-detail' ? { sessionId: 'sess-detail', timeline: outOfOrderTimeline } : null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-detail' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { timeline: Array<{ timestamp: number }> };
+    // Unsorted, this would equal [300, 100, 200] — the raw push order — so
+    // timeline[0].timestamp (300) would be greater than timeline[-1].timestamp
+    // (200), a negative apparent duration.
+    expect(parsed.timeline.map((e) => e.timestamp)).toEqual([100, 200, 300]);
+  });
+
+  it('sorts an out-of-order own-live-session toolCallTimeline chronologically before returning it', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({
+          sessionId: 'live-timeline',
+          sessionName: null,
+          sessionStartTime: 100,
+          sessionDurationMs: 200,
+          toolCallCount: 3,
+          toolCallCountByTool: { Read: 3 },
+          uniqueFilesRead: 1,
+          uniqueFilesWritten: 0,
+          // A later-started, earlier-finishing parallel call landed first.
+          toolCallTimeline: [
+            { timestamp: 300, toolName: 'Read', durationMs: 10, success: true },
+            { timestamp: 100, toolName: 'Edit', durationMs: 20, success: true },
+            { timestamp: 200, toolName: 'Bash', durationMs: 30, success: true },
+          ],
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/live-timeline' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { timeline: Array<{ timestamp: number }> };
+    expect(parsed.timeline.map((e) => e.timestamp)).toEqual([100, 200, 300]);
   });
 });
 
@@ -1189,6 +1328,55 @@ describe('api-handler GET /api/audit', () => {
     expect(parsed[0]).not.toHaveProperty('developer');
     expect(parsed[0]).not.toHaveProperty('action');
   });
+
+  // Regression: the route must bound how many rows it asks getAuditLog()
+  // for, rather than always calling it with no argument (which used to mean
+  // "return everything").
+  it('calls getAuditLog() with a bounded default limit when the query has none', async () => {
+    const getAuditLog = jest.fn((_limit?: number): unknown[] => []);
+    const handler = createApiHandler({
+      auditTrailManager: { getAuditLog } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['auditTrailManager'],
+    });
+    const req = { method: 'GET', url: '/api/audit' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(getAuditLog).toHaveBeenCalledTimes(1);
+    const calledLimit = getAuditLog.mock.calls[0]?.[0] as number | undefined;
+    expect(typeof calledLimit).toBe('number');
+    expect(calledLimit as number).toBeGreaterThan(0);
+  });
+
+  it('clamps an oversized ?limit= query param instead of passing it straight through', async () => {
+    const getAuditLog = jest.fn((_limit?: number): unknown[] => []);
+    const handler = createApiHandler({
+      auditTrailManager: { getAuditLog } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['auditTrailManager'],
+    });
+    const req = { method: 'GET', url: '/api/audit?limit=999999999' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const calledLimit = getAuditLog.mock.calls[0]?.[0] as number | undefined;
+    expect(calledLimit as number).toBeLessThan(999999999);
+  });
+
+  it('honors a reasonable explicit ?limit= query param', async () => {
+    const getAuditLog = jest.fn((_limit?: number): unknown[] => []);
+    const handler = createApiHandler({
+      auditTrailManager: { getAuditLog } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['auditTrailManager'],
+    });
+    const req = { method: 'GET', url: '/api/audit?limit=50' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(getAuditLog).toHaveBeenCalledWith(50);
+  });
 });
 
 describe('api-handler GET /api/weekly', () => {
@@ -1422,6 +1610,53 @@ describe('api-handler GET /api/cost-per-outcome', () => {
     const { res, status } = fakeRes();
     await handler(req, res);
     expect(status()).toBe(503);
+  });
+
+  it("excludes a session whose real startTime falls outside the local N-day window, even when loadAllSessions' own (looser) pre-filter returns it", async () => {
+    const days = 7;
+    // Matches the route's own local-day-aligned window computation, so this
+    // test exercises the real boundary rather than an arbitrary offset.
+    const windowStartMs = localStartOfDay() - (days - 1) * 86_400_000;
+    const outsideSession = {
+      startTime: windowStartMs - 60_000, // just before the local window starts
+      testRunCount: 0,
+      testPassCount: 0,
+      filesModified: [],
+      toolBreakdown: {},
+      toolCallCount: 1,
+      estimatedCostUsd: 5,
+    };
+    const insideSession = {
+      startTime: windowStartMs + 60_000, // just after the local window starts
+      testRunCount: 0,
+      testPassCount: 0,
+      filesModified: [],
+      toolBreakdown: {},
+      toolCallCount: 1,
+      estimatedCostUsd: 1,
+    };
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+        // Simulates loadAllSessions()'s own UTC-anchored filename-date
+        // pre-filter (session-store.ts) being looser than the local window
+        // and returning both sessions regardless.
+        loadAllSessions: () => [outsideSession, insideSession],
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: `/api/cost-per-outcome?days=${days}` } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body());
+    // Only the in-window session counts — without an explicit startTime
+    // check, a raw rolling `since` instant would pass straight through, so a
+    // session outside the intended local window (but inside the looser
+    // pre-filter) would leak into the total.
+    expect(result.totalTasks).toBe(1);
+    expect(result.totalCost).toBeCloseTo(1);
   });
 });
 
@@ -3235,9 +3470,11 @@ describe('api-handler GET /api/concurrency (96-bucket grid)', () => {
   });
 
   it("view=history leaves today's dailyPeaks bucket alone when the disk-derived peak already meets the live peak", async () => {
-    const nowUtcMidnight = new Date();
-    nowUtcMidnight.setUTCHours(0, 0, 0, 0);
-    const todayOverlapTs = nowUtcMidnight.getTime() + 5 * 60_000;
+    // Local (not UTC) midnight — computeDailyPeakConcurrency buckets by the
+    // dashboard server's local day, so the overlap timestamp used
+    // here to land in "today"'s bucket must be anchored the same way.
+    const todayStart = localStartOfDay();
+    const todayOverlapTs = todayStart + 5 * 60_000;
     const allSessions = [
       { sessionId: 'd-1', timeline: [{ timestamp: todayOverlapTs }] },
       { sessionId: 'd-2', timeline: [{ timestamp: todayOverlapTs }] },
@@ -3259,6 +3496,91 @@ describe('api-handler GET /api/concurrency (96-bucket grid)', () => {
     const result = JSON.parse(body());
     expect(result.dailyPeaks).toHaveLength(3);
     expect(result.dailyPeaks[2].peak).toBe(2);
+  });
+
+  it("view=history keys each day's dailyPeaks entry by local date, not UTC", async () => {
+    const handler = createApiHandler({
+      concurrencyTracker: makeConcurrencyTracker(),
+      liveSessionRegistry: makeLiveRegistry(),
+      sessionStore: {
+        loadTodaySessions: () => [],
+        loadAllSessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/concurrency?view=history&days=3' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body());
+    // Last of 3 buckets is today's — its date key must be today's *local*
+    // day key, not `dayStart.toISOString().slice(0, 10)` with dayStart
+    // advanced via setUTCDate/setUTCHours, which disagrees with
+    // localDateKey() for any developer not in UTC.
+    expect(result.dailyPeaks[2].date).toBe(localDateKey());
+  });
+
+  it('keys dailyPeaks correctly across a DST transition, where a local day is 23h (not 86_400_000ms)', async () => {
+    const originalTz = process.env.TZ;
+    process.env.TZ = 'America/New_York';
+    jest.useFakeTimers();
+    try {
+      // 2026-03-08 is a "spring forward" DST transition day in
+      // America/New_York — local midnight to local midnight is only 23 real
+      // hours (82_800_000ms), not 86_400_000ms.
+      const mar8Start = new Date(2026, 2, 8, 0, 0, 0).getTime();
+      const mar9Start = mar8Start + 23 * 60 * 60_000;
+      // "Today" = March 9 mid-afternoon, so days=3 covers Mar 7, 8, 9.
+      jest.setSystemTime(new Date(mar9Start + 15 * 60 * 60_000));
+
+      // Two overlapping sessions active 30 minutes into March 9 local time —
+      // after the *correct* boundary (mar9Start) but still before the
+      // *buggy* one (mar8Start + 86_400_000 = mar9Start + 1h).
+      const overlapTs = mar9Start + 30 * 60_000;
+      const sessions = [
+        { sessionId: 's1', timeline: [{ timestamp: overlapTs }] },
+        { sessionId: 's2', timeline: [{ timestamp: overlapTs }] },
+      ];
+
+      const handler = createApiHandler({
+        concurrencyTracker: makeConcurrencyTracker(),
+        liveSessionRegistry: makeLiveRegistry(),
+        sessionStore: {
+          loadTodaySessions: () => [],
+          loadAllSessions: () => sessions,
+          listSessions: () => [],
+          loadSession: () => null,
+        } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      });
+      const req = {
+        method: 'GET',
+        url: '/api/concurrency?view=history&days=3',
+      } as IncomingMessage;
+      const { res, status, body } = fakeRes();
+      await handler(req, res);
+      expect(status()).toBe(200);
+      const result = JSON.parse(body());
+      // 3-day window [Mar7, Mar8, Mar9] → indices [0, 1, 2].
+      expect(result.dailyPeaks[1].date).toBe('2026-03-08');
+      expect(result.dailyPeaks[2].date).toBe('2026-03-09');
+      // A naive `dayEndMs = mar8Start + 86_400_000` (March 9 01:00 local —
+      // an hour past the true DST-shortened boundary) would wrongly
+      // attribute this overlap to March 8 instead of 9.
+      expect(result.dailyPeaks[1].peak).toBe(0);
+      expect(result.dailyPeaks[2].peak).toBe(2);
+    } finally {
+      jest.useRealTimers();
+      // `process.env.TZ = undefined` coerces to the literal string
+      // "undefined" (env vars are always strings), which then makes
+      // `Intl.DateTimeFormat().resolvedOptions().timeZone` resolve to
+      // "undefined" and silently breaks local-time computation for every
+      // later test in this Jest worker (maxWorkers: 1) — including this
+      // file's own local-vs-UTC tests. Delete the key outright when TZ was
+      // never set, rather than assigning `undefined` to it.
+      if (originalTz === undefined) delete process.env.TZ;
+      else process.env.TZ = originalTz;
+    }
   });
 
   it('counts a session seen only via peekAllBuffers in the current field', async () => {
@@ -4200,6 +4522,54 @@ describe('api-handler GET /api/quality-proxy', () => {
     expect(parsed.totalSignals).toBe(1);
     expect(parsed.diffApplyRate).toBe(1);
   });
+
+  it("day-filters this process's own live signals to today, excluding a stale signal recorded on a prior day", async () => {
+    jest.useFakeTimers();
+    try {
+      const tracker = new QualityProxyTracker();
+      const record = (overrides: Partial<ToolCallRecord>): ToolCallRecord => ({
+        id: `id-${Math.random()}`,
+        sessionId: 'live1',
+        toolName: 'Edit',
+        toolUseId: `tu-${Math.random()}`,
+        timestamp: Date.now(),
+        durationMs: 1,
+        success: true,
+        ...overrides,
+      });
+
+      // Yesterday: a failed diff. QualityEvent.timestamp is stamped from
+      // Date.now() at record time (not from the ToolCallRecord itself), so
+      // this must be recorded under yesterday's mocked system time to land
+      // outside today's window.
+      jest.setSystemTime(new Date(2026, 5, 14, 23, 0, 0));
+      tracker.recordToolCall(record({ toolName: 'Edit', filePath: '/stale.ts', success: false }));
+
+      // Today: a clean diff — this is the only signal that should count.
+      jest.setSystemTime(new Date(2026, 5, 15, 8, 0, 0));
+      tracker.recordToolCall(record({ toolName: 'Edit', filePath: '/fresh.ts', success: true }));
+
+      const handler = createApiHandler({ qualityProxyTracker: tracker });
+      const req = { method: 'GET', url: '/api/quality-proxy' } as IncomingMessage;
+      const { res, status, body } = fakeRes();
+      await handler(req, res);
+      expect(status()).toBe(200);
+      const parsed = JSON.parse(body());
+      // Only today's signal counts toward the top-level totals/rates —
+      // yesterday's failed diff must not drag diffApplyRate down. Before the
+      // fix, GET /api/quality-proxy used tracker.getRawCounts() unfiltered,
+      // which would have included both signals (totalSignals: 2,
+      // diffApplyRate: 0.5).
+      expect(parsed.totalSignals).toBe(1);
+      expect(parsed.diffApplyRate).toBe(1);
+      // events/qualityByTurnBucket still reflect the tracker's whole
+      // lifetime — inherently within-session signals with no persisted
+      // cross-session equivalent, unaffected by the day filter above.
+      expect(parsed.events).toHaveLength(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });
 
 describe('api-handler GET /api/tool-selection-score', () => {
@@ -4470,14 +4840,14 @@ describe('api-handler GET /api/tool-selection-score', () => {
   });
 
   it('does not double-count this own live session when its own in-progress checkpoint is also persisted today', async () => {
-    // Regression test for the bug where index.ts's periodic 30s checkpoint
-    // writes THIS process's own in-progress session to disk (outcome:
-    // 'in progress') with a toolSelectionMetrics summary computed from the
-    // exact same in-memory tool calls toolCallBuffer.getRecords() also
-    // exposes. loadTodaySessions() returns that checkpoint with no
-    // exclusion, so before the fix the route summed the own session's
-    // contribution twice: once via ownRecords -> liveMetrics, and again via
-    // its own persisted checkpoint inside persistedSummaries.
+    // index.ts's periodic 30s checkpoint writes THIS process's own
+    // in-progress session to disk (outcome: 'in progress') with a
+    // toolSelectionMetrics summary computed from the exact same in-memory
+    // tool calls toolCallBuffer.getRecords() also exposes.
+    // loadTodaySessions() returns that checkpoint with no exclusion, so
+    // without a guard the route would sum the own session's contribution
+    // twice: once via ownRecords -> liveMetrics, and again via its own
+    // persisted checkpoint inside persistedSummaries.
     const now = Date.now();
     const ownSessionId = 'sess-own';
     // 3 reads of the same file: the 3rd is the first past the "one re-read
@@ -4886,6 +5256,29 @@ describe('api-handler GET /api/git-efficiency/repos', () => {
     expect(result.repos).toEqual(['alpha-repo', 'current-repo']);
     expect(result.currentRepo).toBe('current-repo');
   });
+
+  it("prefers loadSessionsOverlappingToday() so a cross-midnight session's repo is not dropped from the pills", async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        // Excluded here — its filename date is yesterday's.
+        loadTodaySessions: () => [],
+        // loadSessionsOverlappingToday() must supply it instead, matching
+        // the day-boundary hydration path in src/index.ts.
+        loadSessionsOverlappingToday: () => [
+          { sessionId: 'cross-midnight', repoName: 'cross-midnight-repo' },
+        ],
+        loadAllSessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/git-efficiency/repos' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body());
+    expect(result.repos).toEqual(['cross-midnight-repo']);
+  });
 });
 
 describe('api-handler GET /api/context', () => {
@@ -5248,14 +5641,25 @@ describe('api-handler GET /api/activity-heatmap', () => {
     expect(result.buckets[0]).toBe(1);
   });
 
-  it('returns view=history days aggregated by UTC date, respecting the weeks param', async () => {
-    const nowUtcMidnight = new Date();
-    nowUtcMidnight.setUTCHours(0, 0, 0, 0);
-    const todayKey = nowUtcMidnight.toISOString().slice(0, 10);
+  it('returns view=history days aggregated by local date, walking each timeline entry rather than attributing the whole toolCallCount to the start day', async () => {
+    const todayStart = localStartOfDay();
+    const todayKey = localDateKey(todayStart);
     const handler = createApiHandler({
       sessionStore: {
         loadTodaySessions: () => [],
-        loadAllSessions: () => [{ startTime: nowUtcMidnight.getTime() + 60_000, toolCallCount: 7 }],
+        loadAllSessions: () => [
+          {
+            startTime: todayStart + 60_000,
+            // Must be IGNORED — only the timeline entries below should be
+            // counted (mirroring the already-correct view=today branch).
+            toolCallCount: 999,
+            timeline: [
+              { timestamp: todayStart + 60_000 },
+              { timestamp: todayStart + 120_000 },
+              { timestamp: todayStart + 180_000 },
+            ],
+          },
+        ],
         listSessions: () => [],
         loadSession: () => null,
       } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
@@ -5271,8 +5675,85 @@ describe('api-handler GET /api/activity-heatmap', () => {
     expect(Array.isArray(result.days)).toBe(true);
     const todayEntry = result.days.find((d: { date: string }) => d.date === todayKey);
     expect(todayEntry).toBeDefined();
-    expect(todayEntry.count).toBe(7);
-    expect(result.maxCount).toBeGreaterThanOrEqual(7);
+    expect(todayEntry.count).toBe(3);
+    expect(result.maxCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it("attributes a cross-midnight session's timeline entries to the local day each one actually happened on, not the session's start day", async () => {
+    const todayStart = localStartOfDay();
+    const todayKey = localDateKey(todayStart);
+    const yesterdayEntryTs = todayStart - 1_800_000; // 30 min before local midnight
+    const yesterdayKey = localDateKey(yesterdayEntryTs);
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        loadAllSessions: () => [
+          {
+            // Started yesterday evening...
+            startTime: todayStart - 3_600_000,
+            // ...and the OLD code would have dumped this whole count onto
+            // yesterday's bucket (the start day) and left today's at 0.
+            toolCallCount: 10,
+            timeline: [
+              { timestamp: yesterdayEntryTs },
+              { timestamp: todayStart + 600_000 },
+              { timestamp: todayStart + 1_200_000 },
+            ],
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = {
+      method: 'GET',
+      url: '/api/activity-heatmap?view=history&weeks=2',
+    } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body());
+    const todayEntry = result.days.find((d: { date: string }) => d.date === todayKey);
+    const yesterdayEntry = result.days.find((d: { date: string }) => d.date === yesterdayKey);
+    expect(todayEntry?.count).toBe(2);
+    expect(yesterdayEntry?.count).toBe(1);
+  });
+
+  it('falls back to attributing toolCallCount to the start day for a session with no timeline field, instead of contributing zero', async () => {
+    const todayStart = localStartOfDay();
+    const todayKey = localDateKey(todayStart);
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        loadAllSessions: () => [
+          {
+            // `timeline` was only added to persisted sessions ~2026-06-02
+            // (session-store.ts) — this route's default 12-week window
+            // still reaches sessions saved before that field existed. Such
+            // a session has no `timeline` property at all (not an empty
+            // array).
+            startTime: todayStart + 60_000,
+            toolCallCount: 5,
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = {
+      method: 'GET',
+      url: '/api/activity-heatmap?view=history&weeks=1',
+    } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body());
+    const todayEntry = result.days.find((d: { date: string }) => d.date === todayKey);
+    // A bare `if (!session.timeline) continue;` would skip this session
+    // entirely, silently zeroing out all history predating the timeline
+    // field instead of falling back to the old (still non-zero)
+    // toolCallCount/start-day attribution.
+    expect(todayEntry?.count).toBe(5);
   });
 
   it('returns 400 invalid_view for an unrecognized view param', async () => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -43,6 +43,7 @@ import type { PersonalInsightsResult } from '../../metrics/personal-coach.js';
 import type { Recommendation } from '../../metrics/recommendation-engine.js';
 import type { GitEfficiencyMetrics } from '../../metrics/git-efficiency-tracker.js';
 import type {
+  QualityEvent,
   QualityProxyMetrics,
   QualityProxyRawCounts,
 } from '../../metrics/quality-proxy-tracker.js';
@@ -130,6 +131,8 @@ interface WorkflowRunDto {
   readonly agentCount: number;
   readonly totalTokens: number;
   readonly totalUsd: number | null;
+  /** Partial mitigation — see `WorkflowRunRow.cost_unknown`'s docstring. */
+  readonly costUnknown: boolean;
   readonly declaredPhases: number | null;
   readonly observedPhases: number;
   readonly declaredParallelWidths: ReadonlyArray<number | 'dynamic'>;
@@ -173,6 +176,7 @@ function toWorkflowRunDto(row: unknown): WorkflowRunDto {
     agentCount: r.agent_count,
     totalTokens: r.total_tokens,
     totalUsd: r.total_usd ?? null,
+    costUnknown: r.cost_unknown ?? false,
     declaredPhases: r.declared_phases ?? null,
     observedPhases: r.observed_phases,
     declaredParallelWidths: r.declared_parallel_widths ?? [],
@@ -226,6 +230,11 @@ function toLiveWorkflowDetail(live: LiveWorkflowRunDetail): {
     agentCount: live.agentCount,
     totalTokens: live.totalTokens,
     totalUsd: live.totalUsd,
+    // A still-running workflow's cost comes straight from this process's own
+    // live SubagentWatcher state, not a cross-process/restart-vulnerable
+    // on-disk rollup — so it's never ambiguous the way a completed run's
+    // WorkflowStore-read cost can be.
+    costUnknown: false,
     declaredPhases: live.topology?.declaredPhases ?? null,
     // No phase-title telemetry exists mid-run (that comes from the rollup's
     // workflowProgress), so observed phases are unknown → 0.
@@ -388,9 +397,9 @@ export interface ApiHandlerDeps {
   };
   readonly retryDetector?: { getMetrics: () => RetryDetectorMetrics };
   readonly instructionDriftTracker?: { getMetrics: () => InstructionDriftMetrics };
-  readonly decisionTracker?: { getMetrics: () => DecisionTreeMetrics };
-  readonly turnCostAttributor?: { getMetrics: () => CostAttributionMetrics };
-  readonly auditTrailManager?: { getAuditLog: () => readonly AuditRecord[] };
+  readonly decisionTracker?: { getMetrics: (sessionId?: string) => DecisionTreeMetrics };
+  readonly turnCostAttributor?: { getMetrics: (sessionId?: string) => CostAttributionMetrics };
+  readonly auditTrailManager?: { getAuditLog: (limit?: number) => readonly AuditRecord[] };
   readonly weeklySummaryGenerator?: WeeklySummaryGenerator;
   readonly budgetTracker?: { getStatus: () => BudgetStatus };
   readonly latencyTracker?: { getMetrics: () => LatencyMetrics };
@@ -769,23 +778,50 @@ function computeTodayPeakConcurrency(sessions: readonly SessionActivityLike[]): 
   return peak;
 }
 
+// Mirrors QualityProxyTracker's own getRawCounts()/countBySignal() math, but
+// over a caller-filtered event slice — needed so GET /api/quality-proxy can
+// day-filter this process's own live contribution (see the startMs pattern
+// in GET /api/tool-selection-score) without adding a day-bucketed accessor
+// to the tracker itself.
+function rawQualityCountsFromEvents(events: readonly QualityEvent[]): QualityProxyRawCounts {
+  const count = (signal: QualityEvent['signal']): number =>
+    events.filter((e) => e.signal === signal).length;
+  return {
+    totalSignals: events.length,
+    diffApplyCleanCount: count('diff_applied_clean'),
+    diffFailCount: count('diff_failed'),
+    testPassCount: count('test_pass'),
+    testFailCount: count('test_fail'),
+    backtrackCount: count('backtrack'),
+    selfCorrectionCount: count('self_correction'),
+  };
+}
+
 function computeDailyPeakConcurrency(
   sessions: readonly SessionActivityLike[],
   days: number,
 ): Array<{ date: string; peak: number }> {
-  const now = new Date();
+  // Local (not UTC) day boundaries — see localStartOfDay's doc comment. A
+  // developer's evening session commonly straddles UTC midnight, which would
+  // otherwise land that activity on the wrong calendar day for anyone not in
+  // UTC, and disagree with this same file's local-day `aggregateDailyCost`
+  // equivalent on the client (History.tsx).
+  const todayStart = localStartOfDay();
   const result: Array<{ date: string; peak: number }> = [];
 
   for (let d = days - 1; d >= 0; d--) {
-    const dayStart = new Date(now);
-    dayStart.setUTCDate(dayStart.getUTCDate() - d);
-    dayStart.setUTCHours(0, 0, 0, 0);
-    const dayEnd = new Date(dayStart);
-    dayEnd.setUTCDate(dayEnd.getUTCDate() + 1);
-
+    const dayStart = new Date(todayStart);
+    dayStart.setDate(dayStart.getDate() - d);
     const dayStartMs = dayStart.getTime();
+    // `dayEnd` must be derived via the same local-date arithmetic as
+    // `dayStart`, not `dayStartMs + 86_400_000` — a local calendar day is
+    // 23h or 25h long on the ~2 DST-transition days/year, so the fixed-ms
+    // offset lands an hour into (or short of) the next/previous local day,
+    // misattributing entries near the boundary on those days.
+    const dayEnd = new Date(dayStart);
+    dayEnd.setDate(dayEnd.getDate() + 1);
     const dayEndMs = dayEnd.getTime();
-    const dateKey = dayStart.toISOString().slice(0, 10);
+    const dateKey = localDateKey(dayStartMs);
 
     // Find sessions that overlap with this day and have timeline data
     const events: Array<{ ts: number; delta: number }> = [];
@@ -1046,6 +1082,12 @@ export function createApiHandler(
           durationMs: live.sessionDurationMs,
           toolCallCount: live.toolCallCount,
           estimatedCostUsd: deps.costTracker?.getMetrics().sessionTotalCostUsd ?? null,
+          // costTracker.getMetrics() also exposes the model this live
+          // session is actually using; without it, aggregateModelPerformance
+          // (History.tsx) buckets this session's real-time cost/count under
+          // "unknown" until the session is persisted and rebuilt with a
+          // real `model` field.
+          model: deps.costTracker?.getMetrics().model ?? null,
         } as SessionIdentityLike);
       }
     }
@@ -1650,14 +1692,23 @@ export function createApiHandler(
     jsonOk(res, deps.instructionDriftTracker.getMetrics());
   });
 
-  routes.set('GET /api/decision-tree', (_req, res) => {
+  routes.set('GET /api/decision-tree', (req, res) => {
     if (!deps.decisionTracker) return unavailable(res, 'decisionTracker');
-    jsonOk(res, deps.decisionTracker.getMetrics());
+    // Optional ?sessionId= scopes the result to one session — without
+    // it, this process-global tracker's data can belong to a different
+    // session than the one selected in the dashboard's trace pane (in
+    // `--local` mode, several concurrently-live sessions blended together).
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const sessionId = url.searchParams.get('sessionId') ?? undefined;
+    jsonOk(res, deps.decisionTracker.getMetrics(sessionId));
   });
 
-  routes.set('GET /api/turn-costs', (_req, res) => {
+  routes.set('GET /api/turn-costs', (req, res) => {
     if (!deps.turnCostAttributor) return unavailable(res, 'turnCostAttributor');
-    jsonOk(res, deps.turnCostAttributor.getMetrics());
+    // Same reasoning as /api/decision-tree above.
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const sessionId = url.searchParams.get('sessionId') ?? undefined;
+    jsonOk(res, deps.turnCostAttributor.getMetrics(sessionId));
   });
 
   routes.set('GET /api/compute-waste', (_req, res) => {
@@ -1700,9 +1751,20 @@ export function createApiHandler(
     });
   });
 
-  routes.set('GET /api/audit', (_req, res) => {
+  routes.set('GET /api/audit', (req, res) => {
     if (!deps.auditTrailManager) return unavailable(res, 'auditTrailManager');
-    const log = deps.auditTrailManager.getAuditLog();
+    // Cap here too (not just via getAuditLog()'s own default) so a caller
+    // can't force an unbounded read by passing an absurdly large `limit` —
+    // the audit log is unpruned on disk, so a naive pass-through would let
+    // a single request re-read the entire history.
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const limitStr = url.searchParams.get('limit') ?? '';
+    let limit = 1000;
+    const parsedLimit = parseInt(limitStr, 10);
+    if (!Number.isNaN(parsedLimit)) {
+      limit = Math.min(Math.max(parsedLimit, 1), 2000);
+    }
+    const log = deps.auditTrailManager.getAuditLog(limit);
     jsonOk(res, log.map(toAuditEntry));
   });
 
@@ -1801,8 +1863,21 @@ export function createApiHandler(
     if (!Number.isNaN(parsedDays)) {
       days = Math.min(Math.max(parsedDays, 1), 365);
     }
-    const since = new Date(Date.now() - days * 86_400_000);
-    const sessions = deps.sessionStore.loadAllSessions({ since });
+    // Anchor the window to local midnight `days` ago — matching
+    // aggregateDailyCost's local-day grouping for the sibling "Daily Spend"
+    // chart (History.tsx) — instead of a raw rolling instant, which doesn't
+    // align with any calendar boundary and would draw a different
+    // "last N days" line than that chart. loadAllSessions()'s own
+    // pre-filter still compares against session-store.ts's UTC-derived
+    // filename date, so `since` is widened by one extra day to guarantee it
+    // never excludes a session that actually falls inside the local window;
+    // the startTime check below applies the real, local-day-aligned cutoff.
+    const windowStartMs = localStartOfDay() - (days - 1) * 86_400_000;
+    const since = new Date(windowStartMs - 86_400_000);
+    const sessions = deps.sessionStore.loadAllSessions({ since }).filter((s) => {
+      const startTime = (s as { startTime?: number }).startTime;
+      return startTime === undefined || startTime >= windowStartMs;
+    });
     jsonOk(res, attributeSessionCosts(sessions));
   });
 
@@ -1915,13 +1990,21 @@ export function createApiHandler(
     // live tracker only.
     const live = deps.qualityProxyTracker.getMetrics();
     const ownSessionId = deps.sessionTracker?.getMetrics().sessionId;
+    // Day-filter this process's own live contribution the same way GET
+    // /api/tool-selection-score does just below — QualityProxyTracker has no
+    // concept of "day" internally (events accumulate for the tracker's whole
+    // process lifetime), so a --local dashboard daemon running since before
+    // midnight would otherwise blend yesterday's (or older) signals into
+    // "today's sessions" here, inconsistent with the correctly-scoped Tool
+    // Selection panel right next to it.
+    const startMs = localStartOfDay(Date.now());
+    const liveRawCounts = rawQualityCountsFromEvents(
+      live.events.filter((e) => e.timestamp >= startMs),
+    );
     const persistedCounts = (deps.sessionStore?.loadTodaySessions() ?? [])
       .filter((s) => s.sessionId !== ownSessionId)
       .map((s) => s.qualityProxy ?? ZERO_QUALITY_PROXY_COUNTS);
-    const combined = combineQualityProxyRawCounts([
-      deps.qualityProxyTracker.getRawCounts(),
-      ...persistedCounts,
-    ]);
+    const combined = combineQualityProxyRawCounts([liveRawCounts, ...persistedCounts]);
     jsonOk(res, {
       ...combined,
       qualityByTurnBucket: live.qualityByTurnBucket,
@@ -2078,15 +2161,15 @@ export function createApiHandler(
       // Derive the headline "today peak" from the SAME buckets shown in the
       // chart — rather than from an independent computation over a
       // differently-scoped session set — so the two numbers can never
-      // disagree by construction. (This was the root cause of the bug this
-      // fix addresses: the headline and the chart used to be computed from
-      // two different concurrency models that could silently drift apart.)
+      // disagree by construction. Computing them from two different
+      // concurrency models is exactly how the headline and chart can
+      // silently drift apart.
       //
       // Deliberately NOT folded with `livePeak` here (unlike allTimePeak
       // below): `livePeak` is a synthetic-id-unfiltered, never-reset
       // lifetime max from LiveSessionRegistry, so mixing it into today's
-      // headline can reintroduce a chart/headline disagreement — the exact
-      // class of bug this fix exists to eliminate. It's unnecessary anyway:
+      // headline can reintroduce that same chart/headline disagreement.
+      // It's unnecessary anyway:
       // `windows` already unions each live session's buffered (not-yet-
       // persisted) activity into the same buckets, so a currently-live
       // session with any tool-call activity is already reflected here.
@@ -2112,6 +2195,15 @@ export function createApiHandler(
       const view = url.searchParams.get('view') ?? 'today';
 
       if (view === 'today') {
+        // localStartOfDay() draws "today" using this dashboard *server*
+        // process's own OS/Intl timezone. The browser calls the same helper
+        // client-side (src/lib/date.ts) for its own "today" filtering, so
+        // this endpoint is only guaranteed to agree with the client when
+        // server and browser share a timezone — the common single-machine
+        // `--local`/`--stdio` deployment. A cloud-hosted or containerized
+        // dashboard viewed from a different timezone can see this bucket
+        // range anchored to the wrong midnight; neither side is ever
+        // told the other's offset today.
         const now = Date.now();
         const startMs = localStartOfDay(now);
         const bucketSizeMs = 900_000;
@@ -2160,28 +2252,57 @@ export function createApiHandler(
       if (view === 'history') {
         const weeksParam = url.searchParams.get('weeks');
         const weeks = weeksParam ? Math.min(Math.max(parseInt(weeksParam, 10) || 12, 1), 52) : 12;
-        const now = new Date();
-        const startDate = new Date(now);
-        startDate.setUTCDate(startDate.getUTCDate() - weeks * 7);
-        startDate.setUTCHours(0, 0, 0, 0);
+        // Local (not UTC) day boundaries — see localStartOfDay's doc comment
+        // and computeDailyPeakConcurrency's identical handling just above. A
+        // developer's evening session commonly straddles UTC midnight, which
+        // would otherwise land that activity on the wrong calendar day for
+        // anyone not in UTC.
+        const todayStart = localStartOfDay();
+        const startDate = new Date(todayStart);
+        startDate.setDate(startDate.getDate() - weeks * 7);
 
         const sessions = deps.sessionStore?.loadAllSessions?.({ since: startDate }) ?? [];
 
         const dayMap = new Map<string, number>();
         const cursor = new Date(startDate);
-        while (cursor <= now) {
-          dayMap.set(cursor.toISOString().slice(0, 10), 0);
-          cursor.setUTCDate(cursor.getUTCDate() + 1);
+        while (cursor.getTime() <= todayStart) {
+          dayMap.set(localDateKey(cursor.getTime()), 0);
+          cursor.setDate(cursor.getDate() + 1);
         }
 
+        // Bucket by each timeline entry's own timestamp, mirroring the
+        // `view=today` branch above — not by attributing a session's entire
+        // toolCallCount to the single day it *started* on. A session whose
+        // activity spans a day boundary would otherwise show a false spike
+        // on the start day and a false gap on the day(s) it actually
+        // continued into.
+        //
+        // `timeline` is optional and was only added to persisted sessions
+        // ~2026-06-02 (session-store.ts) — this route's default 12-week
+        // window still reaches sessions saved before that. A session with no
+        // timeline falls back to the old, still local-day-keyed,
+        // start-day/toolCallCount attribution so that older history doesn't
+        // silently drop to zero; only sessions that *do* have a timeline get
+        // the per-entry walk.
+        const startMs = startDate.getTime();
         for (const s of sessions) {
-          const session = s as { startTime?: string | number; toolCallCount?: number };
-          if (!session.startTime) continue;
-          const d = new Date(
-            typeof session.startTime === 'number' ? session.startTime : session.startTime,
-          );
-          if (d < startDate) continue;
-          const key = d.toISOString().slice(0, 10);
+          const session = s as {
+            startTime?: number;
+            toolCallCount?: number;
+            timeline?: readonly { timestamp: number }[];
+          };
+          if (session.timeline) {
+            for (const entry of session.timeline) {
+              if (entry.timestamp < startMs) continue;
+              const key = localDateKey(entry.timestamp);
+              if (dayMap.has(key)) {
+                dayMap.set(key, (dayMap.get(key) ?? 0) + 1);
+              }
+            }
+            continue;
+          }
+          if (!session.startTime || session.startTime < startMs) continue;
+          const key = localDateKey(session.startTime);
           if (dayMap.has(key)) {
             dayMap.set(key, (dayMap.get(key) ?? 0) + (session.toolCallCount ?? 0));
           }
@@ -2203,7 +2324,14 @@ export function createApiHandler(
 
   routes.set('GET /api/git-efficiency/repos', (_req, res) => {
     if (!deps.sessionStore) return unavailable(res, 'sessionStore');
-    const todaySessions = deps.sessionStore.loadTodaySessions() as Array<{
+    // Prefer loadSessionsOverlappingToday() so a session that started
+    // yesterday and crossed into today isn't invisible from these pills —
+    // loadTodaySessions() filters by filename date (= start date) and would
+    // otherwise silently drop it, even though its git activity still counts
+    // toward the KPIs shown alongside these pills — same reasoning as the
+    // day-boundary hydration in src/index.ts.
+    const todaySessions = (deps.sessionStore.loadSessionsOverlappingToday?.() ??
+      deps.sessionStore.loadTodaySessions()) as Array<{
       repoName?: string | null;
       sessionId: string;
     }>;
@@ -2606,6 +2734,13 @@ export function createApiHandler(
           ]);
           const responseBody: Record<string, unknown> = { ...session };
           if (quality.totalSignals > 0) responseBody.qualityProxy = quality;
+          // `session.timeline` is append-only in processing order, not
+          // timestamp order (parallel tool calls can complete out of
+          // start-order) — sort before returning, mirroring the identical
+          // fix already applied to buildReplayResponse()'s persisted branch.
+          if (Array.isArray(session.timeline)) {
+            responseBody.timeline = [...session.timeline].sort((a, b) => a.timestamp - b.timestamp);
+          }
           jsonOk(res, responseBody);
           return;
         }
@@ -2648,13 +2783,17 @@ export function createApiHandler(
                   : undefined,
               // Use the same `timeline` shape as persisted sessions so the
               // Sessions and Replay views can consume one type. See
-              // src/storage/types.ts ReplayTimelineEntry.
-              timeline: live.toolCallTimeline.map((t) => ({
-                timestamp: t.timestamp,
-                toolName: t.toolName,
-                durationMs: t.durationMs,
-                success: t.success ?? true,
-              })),
+              // src/storage/types.ts ReplayTimelineEntry. `toolCallTimeline`
+              // is append-only in processing order, not timestamp order —
+              // sort before returning, mirroring buildReplayResponse().
+              timeline: live.toolCallTimeline
+                .map((t) => ({
+                  timestamp: t.timestamp,
+                  toolName: t.toolName,
+                  durationMs: t.durationMs,
+                  success: t.success ?? true,
+                }))
+                .sort((a, b) => a.timestamp - b.timestamp),
             });
             return;
           }

--- a/src/dashboard/workflow-store.test.ts
+++ b/src/dashboard/workflow-store.test.ts
@@ -129,6 +129,53 @@ describe('WorkflowStore', () => {
     expect(rows[0].total_usd).toBeCloseTo(4.56, 2);
   });
 
+  // total_usd === null is ambiguous between "confirmed $0" and "this
+  // process never observed the run's cost". cost_unknown resolves that
+  // ambiguity when hasCostForRun is wired.
+  describe('cost_unknown', () => {
+    it('is false when total_usd is a real positive number', () => {
+      writeFileSync(join(wfDir, 'wf_abc12345-6dd.json'), makeWfJson());
+      const store = new WorkflowStore({
+        projectsDir,
+        getCostForRun: () => 4.56,
+        hasCostForRun: () => true,
+      });
+      expect(store.listRuns()[0].cost_unknown).toBe(false);
+    });
+
+    it('is false when hasCostForRun confirms a genuine $0 spend', () => {
+      writeFileSync(join(wfDir, 'wf_abc12345-6dd.json'), makeWfJson());
+      const store = new WorkflowStore({
+        projectsDir,
+        getCostForRun: () => 0,
+        hasCostForRun: () => true,
+      });
+      const row = store.listRuns()[0];
+      expect(row.total_usd).toBeNull();
+      expect(row.cost_unknown).toBe(false);
+    });
+
+    it('is true when hasCostForRun reports the cost was never observed', () => {
+      writeFileSync(join(wfDir, 'wf_abc12345-6dd.json'), makeWfJson());
+      const store = new WorkflowStore({
+        projectsDir,
+        getCostForRun: () => 0,
+        hasCostForRun: () => false,
+      });
+      const row = store.listRuns()[0];
+      expect(row.total_usd).toBeNull();
+      expect(row.cost_unknown).toBe(true);
+    });
+
+    it('defaults to true (conservative) when hasCostForRun is not wired at all', () => {
+      writeFileSync(join(wfDir, 'wf_abc12345-6dd.json'), makeWfJson());
+      const store = new WorkflowStore({ projectsDir }); // no getCostForRun/hasCostForRun
+      const row = store.listRuns()[0];
+      expect(row.total_usd).toBeNull();
+      expect(row.cost_unknown).toBe(true);
+    });
+  });
+
   it('returns null when run not found', () => {
     const store = new WorkflowStore({ projectsDir });
     expect(store.getRun('wf_nonexistent')).toBeNull();

--- a/src/dashboard/workflow-store.ts
+++ b/src/dashboard/workflow-store.ts
@@ -66,6 +66,16 @@ export interface WorkflowRunRow {
   readonly agent_count: number;
   readonly total_tokens: number;
   readonly total_usd: number | null;
+  /**
+   * True when `total_usd` is `null` because this process never personally
+   * observed this run's cost (no `hasCostForRun` callback, or it returned
+   * false), as opposed to a confirmed $0. Lets a KPI summing several runs'
+   * `total_usd` flag its total as partial instead of silently treating
+   * "unknown" the same as "zero". A full fix — persisting per-run cost
+   * somewhere readable across process restarts/instances — is deferred as
+   * a follow-up; this is a partial mitigation in the meantime.
+   */
+  readonly cost_unknown: boolean;
   readonly declared_phases: number | null;
   readonly observed_phases: number;
   readonly declared_parallel_widths: Array<number | 'dynamic'>;
@@ -105,6 +115,15 @@ export interface WorkflowStoreOptions {
   readonly windowHours?: number;
   /** Hook so the dashboard can inflate cost from the live cost tracker. */
   readonly getCostForRun?: (runId: string) => number;
+  /**
+   * Hook so the dashboard can tell "confirmed $0" apart from "this process
+   * never observed this run's cost" (a partial mitigation — see
+   * `CostTracker.hasCostForWorkflowRun`'s docstring). Optional: when
+   * omitted, every row with `total_usd === null` is conservatively treated
+   * as `cost_unknown: true` — the whole point of this hook is resolving an
+   * ambiguity that otherwise can't be told apart at all.
+   */
+  readonly hasCostForRun?: (runId: string) => boolean;
 }
 
 interface CacheEntry {
@@ -116,12 +135,14 @@ export class WorkflowStore {
   private readonly projectsDir: string;
   private readonly windowHours: number;
   private readonly getCostForRun: WorkflowStoreOptions['getCostForRun'];
+  private readonly hasCostForRun: WorkflowStoreOptions['hasCostForRun'];
   private readonly cache = new Map<string, CacheEntry>();
 
   constructor(options: WorkflowStoreOptions = {}) {
     this.projectsDir = options.projectsDir ?? join(homedir(), PROJECTS_DIR_NAME);
     this.windowHours = options.windowHours ?? 24 * 30; // 30 days for dashboard listing
     this.getCostForRun = options.getCostForRun;
+    this.hasCostForRun = options.hasCostForRun;
   }
 
   /**
@@ -353,6 +374,11 @@ export class WorkflowStore {
 
     const usd = this.getCostForRun?.(runId) ?? 0;
     const totalUsd = usd > 0 ? usd : null;
+    // usd resolving to 0 is ambiguous: it means either "confirmed $0" or
+    // "this process never observed the cost at all". hasCostForRun
+    // distinguishes them (a partial mitigation); costUnknown is only ever
+    // true when total_usd is null AND the run's cost was never observed.
+    const costUnknown = totalUsd === null && this.hasCostForRun?.(runId) !== true;
 
     const row: WorkflowRunRow = {
       workflow_run_id: runId,
@@ -368,6 +394,7 @@ export class WorkflowStore {
       agent_count: agentCount,
       total_tokens: totalTokens,
       total_usd: totalUsd,
+      cost_unknown: costUnknown,
       declared_phases: topology?.declaredPhases ?? null,
       observed_phases: observedPhases,
       declared_parallel_widths: topology?.declaredParallelWidths

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ import {
   GitEfficiencyTracker,
   parseDefaultBranchFromSymbolicRef,
 } from './metrics/git-efficiency-tracker.js';
+import type { RepoContext } from './metrics/git-efficiency-tracker.js';
 import { TranscriptMessageTracker } from './metrics/transcript-message-tracker.js';
 import { WorkflowRunTracker } from './metrics/workflow-run-tracker.js';
 import { SubagentWatcher } from './hooks/subagent-watcher.js';
@@ -1035,6 +1036,20 @@ async function main(): Promise<void> {
     const turnCostAttributor = new TurnCostAttributor();
     const turnTracker = new TurnTracker();
     const gitEfficiencyTracker = new GitEfficiencyTracker();
+    // Day-boundary reset bookkeeping for gitEfficiencyTracker: the
+    // tracker has a reset() method but, unlike costTracker/modelUsageTracker/
+    // contextCompositionTracker/turnCostAttributor (reset at session
+    // boundaries just below), nothing ever called it for a day boundary. In
+    // a --local dashboard daemon that survives one midnight, "Today's
+    // activity across all sessions" would otherwise silently become an
+    // unbounded all-time counter. `capturedRepoContext`/
+    // `capturedBranchDivergence` are re-hydrated after each reset (see
+    // onRecord below) so resetting the day's activity counters doesn't also
+    // forget which repo/branch this process is watching — that identity is
+    // read from disk once at startup, not part of "today's activity".
+    let gitEfficiencyDayKey = localDateKey();
+    let capturedRepoContext: RepoContext | null = null;
+    let capturedBranchDivergence: { ahead: number; behind: number } | null = null;
     const workflowRunTracker = new WorkflowRunTracker();
     // Always constructed (cheap, stateless until a client calls one of its
     // report_* tools) so nr_observe_report_tool_call/_session_start/_session_end
@@ -1048,6 +1063,10 @@ async function main(): Promise<void> {
     // when the watcher's reconciliation pass needs them.
     const workflowStoreInstance = new WorkflowStore({
       getCostForRun: (runId) => costTracker.getCostForWorkflowRun(runId),
+      // Lets the "Workflow spend" KPI flag its total as partial (a partial
+      // mitigation) instead of silently treating "this process never
+      // observed the run's cost" the same as "confirmed $0".
+      hasCostForRun: (runId) => costTracker.hasCostForWorkflowRun(runId),
     });
 
     // Per-session subagent timeline reader — backs the "agent fan-out"
@@ -1065,34 +1084,6 @@ async function main(): Promise<void> {
     const currentSessionId = sessionTracker.getMetrics().sessionId;
     let currentRepoName: string | null = null;
 
-    // Hydrate git efficiency tracker with today's prior sessions so the
-    // dashboard shows all-day git activity, not just the current session.
-    const todaySessions = sessionStore.loadSessionsOverlappingToday();
-    for (const session of todaySessions) {
-      if (session.sessionId === currentSessionId) continue;
-      if (session.timeline && session.timeline.length > 0) {
-        gitEfficiencyTracker.replayTimeline(session.timeline);
-      }
-    }
-
-    // Hydrate instruction-drift tracker with the last 7 days of prior
-    // sessions so cross-session prompt-variant correlation has real data
-    // from the moment this session starts (mirrors computeHistoricalCosts'
-    // weekAgo window below). Sessions persisted before this field existed
-    // have instructionPromptHash === null and are naturally excluded.
-    const weekAgoForDrift = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const historicalDriftSessions = sessionStore.loadAllSessions({ since: weekAgoForDrift });
-    const driftRecords: SessionOutcomeRecord[] = [];
-    for (const session of historicalDriftSessions) {
-      if (session.sessionId === currentSessionId) continue;
-      const record = sessionSummaryToDriftRecord(session);
-      if (record) driftRecords.push(record);
-    }
-    instructionDriftTracker.loadRecords(driftRecords);
-
-    // Also hydrate from git log — commit commands often aren't captured by
-    // tool hooks (Claude Code commits internally), so we read the actual
-    // repo history to get an accurate commit count for today.
     // Each command is isolated so a slow/missing git or remote doesn't block
     // the others. Uses spawnSync (no shell) to avoid injection; stderr is
     // suppressed via stdio rather than shell redirection. Timeout 2s per call.
@@ -1103,27 +1094,11 @@ async function main(): Promise<void> {
       stdio: ['ignore', 'pipe', 'ignore'] as ['ignore', 'pipe', 'ignore'],
     };
 
-    // spawnSync with ENOENT doesn't throw — it returns { status: null, error: Error }.
-    // The status === 0 guard handles unavailable-git without a try/catch.
-    const todayStr = new Date().toISOString().slice(0, 10);
-    const logResult = spawnSync(
-      'git',
-      ['log', `--since=${todayStr}T00:00:00Z`, '--format=%H %ct'],
-      GIT_OPTS,
-    );
-    if (logResult.status === 0 && logResult.stdout !== null) {
-      const commits = logResult.stdout
-        .trim()
-        .split('\n')
-        .filter(Boolean)
-        .map((line) => {
-          const [hash, epochStr] = line.split(' ');
-          return { hash: hash ?? '', timestamp: parseInt(epochStr ?? '0', 10) * 1000 };
-        });
-      gitEfficiencyTracker.hydrateGitLog(commits);
-    }
-
-    // Repo context for the dashboard header
+    // Repo context for the dashboard header — hydrated BEFORE the
+    // today-sessions replay loop below so GitEfficiencyTracker.
+    // replayTimeline() can filter each session's timeline against this
+    // process's own repoContext.repoName instead of blending in another
+    // repo's commits/conflicts/force-pushes.
     const remoteResult = spawnSync('git', ['remote', 'get-url', 'origin'], GIT_OPTS);
     const branchResult = spawnSync('git', ['branch', '--show-current'], GIT_OPTS);
     const remoteName = 'origin';
@@ -1145,12 +1120,64 @@ async function main(): Promise<void> {
         defaultBranch = parseDefaultBranchFromSymbolicRef(symbolicRefResult.stdout, remoteName);
       }
 
-      gitEfficiencyTracker.hydrateRepoContext({
+      capturedRepoContext = {
         repoName,
         branch: branch || null,
         remoteName,
         defaultBranch,
-      });
+      };
+      gitEfficiencyTracker.hydrateRepoContext(capturedRepoContext);
+    }
+
+    // Hydrate git efficiency tracker with today's prior sessions so the
+    // dashboard shows all-day git activity, not just the current session.
+    // Each session's own repoName is passed through so a session
+    // worked on in a different repo earlier today doesn't get counted
+    // against whichever repo this process's header currently names.
+    const todaySessions = sessionStore.loadSessionsOverlappingToday();
+    for (const session of todaySessions) {
+      if (session.sessionId === currentSessionId) continue;
+      if (session.timeline && session.timeline.length > 0) {
+        gitEfficiencyTracker.replayTimeline(session.timeline, session.repoName);
+      }
+    }
+
+    // Hydrate instruction-drift tracker with the last 7 days of prior
+    // sessions so cross-session prompt-variant correlation has real data
+    // from the moment this session starts (mirrors computeHistoricalCosts'
+    // weekAgo window below). Sessions persisted before this field existed
+    // have instructionPromptHash === null and are naturally excluded.
+    const weekAgoForDrift = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const historicalDriftSessions = sessionStore.loadAllSessions({ since: weekAgoForDrift });
+    const driftRecords: SessionOutcomeRecord[] = [];
+    for (const session of historicalDriftSessions) {
+      if (session.sessionId === currentSessionId) continue;
+      const record = sessionSummaryToDriftRecord(session);
+      if (record) driftRecords.push(record);
+    }
+    instructionDriftTracker.loadRecords(driftRecords);
+
+    // Also hydrate from git log — commit commands often aren't captured by
+    // tool hooks (Claude Code commits internally), so we read the actual
+    // repo history to get an accurate commit count for today.
+    // spawnSync with ENOENT doesn't throw — it returns { status: null, error: Error }.
+    // The status === 0 guard handles unavailable-git without a try/catch.
+    const todayStr = new Date().toISOString().slice(0, 10);
+    const logResult = spawnSync(
+      'git',
+      ['log', `--since=${todayStr}T00:00:00Z`, '--format=%H %ct'],
+      GIT_OPTS,
+    );
+    if (logResult.status === 0 && logResult.stdout !== null) {
+      const commits = logResult.stdout
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => {
+          const [hash, epochStr] = line.split(' ');
+          return { hash: hash ?? '', timestamp: parseInt(epochStr ?? '0', 10) * 1000 };
+        });
+      gitEfficiencyTracker.hydrateGitLog(commits);
     }
 
     // Branch divergence from the real default branch — how far ahead/behind are we?
@@ -1169,6 +1196,7 @@ async function main(): Promise<void> {
       const ahead = parseInt(aheadResult.stdout.trim(), 10);
       const behind = parseInt(behindResult.stdout.trim(), 10);
       if (!Number.isNaN(ahead) && !Number.isNaN(behind)) {
+        capturedBranchDivergence = { ahead, behind };
         gitEfficiencyTracker.hydrateBranchDivergence(ahead, behind);
       }
     }
@@ -1670,6 +1698,51 @@ async function main(): Promise<void> {
           rawRecord.transcriptPath as string | undefined,
         );
         instructionDriftTracker.recordToolCall(rawRecord);
+        // Day-boundary reset — checked on every record rather than on
+        // a timer so it fires promptly on the next real tool call after
+        // midnight without needing a separate interval. reset() clears
+        // repoContext/branch-divergence too, so both are re-hydrated
+        // immediately from what was captured at startup — this endpoint's
+        // "today's activity" counters reset, not the tracker's identity of
+        // which repo/branch it's watching.
+        const gitDayKey = localDateKey();
+        if (gitDayKey !== gitEfficiencyDayKey) {
+          gitEfficiencyDayKey = gitDayKey;
+          gitEfficiencyTracker.reset(sessionTraceId);
+          if (capturedRepoContext) gitEfficiencyTracker.hydrateRepoContext(capturedRepoContext);
+          if (capturedBranchDivergence) {
+            gitEfficiencyTracker.hydrateBranchDivergence(
+              capturedBranchDivergence.ahead,
+              capturedBranchDivergence.behind,
+            );
+          }
+          // Re-run the git-log hydration (mirrors the startup hydration
+          // above) scoped to the new local day. Without this, commits
+          // Claude Code makes internally (not captured by tool hooks — see
+          // the comment on the startup hydration) would only be visible via
+          // hook-observed `git commit` calls made *after* this reset, so
+          // "commits today" would under-report on day 2+ of a long-lived
+          // `--local` daemon. Uses local midnight (not UTC) since that's the
+          // boundary `localDateKey()` just crossed.
+          const newDayMidnight = new Date();
+          newDayMidnight.setHours(0, 0, 0, 0);
+          const dayBoundaryLogResult = spawnSync(
+            'git',
+            ['log', `--since=${newDayMidnight.toISOString()}`, '--format=%H %ct'],
+            GIT_OPTS,
+          );
+          if (dayBoundaryLogResult.status === 0 && dayBoundaryLogResult.stdout !== null) {
+            const dayBoundaryCommits = dayBoundaryLogResult.stdout
+              .trim()
+              .split('\n')
+              .filter(Boolean)
+              .map((line) => {
+                const [hash, epochStr] = line.split(' ');
+                return { hash: hash ?? '', timestamp: parseInt(epochStr ?? '0', 10) * 1000 };
+              });
+            gitEfficiencyTracker.hydrateGitLog(dayBoundaryCommits);
+          }
+        }
         gitEfficiencyTracker.recordToolCall(rawRecord);
 
         const record: ToolCallRecord = { ...rawRecord, turn_id: turnId, turn_number: turnNumber };

--- a/src/metrics/cost-tracker.ts
+++ b/src/metrics/cost-tracker.ts
@@ -330,6 +330,26 @@ export class CostTracker implements Resettable {
     return total;
   }
 
+  /**
+   * Whether THIS process's live CostTracker has ever observed a token event
+   * for `runId` at all, distinct from `getCostForWorkflowRun()` returning 0.
+   * That 0 is ambiguous: it means either "confirmed $0 spend" or "this
+   * process never personally observed this run's cost" (e.g. after a
+   * process restart, or in a `--local` standalone dashboard reading rollups
+   * from disk for a run a different `--stdio` process actually paid for) —
+   * `WorkflowStore` uses this to distinguish the two so the "Workflow
+   * spend" KPI can flag a total as partial instead of silently treating
+   * "unknown" as "zero". A partial mitigation.
+   *
+   * This is a read-only accessor over existing state — it does not change
+   * what `costByWorkflowRunId` tracks or how. A full fix would persist
+   * per-run cost somewhere `WorkflowStore` can read across process
+   * restarts/instances; that's out of scope here.
+   */
+  hasCostForWorkflowRun(runId: string): boolean {
+    return this.costByWorkflowRunId.has(runId);
+  }
+
   /** Iterable view of every (runId, dayKey, usd) tuple — for dashboard joins. */
   *iterCostByWorkflowRun(): IterableIterator<{ runId: string; dayKey: string; usd: number }> {
     for (const [runId, m] of this.costByWorkflowRunId) {

--- a/src/metrics/decision-tracker.test.ts
+++ b/src/metrics/decision-tracker.test.ts
@@ -235,6 +235,78 @@ describe('DecisionTracker.recordToolCall triggers', () => {
   });
 });
 
+// In `--local` mode, HookEventProcessor's `drainAllSessions` feeds
+// this one process-global tracker events from every concurrently-live
+// session, so the dashboard's session-detail drawer must be able to filter
+// down to just the session the user has selected.
+describe('DecisionTracker.getMetrics(sessionId) session isolation', () => {
+  function makeRecord(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
+    return {
+      id: 'id-1',
+      sessionId: 'session-1',
+      toolName: 'Read',
+      toolUseId: 'tool_1',
+      timestamp: Date.now(),
+      durationMs: 10,
+      success: true,
+      ...overrides,
+    };
+  }
+
+  it('scopes totalBranches/failurePoints to the requested session only', () => {
+    const tracker = new DecisionTracker();
+
+    // Session A: an AskUserQuestion branch (resolves as a 'success' outcome
+    // since the call itself succeeds).
+    tracker.recordToolCall(
+      makeRecord({ sessionId: 'session-a', toolName: 'AskUserQuestion', toolUseId: 'a-1' }),
+    );
+    // Session B: a failure followed by a recovery attempt that ALSO fails,
+    // so the recovery branch resolves to a 'failure' outcome.
+    tracker.recordToolCall(
+      makeRecord({ sessionId: 'session-b', toolName: 'Bash', success: false, toolUseId: 'b-1' }),
+    );
+    tracker.recordToolCall(
+      makeRecord({ sessionId: 'session-b', toolName: 'Bash', success: false, toolUseId: 'b-2' }),
+    );
+
+    const aMetrics = tracker.getMetrics('session-a');
+    const bMetrics = tracker.getMetrics('session-b');
+
+    expect(aMetrics.totalBranches).toBe(1);
+    expect(bMetrics.totalBranches).toBe(1);
+    expect(bMetrics.failurePoints).toHaveLength(1);
+    expect(aMetrics.failurePoints).toHaveLength(0);
+    // Unfiltered getMetrics() (no sessionId) still sees both sessions' branches.
+    expect(tracker.getMetrics().totalBranches).toBe(
+      aMetrics.totalBranches + bMetrics.totalBranches,
+    );
+  });
+
+  it('returns zero branches for an unknown sessionId rather than leaking another session', () => {
+    const tracker = new DecisionTracker();
+    tracker.recordToolCall(
+      makeRecord({ sessionId: 'session-a', toolName: 'AskUserQuestion', toolUseId: 'a-1' }),
+    );
+
+    const metrics = tracker.getMetrics('session-does-not-exist');
+    expect(metrics.totalBranches).toBe(0);
+    expect(metrics.failurePoints).toHaveLength(0);
+  });
+
+  it('getMetrics() with no sessionId still returns every branch (back-compat for callers with no single session in view)', () => {
+    const tracker = new DecisionTracker();
+    tracker.recordToolCall(
+      makeRecord({ sessionId: 'session-a', toolName: 'AskUserQuestion', toolUseId: 'a-1' }),
+    );
+    tracker.recordToolCall(
+      makeRecord({ sessionId: 'session-b', toolName: 'AskUserQuestion', toolUseId: 'b-1' }),
+    );
+
+    expect(tracker.getMetrics().totalBranches).toBe(2);
+  });
+});
+
 describe('DecisionTracker transcript reasoning extraction (recordContent)', () => {
   let tmpDir: string;
   let transcriptPath: string;

--- a/src/metrics/decision-tracker.ts
+++ b/src/metrics/decision-tracker.ts
@@ -16,6 +16,13 @@ export interface DecisionBranch {
   readonly outcome: BranchOutcome;
   readonly nextToolSuccess: boolean | null;
   readonly sessionSucceeded: boolean | null;
+  /**
+   * Owning session, tagged from the `ToolCallRecord.sessionId` that produced
+   * this branch — `recordDecision()` callers outside `recordToolCall()`
+   * (tests, `markSessionOutcome()`) don't have a session in scope, so this is
+   * `null` for those. `getMetrics(sessionId)` filters on this field.
+   */
+  readonly sessionId: string | null;
 }
 
 export interface DecisionTreeMetrics {
@@ -68,6 +75,7 @@ export class DecisionTracker {
     this.turnCounter++;
     const turn = this.turnCounter;
     const transcriptPath = record.transcriptPath as string | undefined;
+    const sessionId = record.sessionId ?? null;
 
     if (this.lastRecordFailed) {
       // Previous tool failed — this tool call represents a recovery decision
@@ -78,6 +86,7 @@ export class DecisionTracker {
           `recovery after ${this.lastToolName ?? 'unknown'} failure`,
         chosenAction: record.toolName,
         toolName: record.toolName,
+        sessionId,
       });
     }
 
@@ -87,6 +96,7 @@ export class DecisionTracker {
         reasoning: this.extractReasoning(transcriptPath, record.toolUseId) ?? 'delegating to user',
         chosenAction: 'ask_user',
         toolName: record.toolName,
+        sessionId,
       });
     }
 
@@ -104,6 +114,7 @@ export class DecisionTracker {
             `retrying ${record.toolName} on ${filePath} (${count} attempts)`,
           chosenAction: 'retry',
           toolName: record.toolName,
+          sessionId,
         });
       }
     }
@@ -127,6 +138,7 @@ export class DecisionTracker {
     reasoning: string;
     chosenAction: string;
     toolName: string | null;
+    sessionId?: string | null;
   }): void {
     const branch: DecisionBranch = {
       turnNumber: input.turnNumber,
@@ -137,6 +149,7 @@ export class DecisionTracker {
       outcome: 'unknown',
       nextToolSuccess: null,
       sessionSucceeded: null,
+      sessionId: input.sessionId ?? null,
     };
 
     this.branches.push(branch);
@@ -173,18 +186,31 @@ export class DecisionTracker {
     }
   }
 
-  getMetrics(): DecisionTreeMetrics {
-    const resolved = this.branches.filter((b) => b.outcome !== 'unknown');
+  /**
+   * @param sessionId When provided, scopes every stat to branches tagged
+   *   with this session — without this, `/api/decision-tree` would return
+   *   whatever this process-global tracker happens to contain, which in
+   *   `--local` mode can be several concurrently-live sessions blended
+   *   together. Omit to get every branch this tracker has ever recorded —
+   *   used by callers with no single session in view, e.g. the
+   *   `nr_observe_get_decision_tree` MCP tool.
+   */
+  getMetrics(sessionId?: string): DecisionTreeMetrics {
+    const branches =
+      sessionId !== undefined
+        ? this.branches.filter((b) => b.sessionId === sessionId)
+        : this.branches;
+    const resolved = branches.filter((b) => b.outcome !== 'unknown');
     const successes = resolved.filter((b) => b.outcome === 'success').length;
     const successRate = resolved.length > 0 ? successes / resolved.length : null;
-    const failurePoints = this.branches.filter((b) => b.outcome === 'failure');
+    const failurePoints = branches.filter((b) => b.outcome === 'failure');
 
     return {
-      totalBranches: this.branches.length,
+      totalBranches: branches.length,
       successRate: successRate !== null ? Math.round(successRate * 1000) / 1000 : null,
       failurePoints,
-      longestFailureStreak: this.computeLongestFailureStreak(),
-      firstFailureIndex: this.findFirstFailureIndex(),
+      longestFailureStreak: this.computeLongestFailureStreak(branches),
+      firstFailureIndex: this.findFirstFailureIndex(branches),
       note: DECISION_TREE_REASONING_NOTE,
     };
   }
@@ -222,11 +248,11 @@ export class DecisionTracker {
     this.fileCallCounts.clear();
   }
 
-  private computeLongestFailureStreak(): number {
+  private computeLongestFailureStreak(branches: readonly DecisionBranch[]): number {
     let maxStreak = 0;
     let currentStreak = 0;
 
-    for (const branch of this.branches) {
+    for (const branch of branches) {
       if (branch.outcome === 'failure') {
         currentStreak++;
         maxStreak = Math.max(maxStreak, currentStreak);
@@ -238,9 +264,9 @@ export class DecisionTracker {
     return maxStreak;
   }
 
-  private findFirstFailureIndex(): number | null {
-    for (let i = 0; i < this.branches.length; i++) {
-      if (this.branches[i].outcome === 'failure') {
+  private findFirstFailureIndex(branches: readonly DecisionBranch[]): number | null {
+    for (let i = 0; i < branches.length; i++) {
+      if (branches[i].outcome === 'failure') {
         return i;
       }
     }

--- a/src/metrics/git-efficiency-tracker.test.ts
+++ b/src/metrics/git-efficiency-tracker.test.ts
@@ -164,6 +164,51 @@ describe('GitEfficiencyTracker', () => {
     expect(metrics.conflictResolutionRate).toBe(1);
   });
 
+  // this.events is only ever .push()'d, in whatever order
+  // recordToolCall is invoked — not necessarily ascending timestamp order.
+  // Two realistic causes: parallel tool calls within a session (a
+  // later-started, earlier-finishing command lands first) or multi-session
+  // buffer draining. GitEfficiency.tsx's "Recent Git Activity" does
+  // `[...gitCommandTimeline].reverse().slice(0, 30)`, which only picks the
+  // true newest 30 if the source is already ascending.
+  it('sorts gitCommandTimeline by timestamp ascending regardless of push order', () => {
+    tracker.recordToolCall(makeRecord({ command: 'git status', timestamp: 300 }));
+    tracker.recordToolCall(makeRecord({ command: 'git status', timestamp: 100 }));
+    tracker.recordToolCall(makeRecord({ command: 'git status', timestamp: 200 }));
+    const metrics = tracker.getMetrics();
+    // Unsorted, this would equal [300, 100, 200] — raw push order — so
+    // .reverse().slice(0, N) on the frontend would silently pick the wrong
+    // window instead of the true newest N.
+    expect(metrics.gitCommandTimeline.map((e) => e.timestamp)).toEqual([100, 200, 300]);
+  });
+
+  it('sorts conflictHistory by timestamp ascending when conflict sequences interleave out of order', () => {
+    // Conflict B (timestamp 100) is processed AFTER conflict A (timestamp
+    // 200) — e.g. two concurrent sessions whose buffers were drained in an
+    // order that doesn't match wall-clock order.
+    tracker.recordToolCall(
+      makeRecord({
+        command: 'git merge main',
+        timestamp: 200,
+        success: false,
+        error: 'CONFLICT (content): Merge conflict in src/a.ts',
+      }),
+    );
+    tracker.recordToolCall(makeRecord({ command: 'git commit -m "resolve a"', timestamp: 250 }));
+    tracker.recordToolCall(
+      makeRecord({
+        command: 'git merge main',
+        timestamp: 100,
+        success: false,
+        error: 'CONFLICT (content): Merge conflict in src/b.ts',
+      }),
+    );
+    tracker.recordToolCall(makeRecord({ command: 'git commit -m "resolve b"', timestamp: 150 }));
+    const metrics = tracker.getMetrics();
+    // Unsorted, this would equal [200, 100] — raw push order.
+    expect(metrics.conflictHistory.map((c) => c.timestamp)).toEqual([100, 200]);
+  });
+
   it('extracts conflicted file paths', () => {
     tracker.recordToolCall(
       makeRecord({
@@ -497,6 +542,98 @@ describe('GitEfficiencyTracker', () => {
     expect(metrics.riskIndicators.syncedBeforeEditing).toBeNull();
   });
 
+  // Without a day-boundary reset, GitEfficiencyTracker never resets, so in
+  // --local mode (a persistent, multi-day dashboard daemon) "Today's
+  // activity across all sessions" would silently become an unbounded
+  // all-time counter. The actual day-boundary trigger lives in
+  // src/index.ts's onRecord handler (calls reset() then re-hydrates
+  // repoContext/branch-divergence from what was captured at startup, once
+  // localDateKey() changes) — not unit-testable from this file. This test
+  // instead verifies the composability that depends on: reset() must clear
+  // the day's accumulated activity while leaving room for the caller to
+  // immediately re-hydrate the repo identity (which isn't "today's
+  // activity" and has no periodic refresh of its own), so a day-boundary
+  // reset doesn't also make the "Repos Today" pills lose their repoName.
+  it('a day-boundary reset followed by re-hydration clears activity but the repo identity can be restored', () => {
+    tracker.hydrateRepoContext({
+      repoName: 'org/repo',
+      branch: 'main',
+      remoteName: 'origin',
+      defaultBranch: 'main',
+    });
+    tracker.recordToolCall(makeRecord({ command: 'git commit -m "a"' }));
+    tracker.recordToolCall(makeRecord({ command: 'git commit -m "b"' }));
+    expect(tracker.getMetrics().commitCount).toBe(2);
+    expect(tracker.getMetrics().repoContext.repoName).toBe('org/repo');
+
+    // Simulate the day-boundary reset+re-hydrate sequence performed in
+    // src/index.ts's onRecord handler when localDateKey() changes.
+    tracker.reset('next-session');
+    tracker.hydrateRepoContext({
+      repoName: 'org/repo',
+      branch: 'main',
+      remoteName: 'origin',
+      defaultBranch: 'main',
+    });
+
+    const metrics = tracker.getMetrics();
+    // Yesterday's commits don't leak into today's count.
+    expect(metrics.commitCount).toBe(0);
+    // But the repo identity survives, because the caller re-hydrated it
+    // immediately after reset() — it isn't "today's activity" and has no
+    // other refresh path once the process is running.
+    expect(metrics.repoContext.repoName).toBe('org/repo');
+  });
+
+  // Follow-up to the test above: src/index.ts's day-boundary handler now also
+  // re-runs `git log --since=<new local midnight>` (mirroring the startup
+  // hydration) and feeds the result through hydrateGitLog() right after
+  // reset(), so commits Claude Code makes internally — which never reach
+  // recordToolCall() via tool hooks (see the comment on the startup
+  // hydration in src/index.ts) — still count toward "today's commits" on
+  // day 2+ of a long-lived --local daemon, instead of only ever seeing
+  // hook-observed commits made after the reset.
+  it('a day-boundary reset followed by hydrateGitLog() recovers commits made outside tool hooks', () => {
+    tracker.recordToolCall(makeRecord({ command: 'git commit -m "a"' }));
+    expect(tracker.getMetrics().commitCount).toBe(1);
+
+    tracker.reset('next-session');
+    expect(tracker.getMetrics().commitCount).toBe(0);
+
+    // Simulates src/index.ts feeding the day-scoped `git log` output
+    // (commits not captured by tool hooks) back into the tracker right
+    // after the reset.
+    tracker.hydrateGitLog([
+      { hash: 'abc123', timestamp: Date.now() },
+      { hash: 'def456', timestamp: Date.now() },
+    ]);
+
+    expect(tracker.getMetrics().commitCount).toBe(2);
+  });
+
+  // A drain batch can hold hook-observed records for commits that already
+  // landed by the time the day-boundary `git log` snapshot ran — that
+  // snapshot's hydrateGitLog() call sees them too. Without a way to tell
+  // "this hook event is the same commit `git log` already vouched for" from
+  // "this is a genuinely new commit," recordToolCall() would double-count.
+  it('does not double-count a hook-observed commit whose timestamp hydrateGitLog() already covered', () => {
+    const hydratedAt = Date.now();
+    tracker.hydrateGitLog([{ hash: 'abc123', timestamp: hydratedAt }]);
+    expect(tracker.getMetrics().commitCount).toBe(1);
+
+    // The buffered hook event for that same commit, still queued from before
+    // the day-boundary flip, now gets processed — its timestamp is at or
+    // before what git log already covered.
+    tracker.recordToolCall(makeRecord({ command: 'git commit -m "a"', timestamp: hydratedAt }));
+    expect(tracker.getMetrics().commitCount).toBe(1);
+
+    // A genuinely new commit made after the hydration snapshot still counts.
+    tracker.recordToolCall(
+      makeRecord({ command: 'git commit -m "b"', timestamp: hydratedAt + 5_000 }),
+    );
+    expect(tracker.getMetrics().commitCount).toBe(2);
+  });
+
   describe('replayTimeline', () => {
     it('hydrates tracker from prior session timeline entries', () => {
       const t = Date.now() - 3600_000;
@@ -638,6 +775,81 @@ describe('GitEfficiencyTracker', () => {
       tracker.replayTimeline(timeline);
       const metrics = tracker.getMetrics();
       expect(metrics.forcePushes).toBe(1);
+    });
+
+    // A developer who worked in a different repo earlier today must
+    // not have that repo's commits/conflicts/force-pushes counted against
+    // whichever repo this tracker's header currently names.
+    describe('cross-repo filtering', () => {
+      const t = Date.now() - 3600_000;
+      const otherRepoTimeline: ReplayTimelineEntry[] = [
+        {
+          timestamp: t,
+          toolName: 'Bash',
+          durationMs: 100,
+          success: true,
+          command: 'git commit -m "work in repo A"',
+        },
+        {
+          timestamp: t + 1000,
+          toolName: 'Bash',
+          durationMs: 100,
+          success: true,
+          command: 'git push --force origin feature',
+        },
+      ];
+
+      it('skips a replayed session from a different repo than the current repoContext', () => {
+        tracker.hydrateRepoContext({
+          repoName: 'org/repo-b',
+          branch: 'main',
+          remoteName: 'origin',
+          defaultBranch: 'main',
+        });
+
+        tracker.replayTimeline(otherRepoTimeline, 'org/repo-a');
+
+        const metrics = tracker.getMetrics();
+        expect(metrics.totalGitCommands).toBe(0);
+        expect(metrics.commitCount).toBe(0);
+        expect(metrics.forcePushes).toBe(0);
+      });
+
+      it('replays a session from the SAME repo as the current repoContext', () => {
+        tracker.hydrateRepoContext({
+          repoName: 'org/repo-a',
+          branch: 'main',
+          remoteName: 'origin',
+          defaultBranch: 'main',
+        });
+
+        tracker.replayTimeline(otherRepoTimeline, 'org/repo-a');
+
+        const metrics = tracker.getMetrics();
+        expect(metrics.totalGitCommands).toBe(2);
+        expect(metrics.commitCount).toBe(1);
+        expect(metrics.forcePushes).toBe(1);
+      });
+
+      it('replays unfiltered when the session repoName is unknown (null)', () => {
+        tracker.hydrateRepoContext({
+          repoName: 'org/repo-b',
+          branch: 'main',
+          remoteName: 'origin',
+          defaultBranch: 'main',
+        });
+
+        tracker.replayTimeline(otherRepoTimeline, null);
+
+        expect(tracker.getMetrics().totalGitCommands).toBe(2);
+      });
+
+      it('replays unfiltered when the tracker has no repoContext yet', () => {
+        // No hydrateRepoContext() call — repoContext.repoName stays null.
+        tracker.replayTimeline(otherRepoTimeline, 'org/repo-a');
+
+        expect(tracker.getMetrics().totalGitCommands).toBe(2);
+      });
     });
   });
 

--- a/src/metrics/git-efficiency-tracker.ts
+++ b/src/metrics/git-efficiency-tracker.ts
@@ -252,6 +252,12 @@ export class GitEfficiencyTracker {
   private totalToolCalls = 0;
   private sessionStartTimestamp: number | null = null;
   private commitTimestamps: number[] = [];
+  // Latest commit timestamp covered by a `hydrateGitLog()` call. A live
+  // `git commit` event with a timestamp at or before this is one `git log`
+  // already saw at hydration time — recordToolCall() must skip it rather
+  // than double-count a commit that's about to arrive (or already has)
+  // through the normal hook-observed path too. See recordToolCall().
+  private hydratedThroughMs = 0;
   private worktreeCommands = 0;
   private oursCount = 0;
   private theirsCount = 0;
@@ -305,6 +311,14 @@ export class GitEfficiencyTracker {
     if (!GIT_COMMAND_RE.test(command)) return;
 
     const event = this.classifyGitCommand(command, record);
+    // A hook-observed commit whose timestamp `hydrateGitLog()` already saw
+    // (via `git log`) is the same commit, not a new one — hydrateGitLog()
+    // can't dedupe this itself since a live event's `command` is the raw
+    // shell string, not `git commit (<hash>)`, so it never matches its own
+    // hash-based check. Without this, a day-boundary hydration followed by
+    // this same commit's hook event arriving from the same drain batch
+    // would count it twice.
+    if (event.type === 'commit' && event.timestamp <= this.hydratedThroughMs) return;
     this.events.push(event);
     this.processEvent(event, command, record);
   }
@@ -384,10 +398,36 @@ export class GitEfficiencyTracker {
         // Don't increment commitsSinceLastSync for historical commits — this counter
         // tracks real-time session activity, not replayed history.
       }
+      // Advance the watermark even for a commit that was already tracked —
+      // either way, `git log` has now vouched for everything up to here, so
+      // recordToolCall() must not add it again when the hook-observed event
+      // for it (still queued in the same drain batch) gets processed.
+      if (commit.timestamp > this.hydratedThroughMs) {
+        this.hydratedThroughMs = commit.timestamp;
+      }
     }
   }
 
-  replayTimeline(entries: readonly ReplayTimelineEntry[]): void {
+  /**
+   * @param repoName The replayed session's own repo (from `SessionSummary.repoName`).
+   *   When both this and the tracker's own `repoContext.repoName` (set via
+   *   `hydrateRepoContext()`) are known and they don't match, the whole
+   *   timeline is skipped — otherwise a session worked on in a
+   *   different repo earlier today would have its commits/conflicts/force-
+   *   pushes counted against whichever repo this process's header currently
+   *   names. When either side is unknown (null/undefined — e.g. no git
+   *   remote configured, or `repoContext` not hydrated yet), the timeline is
+   *   replayed unfiltered rather than risk dropping legitimate same-repo
+   *   history.
+   */
+  replayTimeline(entries: readonly ReplayTimelineEntry[], repoName?: string | null): void {
+    if (
+      repoName != null &&
+      this.repoContext.repoName != null &&
+      repoName !== this.repoContext.repoName
+    ) {
+      return;
+    }
     for (const entry of entries) {
       const syntheticRecord: ToolCallRecord = {
         id: `replay-${entry.timestamp}`,
@@ -496,8 +536,15 @@ export class GitEfficiencyTracker {
       conflictResolutionRate,
       avgConflictResolutionMs,
       staleBranchPulls,
-      gitCommandTimeline: this.events.slice(-50),
-      conflictHistory: this.conflictRecords,
+      // this.events/this.conflictRecords are append-only in processing
+      // order, not timestamp order — parallel tool calls within a session,
+      // or multi-session buffer draining, can push an earlier-timestamped
+      // event after a later one. Sort by timestamp ascending (oldest-first)
+      // before exposing, so gitCommandTimeline's consumer
+      // (GitEfficiency.tsx's `[...timeline].reverse().slice(0, 30)`) picks
+      // the true newest 30, not whichever 30 happened to be pushed last.
+      gitCommandTimeline: [...this.events].sort((a, b) => a.timestamp - b.timestamp).slice(-50),
+      conflictHistory: [...this.conflictRecords].sort((a, b) => a.timestamp - b.timestamp),
       suggestions,
       bestPractices,
       preventionScore,
@@ -534,6 +581,7 @@ export class GitEfficiencyTracker {
     this.totalToolCalls = 0;
     this.sessionStartTimestamp = null;
     this.commitTimestamps = [];
+    this.hydratedThroughMs = 0;
     this.worktreeCommands = 0;
     this.oursCount = 0;
     this.theirsCount = 0;

--- a/src/metrics/turn-cost-attributor.test.ts
+++ b/src/metrics/turn-cost-attributor.test.ts
@@ -38,6 +38,12 @@ function makeTokenEvent(overrides?: Partial<TokenEvent>): TokenEvent {
     cacheReadTokens: 0,
     cacheCreationTokens: 0,
     model: 'claude-sonnet-4-20250514',
+    // Matches makeRecord()'s default sessionId — in production a token
+    // event's sessionId always comes from the same underlying hook-event
+    // session as the tool-call records around it (event-processor.ts's
+    // handleTokenEvent), so a real recordToolCall()+recordTokenEvent() pair
+    // always land in the same per-session bucket.
+    sessionId: 'sess-001',
     ...overrides,
   };
 }
@@ -217,6 +223,173 @@ describe('TurnCostAttributor', () => {
       // output: 2000 * 15 / 1_000_000 = 0.03
       // total = 0.06
       expect(metrics.turns[0].estimatedCostUsd).toBeCloseTo(0.06, 4);
+    });
+  });
+
+  // In `--local` mode, HookEventProcessor's `drainAllSessions` feeds
+  // this one process-global tracker events from every concurrently-live
+  // session. Without per-session partitioning, tool calls from two sessions
+  // within TURN_GAP_MS of each other would merge into a single turn
+  // attributed to whichever session's record started the accumulator.
+  describe('per-session isolation', () => {
+    it('keeps two concurrent sessions from merging into the same turn even when interleaved within the turn gap', () => {
+      const attributor = new TurnCostAttributor();
+
+      // Session A and session B tool calls interleaved 500ms apart — well
+      // within TURN_GAP_MS (2s) of each other, so a session-blind tracker
+      // would merge them into one turn.
+      attributor.recordToolCall(
+        makeRecord({ sessionId: 'session-a', toolUseId: 'a-1', toolName: 'Read', timestamp: 1000 }),
+      );
+      attributor.recordToolCall(
+        makeRecord({
+          sessionId: 'session-b',
+          toolUseId: 'b-1',
+          toolName: 'Write',
+          timestamp: 1500,
+        }),
+      );
+      attributor.recordTokenEvent(makeTokenEvent({ sessionId: 'session-a', timestamp: 1100 }));
+      attributor.recordTokenEvent(makeTokenEvent({ sessionId: 'session-b', timestamp: 1600 }));
+
+      const aMetrics = attributor.getMetrics('session-a');
+      const bMetrics = attributor.getMetrics('session-b');
+
+      expect(aMetrics.turns).toHaveLength(1);
+      expect(aMetrics.turns[0].toolCalls).toEqual(['a-1']);
+      expect(aMetrics.turns[0].sessionId).toBe('session-a');
+
+      expect(bMetrics.turns).toHaveLength(1);
+      expect(bMetrics.turns[0].toolCalls).toEqual(['b-1']);
+      expect(bMetrics.turns[0].sessionId).toBe('session-b');
+    });
+
+    it('scopes totalAttributedCost and attributionRate to the requested session only', () => {
+      const attributor = new TurnCostAttributor();
+
+      attributor.recordToolCall(makeRecord({ sessionId: 'session-a', toolUseId: 'a-1' }));
+      attributor.recordTokenEvent(
+        makeTokenEvent({
+          sessionId: 'session-a',
+          timestamp: 1100,
+          inputTokens: 1000,
+          outputTokens: 100,
+        }),
+      );
+      attributor.recordToolCall(
+        makeRecord({ sessionId: 'session-b', toolUseId: 'b-1', timestamp: 5000 }),
+      );
+      attributor.recordTokenEvent(
+        makeTokenEvent({
+          sessionId: 'session-b',
+          timestamp: 5100,
+          inputTokens: 100_000,
+          outputTokens: 20_000,
+        }),
+      );
+
+      const aMetrics = attributor.getMetrics('session-a');
+      const bMetrics = attributor.getMetrics('session-b');
+
+      expect(aMetrics.totalAttributedCost).toBeGreaterThan(0);
+      expect(bMetrics.totalAttributedCost).toBeGreaterThan(aMetrics.totalAttributedCost);
+      expect(aMetrics.attributionRate).toBe(1);
+      expect(bMetrics.attributionRate).toBe(1);
+    });
+
+    it('returns empty metrics for an unknown sessionId rather than leaking another session', () => {
+      const attributor = new TurnCostAttributor();
+      attributor.recordToolCall(makeRecord({ sessionId: 'session-a', toolUseId: 'a-1' }));
+      attributor.recordTokenEvent(makeTokenEvent({ sessionId: 'session-a' }));
+
+      const metrics = attributor.getMetrics('session-does-not-exist');
+      expect(metrics.turns).toEqual([]);
+      expect(metrics.totalAttributedCost).toBe(0);
+      expect(metrics.attributionRate).toBe(0);
+    });
+
+    it('getCostForToolCall finds a tool call regardless of which session it belongs to', () => {
+      const attributor = new TurnCostAttributor();
+      attributor.recordToolCall(makeRecord({ sessionId: 'session-a', toolUseId: 'a-1' }));
+      attributor.recordTokenEvent(makeTokenEvent({ sessionId: 'session-a' }));
+      attributor.recordToolCall(
+        makeRecord({ sessionId: 'session-b', toolUseId: 'b-1', timestamp: 5000 }),
+      );
+      attributor.recordTokenEvent(makeTokenEvent({ sessionId: 'session-b', timestamp: 5100 }));
+
+      expect(attributor.getCostForToolCall('a-1')).not.toBeNull();
+      expect(attributor.getCostForToolCall('b-1')).not.toBeNull();
+    });
+
+    // Regression: no-arg getMetrics() used to fall back to whichever
+    // session was most recently touched. It must instead return a real
+    // aggregate across every session — matching DecisionTracker's
+    // "no-arg = everything" convention — since nr_observe_get_cost_per_tool
+    // (a process-wide MCP tool) calls getMetrics() with no argument and
+    // expects the sum of everything, not one arbitrary session's data.
+    it('getMetrics() with no sessionId aggregates totals, costByToolType, and turns across every session', () => {
+      const attributor = new TurnCostAttributor();
+      attributor.recordToolCall(
+        makeRecord({ sessionId: 'session-a', toolUseId: 'a-1', toolName: 'Read', timestamp: 1000 }),
+      );
+      attributor.recordTokenEvent(
+        makeTokenEvent({
+          sessionId: 'session-a',
+          timestamp: 1100,
+          inputTokens: 1_000,
+          outputTokens: 100,
+        }),
+      );
+      attributor.recordToolCall(
+        makeRecord({
+          sessionId: 'session-b',
+          toolUseId: 'b-1',
+          toolName: 'Write',
+          timestamp: 5000,
+        }),
+      );
+      attributor.recordTokenEvent(
+        makeTokenEvent({
+          sessionId: 'session-b',
+          timestamp: 5100,
+          inputTokens: 2_000,
+          outputTokens: 200,
+        }),
+      );
+
+      const aMetrics = attributor.getMetrics('session-a');
+      const bMetrics = attributor.getMetrics('session-b');
+      const allMetrics = attributor.getMetrics();
+
+      // Touch session-a again last, so a "most recently touched" fallback
+      // would (incorrectly) have returned session-a's data instead of the
+      // aggregate — proving the result isn't just "happens to equal the last
+      // session touched" by coincidence of test ordering.
+      attributor.recordToolCall(
+        makeRecord({ sessionId: 'session-a', toolUseId: 'a-2', toolName: 'Read', timestamp: 9000 }),
+      );
+
+      const aggregateAfterTouch = attributor.getMetrics();
+      expect(aggregateAfterTouch.turns).toHaveLength(2);
+      expect(allMetrics.turns).toHaveLength(2);
+      expect(allMetrics.totalAttributedCost).toBeCloseTo(
+        aMetrics.totalAttributedCost + bMetrics.totalAttributedCost,
+        10,
+      );
+      expect(allMetrics.costByToolType['Read'].callCount).toBe(1);
+      expect(allMetrics.costByToolType['Write'].callCount).toBe(1);
+    });
+
+    it('getMetrics() with no sessionId includes tool calls with no sessionId at all', () => {
+      const attributor = new TurnCostAttributor();
+      attributor.recordToolCall(
+        makeRecord({ sessionId: undefined, toolUseId: 'no-session-1', timestamp: 1000 }),
+      );
+      attributor.recordTokenEvent(makeTokenEvent({ sessionId: undefined, timestamp: 1100 }));
+
+      const metrics = attributor.getMetrics();
+      expect(metrics.turns).toHaveLength(1);
+      expect(metrics.totalAttributedCost).toBeGreaterThan(0);
     });
   });
 });

--- a/src/metrics/turn-cost-attributor.ts
+++ b/src/metrics/turn-cost-attributor.ts
@@ -20,6 +20,14 @@ export interface TurnCostAttribution {
   readonly model: string;
   readonly estimatedCostUsd: number;
   readonly costPerToolCall: number;
+  /**
+   * Owning session — tagged from the `ToolCallRecord.sessionId` that
+   * started the turn's pending accumulator. `getMetrics(sessionId)` uses
+   * this to scope the dashboard's session-detail drawer to the session
+   * actually selected, instead of whichever session(s) this process-global
+   * tracker happened to have most recently accumulated.
+   */
+  readonly sessionId: string | null;
 }
 
 export interface ToolTypeCostEntry {
@@ -63,30 +71,87 @@ interface PendingTurn {
   toolCalls: Array<{ toolUseId: string; toolName: string }>;
 }
 
+// A dedicated bucket for records/events with no sessionId (null/undefined) —
+// distinct from any real session id string so it can never collide with one.
+const NULL_SESSION_KEY = '__no_session__';
+// Mirrors ContextTrackerRegistry's default (src/metrics/context-tracker.ts)
+// so a long-running `--local` process watching many concurrent/historical
+// sessions doesn't grow this map unboundedly.
+const DEFAULT_MAX_SESSIONS = 50;
+
+interface SessionState {
+  turns: TurnCostAttribution[];
+  pendingTurn: PendingTurn | null;
+  costByToolType: Map<string, { totalCost: number; callCount: number }>;
+  totalAttributedCost: number;
+  totalToolCalls: number;
+  attributedToolCalls: number;
+}
+
+function createSessionState(): SessionState {
+  return {
+    turns: [],
+    pendingTurn: null,
+    costByToolType: new Map(),
+    totalAttributedCost: 0,
+    totalToolCalls: 0,
+    attributedToolCalls: 0,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // TurnCostAttributor
 // ---------------------------------------------------------------------------
 
+/**
+ * Per-session partitioned — each session's turns/pending-accumulator/
+ * cost-by-tool-type live in their own bucket (keyed by
+ * `ToolCallRecord.sessionId`/`TokenEvent.sessionId`), so tool calls from two
+ * concurrently-live sessions (`--local` mode's `drainAllSessions`) can never
+ * merge into one turn or blend into one session's totals. `getMetrics()`
+ * without a `sessionId` returns a real aggregate across every session this
+ * process has seen (summed/merged), matching `DecisionTracker.getMetrics()`'s
+ * "no-arg = everything" convention — not a "most recently touched session"
+ * heuristic, which `nr_observe_get_cost_per_tool` (a process-wide MCP tool
+ * with no single session in view) would otherwise silently receive instead
+ * of the sum callers actually expect.
+ */
 export class TurnCostAttributor {
-  private turns: TurnCostAttribution[] = [];
-  private pendingTurn: PendingTurn | null = null;
-  private costByToolType = new Map<string, { totalCost: number; callCount: number }>();
-  private totalAttributedCost = 0;
-  private totalToolCalls = 0;
-  private attributedToolCalls = 0;
+  private readonly sessions = new Map<string, SessionState>();
+
+  private getOrCreateSession(sessionId: string | null | undefined): SessionState {
+    const key = sessionId ?? NULL_SESSION_KEY;
+    let state = this.sessions.get(key);
+    if (state) {
+      // Move to the end so the DEFAULT_MAX_SESSIONS eviction below stays a
+      // real LRU (evicts the least-recently-touched session, not just the
+      // least-recently-created one).
+      this.sessions.delete(key);
+      this.sessions.set(key, state);
+      return state;
+    }
+    if (this.sessions.size >= DEFAULT_MAX_SESSIONS) {
+      const oldest = this.sessions.keys().next().value;
+      if (oldest !== undefined) this.sessions.delete(oldest);
+    }
+    state = createSessionState();
+    this.sessions.set(key, state);
+    return state;
+  }
 
   recordToolCall(record: ToolCallRecord, turnId?: string): void {
-    this.totalToolCalls++;
+    const state = this.getOrCreateSession(record.sessionId);
+    state.totalToolCalls++;
     const endTime = record.timestamp + (record.durationMs ?? 0);
 
-    if (this.pendingTurn && record.timestamp - this.pendingTurn.endTime <= TURN_GAP_MS) {
-      this.pendingTurn.endTime = endTime;
-      this.pendingTurn.toolCalls.push({
+    if (state.pendingTurn && record.timestamp - state.pendingTurn.endTime <= TURN_GAP_MS) {
+      state.pendingTurn.endTime = endTime;
+      state.pendingTurn.toolCalls.push({
         toolUseId: record.toolUseId,
         toolName: record.toolName,
       });
     } else {
-      this.pendingTurn = {
+      state.pendingTurn = {
         turnId: turnId ?? randomUUID(),
         startTime: record.timestamp,
         endTime,
@@ -96,13 +161,14 @@ export class TurnCostAttributor {
   }
 
   recordTokenEvent(event: TokenEvent): void {
-    if (!this.pendingTurn) return;
+    const state = this.getOrCreateSession(event.sessionId);
+    if (!state.pendingTurn) return;
 
     // A token event outside the match window can't be reliably tied to the
     // pending turn — silently drop it rather than risk mis-attributing cost
     // to the wrong turn. Dropped events show up as a lower `attributionRate`
     // in getMetrics(), not as an error.
-    const timeSinceLastTool = event.timestamp - this.pendingTurn.endTime;
+    const timeSinceLastTool = event.timestamp - state.pendingTurn.endTime;
     if (timeSinceLastTool < 0 || timeSinceLastTool > TOKEN_MATCH_WINDOW_MS) return;
 
     const usage: TokenUsage = {
@@ -116,58 +182,113 @@ export class TurnCostAttributor {
 
     const breakdown = calculateCost(event.model, usage);
     const costUsd = breakdown.totalUsd;
-    const toolCount = this.pendingTurn.toolCalls.length;
+    const toolCount = state.pendingTurn.toolCalls.length;
     const costPerTool = toolCount > 0 ? costUsd / toolCount : 0;
 
     const attribution: TurnCostAttribution = {
-      turnId: this.pendingTurn.turnId,
-      startTime: this.pendingTurn.startTime,
-      endTime: this.pendingTurn.endTime,
-      toolCalls: this.pendingTurn.toolCalls.map((tc) => tc.toolUseId),
-      toolNames: this.pendingTurn.toolCalls.map((tc) => tc.toolName),
+      turnId: state.pendingTurn.turnId,
+      startTime: state.pendingTurn.startTime,
+      endTime: state.pendingTurn.endTime,
+      toolCalls: state.pendingTurn.toolCalls.map((tc) => tc.toolUseId),
+      toolNames: state.pendingTurn.toolCalls.map((tc) => tc.toolName),
       inputTokens: event.inputTokens,
       outputTokens: event.outputTokens,
       cacheReadTokens: event.cacheReadTokens,
       model: event.model,
       estimatedCostUsd: costUsd,
       costPerToolCall: costPerTool,
+      sessionId: event.sessionId ?? null,
     };
 
-    this.turns.push(attribution);
-    if (this.turns.length > MAX_TURNS) {
-      this.turns.shift();
+    state.turns.push(attribution);
+    if (state.turns.length > MAX_TURNS) {
+      state.turns.shift();
     }
 
-    this.totalAttributedCost += costUsd;
-    this.attributedToolCalls += toolCount;
+    state.totalAttributedCost += costUsd;
+    state.attributedToolCalls += toolCount;
 
-    for (const tc of this.pendingTurn.toolCalls) {
-      const entry = this.costByToolType.get(tc.toolName) ?? { totalCost: 0, callCount: 0 };
+    for (const tc of state.pendingTurn.toolCalls) {
+      const entry = state.costByToolType.get(tc.toolName) ?? { totalCost: 0, callCount: 0 };
       entry.totalCost += costPerTool;
       entry.callCount += 1;
-      this.costByToolType.set(tc.toolName, entry);
+      state.costByToolType.set(tc.toolName, entry);
     }
 
-    this.pendingTurn = null;
+    state.pendingTurn = null;
   }
 
   getCostForToolCall(
     toolUseId: string,
   ): { estimatedTurnCostUsd: number; costPerToolCallUsd: number } | null {
-    for (const turn of this.turns) {
-      if (turn.toolCalls.includes(toolUseId)) {
-        return {
-          estimatedTurnCostUsd: turn.estimatedCostUsd,
-          costPerToolCallUsd: turn.costPerToolCall,
-        };
+    for (const state of this.sessions.values()) {
+      for (const turn of state.turns) {
+        if (turn.toolCalls.includes(toolUseId)) {
+          return {
+            estimatedTurnCostUsd: turn.estimatedCostUsd,
+            costPerToolCallUsd: turn.costPerToolCall,
+          };
+        }
       }
     }
     return null;
   }
 
-  getMetrics(): CostAttributionMetrics {
+  /**
+   * @param sessionId When provided, scopes every stat to that session's own
+   *   bucket. Omit to get a real aggregate across every session in
+   *   `this.sessions` — sums (`totalAttributedCost`, `totalToolCalls`,
+   *   `attributedToolCalls`), merges (`costByToolType`), and concatenates
+   *   (`turns`, capped back down to `MAX_TURNS` by recency) — matching
+   *   `DecisionTracker.getMetrics()`'s "no-arg = everything" convention.
+   *   Used by callers with no single session in view, e.g. the
+   *   `nr_observe_get_cost_per_tool` MCP tool.
+   */
+  getMetrics(sessionId?: string): CostAttributionMetrics {
+    const empty: CostAttributionMetrics = {
+      turns: [],
+      costByToolType: {},
+      totalAttributedCost: 0,
+      attributionRate: 0,
+    };
+
+    if (sessionId !== undefined) {
+      const state = this.sessions.get(sessionId);
+      if (!state) return empty;
+      return TurnCostAttributor.buildMetrics(state);
+    }
+
+    if (this.sessions.size === 0) return empty;
+    return TurnCostAttributor.buildMetrics(this.aggregateAllSessions());
+  }
+
+  /** Sums/merges every session bucket into one `SessionState`-shaped value. */
+  private aggregateAllSessions(): SessionState {
+    const aggregate = createSessionState();
+    for (const state of this.sessions.values()) {
+      aggregate.turns.push(...state.turns);
+      aggregate.totalAttributedCost += state.totalAttributedCost;
+      aggregate.totalToolCalls += state.totalToolCalls;
+      aggregate.attributedToolCalls += state.attributedToolCalls;
+      for (const [tool, entry] of state.costByToolType) {
+        const existing = aggregate.costByToolType.get(tool) ?? { totalCost: 0, callCount: 0 };
+        existing.totalCost += entry.totalCost;
+        existing.callCount += entry.callCount;
+        aggregate.costByToolType.set(tool, existing);
+      }
+    }
+    // Same cap as each per-session bucket already enforces on insert — keep
+    // only the most recent MAX_TURNS across the merged set, by start time.
+    if (aggregate.turns.length > MAX_TURNS) {
+      aggregate.turns.sort((a, b) => a.startTime - b.startTime);
+      aggregate.turns = aggregate.turns.slice(-MAX_TURNS);
+    }
+    return aggregate;
+  }
+
+  private static buildMetrics(state: SessionState): CostAttributionMetrics {
     const costByToolType: Record<string, ToolTypeCostEntry> = {};
-    for (const [tool, entry] of this.costByToolType) {
+    for (const [tool, entry] of state.costByToolType) {
       costByToolType[tool] = {
         totalCost: entry.totalCost,
         callCount: entry.callCount,
@@ -176,19 +297,15 @@ export class TurnCostAttributor {
     }
 
     return {
-      turns: [...this.turns],
+      turns: [...state.turns],
       costByToolType,
-      totalAttributedCost: this.totalAttributedCost,
-      attributionRate: this.totalToolCalls > 0 ? this.attributedToolCalls / this.totalToolCalls : 0,
+      totalAttributedCost: state.totalAttributedCost,
+      attributionRate:
+        state.totalToolCalls > 0 ? state.attributedToolCalls / state.totalToolCalls : 0,
     };
   }
 
   reset(_sessionId?: string): void {
-    this.turns = [];
-    this.pendingTurn = null;
-    this.costByToolType = new Map();
-    this.totalAttributedCost = 0;
-    this.totalToolCalls = 0;
-    this.attributedToolCalls = 0;
+    this.sessions.clear();
   }
 }

--- a/src/security/audit-trail.test.ts
+++ b/src/security/audit-trail.test.ts
@@ -384,6 +384,23 @@ describe('AuditTrailManager', () => {
     expect(mgr.getSensitiveAccessLog()).toHaveLength(0);
   });
 
+  // entries is append-only in processing order, not timestamp order.
+  // Audit.tsx does `visible.slice(0, VISIBLE_LIMIT)` assuming newest-first,
+  // so getAuditLog() must sort by timestamp descending before returning —
+  // otherwise, once more than VISIBLE_LIMIT entries exist, the page shows
+  // the oldest entries forever instead of the most recent ones.
+  it('getAuditLog returns entries sorted by timestamp descending regardless of push order', () => {
+    const mgr = makeManager();
+    mgr.recordToolCall(makeRecord({ toolName: 'Read', timestamp: 300 }));
+    mgr.recordToolCall(makeRecord({ toolName: 'Write', timestamp: 100 }));
+    mgr.recordToolCall(makeRecord({ toolName: 'Bash', timestamp: 200 }));
+
+    // Unsorted, this would equal [300, 100, 200] — raw push order — so
+    // slice(0, N) on the frontend would keep whichever N happened to be
+    // pushed first, not the true newest N.
+    expect(mgr.getAuditLog().map((e) => e.timestamp)).toEqual([300, 200, 100]);
+  });
+
   // 11. Write → FileWrite
   it('classifies Write as FileWrite', () => {
     const mgr = makeManager();
@@ -549,6 +566,194 @@ describe('AuditTrailManager', () => {
   it('does not throw when no localStore is provided', () => {
     const mgr = makeManager();
     expect(() => mgr.recordToolCall(makeRecord())).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Synthetic session-id filtering on record.sessionId itself
+// ---------------------------------------------------------------------------
+
+describe('AuditTrailManager synthetic sessionId filtering', () => {
+  it.each(['pending-1738000000000', 'local-1738000000000', 'proxy-1738000000000'])(
+    'nulls out a synthetic record.sessionId ("%s") on recordToolCall, even though it is non-null',
+    (syntheticId) => {
+      const mgr = makeManager({ sessionId: 'sess-real' });
+      const audit = mgr.recordToolCall(makeRecord({ sessionId: syntheticId }));
+      expect(audit.sessionId).toBeNull();
+    },
+  );
+
+  it('nulls out a synthetic record.sessionId on recordProxyCall', () => {
+    const mgr = makeManager({ sessionId: 'sess-real' });
+    const audit = mgr.recordProxyCall(makeProxyRecord({ sessionId: 'proxy-conn-abc123' }));
+    expect(audit.sessionId).toBeNull();
+  });
+
+  it('still nulls out via the manager fallback when record.sessionId is null and the manager id is synthetic', () => {
+    const mgr = makeManager({ sessionId: 'local-1738000000000' });
+    const audit = mgr.recordToolCall(makeRecord({ sessionId: null }));
+    expect(audit.sessionId).toBeNull();
+  });
+
+  it('keeps a real, non-synthetic record.sessionId', () => {
+    const mgr = makeManager({ sessionId: 'local-1738000000000' });
+    const audit = mgr.recordToolCall(makeRecord({ sessionId: 'sess-abc-real' }));
+    expect(audit.sessionId).toBe('sess-abc-real');
+  });
+
+  it("a synthetic sessionId never appears in getAuditLog()'s output", () => {
+    const mgr = makeManager({ sessionId: 'sess-real' });
+    mgr.recordToolCall(makeRecord({ sessionId: 'pending-1738000000000', toolName: 'Read' }));
+    mgr.recordToolCall(makeRecord({ sessionId: 'sess-real', toolName: 'Write' }));
+
+    const log = mgr.getAuditLog();
+    expect(
+      log.every((e) => e.sessionId == null || !e.sessionId.match(/^(pending|local|proxy)-/)),
+    ).toBe(true);
+    expect(log.find((e) => e.tool === 'Read')?.sessionId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Disk read-back merges other processes' persisted audit history
+// ---------------------------------------------------------------------------
+
+describe('AuditTrailManager.getAuditLog() disk read-back', () => {
+  function makeLocalStoreWithDisk(diskEntries: unknown[]): {
+    store: LocalStore;
+    appendSpy: ReturnType<typeof jest.fn>;
+  } {
+    const appendSpy = jest.fn();
+    const store = {
+      appendAuditLog: appendSpy,
+      peekAllAuditLogs: jest.fn(() => diskEntries),
+    } as unknown as LocalStore;
+    return { store, appendSpy };
+  }
+
+  it("merges in a second (simulated) process's persisted audit records", () => {
+    // Simulates a second --stdio process that wrote to the shared audit/
+    // directory but whose in-memory AuditTrailManager this process never saw.
+    const otherProcessEntry = {
+      timestamp: 999,
+      sessionId: 'sess-other-process',
+      action: 'FileRead',
+      tool: 'Read',
+      detail: 'Read src/other-process-file.ts',
+      developer: 'bob',
+    };
+    const { store } = makeLocalStoreWithDisk([otherProcessEntry]);
+    const mgr = makeManager({ localStore: store });
+
+    mgr.recordToolCall(makeRecord({ toolName: 'Write', filePath: 'src/this-process-file.ts' }));
+
+    const log = mgr.getAuditLog();
+    expect(log.some((e) => e.detail === 'Read src/other-process-file.ts')).toBe(true);
+    expect(log.some((e) => e.detail.includes('this-process-file.ts'))).toBe(true);
+  });
+
+  it('does not double-count a record this process already has in memory AND already persisted to disk', () => {
+    const { store } = makeLocalStoreWithDisk([]);
+    const mgr = makeManager({ localStore: store });
+    const audit = mgr.recordToolCall(makeRecord({ toolName: 'Read', filePath: 'src/app.ts' }));
+
+    // The disk read-back sees this exact record (same shape it was
+    // persisted as) reflected back — simulating peekAllAuditLogs() reading
+    // the very entry this process's own persistToDisk() just wrote.
+    (store.peekAllAuditLogs as unknown as jest.Mock).mockReturnValue([
+      {
+        timestamp: audit.timestamp,
+        sessionId: audit.sessionId,
+        action: audit.action,
+        tool: audit.tool,
+        detail: audit.detail,
+        developer: audit.developer,
+        filePath: audit.filePath,
+      },
+    ]);
+
+    expect(mgr.getAuditLog()).toHaveLength(1);
+  });
+
+  it('drops a disk entry missing required fields instead of surfacing a broken row', () => {
+    const { store } = makeLocalStoreWithDisk([
+      { timestamp: 123, action: 'not-a-real-action', tool: 'Read', detail: 'x', developer: 'x' },
+      { timestamp: 123, tool: 'Read' }, // missing action/detail/developer
+    ]);
+    const mgr = makeManager({ localStore: store });
+
+    expect(mgr.getAuditLog()).toEqual([]);
+  });
+
+  it('re-filters a synthetic sessionId found in an old on-disk entry written before this filtering existed', () => {
+    const { store } = makeLocalStoreWithDisk([
+      {
+        timestamp: 555,
+        sessionId: 'pending-1738000000000',
+        action: 'FileRead',
+        tool: 'Read',
+        detail: 'Read src/old.ts',
+        developer: 'alice',
+      },
+    ]);
+    const mgr = makeManager({ localStore: store });
+
+    const log = mgr.getAuditLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]?.sessionId).toBeNull();
+  });
+
+  it('works with no localStore configured (falls back to in-memory only)', () => {
+    const mgr = makeManager();
+    mgr.recordToolCall(makeRecord({ toolName: 'Read' }));
+    expect(mgr.getAuditLog()).toHaveLength(1);
+  });
+
+  // Regression for the unbounded CPU/payload finding: getAuditLog() must
+  // cap its result and must forward that cap to peekAllAuditLogs() so the
+  // disk read itself stays bounded — not just the final in-memory slice.
+  it('passes an explicit limit through to localStore.peekAllAuditLogs()', () => {
+    const { store } = makeLocalStoreWithDisk([]);
+    const mgr = makeManager({ localStore: store });
+
+    mgr.getAuditLog(42);
+
+    expect(store.peekAllAuditLogs).toHaveBeenCalledWith(42);
+  });
+
+  it('defaults the limit passed to peekAllAuditLogs() when the caller omits one', () => {
+    const { store } = makeLocalStoreWithDisk([]);
+    const mgr = makeManager({ localStore: store });
+
+    mgr.getAuditLog();
+
+    // Whatever the concrete default is, it must be a bounded number, not
+    // "call with no argument" (which is what regressed to an unbounded
+    // disk read).
+    const [calledLimit] = (store.peekAllAuditLogs as unknown as jest.Mock).mock.calls[0] as [
+      number,
+    ];
+    expect(typeof calledLimit).toBe('number');
+    expect(calledLimit).toBeGreaterThan(0);
+  });
+
+  it('caps the merged in-memory + disk result to the requested limit', () => {
+    const diskEntries = Array.from({ length: 10 }, (_, i) => ({
+      timestamp: 1000 + i,
+      sessionId: null,
+      action: 'FileRead',
+      tool: 'Read',
+      detail: `disk-${i}`,
+      developer: 'alice',
+    }));
+    const { store } = makeLocalStoreWithDisk(diskEntries);
+    const mgr = makeManager({ localStore: store });
+    for (let i = 0; i < 10; i++) {
+      mgr.recordToolCall(makeRecord({ toolName: 'Read', filePath: `mem-${i}.ts` }));
+    }
+
+    const log = mgr.getAuditLog(5);
+    expect(log).toHaveLength(5);
   });
 });
 

--- a/src/security/audit-trail.ts
+++ b/src/security/audit-trail.ts
@@ -6,7 +6,7 @@
 
 import { createLogger } from '../shared/index.js';
 import type { NrEventData } from '../shared/index.js';
-import type { ToolCallRecord } from '../storage/types.js';
+import type { ToolCallRecord, AuditEntry } from '../storage/types.js';
 import type { ProxyToolCallRecord } from '../proxy/types.js';
 import type { LocalStore } from '../storage/local-store.js';
 import { redactSensitive } from '../config.js';
@@ -270,6 +270,115 @@ export function securityAlertToNrEvent(
 }
 
 // ---------------------------------------------------------------------------
+// Session ID resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * `record.sessionId` can itself already be synthetic
+ * (`pending-<ts>` before stdio session-ID resolution, `local-<ts>` in
+ * `--local` mode, `proxy-<ts>`/`proxy-conn-<uuid>` proxy fallbacks — see
+ * `src/index.ts`), so `isSyntheticSessionId()` must run against whichever
+ * value is actually used (the record's own id when present, otherwise the
+ * manager's own fallback `managerSessionId`), not only against the
+ * fallback. Matches the pattern already used by `SessionStore.
+ * loadAllSessions()` and `LiveSessionRegistry.getLiveSessions()`.
+ */
+function resolveAuditSessionId(
+  recordSessionId: string | null | undefined,
+  managerSessionId: string | null,
+): string | null {
+  const raw = recordSessionId ?? managerSessionId;
+  return isSyntheticSessionId(raw) ? null : raw;
+}
+
+// ---------------------------------------------------------------------------
+// Disk read-back
+// ---------------------------------------------------------------------------
+
+function isAuditAction(value: string): value is AuditAction {
+  return (
+    value === 'FileRead' ||
+    value === 'FileWrite' ||
+    value === 'FileEdit' ||
+    value === 'BashCommand' ||
+    value === 'McpToolCall' ||
+    value === 'AgentSpawn' ||
+    value === 'Search' ||
+    value === 'Other'
+  );
+}
+
+function isAlertSeverity(value: unknown): value is AlertSeverity {
+  return value === 'critical' || value === 'high' || value === 'medium';
+}
+
+/**
+ * Converts one on-disk `AuditEntry` (persisted by `appendAuditLog()`, from
+ * this process or another one) back into an `AuditRecord`. Returns `null`
+ * for a line that's missing/mistyped a required field rather than throwing
+ * or fabricating placeholder values — a malformed line is dropped, not
+ * surfaced as a broken row in the Audit page.
+ *
+ * Defensively re-applies `isSyntheticSessionId()` to the persisted
+ * `sessionId` too: files written before that filtering existed may still
+ * contain an unfiltered synthetic id (`pending-*`/`local-*`/`proxy-*`).
+ */
+function auditEntryToRecord(entry: AuditEntry): AuditRecord | null {
+  const { timestamp, action, tool, detail, developer } = entry;
+  if (
+    typeof timestamp !== 'number' ||
+    typeof action !== 'string' ||
+    typeof tool !== 'string' ||
+    typeof detail !== 'string' ||
+    typeof developer !== 'string' ||
+    !isAuditAction(action)
+  ) {
+    return null;
+  }
+
+  const rawSessionId = entry.sessionId;
+  const sessionId =
+    typeof rawSessionId === 'string' && !isSyntheticSessionId(rawSessionId) ? rawSessionId : null;
+  const filePath = typeof entry.filePath === 'string' ? entry.filePath : undefined;
+  const command = typeof entry.command === 'string' ? entry.command : undefined;
+
+  let securityAlert: SecurityAlert | undefined;
+  const rawAlert = entry.securityAlert;
+  if (rawAlert && typeof rawAlert === 'object') {
+    const a = rawAlert as Record<string, unknown>;
+    if (isAlertSeverity(a.severity) && typeof a.alertType === 'string') {
+      securityAlert = {
+        severity: a.severity,
+        alertType: a.alertType,
+        description: typeof a.description === 'string' ? a.description : a.alertType,
+      };
+    }
+  }
+
+  return {
+    timestamp,
+    sessionId,
+    action,
+    tool,
+    detail,
+    developer,
+    filePath,
+    command,
+    securityAlert,
+  };
+}
+
+/** Best-effort content fingerprint — AuditRecord has no unique id field, so
+ * this is the identity dedup key used to avoid double-counting a record
+ * that exists both in this process's own in-memory `entries` (not yet
+ * evicted) AND in the disk file it was already persisted to. */
+function auditIdentityKey(
+  r: Pick<AuditRecord, 'timestamp' | 'sessionId' | 'tool' | 'detail'>,
+): string {
+  return `${r.timestamp}|${r.sessionId ?? ''}|${r.tool}|${r.detail}`;
+}
+
+// ---------------------------------------------------------------------------
 // AuditTrailManager
 // ---------------------------------------------------------------------------
 
@@ -294,6 +403,16 @@ export class AuditTrailManager {
   private entries: AuditRecord[] = [];
   private sensitiveAccessLog: AuditRecord[] = [];
   private static readonly MAX_ENTRIES = 10_000;
+  /**
+   * Default cap for `getAuditLog()` when the caller doesn't pass an
+   * explicit `limit`. The largest known consumer is `Audit.tsx`, which
+   * renders at most 200 rows and exports at most the same 200-row slice —
+   * 1000 gives headroom for its per-classification client-side filter
+   * (a rare classification like `external_network` may need to look past
+   * more than 200 raw rows to find 200 matching ones) without ever falling
+   * back to a full unbounded disk read.
+   */
+  private static readonly DEFAULT_LOG_LIMIT = 1000;
 
   constructor(options: AuditTrailManagerOptions) {
     this.developer = options.developer;
@@ -319,7 +438,7 @@ export class AuditTrailManager {
     const rawCommand = record.command as string | undefined;
     const auditRecord: AuditRecord = {
       timestamp: record.timestamp,
-      sessionId: record.sessionId ?? (isSyntheticSessionId(this.sessionId) ? null : this.sessionId),
+      sessionId: resolveAuditSessionId(record.sessionId, this.sessionId),
       action,
       tool: record.toolName,
       detail,
@@ -363,7 +482,7 @@ export class AuditTrailManager {
 
     const auditRecord: AuditRecord = {
       timestamp: record.timestamp,
-      sessionId: record.sessionId ?? (isSyntheticSessionId(this.sessionId) ? null : this.sessionId),
+      sessionId: resolveAuditSessionId(record.sessionId, this.sessionId),
       action: 'McpToolCall',
       tool: record.toolName,
       detail,
@@ -392,8 +511,47 @@ export class AuditTrailManager {
     return auditRecord;
   }
 
-  getAuditLog(): readonly AuditRecord[] {
-    return this.entries;
+  /**
+   * Merges this process's own in-memory `entries` (capped at
+   * `MAX_ENTRIES`, evicted FIFO) with every process's persisted history from
+   * `~/.newrelic-preflight/audit/*.jsonl` via `LocalStore.peekAllAuditLogs()`,
+   * so disk is the durable source of truth and the in-memory array is just
+   * this process's own cache. Without this, every OTHER concurrent (or
+   * already-exited) process's flagged sensitive-file/destructive-command/
+   * external-network events would be invisible through this API even
+   * though they were faithfully written to disk.
+   *
+   * Bounded to `limit` (default `DEFAULT_LOG_LIMIT`): a long-lived `--local`
+   * daemon accumulates hundreds of thousands of on-disk rows across many
+   * `audit/*.jsonl` files, and reading/parsing all of them on every call
+   * would be unbounded CPU and payload for a caller that only ever renders
+   * or exports a couple hundred rows. `LocalStore.peekAllAuditLogs(limit)`
+   * itself stops reading once it has collected `limit` rows (newest files
+   * first), which is sufficient here: the merged set's size is always at
+   * least `max(this.entries.length, diskRowsPulled)`, so pulling `limit`
+   * disk rows guarantees at least `limit` total distinct rows are available
+   * to sort and slice below, whenever that many actually exist.
+   */
+  getAuditLog(limit: number = AuditTrailManager.DEFAULT_LOG_LIMIT): readonly AuditRecord[] {
+    const combined = [...this.entries];
+
+    if (this.localStore) {
+      const seen = new Set(combined.map(auditIdentityKey));
+      for (const diskEntry of this.localStore.peekAllAuditLogs(limit)) {
+        const record = auditEntryToRecord(diskEntry);
+        if (!record) continue;
+        const key = auditIdentityKey(record);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        combined.push(record);
+      }
+    }
+
+    // `entries` is append-only in processing order, not timestamp order —
+    // sort newest-first before slicing, so the cap (and the route's own
+    // `Audit.tsx` 200-row render/export slice) keeps the most recent
+    // entries, not whichever ones happen to sit at the front of the array.
+    return combined.sort((a, b) => b.timestamp - a.timestamp).slice(0, limit);
   }
 
   getSensitiveAccessLog(): readonly AuditRecord[] {

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -271,6 +271,145 @@ describe('LocalStore', () => {
     });
   });
 
+  // Read-only cross-file merge, mirroring peekAllBuffers()'s pattern.
+  describe('peekAllAuditLogs()', () => {
+    it('returns [] when the audit directory does not exist yet', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      // No appendAuditLog() call — directory exists (initialize() creates
+      // it) but is empty.
+      expect(store.peekAllAuditLogs()).toEqual([]);
+    });
+
+    it('reads entries back from a single day file without deleting it', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      const entry = makeAudit({ timestamp: Date.now(), tool: 'Read', detail: 'src/a.ts' });
+      store.appendAuditLog(entry);
+
+      const peeked = store.peekAllAuditLogs();
+      expect(peeked).toEqual([entry]);
+
+      const dateStr = new Date(entry.timestamp).toISOString().slice(0, 10);
+      const filepath = resolve(tmpDir, 'audit', `${dateStr}.jsonl`);
+      expect(existsSync(filepath)).toBe(true); // read-only — file untouched
+    });
+
+    it('merges entries from multiple day files, across multiple simulated processes', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      const day1 = new Date('2025-06-15T12:00:00Z').getTime();
+      const day2 = new Date('2025-06-16T12:00:00Z').getTime();
+      store.appendAuditLog(makeAudit({ timestamp: day1, detail: 'from day 1' }));
+      store.appendAuditLog(makeAudit({ timestamp: day2, detail: 'from day 2' }));
+
+      // A second process's LocalStore instance, writing to the same shared
+      // storagePath, appends its own entry to today's file.
+      const otherProcessStore = new LocalStore(tmpDir);
+      otherProcessStore.appendAuditLog(makeAudit({ timestamp: Date.now(), detail: 'from proc 2' }));
+
+      const peeked = store.peekAllAuditLogs();
+      expect(peeked).toHaveLength(3);
+      expect(peeked.map((e) => e.detail).sort()).toEqual(
+        ['from day 1', 'from day 2', 'from proc 2'].sort(),
+      );
+    });
+
+    it('drops a malformed mid-file line but keeps the torn last line silent', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      const dateStr = new Date().toISOString().slice(0, 10);
+      const filepath = resolve(tmpDir, 'audit', `${dateStr}.jsonl`);
+      const good = JSON.stringify(makeAudit({ detail: 'good' }));
+      writeFileSync(filepath, `${good}\nnot valid json\n{"timestamp":1,"action":"a","tool":"t"`);
+
+      const peeked = store.peekAllAuditLogs();
+      expect(peeked).toEqual([JSON.parse(good)]);
+
+      const warnCalls = (stderrSpy.mock.calls as unknown[][]).filter((args) =>
+        String(args[0]).includes('peekAllAuditLogs: dropping malformed mid-file line'),
+      );
+      expect(warnCalls).toHaveLength(1);
+    });
+
+    // Regression for the unbounded-CPU/payload finding: a long-lived daemon
+    // can accumulate far more `audit/*.jsonl` day-files (and rows) than any
+    // consumer ever renders or exports. `limit` must stop opening older
+    // files once enough rows are collected, not just truncate the result
+    // after reading everything.
+    //
+    // Proof that the older files are never *opened* (not just filtered out
+    // of the result afterwards): every one of the 8 oldest day-files is
+    // written with a mid-file malformed line, which — per the "drops a
+    // malformed mid-file line" test above — triggers a
+    // 'peekAllAuditLogs: dropping malformed mid-file line' warning if and
+    // only if that file is actually read and parsed. If the early stop
+    // works, those 8 files are never opened and no such warning fires for
+    // them.
+    it('with a limit, stops opening older day-files once enough rows are collected', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+      const auditDir = resolve(tmpDir, 'audit');
+
+      const dayCount = 10;
+      const rowsPerNewDay = 3; // the 2 newest days: clean, 3 valid rows each
+      const baseDay = new Date('2025-01-01T12:00:00Z').getTime();
+      const dayFile = (d: number): string =>
+        resolve(
+          auditDir,
+          `${new Date(baseDay + d * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)}.jsonl`,
+        );
+
+      // 8 oldest days: each has a mid-file malformed line, which would warn
+      // if (and only if) the file is opened and parsed.
+      for (let d = 0; d < dayCount - 2; d++) {
+        const good = JSON.stringify(makeAudit({ detail: `day${d}-good` }));
+        writeFileSync(dayFile(d), `${good}\nnot valid json\n${good}\n`);
+      }
+      // 2 newest days: clean rows only.
+      for (let d = dayCount - 2; d < dayCount; d++) {
+        for (let r = 0; r < rowsPerNewDay; r++) {
+          store.appendAuditLog(
+            makeAudit({ timestamp: baseDay + d * 24 * 60 * 60 * 1000, detail: `day${d}-row${r}` }),
+          );
+        }
+      }
+
+      stderrSpy.mockClear();
+
+      // 2 newest days hold 6 rows combined, comfortably over this limit —
+      // so the loop should stop after those 2 files and never touch the 8
+      // older (malformed) ones.
+      const limit = 5;
+      const peeked = store.peekAllAuditLogs(limit);
+
+      expect(peeked.length).toBeGreaterThanOrEqual(limit);
+      const details = peeked.map((e) => e.detail);
+      for (const d of details) {
+        expect(d).toMatch(/^day[89]-row/);
+      }
+
+      const malformedWarnings = (stderrSpy.mock.calls as unknown[][]).filter((args) =>
+        String(args[0]).includes('peekAllAuditLogs: dropping malformed mid-file line'),
+      );
+      expect(malformedWarnings).toHaveLength(0);
+    });
+
+    it('without a limit, reads every day-file (existing unbounded behavior preserved)', () => {
+      const store = new LocalStore(tmpDir);
+      store.initialize();
+
+      const dayCount = 6;
+      const baseDay = new Date('2025-02-01T12:00:00Z').getTime();
+      for (let d = 0; d < dayCount; d++) {
+        store.appendAuditLog(makeAudit({ timestamp: baseDay + d * 24 * 60 * 60 * 1000 }));
+      }
+
+      const peeked = store.peekAllAuditLogs();
+      expect(peeked).toHaveLength(dayCount);
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Fault injection
   // ---------------------------------------------------------------------------

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -1040,4 +1040,91 @@ export class LocalStore {
       logger.warn('Failed to append audit log', { error: String(err) });
     }
   }
+
+  /**
+   * Read persisted audit-log JSONL files under `audit/` (one per calendar
+   * day, written by `appendAuditLog()` — including by *other* processes'
+   * `AuditTrailManager` instances, since every `--stdio`/`--local` process
+   * persists to the same shared `audit/` directory) WITHOUT deleting or
+   * moving anything — read-only, unlike `drainAllBuffers()`, because the
+   * audit log is meant to be a durable record, not a work queue. Used by
+   * `AuditTrailManager.getAuditLog()` to merge in every process's
+   * persisted history instead of returning only the calling process's own
+   * capped in-memory `entries` array.
+   *
+   * Mirrors `peekAllBuffers()`'s torn-tail-tolerant parse pattern above: the
+   * last non-empty line of a file may legitimately be torn by a concurrent
+   * appender and is dropped silently, but a parse failure on any earlier
+   * line is real corruption and is logged.
+   *
+   * @param limit Optional cap on how many rows to return. Filenames are
+   *   `YYYY-MM-DD.jsonl`, which sort lexicographically in calendar order, so
+   *   files are read newest-day-first and reading stops as soon as `limit`
+   *   rows have been collected — older files are never opened. A whole file
+   *   is always read to completion once opened (rows aren't truncated
+   *   mid-file), so the result may overshoot `limit` slightly; callers that
+   *   need an exact count should slice the result themselves. Without a
+   *   `limit`, every file is read (unbounded, same as `peekAllBuffers()`) —
+   *   audit files are never pruned, so a very long-lived
+   *   `~/.newrelic-preflight/audit/` directory means more files read on
+   *   every call in that mode.
+   */
+  peekAllAuditLogs(limit?: number): AuditEntry[] {
+    const all: AuditEntry[] = [];
+    const auditDir = resolve(this.storagePath, 'audit');
+    let entries: string[];
+    try {
+      if (!existsSync(auditDir)) return [];
+      entries = readdirSync(auditDir);
+    } catch (err) {
+      logger.warn('Failed to enumerate audit dir for peekAllAuditLogs', { error: String(err) });
+      return [];
+    }
+    // Newest day-file first so a `limit` can stop opening older files once
+    // enough rows are collected — `YYYY-MM-DD.jsonl` names sort
+    // chronologically as plain strings, so lexicographic descending order
+    // is newest-first.
+    const jsonlFiles = entries
+      .filter((name) => name.endsWith('.jsonl'))
+      .sort()
+      .reverse();
+    for (const name of jsonlFiles) {
+      const path = resolve(auditDir, name);
+      let raw: string;
+      try {
+        raw = readFileSync(path, 'utf-8');
+      } catch {
+        continue;
+      }
+      if (!raw.trim()) continue;
+      const lines = raw.split('\n');
+      let lastNonEmptyIdx = -1;
+      for (let i = lines.length - 1; i >= 0; i--) {
+        if (lines[i]!.trim()) {
+          lastNonEmptyIdx = i;
+          break;
+        }
+      }
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]!;
+        if (!line.trim()) continue;
+        try {
+          all.push(JSON.parse(line) as AuditEntry);
+        } catch {
+          if (i === lastNonEmptyIdx) {
+            // Torn-tail race against a concurrent appender — expected.
+            continue;
+          }
+          logger.warn('peekAllAuditLogs: dropping malformed mid-file line', {
+            file: name,
+            lineIndex: i,
+            preview: line.slice(0, 100),
+            entriesSoFar: all.length,
+          });
+        }
+      }
+      if (limit !== undefined && all.length >= limit) break;
+    }
+    return all;
+  }
 }

--- a/src/tools/session-stats.test.ts
+++ b/src/tools/session-stats.test.ts
@@ -11,6 +11,7 @@ import { CostTracker } from '../metrics/cost-tracker.js';
 import { BudgetTracker } from '../metrics/budget-tracker.js';
 import { ContextWindowTracker } from '../metrics/context-window-tracker.js';
 import { TaskDetector } from '../metrics/task-detector.js';
+import { TurnCostAttributor } from '../metrics/turn-cost-attributor.js';
 import { SessionStore } from '../storage/session-store.js';
 import { GenericMcpAdapter } from '../platforms/generic-mcp-adapter.js';
 import { FeedbackCollector } from './workflow-tools.js';
@@ -24,7 +25,7 @@ import {
 } from './session-stats.js';
 import type { ConfigSummary, ToolRegistrationOptions } from './session-stats.js';
 import type { HeadlessInstallResult } from '../install/headless-install.js';
-import type { ToolCallRecord } from '../storage/types.js';
+import type { ToolCallRecord, TokenEvent } from '../storage/types.js';
 import type { WeeklySummaryGenerator } from '../storage/weekly-summary.js';
 import type { TrendAnalyzer } from '../metrics/trend-analyzer.js';
 import type { CollaborationProfiler } from '../metrics/collaboration-profile.js';
@@ -1006,6 +1007,58 @@ describe('MCP protocol integration — direct registerTools() dispatch', () => {
     const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
     expect(typeof body.confidenceNote).toBe('string');
     expect(body.forecastEndOfDayUsd).toBeGreaterThanOrEqual(0);
+  });
+
+  // Regression: nr_observe_get_cost_per_tool calls TurnCostAttributor
+  // .getMetrics() with no argument, so a process-wide MCP tool with no
+  // single session in view must get a real aggregate across every session
+  // the tracker has seen — not whichever single session happened to be
+  // touched most recently.
+  it('nr_observe_get_cost_per_tool aggregates across every session when called with no session filter', async () => {
+    const turnCostAttributor = new TurnCostAttributor();
+    turnCostAttributor.recordToolCall(
+      makeRecord({ sessionId: 'session-a', toolUseId: 'a-1', toolName: 'Read', timestamp: 1000 }),
+    );
+    turnCostAttributor.recordTokenEvent({
+      mode: 'token',
+      timestamp: 1100,
+      inputTokens: 1_000,
+      outputTokens: 100,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      model: 'claude-sonnet-4',
+      sessionId: 'session-a',
+    } as TokenEvent);
+    turnCostAttributor.recordToolCall(
+      makeRecord({ sessionId: 'session-b', toolUseId: 'b-1', toolName: 'Write', timestamp: 5000 }),
+    );
+    turnCostAttributor.recordTokenEvent({
+      mode: 'token',
+      timestamp: 5100,
+      inputTokens: 2_000,
+      outputTokens: 200,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      model: 'claude-sonnet-4',
+      sessionId: 'session-b',
+    } as TokenEvent);
+
+    await connectDirect({ turnCostAttributor });
+
+    const result = await client.callTool({ name: 'nr_observe_get_cost_per_tool', arguments: {} });
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+
+    // Both sessions' turns and cost are present — a "most recently touched
+    // session" fallback would have returned only session-b's data here.
+    expect(body.turns).toHaveLength(2);
+    expect(body.totalAttributedCost).toBeGreaterThan(0);
+    expect(body.totalAttributedCost).toEqual(
+      turnCostAttributor.getMetrics('session-a').totalAttributedCost +
+        turnCostAttributor.getMetrics('session-b').totalAttributedCost,
+    );
+    expect(body.costByToolType['Read']).toBeDefined();
+    expect(body.costByToolType['Write']).toBeDefined();
   });
 
   it('nr_observe_get_session_history silently coerces a numeric "since" (documented as an ISO string) via new Date(number) instead of rejecting it', async () => {

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -358,10 +358,21 @@ export interface TurnCostsResponse {
   readonly attributionRate: number;
 }
 
-export const fetchDecisionTree = (): Promise<DecisionTreeResponse> =>
-  getJson<DecisionTreeResponse>('/api/decision-tree');
-export const fetchTurnCosts = (): Promise<TurnCostsResponse> =>
-  getJson<TurnCostsResponse>('/api/turn-costs');
+// sessionId scopes the result to one session's own decision-
+// tree/turn-cost data instead of whichever session(s) this process-global
+// tracker happened to have most recently accumulated (in `--local` mode,
+// several concurrently-live sessions blended together). Omit to preserve
+// the old unscoped behavior.
+export const fetchDecisionTree = (sessionId?: string): Promise<DecisionTreeResponse> =>
+  getJson<DecisionTreeResponse>(
+    sessionId
+      ? `/api/decision-tree?sessionId=${encodeURIComponent(sessionId)}`
+      : '/api/decision-tree',
+  );
+export const fetchTurnCosts = (sessionId?: string): Promise<TurnCostsResponse> =>
+  getJson<TurnCostsResponse>(
+    sessionId ? `/api/turn-costs?sessionId=${encodeURIComponent(sessionId)}` : '/api/turn-costs',
+  );
 
 export interface QualityEvent {
   readonly signal:
@@ -1081,6 +1092,14 @@ export interface WorkflowRunInfo {
   readonly agentCount?: number | null;
   readonly totalTokens?: number | null;
   readonly totalUsd?: number | null;
+  /**
+   * True when `totalUsd` is `null` because the cost was never observed by
+   * any process (as opposed to a confirmed $0) — see
+   * `WorkflowRunRow.cost_unknown`'s docstring (`workflow-store.ts`). Sum a
+   * KPI over several runs' `totalUsd` and flag the sum as partial when any
+   * contributing run has `costUnknown: true`.
+   */
+  readonly costUnknown?: boolean;
   readonly declaredPhases?: number | null;
   readonly observedPhases?: number | null;
   readonly declaredParallelWidths?: ReadonlyArray<number | 'dynamic'> | null;

--- a/src/web/components/SessionDetailDialog.tsx
+++ b/src/web/components/SessionDetailDialog.tsx
@@ -101,8 +101,9 @@ export function SessionDetailDialog({
           <div className="flex-1 min-w-0">
             <h2 className="text-sm font-semibold text-ink-base">Session Detail</h2>
             <p className="mt-1 text-[10px] text-ink-muted">
-              Live, current-process-only — reflects this dashboard process&rsquo;s own current
-              session.
+              Decision Tree and Turn Costs below are scoped to the selected session. Context
+              Composition &amp; Efficiency remain live, current-process-only — they reflect this
+              dashboard process&rsquo;s own current session, not necessarily the one selected above.
             </p>
           </div>
           <button

--- a/src/web/store/liveStore.ts
+++ b/src/web/store/liveStore.ts
@@ -119,6 +119,18 @@ interface LiveState {
   addSubagentTurn(usdEstimate: number | null): void;
   upsertWorkflowRun(run: WorkflowRunLiveState): void;
   setObservabilityHealth(health: ObservabilityHealthState): void;
+  /**
+   * Clears the SSE-derived `cost` snapshot and resets the subagent
+   * accumulators once the caller has detected a local-midnight rollover
+   * (see the interval in Today.tsx). `setCost`/`addSubagentTurn`
+   * only fire on a fresh server push, so a tab left open across midnight
+   * with no new tool-call activity right away would otherwise keep
+   * displaying yesterday's "Spend Today"/forecast/subagent numbers forever
+   * — nothing else ever invalidates the cached value. After this runs, the
+   * KPIs fall back to the day-aware `/api/sessions/today/aggregate`/
+   * persisted-session values until a fresh same-day SSE frame arrives.
+   */
+  handleDayRollover(): void;
 }
 
 const RECENT_CAP = 20;
@@ -245,6 +257,8 @@ export const useLiveStore = create<LiveState>((set) => ({
     }),
 
   setObservabilityHealth: (health) => set({ observabilityHealth: health }),
+
+  handleDayRollover: () => set({ cost: null, todaySubagentUsd: 0, todaySubagentTurnCount: 0 }),
 }));
 
 // ---------------------------------------------------------------------------

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -486,6 +486,23 @@ describe('Sessions view — workflow consolidation', () => {
     expect(container.textContent).toMatch(/\$3(\.0+)?/);
   });
 
+  // A run's totalUsd being null is ambiguous between "confirmed $0" and "no
+  // process ever observed this run's cost". costUnknown distinguishes the
+  // two (a partial mitigation); the KPI must disclose when it does.
+  it('flags the Workflow spend KPI as partial when a run has an unknown (not confirmed-zero) cost', async () => {
+    const runsWithUnknownCost = [RUNS[0], { ...RUNS[1], totalUsd: null, costUnknown: true }];
+    renderSessionsFull(SESSIONS, runsWithUnknownCost);
+    await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());
+    expect(screen.getByText(/partial/i)).toBeInTheDocument();
+  });
+
+  it('does not flag the Workflow spend KPI as partial when every null cost is a confirmed $0', async () => {
+    const runsWithConfirmedZero = [RUNS[0], { ...RUNS[1], totalUsd: null, costUnknown: false }];
+    renderSessionsFull(SESSIONS, runsWithConfirmedZero);
+    await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());
+    expect(screen.queryByText(/partial/i)).not.toBeInTheDocument();
+  });
+
   it('scopes the visible session list to the run-source filter', async () => {
     renderSessionsFull(SESSIONS, RUNS);
     await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -287,9 +287,15 @@ export function Sessions(): JSX.Element {
     const totalAgents = filteredRuns.reduce((sum, r) => sum + (r.agentCount ?? 0), 0);
     const spendVals = filteredRuns.map((r) => r.totalUsd).filter((v): v is number => v != null);
     const totalSpend = spendVals.length > 0 ? spendVals.reduce((a, b) => a + b, 0) : null;
+    // A run's totalUsd can be null either because it's a confirmed $0 or
+    // because no process ever observed its cost (restart, or a --local
+    // dashboard reading a different --stdio process's run). costUnknown
+    // distinguishes the two (a partial mitigation); if any filtered run has
+    // it set, the KPI sum above is missing real spend, not just zeros.
+    const spendIsPartial = filteredRuns.some((r) => r.costUnknown === true);
     const durs = filteredRuns.map((r) => r.durationMs).filter((v): v is number => v != null);
     const avgDurationMs = durs.length > 0 ? durs.reduce((a, b) => a + b, 0) / durs.length : null;
-    return { totalRuns, totalAgents, totalSpend, avgDurationMs };
+    return { totalRuns, totalAgents, totalSpend, spendIsPartial, avgDurationMs };
   }, [filteredRuns]);
   // runId-set per session, built from the FILTERED runs — drives both the
   // per-session run tree and which sessions stay visible when a filter is set.
@@ -380,8 +386,13 @@ export function Sessions(): JSX.Element {
           <div className="px-3">
             <Kpi
               label="Workflow spend"
-              value={formatUsdOrDash(kpis.totalSpend)}
+              value={formatUsdOrDash(kpis.totalSpend) + (kpis.spendIsPartial ? '*' : '')}
               tone={kpis.totalSpend !== null ? 'warn' : 'neutral'}
+              sub={
+                kpis.spendIsPartial
+                  ? '*partial — some runs have cost never observed by any process'
+                  : undefined
+              }
             />
           </div>
           <div className="px-3">

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Today } from './Today';
 import { useLiveStore } from '../store/liveStore';
 import { qk } from '../api/client';
+import { localStartOfDay } from '../../lib/date.js';
 
 function renderToday(qc?: QueryClient) {
   const client =
@@ -232,6 +233,122 @@ describe('Today view', () => {
       </QueryClientProvider>,
     );
     await waitFor(() => expect(screen.queryByText(/session detail/i)).toBeNull());
+  });
+
+  // With two concurrently-live sessions (a documented, supported
+  // scenario in `--local` mode), the session-detail drawer must only ever
+  // show the SELECTED session's turn-cost/decision-tree data, not a blend
+  // of both or whichever session this process-global tracker last recorded.
+  it('scopes the session-detail drawer to the selected session when two sessions are concurrently live', async () => {
+    const liveSessions = [
+      { sessionId: 'session-alpha', sessionName: 'alpha', startTime: 1, lastActivity: 9_000 },
+      { sessionId: 'session-beta', sessionName: 'beta', startTime: 1, lastActivity: 1_000 },
+    ];
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/sessions/live')) {
+        return new Response(JSON.stringify(liveSessions), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.startsWith('/api/turn-costs')) {
+        const sessionId = new URL(url, 'http://localhost').searchParams.get('sessionId');
+        const isAlpha = sessionId === 'session-alpha';
+        return new Response(
+          JSON.stringify({
+            turns: [
+              {
+                turnId: 't1',
+                startTime: 0,
+                endTime: 1,
+                toolCalls: ['toolu_1'],
+                toolNames: ['Read'],
+                inputTokens: 500,
+                outputTokens: 200,
+                cacheReadTokens: 0,
+                model: 'claude-sonnet-5',
+                estimatedCostUsd: isAlpha ? 0.11 : 0.99,
+                costPerToolCall: isAlpha ? 0.11 : 0.99,
+              },
+            ],
+            costByToolType: {},
+            totalAttributedCost: isAlpha ? 0.11 : 0.99,
+            attributionRate: 1,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.startsWith('/api/decision-tree')) {
+        return new Response(
+          JSON.stringify({
+            totalBranches: 0,
+            successRate: null,
+            failurePoints: [],
+            longestFailureStreak: 0,
+            firstFailureIndex: null,
+            note: '',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(
+          JSON.stringify({
+            toolCallCount: 1,
+            totalCostUsd: 0,
+            antiPatternCount: 0,
+            avgDurationMs: 0,
+            sessionCount: 2,
+            sparkline: { startTimestamp: 0, bucketSizeMs: 60_000, points: [] },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions/session-alpha/replay')) {
+        return new Response(JSON.stringify({ sessionId: 'session-alpha', timeline: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/sessions/session-beta/replay')) {
+        return new Response(JSON.stringify({ sessionId: 'session-beta', timeline: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.startsWith('/api/context')) {
+        return new Response(
+          JSON.stringify({
+            turnCount: 0,
+            growth: { startTokens: 0, currentTokens: 0, deltaTokens: 0 },
+            currentBreakdown: { system: 0, tools: 0, user: 0, assistant: 0 },
+            fillPercent: 0,
+            contextWindow: 200_000,
+            toolContributions: [],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+
+    // Default selection is the most-recently-active session (alpha).
+    const alphaTrigger = await screen.findByText(/\$0\.11.*session detail/i);
+    expect(alphaTrigger).toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.99/)).toBeNull();
+
+    // Switch to beta — the drawer trigger must update to beta's own data,
+    // not stay pinned to alpha's or show a blend of both.
+    fireEvent.click(screen.getByText('beta'));
+    const betaTrigger = await screen.findByText(/\$0\.99.*session detail/i);
+    expect(betaTrigger).toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.11/)).toBeNull();
   });
 
   it('shows the session detail trigger from context-history data alone, with no decision/cost data', async () => {
@@ -1508,5 +1625,247 @@ describe('Today view — Compute Waste panel', () => {
     renderToday();
     expect(await screen.findByText(/retry: ~200/)).toBeInTheDocument();
     expect(screen.getByText(/anti-pattern: ~400/)).toBeInTheDocument();
+  });
+});
+
+describe('Today view — cross-midnight session proration', () => {
+  beforeEach(() => {
+    useLiveStore.setState({
+      connected: true,
+      recentToolCalls: [],
+      cost: null,
+      antiPatterns: [],
+      firingAlerts: new Map(),
+      dismissedAlerts: new Set(),
+      activeSessionId: null,
+    });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prorates a cross-midnight session's tool-call/flag counts and hourly spend by its today-portion, instead of its full lifetime count or excluding it entirely", async () => {
+    const dayStart = localStartOfDay();
+    // Started 2h before local midnight and ran 4h total (ends 2h into
+    // today) — half the session's lifetime overlaps today, ratio 0.5.
+    const crossMidnightSession = {
+      sessionId: 'cross-midnight',
+      startTime: dayStart - 2 * 60 * 60 * 1000,
+      durationMs: 4 * 60 * 60 * 1000,
+      toolCallCount: 100,
+      estimatedCostUsd: 10,
+      antiPatterns: Array.from({ length: 10 }, (_, i) => ({
+        type: 'thrashing',
+        target: `f${i}.ts`,
+      })),
+    };
+
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(
+          JSON.stringify({
+            toolCallCount: 0,
+            totalCostUsd: 0,
+            antiPatternCount: 0,
+            avgDurationMs: 0,
+            sessionCount: 0,
+            sparkline: { startTimestamp: 0, bucketSizeMs: 60_000, points: [] },
+            forecastEndOfDayUsd: 5,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions?limit=')) {
+        return new Response(JSON.stringify([crossMidnightSession]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+
+    // 100 tool calls * 0.5 ratio = 50 — not the full lifetime count of 100.
+    // Using ratio only as an inclusion gate and adding the entire
+    // toolCallCount once the session qualifies would show 100 instead.
+    expect(await screen.findByText('50')).toBeInTheDocument();
+    // 10 flags * 0.5 ratio = 5 — not the full lifetime count of 10, for the
+    // same reason.
+    expect(screen.getByText('5')).toBeInTheDocument();
+    // buildHourlySpend must not skip a session that didn't *start* today
+    // entirely (a naive `!isToday(s.startTime)` → continue would drop it),
+    // or the hourly chart would be absent here even though todayTotal > 0.
+    expect(screen.getByRole('img', { name: /Hourly spend today/ })).toBeInTheDocument();
+  });
+});
+
+describe('Today view — day-rollover clears stale SSE snapshot', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ) as typeof fetch;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('clears the stale SSE cost/subagent snapshot once the 60s tick detects a local-midnight rollover', () => {
+    vi.setSystemTime(new Date(2026, 5, 14, 23, 59, 0));
+    useLiveStore.setState({
+      connected: true,
+      recentToolCalls: [],
+      cost: { sessionTotalUsd: 12, todayTotalUsd: 999, forecastEodUsd: 999 },
+      antiPatterns: [],
+      firingAlerts: new Map(),
+      dismissedAlerts: new Set(),
+      todaySubagentUsd: 3,
+      todaySubagentTurnCount: 4,
+      activeSessionId: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <Today />
+      </QueryClientProvider>,
+    );
+
+    // Sanity check: the stale-but-same-day snapshot is present before the
+    // rollover.
+    expect(useLiveStore.getState().cost?.todayTotalUsd).toBe(999);
+
+    // Cross local midnight and let the 60s tick run — asserted against the
+    // store directly (not the rendered KPI text), since the KPI's displayed
+    // value also depends on unrelated TanStack Query fetches settling,
+    // which isn't what this test is verifying.
+    act(() => {
+      vi.setSystemTime(new Date(2026, 5, 15, 0, 1, 0));
+      vi.advanceTimersByTime(60_000);
+    });
+
+    // Without invalidating this cached SSE snapshot, it would keep
+    // reporting yesterday's numbers forever once the tab was left open
+    // across midnight with no new SSE frame.
+    const state = useLiveStore.getState();
+    expect(state.cost).toBeNull();
+    expect(state.todaySubagentUsd).toBe(0);
+    expect(state.todaySubagentTurnCount).toBe(0);
+  });
+});
+
+describe('Today view — traceWindow ignores the no-subagent sentinel window', () => {
+  beforeEach(() => {
+    useLiveStore.setState({
+      connected: true,
+      recentToolCalls: [],
+      cost: null,
+      antiPatterns: [],
+      firingAlerts: new Map(),
+      dismissedAlerts: new Set(),
+      activeSessionId: null,
+    });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not drag the shared trace window down to epoch 0 when the session has no subagents', async () => {
+    const startMs = 1_700_000_000_000;
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/sessions/live')) {
+        return new Response(
+          JSON.stringify([
+            {
+              sessionId: 'no-agents',
+              sessionName: 'solo',
+              startTime: startMs,
+              lastActivity: startMs,
+            },
+          ]),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions/no-agents/replay')) {
+        return new Response(
+          JSON.stringify({
+            sessionId: 'no-agents',
+            // Two entries spanning 65s of real, recent wall-clock time.
+            timeline: [
+              { timestamp: startMs, toolName: 'Read', durationMs: 0, success: true },
+              { timestamp: startMs + 65_000, toolName: 'Read', durationMs: 0, success: true },
+            ],
+            segments: [],
+            worstSegment: null,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions/no-agents/subagents')) {
+        // getSubagentsForSession's documented no-transcripts sentinel.
+        return new Response(JSON.stringify({ window: { startMs: 0, endMs: 0 }, agents: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/sessions/today/aggregate')) {
+        // Nonzero toolCallCount so the page doesn't fall into the
+        // no-activity-today empty state, which would hide the trace pane
+        // entirely.
+        return new Response(
+          JSON.stringify({
+            toolCallCount: 2,
+            totalCostUsd: 0,
+            antiPatternCount: 0,
+            avgDurationMs: 0,
+            sessionCount: 1,
+            sparkline: { startTimestamp: 0, bucketSizeMs: 60_000, points: [] },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/context')) {
+        // The session is live, so ContextBar renders below the trace and
+        // needs a well-shaped response.
+        return new Response(
+          JSON.stringify({
+            turnCount: 0,
+            growth: { startTokens: 0, currentTokens: 0, deltaTokens: 0 },
+            currentBreakdown: { system: 0, tools: 0, user: 0, assistant: 0 },
+            fillPercent: 0,
+            toolContributions: [],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+
+    // Sanity: the trace pane actually rendered the Gantt view for this session.
+    expect(await screen.findByText('Parent')).toBeInTheDocument();
+
+    // With a real ~65s window, the axis's ticks land on small mm:ss values
+    // (e.g. "1:00" at the 60s mark). A naive `Number.isFinite(0)` check
+    // would let the {startMs:0,endMs:0} sentinel merge in, dragging startMs
+    // to epoch 0 and inflating the span to ~1.7e12ms — every tick label
+    // would then render as a multi-million-minute value instead.
+    expect(await screen.findByText('1:00')).toBeInTheDocument();
+    expect(screen.queryByText(/^\d{4,}:\d{2}$/)).toBeNull();
   });
 });

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -70,7 +70,7 @@ import {
   scoreColor,
   shortToolName,
 } from '../lib/format';
-import { isSameLocalDay, localStartOfDay } from '../../lib/date.js';
+import { isSameLocalDay, localStartOfDay, todayPortionRatio } from '../../lib/date.js';
 
 const HEADER_TIMESTAMP_FORMAT = {
   weekday: 'short',
@@ -298,11 +298,24 @@ export function Today(): JSX.Element {
   const [headerTimestamp, setHeaderTimestamp] = useState(() =>
     new Date().toLocaleString(undefined, HEADER_TIMESTAMP_FORMAT),
   );
+  // Tracks the local calendar day this component last observed. The same
+  // 60s tick that refreshes the header clock also checks for a local-
+  // midnight rollover and clears the SSE-derived cost/subagent snapshot when
+  // one is detected — without this, a dashboard tab left open across
+  // midnight with no new tool-call activity right away keeps rendering
+  // yesterday's "Spend Today"/forecast/subagent numbers forever, since
+  // setCost()/addSubagentTurn() only fire on a fresh server push and nothing
+  // else invalidates the cached value.
+  const lastSeenDayRef = useRef(Date.now());
   useEffect(() => {
-    const id = setInterval(
-      () => setHeaderTimestamp(new Date().toLocaleString(undefined, HEADER_TIMESTAMP_FORMAT)),
-      60_000,
-    );
+    const id = setInterval(() => {
+      const now = Date.now();
+      setHeaderTimestamp(new Date(now).toLocaleString(undefined, HEADER_TIMESTAMP_FORMAT));
+      if (!isSameLocalDay(now, lastSeenDayRef.current)) {
+        lastSeenDayRef.current = now;
+        useLiveStore.getState().handleDayRollover();
+      }
+    }, 60_000);
     return () => clearInterval(id);
   }, []);
 
@@ -1076,17 +1089,19 @@ function LiveSessionPane({
   });
 
   // Decision-tree + per-turn cost detail — both trackers are live,
-  // in-memory, current-process-only accumulators (no persistence), so this
-  // always reflects this dashboard process's own current session, not
-  // necessarily the session selected in the list on the left.
+  // in-memory, process-scoped accumulators (no persistence), but are
+  // filtered server-side to the selected session by passing
+  // `activeId` through as `?sessionId=`, so the session-detail drawer below
+  // always reflects the session actually selected in the trace pane above
+  // it, not just whichever session this process last recorded.
   const { data: turnCosts } = useQuery<TurnCostsResponse>({
-    queryKey: ['turn-costs'],
-    queryFn: fetchTurnCosts,
+    queryKey: activeId ? ['turn-costs', activeId] : ['turn-costs'],
+    queryFn: () => fetchTurnCosts(activeId ?? undefined),
     refetchInterval: 10_000,
   });
   const { data: decisionTree } = useQuery<DecisionTreeResponse>({
-    queryKey: ['decision-tree'],
-    queryFn: fetchDecisionTree,
+    queryKey: activeId ? ['decision-tree', activeId] : ['decision-tree'],
+    queryFn: () => fetchDecisionTree(activeId ?? undefined),
     refetchInterval: 10_000,
   });
   // Mirrors ContextBar's own internal query for the same sessionId — using
@@ -1098,6 +1113,13 @@ function LiveSessionPane({
     refetchInterval: 10_000,
     enabled: isLive && Boolean(activeId),
   });
+  // Unlike turnCosts/decisionTree above, ContextCompositionTracker and
+  // ContextWindowTracker (behind /api/context-efficiency) have no
+  // per-session partitioning (only DecisionTracker/TurnCostAttributor are
+  // partitioned) — these two remain live, in-memory,
+  // current-process-only accumulators. SessionDetailDialog's header caveat
+  // discloses this so the dialog doesn't imply these two sections are also
+  // scoped to the selected session.
   const { data: contextComposition } = useQuery<ContextCompositionResponse>({
     queryKey: ['context-composition'],
     queryFn: fetchContextComposition,
@@ -1195,8 +1217,13 @@ function LiveSessionPane({
       if (startMs === null || e.timestamp < startMs) startMs = e.timestamp;
       if (endMs === null || end > endMs) endMs = end;
     }
-    const sub = subagentData?.window;
-    if (sub && Number.isFinite(sub.startMs) && Number.isFinite(sub.endMs)) {
+    // Guard against the `{ startMs: 0, endMs: 0 }` sentinel returned when a
+    // session has no subagent transcripts (Number.isFinite(0) is true, so a
+    // naive finiteness check let the sentinel drag startMs down to epoch 0).
+    // Mirrors the hasAgents guard in Sessions.tsx's SessionTraceSection.
+    const hasAgents = (subagentData?.agents?.length ?? 0) > 0;
+    const sub = hasAgents ? subagentData!.window : null;
+    if (sub) {
       startMs = startMs === null ? sub.startMs : Math.min(startMs, sub.startMs);
       endMs = endMs === null ? sub.endMs : Math.max(endMs, sub.endMs);
     }
@@ -1517,6 +1544,32 @@ function formatRelativeTime(ts: number): string {
 const isToday = (ts: number): boolean => isSameLocalDay(ts);
 
 /**
+ * What fraction of a session's [startTime, end) window falls within today's
+ * local day, for the more limited fields the dashboard list endpoint exposes
+ * (no timeline — just startTime/endTime/durationMs). Delegates to the
+ * shared `todayPortionRatio` (src/lib/date.ts) so this client-side estimate
+ * uses the exact same elapsed-time-overlap math as the server's
+ * `todayPortionOfSessionCost`, instead of reimplementing it here.
+ *
+ * Used to prorate every "how much of this session counts toward today"
+ * metric consistently — cost, tool calls, and anti-pattern flags — so a
+ * cross-midnight session contributes its today-portion everywhere, not just
+ * for cost. Without this, `computeTodayToolCalls`/`computeTodayFlags` would
+ * add a cross-midnight session's *entire lifetime* count once
+ * `todayPortionOfSession(s) > 0`, rather than prorating the count itself.
+ */
+function todayOverlapRatio(s: SessionSummary): number {
+  if (s.startTime == null) return 0;
+  const end =
+    typeof s.endTime === 'number'
+      ? s.endTime
+      : typeof s.durationMs === 'number'
+        ? s.startTime + s.durationMs
+        : Date.now(); // live session with no end info: assume still running
+  return todayPortionRatio({ startTime: s.startTime, endTime: end });
+}
+
+/**
  * Today-portion of a session's cost. Mirrors the server-side
  * todayPortionOfSessionCost helper but with the more limited fields the
  * dashboard list endpoint exposes (no timeline). For sessions straddling
@@ -1528,27 +1581,7 @@ const isToday = (ts: number): boolean => isSameLocalDay(ts);
 function todayPortionOfSession(s: SessionSummary): number {
   const cost = s.estimatedCostUsd;
   if (cost == null || cost <= 0) return 0;
-  if (s.startTime == null) return 0;
-
-  const dayStart = localStartOfDay();
-  const dayEnd = dayStart + 86_400_000;
-
-  const start = s.startTime;
-  const end =
-    typeof s.endTime === 'number'
-      ? s.endTime
-      : typeof s.durationMs === 'number'
-        ? s.startTime + s.durationMs
-        : Date.now(); // live session with no end info: assume still running
-
-  if (end < dayStart) return 0;
-  if (start >= dayEnd) return 0;
-
-  if (start >= dayStart && end < dayEnd) return cost;
-
-  const overlapMs = Math.min(end, dayEnd) - Math.max(start, dayStart);
-  const totalMs = Math.max(1, end - start);
-  return cost * (overlapMs / totalMs);
+  return cost * todayOverlapRatio(s);
 }
 
 function computeTodaySpend(sessions: SessionSummary[]): number {
@@ -1560,24 +1593,19 @@ function computeTodaySpend(sessions: SessionSummary[]): number {
 function computeTodayToolCalls(sessions: SessionSummary[]): number {
   let total = 0;
   for (const s of sessions) {
-    // isToday fast-path includes sessions that started today regardless of cost
-    // (cost may be null before token data arrives). todayPortionOfSession > 0
-    // additionally picks up cross-midnight sessions with non-null cost.
-    if ((s.startTime && isToday(s.startTime)) || todayPortionOfSession(s) > 0) {
-      total += s.toolCallCount ?? 0;
-    }
+    const ratio = todayOverlapRatio(s);
+    if (ratio > 0) total += (s.toolCallCount ?? 0) * ratio;
   }
-  return total;
+  return Math.round(total);
 }
 
 function computeTodayFlags(sessions: SessionSummary[]): number {
   let total = 0;
   for (const s of sessions) {
-    if ((s.startTime && isToday(s.startTime)) || todayPortionOfSession(s) > 0) {
-      total += s.antiPatterns?.length ?? 0;
-    }
+    const ratio = todayOverlapRatio(s);
+    if (ratio > 0) total += (s.antiPatterns?.length ?? 0) * ratio;
   }
-  return total;
+  return Math.round(total);
 }
 
 function buildHourlySpend(sessions: SessionSummary[]): HourlyCostEntry[] {
@@ -1587,10 +1615,48 @@ function buildHourlySpend(sessions: SessionSummary[]): HourlyCostEntry[] {
   // `sessions`, so no separate currentSessionCost addition is needed — adding
   // it separately caused the live session's cost to be counted twice.
   const buckets = new Array<number>(24).fill(0);
+  const dayStart = localStartOfDay();
+  const dayEnd = dayStart + 86_400_000;
+
   for (const s of sessions) {
-    if (!s.startTime || !isToday(s.startTime) || s.estimatedCostUsd == null) continue;
-    const hour = new Date(s.startTime).getHours();
-    buckets[hour]! += s.estimatedCostUsd;
+    if (!s.startTime || s.estimatedCostUsd == null || s.estimatedCostUsd <= 0) continue;
+    const start = s.startTime;
+    const end =
+      typeof s.endTime === 'number'
+        ? s.endTime
+        : typeof s.durationMs === 'number'
+          ? s.startTime + s.durationMs
+          : Date.now();
+
+    // Clamp the session's activity window to today's local day — a session
+    // that started yesterday and is still running now contributes its
+    // today-portion instead of being skipped entirely. A naive `continue`
+    // on any session that didn't *start* today would hide the chart even
+    // when `todayTotal > 0`.
+    const clampedStart = Math.max(start, dayStart);
+    const clampedEnd = Math.min(end, dayEnd);
+    if (clampedEnd <= clampedStart) continue;
+
+    const totalMs = Math.max(1, end - start);
+    const todayShareMs = clampedEnd - clampedStart;
+    const todayCost = s.estimatedCostUsd * (todayShareMs / totalMs);
+
+    // Spread todayCost across every hour bucket the clamped window actually
+    // touches, weighted by time-in-bucket — instead of dumping the whole
+    // amount into the session's start hour, which would make a
+    // multi-hour session appear as one artificial spike.
+    let cursor = clampedStart;
+    while (cursor < clampedEnd) {
+      const cursorDate = new Date(cursor);
+      const hour = cursorDate.getHours();
+      const nextHour = new Date(cursorDate);
+      nextHour.setMinutes(0, 0, 0);
+      nextHour.setHours(hour + 1);
+      const segmentEnd = Math.min(clampedEnd, nextHour.getTime());
+      const segmentMs = segmentEnd - cursor;
+      buckets[hour]! += todayCost * (segmentMs / todayShareMs);
+      cursor = segmentEnd;
+    }
   }
   return buckets.map((cost, hour) => ({ hour, cost }));
 }


### PR DESCRIPTION
## Summary

- Unified local-day (not UTC) boundary handling across the Today/History dashboard's concurrency, activity-heatmap, and cost/tool-call/anti-pattern-flag routes — DST-safe, and consistent with the sibling charts they're meant to agree with.
- A session spanning local midnight now contributes its correct proportional share to today's tool-call count, flag count, and hourly spend, instead of being skipped or counted at its full lifetime total.
- Several timeline/history arrays (session activity, audit log, git commit/conflict history) are now sorted by timestamp before being sliced or windowed.
- Session-, repo-, and process-scoped data is now attributed to the right owner (live session model, cross-repo git activity, per-session decision-tree/turn-cost data).
- `GET /api/audit` and the underlying audit-log reader now cap how much history is read from disk per request.
- The "Workflow spend" KPI now distinguishes a confirmed $0 from a cost this process never observed, and shows a "partial" caveat when any included run falls in the latter case.

Bumps to v1.14.36. See CHANGELOG.md

Fixes #369, Fixes #376, Fixes #378, Fixes #379, Fixes #382, Fixes #383, Fixes #393, Fixes #396, Fixes #399, Fixes #402, Fixes #403, Fixes #408, Fixes #409, Fixes #410, Fixes #422, Fixes #426, Fixes #427, Fixes #430.

Related to #381 — the activity heatmap's day-boundary handling is now local instead of UTC, but the server-vs-browser timezone mismatch #381 describes is a separate, deeper issue (no timezone offset is exchanged between client and server at all) and is not fixed by this PR.

## Test plan

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`