### PR TITLE
Fix: Git Efficiency KPI/counter and conflict/suggestion/best-practice logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.37] - 2026-08-09
+
+### Fixed
+
+- **The Git Efficiency page's force-push risk assessment no longer contradicts itself.** A dangerous bare `--force` push and safe `--force-with-lease` pushes now rank consistently across the Best Practices and Suggestions panels, and a bare push to the shared default branch is now flagged as more severe than one to a personal feature branch.
+- **The "commits today" and "behind main" KPIs are more accurate on long-running, non-`--local` processes.** Commit deduplication after a process restart no longer relies on a hash match that could never succeed; branch-divergence now refreshes periodically instead of staying frozen at process startup.
+- **PR-tracking KPIs no longer silently drop data.** A `git push` chained with `&&`/`;`/`|` before a `gh pr create` command is now recognized, "Time to PR" now reflects the most recent PR rather than only the first one of the session, and the worktree-usage indicators only count real `add`/`remove` activity, not read-only inspection like `git worktree list`.
+- **The Best Practices and Suggestions panels no longer duplicate the same finding with disagreeing detail, and both now sort by severity** so a critical item never renders below a lower-severity one.
+- **Conflict-resolution counts now correspond to real conflicts.** Accept-ours/accept-theirs/cherry-pick counts are attributed per pending conflict instead of per matching command, concurrent pending conflicts are tracked independently instead of overwriting each other, and a pull that conflicts directly is now counted as a stale-branch pull.
+
 ## [1.14.36] - 2026-08-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.36",
+  "version": "1.14.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.36",
+      "version": "1.14.37",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.36",
+  "version": "1.14.37",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -736,6 +736,11 @@ async function main(): Promise<void> {
   // independent of dashboard-bind status. Cleared in the shutdown handler.
   let maintenanceGcInterval: NodeJS.Timeout | undefined;
   let retentionInterval: NodeJS.Timeout | undefined;
+  // Periodic re-fetch of ahead/behind-main counts so the Git Efficiency
+  // dashboard's "behind main" KPI doesn't stay frozen at its startup value
+  // for the life of a long-running `--local` daemon. Cleared in the
+  // shutdown handler.
+  let branchDivergenceInterval: NodeJS.Timeout | undefined;
   // Periodic local session-JSON flush so a non-clean exit (crash/SIGKILL)
   // loses at most one interval of session data — persistSession otherwise runs
   // only on clean shutdown. Cleared in the shutdown handler. Synthetic /
@@ -811,6 +816,7 @@ async function main(): Promise<void> {
       if (alertEvaluationInterval) clearInterval(alertEvaluationInterval);
       if (maintenanceGcInterval) clearInterval(maintenanceGcInterval);
       if (retentionInterval) clearInterval(retentionInterval);
+      if (branchDivergenceInterval) clearInterval(branchDivergenceInterval);
       if (dashboardRepollInterval) clearInterval(dashboardRepollInterval);
       if (sessionPersistInterval) clearInterval(sessionPersistInterval);
       if (pendingConfirmationCapTimer) clearTimeout(pendingConfirmationCapTimer);
@@ -1093,6 +1099,7 @@ async function main(): Promise<void> {
       timeout: 2000,
       stdio: ['ignore', 'pipe', 'ignore'] as ['ignore', 'pipe', 'ignore'],
     };
+    const BRANCH_DIVERGENCE_REFRESH_MS = 5 * 60 * 1000;
 
     // Repo context for the dashboard header — hydrated BEFORE the
     // today-sessions replay loop below so GitEfficiencyTracker.
@@ -1180,26 +1187,36 @@ async function main(): Promise<void> {
       gitEfficiencyTracker.hydrateGitLog(commits);
     }
 
-    // Branch divergence from the real default branch — how far ahead/behind are we?
+    // Branch divergence from the real default branch — how far ahead/behind
+    // are we? The dashboard polls this every 5s, implying a live number, but
+    // without this re-hydration it would otherwise be computed once here at
+    // startup and then frozen for the life of the process. Re-running it on
+    // an interval (rather than only at startup) keeps it reasonably current
+    // in a long-running `--local` daemon.
     const remoteDefaultBranch = `${remoteName}/${defaultBranch}`;
-    const aheadResult = spawnSync(
-      'git',
-      ['rev-list', '--count', `${remoteDefaultBranch}..HEAD`],
-      GIT_OPTS,
-    );
-    const behindResult = spawnSync(
-      'git',
-      ['rev-list', '--count', `HEAD..${remoteDefaultBranch}`],
-      GIT_OPTS,
-    );
-    if (aheadResult.status === 0 && behindResult.status === 0) {
-      const ahead = parseInt(aheadResult.stdout.trim(), 10);
-      const behind = parseInt(behindResult.stdout.trim(), 10);
-      if (!Number.isNaN(ahead) && !Number.isNaN(behind)) {
-        capturedBranchDivergence = { ahead, behind };
-        gitEfficiencyTracker.hydrateBranchDivergence(ahead, behind);
+    const refreshBranchDivergence = (): void => {
+      const aheadResult = spawnSync(
+        'git',
+        ['rev-list', '--count', `${remoteDefaultBranch}..HEAD`],
+        GIT_OPTS,
+      );
+      const behindResult = spawnSync(
+        'git',
+        ['rev-list', '--count', `HEAD..${remoteDefaultBranch}`],
+        GIT_OPTS,
+      );
+      if (aheadResult.status === 0 && behindResult.status === 0) {
+        const ahead = parseInt(aheadResult.stdout.trim(), 10);
+        const behind = parseInt(behindResult.stdout.trim(), 10);
+        if (!Number.isNaN(ahead) && !Number.isNaN(behind)) {
+          capturedBranchDivergence = { ahead, behind };
+          gitEfficiencyTracker.hydrateBranchDivergence(ahead, behind);
+        }
       }
-    }
+    };
+    refreshBranchDivergence();
+    branchDivergenceInterval = setInterval(refreshBranchDivergence, BRANCH_DIVERGENCE_REFRESH_MS);
+    branchDivergenceInterval.unref?.();
 
     // Cached prior-cost baseline. Refreshed lazily so:
     //   - sessions persisted by other MCPs during this session land in totals

--- a/src/metrics/git-efficiency-tracker.test.ts
+++ b/src/metrics/git-efficiency-tracker.test.ts
@@ -250,10 +250,129 @@ describe('GitEfficiencyTracker', () => {
     expect(metrics.staleBranchPulls).toBe(2);
   });
 
+  // A `git pull` whose own output contains a conflict indicator classifies
+  // as merge_conflict/rebase_conflict, never as 'pull' — so the common case
+  // (a pull that directly conflicts)
+  // must be detected off that single event's own command, not only via the
+  // adjacent-event pattern (which is preserved below for the separate,
+  // rarer case of a clean pull followed by an unrelated conflicting command).
+  it('detects a pull that directly conflicts, not just a pull followed by a separate conflicting command', () => {
+    tracker.recordToolCall(
+      makeRecord({
+        command: 'git pull origin main',
+        success: false,
+        error: 'CONFLICT (content): Merge conflict in foo.ts',
+      }),
+    );
+    const metrics = tracker.getMetrics();
+    expect(metrics.staleBranchPulls).toBe(1);
+  });
+
+  describe('pending conflicts', () => {
+    it('includes an open, unresolved conflict in the resolution-rate denominator as "pending"', () => {
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git merge main',
+          success: false,
+          error: 'CONFLICT (content): Merge conflict in a.ts',
+        }),
+      );
+      const metrics = tracker.getMetrics();
+      // Without counting the open conflict, conflictRecords would be empty
+      // (nothing has aborted or resolved yet) and the rate would show null
+      // rather than reflecting that a real conflict is unresolved.
+      expect(metrics.conflictResolutionRate).toBe(0);
+      const pendingEntry = metrics.conflictHistory.find((c) => c.resolution === 'pending');
+      expect(pendingEntry).toBeDefined();
+    });
+
+    it('reflects a mix of one resolved and one still-open conflict as a 50% resolution rate, not 100%', () => {
+      const t = Date.now();
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git merge main',
+          timestamp: t,
+          success: false,
+          error: 'CONFLICT (content): Merge conflict in a.ts',
+        }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git commit -m "resolve a"', timestamp: t + 1000 }),
+      );
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git rebase main',
+          timestamp: t + 2000,
+          success: false,
+          error: 'rebase conflict could not apply patch',
+        }),
+      );
+      const metrics = tracker.getMetrics();
+      expect(metrics.conflictResolutionRate).toBe(0.5);
+    });
+
+    // A second conflict arriving while one is already pending must be
+    // queued, not silently overwrite the first — both must eventually
+    // resolve independently, in the order they arose.
+    it('queues a second conflict arriving while one is already pending, instead of overwriting the first', () => {
+      const t = Date.now();
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git merge main',
+          timestamp: t,
+          success: false,
+          error: 'CONFLICT (content): Merge conflict in a.ts',
+        }),
+      );
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git rebase main',
+          timestamp: t + 1000,
+          success: false,
+          error: 'rebase conflict could not apply patch',
+        }),
+      );
+      // Both still open at this point.
+      let metrics = tracker.getMetrics();
+      expect(metrics.conflictHistory.filter((c) => c.resolution === 'pending')).toHaveLength(2);
+
+      // Resolving in FIFO order: the first (a.ts) conflict resolves first.
+      tracker.recordToolCall(
+        makeRecord({ command: 'git commit -m "resolve a"', timestamp: t + 2000 }),
+      );
+      metrics = tracker.getMetrics();
+      expect(metrics.conflictHistory.filter((c) => c.resolution === 'resolved')).toHaveLength(1);
+      expect(metrics.conflictHistory.filter((c) => c.resolution === 'pending')).toHaveLength(1);
+
+      // The second conflict resolves next — it was queued, not dropped.
+      tracker.recordToolCall(
+        makeRecord({ command: 'git commit -m "resolve b"', timestamp: t + 3000 }),
+      );
+      metrics = tracker.getMetrics();
+      expect(metrics.conflictHistory.filter((c) => c.resolution === 'resolved')).toHaveLength(2);
+      expect(metrics.conflictResolutionRate).toBe(1);
+    });
+  });
+
   it('detects worktree usage', () => {
     tracker.recordToolCall(makeRecord({ command: 'git worktree add ../feature-x feature-x' }));
     const metrics = tracker.getMetrics();
     expect(metrics.riskIndicators.usesWorktrees).toBe(true);
+  });
+
+  it('does not count read-only worktree inspection (e.g. "list") toward the worktree-ops counter', () => {
+    tracker.recordToolCall(makeRecord({ command: 'git worktree list' }));
+    tracker.recordToolCall(makeRecord({ command: 'git worktree list' }));
+    const metrics = tracker.getMetrics();
+    expect(metrics.velocityMetrics.worktreeCount).toBe(0);
+  });
+
+  it('counts only "add"/"remove" worktree subcommands toward the worktree-ops counter', () => {
+    tracker.recordToolCall(makeRecord({ command: 'git worktree add ../feature-x feature-x' }));
+    tracker.recordToolCall(makeRecord({ command: 'git worktree remove ../feature-x' }));
+    tracker.recordToolCall(makeRecord({ command: 'git worktree list' }));
+    const metrics = tracker.getMetrics();
+    expect(metrics.velocityMetrics.worktreeCount).toBe(2);
   });
 
   it('detects push rejections', () => {
@@ -377,6 +496,16 @@ describe('GitEfficiencyTracker', () => {
       expect(practice?.status).toBe('fail');
     });
 
+    it('does not treat read-only worktree inspection as real worktree usage in the use_worktrees check', () => {
+      tracker.recordToolCall(makeRecord({ command: 'git worktree list' }));
+      const metrics = tracker.getMetrics();
+      expect(metrics.velocityMetrics.worktreeCount).toBe(0);
+      expect(metrics.riskIndicators.usesWorktrees).toBe(false);
+      const practice = metrics.bestPractices.find((p) => p.id === 'use_worktrees');
+      expect(practice?.status).not.toBe('pass');
+      expect(practice?.status).toBe('unknown');
+    });
+
     it('fails force_with_lease check when bare --force is used', () => {
       tracker.recordToolCall(makeRecord({ command: 'git push --force origin feature' }));
       const metrics = tracker.getMetrics();
@@ -389,6 +518,19 @@ describe('GitEfficiencyTracker', () => {
       const metrics = tracker.getMetrics();
       const practice = metrics.bestPractices.find((p) => p.id === 'force_with_lease');
       expect(practice?.status).toBe('pass');
+    });
+
+    // A bare --force push is the riskiest single operation this tracker
+    // tracks. The check must catch it even when a later, safe
+    // --force-with-lease push also occurred in the same session — checking
+    // only whether lease was ever used would let the safe push mask the
+    // unsafe one with a "pass".
+    it('warns (not passes) force_with_lease check when a bare --force push is mixed with a later --force-with-lease push', () => {
+      tracker.recordToolCall(makeRecord({ command: 'git push --force origin feature' }));
+      tracker.recordToolCall(makeRecord({ command: 'git push --force-with-lease origin feature' }));
+      const metrics = tracker.getMetrics();
+      const practice = metrics.bestPractices.find((p) => p.id === 'force_with_lease');
+      expect(practice?.status).toBe('warn');
     });
   });
 
@@ -410,26 +552,51 @@ describe('GitEfficiencyTracker', () => {
       expect(conflictSuggestion!.message).toContain('worktrees');
     });
 
-    it('warns about no initial sync', () => {
+    // syncedBeforeEditing is surfaced solely by the sync_before_edit best
+    // practice; it must not also fire as a 'no_initial_sync' suggestion,
+    // which would render the identical fact twice.
+    it('does not duplicate "no initial sync" as a suggestion — it is a Best Practices condition', () => {
       const t = Date.now();
       tracker.recordToolCall(makeRecord({ toolName: 'Edit', filePath: 'src/a.ts', timestamp: t }));
       // Need a git command for suggestions to fire
       tracker.recordToolCall(makeRecord({ command: 'git status', timestamp: t + 100 }));
       const metrics = tracker.getMetrics();
-      const syncSuggestion = metrics.suggestions.find((s) => s.category === 'no_initial_sync');
-      expect(syncSuggestion).toBeDefined();
-      expect(syncSuggestion!.message).toContain('git fetch');
+      expect(metrics.suggestions.find((s) => s.category === 'no_initial_sync')).toBeUndefined();
+      const practice = metrics.bestPractices.find((p) => p.id === 'sync_before_edit');
+      expect(practice?.status).toBe('fail');
     });
 
-    it('warns about drift risk', () => {
+    // commitsSinceLastSync > 8 is surfaced solely by the frequent_sync
+    // best practice; it must not also fire as a 'drift_risk' suggestion,
+    // which would render the identical fact twice.
+    it('does not duplicate "drift risk" as a suggestion — it is a Best Practices condition', () => {
       tracker.recordToolCall(makeRecord({ command: 'git pull origin main' }));
       for (let i = 0; i < 12; i++) {
         tracker.recordToolCall(makeRecord({ command: `git commit -m "c${i}"` }));
       }
       const metrics = tracker.getMetrics();
-      const driftSuggestion = metrics.suggestions.find((s) => s.category === 'drift_risk');
-      expect(driftSuggestion).toBeDefined();
-      expect(driftSuggestion!.message).toContain('rebase');
+      expect(metrics.suggestions.find((s) => s.category === 'drift_risk')).toBeUndefined();
+      const practice = metrics.bestPractices.find((p) => p.id === 'frequent_sync');
+      expect(practice?.status).toBe('fail');
+    });
+
+    // hotFiles is surfaced solely by the avoid_hot_files best practice; it
+    // must not also fire as a 'hot_files' suggestion with a different
+    // severity for the identical trigger.
+    it('does not duplicate "hot files" as a suggestion — it is a Best Practices condition', () => {
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git merge main',
+          success: false,
+          error: 'CONFLICT (content): Merge conflict in src/hot.ts',
+        }),
+      );
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "resolve"' }));
+      tracker.recordToolCall(makeRecord({ toolName: 'Edit', filePath: 'src/hot.ts' }));
+      const metrics = tracker.getMetrics();
+      expect(metrics.suggestions.find((s) => s.category === 'hot_files')).toBeUndefined();
+      const practice = metrics.bestPractices.find((p) => p.id === 'avoid_hot_files');
+      expect(practice?.status).toBe('warn');
     });
 
     it('flags force-push-after-rejection pattern', () => {
@@ -459,6 +626,150 @@ describe('GitEfficiencyTracker', () => {
       const syncSuggestion = metrics.suggestions.find((s) => s.category === 'sync_frequency');
       expect(syncSuggestion).toBeDefined();
       expect(syncSuggestion!.severity).toBe('info');
+    });
+
+    // A single bare --force push is the riskiest single operation this
+    // tracker tracks, so its severity must never rate as the mildest tier
+    // ('info') — severity has to account for whether the push was actually
+    // safe, not just how many force pushes occurred.
+    it('elevates a single bare --force push suggestion above info severity', () => {
+      tracker.recordToolCall(makeRecord({ command: 'git push --force origin feature' }));
+      const metrics = tracker.getMetrics();
+      const suggestion = metrics.suggestions.find((s) => s.category === 'force_push');
+      expect(suggestion).toBeDefined();
+      expect(suggestion!.severity).not.toBe('info');
+    });
+
+    // The force_push suggestion's severity must agree with the
+    // force_with_lease best-practice check on which of these two sessions is
+    // riskier: adding a safe --force-with-lease push on top of an existing
+    // bare push must never raise severity above what the bare push alone
+    // already set, since only the bare push is actually unsafe.
+    it('does not escalate force_push suggestion severity when a safe --force-with-lease push follows a bare push', () => {
+      const bareOnly = new GitEfficiencyTracker();
+      bareOnly.recordToolCall(makeRecord({ command: 'git push --force origin feature' }));
+      const bareOnlySuggestion = bareOnly
+        .getMetrics()
+        .suggestions.find((s) => s.category === 'force_push');
+      expect(bareOnlySuggestion?.severity).toBe('warning');
+
+      const bareThenLease = new GitEfficiencyTracker();
+      bareThenLease.recordToolCall(makeRecord({ command: 'git push --force origin feature' }));
+      bareThenLease.recordToolCall(
+        makeRecord({ command: 'git push --force-with-lease origin feature' }),
+      );
+      const bareThenLeaseSuggestion = bareThenLease
+        .getMetrics()
+        .suggestions.find((s) => s.category === 'force_push');
+      expect(bareThenLeaseSuggestion?.severity).toBe('warning');
+    });
+
+    // Two safe, lease-protected force pushes must never rate worse than the
+    // single unsafe bare push case above — and must never surface advice to
+    // "always use --force-with-lease" when the user is already doing
+    // exactly that.
+    it('does not fire a force_push suggestion for a single lease-protected push with no bare push present', () => {
+      tracker.recordToolCall(makeRecord({ command: 'git push --force-with-lease origin feature' }));
+      const metrics = tracker.getMetrics();
+      expect(metrics.suggestions.find((s) => s.category === 'force_push')).toBeUndefined();
+    });
+
+    it('rates repeated lease-protected force pushes as info, not critical, when no bare push occurred', () => {
+      tracker.recordToolCall(makeRecord({ command: 'git push --force-with-lease origin feature' }));
+      tracker.recordToolCall(makeRecord({ command: 'git push --force-with-lease origin feature' }));
+      const metrics = tracker.getMetrics();
+      const suggestion = metrics.suggestions.find((s) => s.category === 'force_push');
+      expect(suggestion?.severity).toBe('info');
+    });
+
+    // Force-push severity must be branch-aware: a bare --force push to the
+    // shared default branch is categorically more dangerous (it can clobber
+    // other collaborators' work) than an identical bare --force push to a
+    // branch only one person is using, so the two must not produce the same
+    // severity.
+    it('escalates a bare force push on the default branch above an identical push on a feature branch', () => {
+      const onDefaultBranch = new GitEfficiencyTracker();
+      onDefaultBranch.hydrateRepoContext({
+        repoName: 'org/repo',
+        branch: 'main',
+        remoteName: 'origin',
+        defaultBranch: 'main',
+      });
+      onDefaultBranch.recordToolCall(makeRecord({ command: 'git push --force origin main' }));
+
+      const onFeatureBranch = new GitEfficiencyTracker();
+      onFeatureBranch.hydrateRepoContext({
+        repoName: 'org/repo',
+        branch: 'feature-x',
+        remoteName: 'origin',
+        defaultBranch: 'main',
+      });
+      onFeatureBranch.recordToolCall(makeRecord({ command: 'git push --force origin feature-x' }));
+
+      const defaultBranchSuggestion = onDefaultBranch
+        .getMetrics()
+        .suggestions.find((s) => s.category === 'force_push');
+      const featureBranchSuggestion = onFeatureBranch
+        .getMetrics()
+        .suggestions.find((s) => s.category === 'force_push');
+
+      expect(defaultBranchSuggestion?.severity).toBe('critical');
+      expect(featureBranchSuggestion?.severity).toBe('warning');
+    });
+  });
+
+  describe('severity sort order', () => {
+    it('sorts suggestions by severity — critical before warning before info, even when a lower-severity item is pushed first in source order', () => {
+      // discarded_changes (info) and sync_frequency (info) are both pushed,
+      // in generateSuggestions' fixed source-code order, before
+      // divergence_risk (warning) — the output must be sorted by severity
+      // rather than relying on source-code order, or both info items would
+      // land ahead of the warning.
+      for (let i = 0; i < 3; i++) {
+        tracker.recordToolCall(makeRecord({ command: 'git checkout -- src/file.ts' }));
+      }
+      for (let i = 0; i < 11; i++) {
+        tracker.recordToolCall(makeRecord({ command: `git commit -m "c${i}"` }));
+      }
+      const metrics = tracker.getMetrics();
+      const categories = metrics.suggestions.map((s) => s.category);
+      expect(categories).toEqual(
+        expect.arrayContaining(['discarded_changes', 'sync_frequency', 'divergence_risk']),
+      );
+      const severities = metrics.suggestions.map((s) => s.severity);
+      const rank: Record<string, number> = { critical: 0, warning: 1, info: 2 };
+      const sortedRanks = severities.map((s) => rank[s]);
+      expect(sortedRanks).toEqual([...sortedRanks].sort((a, b) => a - b));
+      expect(metrics.suggestions[0]?.category).toBe('divergence_risk');
+    });
+
+    it('sorts the failing/warning bestPractices subset — fail before warn, even when warn is pushed first in source order', () => {
+      // frequent_sync (check #2, 'warn' here) is pushed before use_worktrees
+      // (check #4, 'fail' here) in evaluateBestPractices' fixed source-code
+      // order — the failing/warning subset must be sorted by status rather
+      // than relying on source-code order, or the 'warn' would land first.
+      tracker.recordToolCall(makeRecord({ command: 'git pull origin main' }));
+      for (let i = 0; i < 6; i++) {
+        tracker.recordToolCall(makeRecord({ command: `git commit -m "c${i}"` }));
+      }
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git merge main',
+          success: false,
+          error: 'CONFLICT (content): Merge conflict in file.ts',
+        }),
+      );
+      const metrics = tracker.getMetrics();
+      const frequentSync = metrics.bestPractices.find((p) => p.id === 'frequent_sync');
+      const useWorktrees = metrics.bestPractices.find((p) => p.id === 'use_worktrees');
+      expect(frequentSync?.status).toBe('warn');
+      expect(useWorktrees?.status).toBe('fail');
+
+      const relevant = metrics.bestPractices.filter(
+        (p) => p.status === 'fail' || p.status === 'warn',
+      );
+      expect(relevant[0]?.id).toBe('use_worktrees');
+      expect(relevant[1]?.id).toBe('frequent_sync');
     });
   });
 
@@ -603,9 +914,10 @@ describe('GitEfficiencyTracker', () => {
     // Simulates src/index.ts feeding the day-scoped `git log` output
     // (commits not captured by tool hooks) back into the tracker right
     // after the reset.
+    const hydratedAt = Date.now();
     tracker.hydrateGitLog([
-      { hash: 'abc123', timestamp: Date.now() },
-      { hash: 'def456', timestamp: Date.now() },
+      { hash: 'abc123', timestamp: hydratedAt },
+      { hash: 'def456', timestamp: hydratedAt + 1_000 },
     ]);
 
     expect(tracker.getMetrics().commitCount).toBe(2);
@@ -884,6 +1196,43 @@ describe('GitEfficiencyTracker', () => {
       const metrics = tracker.getMetrics();
       expect(metrics.prMetrics.created).toBe(0);
     });
+
+    it('detects a gh command chained after a git command in a compound shell invocation', () => {
+      tracker.recordToolCall(
+        makeRecord({ command: 'git push origin main && gh pr create --fill' }),
+      );
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.prMetrics.created).toBe(1);
+    });
+
+    it('detects a gh command separated by ";" or "|" from a preceding git command', () => {
+      tracker.recordToolCall(makeRecord({ command: 'git push origin main; gh pr create --fill' }));
+      tracker.recordToolCall(makeRecord({ command: 'git status | gh pr checks 42' }));
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.prMetrics.created).toBe(1);
+      expect(metrics.prMetrics.checksViewed).toBe(1);
+    });
+
+    it('computes avgTimeToCreateMs across every PR opened this session, not just the first', () => {
+      const t = Date.now();
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "a"', timestamp: t }));
+      tracker.recordToolCall(
+        makeRecord({ command: 'gh pr create --title "first"', timestamp: t + 10_000 }),
+      );
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "b"', timestamp: t + 20_000 }));
+      tracker.recordToolCall(
+        makeRecord({ command: 'gh pr create --title "second"', timestamp: t + 25_000 }),
+      );
+
+      const metrics = tracker.getMetrics();
+      // First PR: 10s after its preceding commit. Second PR: 5s after its own
+      // most recent preceding commit. True average of the two is 7.5s — not
+      // 10s, which is what you'd get by anchoring every PR to the very first
+      // commit the tracker ever saw.
+      expect(metrics.prMetrics.avgTimeToCreateMs).toBe(7_500);
+    });
   });
 
   describe('hydration entry points', () => {
@@ -891,7 +1240,7 @@ describe('GitEfficiencyTracker', () => {
       const t = Date.now() - 3600_000;
       tracker.hydrateGitLog([
         { timestamp: t, hash: 'abc123' },
-        { timestamp: t + 1000, hash: 'def456' },
+        { timestamp: t + 1_000, hash: 'def456' },
       ]);
 
       let metrics = tracker.getMetrics();
@@ -906,12 +1255,91 @@ describe('GitEfficiencyTracker', () => {
       expect(metrics.commitCount).toBe(2);
     });
 
+    // Two genuinely distinct commits landing within the dedup window must
+    // both be counted — a hydrated-vs-hydrated comparison has a real hash on
+    // both sides, so it must match by hash equality rather than timestamp
+    // proximity, or two rapid sequential commits in the same `git log` batch
+    // would incorrectly collapse into one.
+    it('counts two distinct commits within the dedup window as separate commits, not a duplicate', () => {
+      const t = Date.now() - 3600_000;
+      tracker.hydrateGitLog([
+        { timestamp: t, hash: 'abc123' },
+        { timestamp: t + 500, hash: 'def456' },
+      ]);
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.commitCount).toBe(2);
+      expect(metrics.totalGitCommands).toBe(2);
+    });
+
+    // The day-boundary re-hydration path in src/index.ts resets the tracker
+    // (emptying this.events) and then feeds it the whole day's `git log`
+    // output in one call — every proximity comparison in that batch is
+    // hydrated-vs-hydrated, with no hook events to dedup against, so it must
+    // rely on hash equality to avoid collapsing distinct commits.
+    it('counts two distinct commits within the dedup window after a day-boundary reset', () => {
+      tracker.reset('next-session');
+      const hydratedAt = Date.now();
+      tracker.hydrateGitLog([
+        { hash: 'abc123', timestamp: hydratedAt },
+        { hash: 'def456', timestamp: hydratedAt + 500 },
+      ]);
+
+      expect(tracker.getMetrics().commitCount).toBe(2);
+    });
+
+    // Simulates a process restart mid-day: a prior, now-ended session's
+    // commit was already replayed as a raw hook event (command text with no
+    // hash), then the startup `git log` hydration sees the same commit by
+    // hash. A hash-substring dedup can never match a raw command string, so
+    // this would double-count every commit made before the restart.
+    it('does not double-count a commit already present as a replayed hook event, on process restart', () => {
+      const commitTimestamp = Date.now() - 60_000;
+      tracker.replayTimeline([
+        {
+          timestamp: commitTimestamp,
+          toolName: 'Bash',
+          durationMs: 100,
+          success: true,
+          command: 'git commit -m "fix thing"',
+        },
+      ]);
+      expect(tracker.getMetrics().commitCount).toBe(1);
+
+      tracker.hydrateGitLog([{ timestamp: commitTimestamp, hash: 'abc123' }]);
+
+      expect(tracker.getMetrics().commitCount).toBe(1);
+    });
+
     it('hydrateBranchDivergence sets ahead/behind counts on risk indicators', () => {
       tracker.hydrateBranchDivergence(3, 7);
 
       const metrics = tracker.getMetrics();
       expect(metrics.riskIndicators.commitsAheadOfMain).toBe(3);
       expect(metrics.riskIndicators.commitsBehindMain).toBe(7);
+    });
+
+    // The "behind main" KPI polls every 5s, implying a live number, but
+    // hydrateBranchDivergence() only ever gets called by whatever invokes it
+    // — the tracker itself has no way to notice staleness or re-fetch on its
+    // own. The actual periodic re-fetch trigger lives in src/index.ts (a
+    // setInterval re-running `git rev-list` and re-hydrating) and isn't
+    // unit-testable from this file; this test instead verifies the
+    // composability that periodic re-fetch depends on: calling
+    // hydrateBranchDivergence() again must fully replace the previous
+    // snapshot, not just supplement it.
+    it('supports a later hydrateBranchDivergence() call replacing a stale snapshot', () => {
+      tracker.hydrateBranchDivergence(0, 12);
+      expect(tracker.getMetrics().riskIndicators.commitsBehindMain).toBe(12);
+
+      jest.useFakeTimers().setSystemTime(Date.now() + 10 * 60_000);
+      // With no re-fetch, the value stays frozen — the tracker itself never
+      // refreshes it on its own; only an explicit re-hydration call does.
+      expect(tracker.getMetrics().riskIndicators.commitsBehindMain).toBe(12);
+
+      tracker.hydrateBranchDivergence(0, 3);
+      expect(tracker.getMetrics().riskIndicators.commitsBehindMain).toBe(3);
+      jest.useRealTimers();
     });
 
     it('hydrateRepoContext sets the repo context returned in metrics', () => {
@@ -933,15 +1361,121 @@ describe('GitEfficiencyTracker', () => {
   });
 
   describe('conflict resolution strategy', () => {
-    it('tracks ours/theirs/cherry-pick conflict resolution counters', () => {
+    // oursCount/theirsCount/cherryPickCount must attribute to the specific
+    // pending conflict they resolve (one credit
+    // per conflict), not increment per matching command — a strategy command
+    // run with no conflict pending isn't resolving anything.
+    it('does not credit ours/theirs/cherry-pick strategy when no conflict is pending', () => {
       tracker.recordToolCall(makeRecord({ command: 'git checkout --ours file.ts' }));
       tracker.recordToolCall(makeRecord({ command: 'git checkout --theirs other.ts' }));
       tracker.recordToolCall(makeRecord({ command: 'git cherry-pick abc123' }));
 
       const metrics = tracker.getMetrics();
+      expect(metrics.conflictResolutionStrategy.oursCount).toBe(0);
+      expect(metrics.conflictResolutionStrategy.theirsCount).toBe(0);
+      expect(metrics.conflictResolutionStrategy.cherryPickCount).toBe(0);
+    });
+
+    // Concrete example: one conflict spanning 3 files, resolved by
+    // running `git checkout --ours <file>` once per file then committing
+    // once. oursCount must be 1 (one conflict resolved with that strategy),
+    // not 3 (one per command).
+    it('dedupes ours/theirs credit per conflict, not per command, for a multi-file conflict', () => {
+      const t = Date.now();
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git merge main',
+          timestamp: t,
+          success: false,
+          error:
+            'CONFLICT (content): Merge conflict in a.ts\n' +
+            'CONFLICT (content): Merge conflict in b.ts\n' +
+            'CONFLICT (content): Merge conflict in c.ts',
+        }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git checkout --ours a.ts', timestamp: t + 1000 }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git checkout --ours b.ts', timestamp: t + 2000 }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git checkout --ours c.ts', timestamp: t + 3000 }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git commit -m "resolve"', timestamp: t + 4000 }),
+      );
+
+      const metrics = tracker.getMetrics();
       expect(metrics.conflictResolutionStrategy.oursCount).toBe(1);
-      expect(metrics.conflictResolutionStrategy.theirsCount).toBe(1);
+      expect(metrics.conflictResolutionStrategy.totalResolutions).toBe(1);
+    });
+
+    it('credits ours/theirs/cherry-pick strategy once each conflict resolves via commit', () => {
+      const t = Date.now();
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git merge main',
+          timestamp: t,
+          success: false,
+          error: 'CONFLICT (content): Merge conflict in file.ts',
+        }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git checkout --ours file.ts', timestamp: t + 1000 }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git commit -m "resolve"', timestamp: t + 2000 }),
+      );
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.conflictResolutionStrategy.oursCount).toBe(1);
+      expect(metrics.conflictResolutionStrategy.theirsCount).toBe(0);
+      expect(metrics.conflictResolutionStrategy.cherryPickCount).toBe(0);
+    });
+
+    // Cherry-picks must be included in totalResolutions, not tallied
+    // separately and excluded from the total.
+    it('includes cherry-pick resolutions in totalResolutions', () => {
+      const t = Date.now();
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git cherry-pick abc123',
+          timestamp: t,
+          success: false,
+          error: 'CONFLICT (content): Merge conflict in file.ts',
+        }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git cherry-pick --continue', timestamp: t + 1000 }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git commit -m "resolve"', timestamp: t + 2000 }),
+      );
+
+      const metrics = tracker.getMetrics();
       expect(metrics.conflictResolutionStrategy.cherryPickCount).toBe(1);
+      expect(metrics.conflictResolutionStrategy.totalResolutions).toBe(1);
+    });
+
+    // `git cherry-pick --abort` is an abort, not a resolution, and must not
+    // be counted toward cherryPickCount.
+    it('does not credit cherryPickCount for a cherry-pick that was aborted', () => {
+      const t = Date.now();
+      tracker.recordToolCall(
+        makeRecord({
+          command: 'git cherry-pick abc123',
+          timestamp: t,
+          success: false,
+          error: 'CONFLICT (content): Merge conflict in file.ts',
+        }),
+      );
+      tracker.recordToolCall(
+        makeRecord({ command: 'git cherry-pick --abort', timestamp: t + 1000 }),
+      );
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.conflictResolutionStrategy.cherryPickCount).toBe(0);
     });
   });
 

--- a/src/metrics/git-efficiency-tracker.ts
+++ b/src/metrics/git-efficiency-tracker.ts
@@ -56,6 +56,10 @@ const GIT_DIFF_RE = /\bgit\s+diff\b/;
 const GIT_LOG_RE = /\bgit\s+log\b/;
 const GIT_COMMIT_RE = /\bgit\s+commit\b/;
 const GIT_WORKTREE_RE = /\bgit\s+worktree\b/;
+// Only `add`/`remove` create or tear down real isolation — `list`/`prune`/
+// `lock`/etc. are read-only inspection and shouldn't inflate the "worktree
+// ops" count with commands that don't reflect any parallel-isolation work.
+const GIT_WORKTREE_ADD_REMOVE_RE = /\bgit\s+worktree\s+(?:add|remove)\b/;
 const GIT_CHECKOUT_OURS_RE = /\bgit\s+checkout\s+--ours\b/;
 const GIT_CHECKOUT_THEIRS_RE = /\bgit\s+checkout\s+--theirs\b/;
 const GIT_CHERRY_PICK_RE = /\bgit\s+cherry-pick\b/;
@@ -71,6 +75,28 @@ const GH_COMMAND_RE = /\bgh\s+/;
 
 // Extract PR number from gh commands
 const GH_PR_NUMBER_RE = /\bgh\s+pr\s+\w+\s+(\d+)/;
+
+// hydrateGitLog()'s dedup window, used only against a hook-observed commit
+// event (one with no hash in its command text): `git log`'s %ct has 1-second
+// resolution and a hook-observed commit event's timestamp is recorded when
+// the tool call completes, so the two timestamps for the same commit are
+// close but never exactly equal — and the hook event's command text is the
+// raw pre-execution shell string, which never contains the resulting hash,
+// so dedup against it can't key on a hash match. Treat any existing
+// hook-observed commit event within this window as the same commit.
+//
+// A hydrated commit ALWAYS carries a real hash from `git log`, so comparing
+// it against another hydrated event uses exact hash equality (via
+// HYDRATED_COMMIT_HASH_RE below) instead of this proximity window — two
+// genuinely distinct commits landing within the window (e.g. rapid
+// sequential commits in the same `git log` batch) must not collapse into
+// one just because their timestamps are close.
+const COMMIT_DEDUP_WINDOW_MS = 5_000;
+
+// Matches the synthetic command text hydrateGitLog() gives its own events
+// (see below), letting isDuplicate() tell a hydrated event apart from a
+// hook-observed one and recover its hash.
+const HYDRATED_COMMIT_HASH_RE = /^git commit \((.+)\)$/;
 
 const REJECT_INDICATORS = [
   /\[rejected\]/i,
@@ -125,6 +151,21 @@ export interface MergeConflictRecord {
   readonly resolutionTimeMs: number | null;
   readonly command: string;
   readonly files: readonly string[];
+}
+
+// A conflict that's been detected but not yet aborted or resolved via commit.
+// Kept as a queue (not a single scalar) so a second conflict arriving while
+// one is already open is queued rather than silently overwriting the first.
+// The used*/ flags accumulate as ours/theirs/cherry-pick commands run while
+// this conflict is the oldest pending one, and are only credited to the
+// strategy counters once this conflict actually resolves.
+interface PendingConflict {
+  timestamp: number;
+  command: string;
+  files: string[];
+  usedOurs: boolean;
+  usedTheirs: boolean;
+  usedCherryPick: boolean;
 }
 
 export interface GitEfficiencyMetrics {
@@ -208,6 +249,22 @@ export interface BestPractice {
   readonly detail: string;
 }
 
+// Render order for suggestions/best-practices — most severe first — rather
+// than fixed source-code push order, which could put a critical item below
+// a milder one.
+const SUGGESTION_SEVERITY_RANK: Record<GitSuggestion['severity'], number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+};
+
+const BEST_PRACTICE_STATUS_RANK: Record<BestPractice['status'], number> = {
+  fail: 0,
+  warn: 1,
+  pass: 2,
+  unknown: 3,
+};
+
 export interface RiskIndicators {
   readonly syncedBeforeEditing: boolean | null;
   readonly timeSinceLastSyncMs: number | null;
@@ -231,9 +288,7 @@ export interface RiskIndicators {
 export class GitEfficiencyTracker {
   private events: GitEvent[] = [];
   private conflictRecords: MergeConflictRecord[] = [];
-  private pendingConflictTimestamp: number | null = null;
-  private pendingConflictCommand: string = '';
-  private pendingConflictFiles: string[] = [];
+  private pendingConflicts: PendingConflict[] = [];
   private lastSyncTimestamp: number | null = null;
   private pullsSinceLastConflict = 0;
   private consecutiveFailedPushes = 0;
@@ -249,6 +304,24 @@ export class GitEfficiencyTracker {
   private editedFiles = new Set<string>();
   private hasUsedWorktree = false;
   private hasUsedForceWithLease = false;
+  // Tracks whether ANY bare (non-lease) force-push occurred this session,
+  // independent of whether --force-with-lease was ever also used. This is
+  // the single shared signal both the force_with_lease best-practice check
+  // and the force_push suggestion's severity gate on, so the two checks
+  // agree on what counts as "was this session's force-push usage safe."
+  private hasUsedBareForcePush = false;
+  // Count of bare (non-lease) force-pushes specifically — kept separate from
+  // stats.forcePushes (which sums bare AND lease-protected pushes) so
+  // severity scales with how much *unsafe* force-pushing happened, not with
+  // total force-push volume. A safe --force-with-lease push must never be
+  // able to escalate severity that a bare push alone already set.
+  private bareForcePushCount = 0;
+  // Snapshot of whether any bare force-push landed while repoContext.branch
+  // matched repoContext.defaultBranch — a bare push to the shared default
+  // branch can clobber other collaborators' work, unlike an identical push
+  // to a personal feature branch only one person is using, so the two must
+  // not scale to the same severity.
+  private hasForcePushedToDefaultBranch = false;
   private totalToolCalls = 0;
   private sessionStartTimestamp: number | null = null;
   private commitTimestamps: number[] = [];
@@ -269,7 +342,6 @@ export class GitEfficiencyTracker {
   private commitsBehindMain: number | null = null;
   private quickConflictResolutions = 0;
   private prEvents: PrEvent[] = [];
-  private firstCommitTimestamp: number | null = null;
   private repoContext: RepoContext = {
     repoName: null,
     branch: null,
@@ -302,10 +374,18 @@ export class GitEfficiencyTracker {
     const command = record.command as string | undefined;
     if (!command) return;
 
-    // Track GitHub CLI PR commands (skip if `git commit` is the *command*, not
-    // text that happens to appear inside a gh argument like --title).
-    if (GH_COMMAND_RE.test(command) && !command.trimStart().startsWith('git ')) {
-      this.processGhCommand(command, record.timestamp);
+    // Track GitHub CLI PR commands. Split on shell separators first so a
+    // `gh` invocation chained after a `git` command (e.g. `git push && gh pr
+    // create --fill`) is still detected — checking the git-prefix guard
+    // against the whole compound string would skip it even though only the
+    // first segment is a `git` command. Each segment still skips the case
+    // where "gh" is just text inside a git argument, e.g. `git commit -m "gh
+    // pr create note"`.
+    for (const segment of command.split(/&&|;|\|/)) {
+      const trimmedSegment = segment.trim();
+      if (GH_COMMAND_RE.test(trimmedSegment) && !trimmedSegment.startsWith('git ')) {
+        this.processGhCommand(trimmedSegment, record.timestamp);
+      }
     }
 
     if (!GIT_COMMAND_RE.test(command)) return;
@@ -359,14 +439,28 @@ export class GitEfficiencyTracker {
       (e) => e.action === 'edit' || e.action === 'ready',
     ).length;
 
-    // Time from first commit to first PR creation
-    let avgTimeToCreateMs: number | null = null;
-    if (created > 0 && this.firstCommitTimestamp !== null) {
-      const firstCreate = this.prEvents.find((e) => e.action === 'create');
-      if (firstCreate) {
-        avgTimeToCreateMs = Math.max(0, firstCreate.timestamp - this.firstCommitTimestamp);
+    // Time from each PR's most recent preceding commit to its `gh pr
+    // create`, averaged across every PR opened this session — not a single
+    // delta anchored to whichever commit happened to be the very first one
+    // this tracker ever saw, which would go stale after the first PR and
+    // ignore every PR opened later in the same session.
+    const sortedCommitTimestamps = [...this.commitTimestamps].sort((a, b) => a - b);
+    const timesToCreate: number[] = [];
+    for (const prEvent of this.prEvents) {
+      if (prEvent.action !== 'create') continue;
+      let precedingCommitTimestamp: number | null = null;
+      for (const commitTimestamp of sortedCommitTimestamps) {
+        if (commitTimestamp > prEvent.timestamp) break;
+        precedingCommitTimestamp = commitTimestamp;
+      }
+      if (precedingCommitTimestamp !== null) {
+        timesToCreate.push(Math.max(0, prEvent.timestamp - precedingCommitTimestamp));
       }
     }
+    const avgTimeToCreateMs =
+      timesToCreate.length > 0
+        ? timesToCreate.reduce((a, b) => a + b, 0) / timesToCreate.length
+        : null;
 
     return {
       created,
@@ -388,10 +482,23 @@ export class GitEfficiencyTracker {
         success: true,
         durationMs: null,
       };
-      // Only add if we don't already have this commit tracked
-      const isDuplicate = this.events.some(
-        (e) => e.type === 'commit' && e.command?.includes(commit.hash),
-      );
+      // Only add if we don't already have this commit tracked. Against an
+      // existing hydrated event (one carrying its own real hash), match by
+      // exact hash equality — precise, and avoids collapsing two genuinely
+      // distinct commits that just happen to land within the proximity
+      // window. Against an existing hook-observed event, fall back to
+      // timestamp proximity: a prior session's hook-observed `commit` event,
+      // replayed via replayTimeline() before this method ever runs, has no
+      // hash in its command text at all, so a hash match would never catch
+      // it and every restart would double-count that commit.
+      const isDuplicate = this.events.some((e) => {
+        if (e.type !== 'commit') return false;
+        const existingHash = e.command ? HYDRATED_COMMIT_HASH_RE.exec(e.command)?.[1] : undefined;
+        if (existingHash !== undefined) {
+          return existingHash === commit.hash;
+        }
+        return Math.abs(e.timestamp - commit.timestamp) < COMMIT_DEDUP_WINDOW_MS;
+      });
       if (!isDuplicate) {
         this.events.push(event);
         this.commitTimestamps.push(commit.timestamp);
@@ -467,9 +574,29 @@ export class GitEfficiencyTracker {
     const commitCount = this.events.filter((e) => e.type === 'commit').length;
     const branchOperations = this.events.filter((e) => e.type === 'branch').length;
 
-    const resolved = this.conflictRecords.filter((c) => c.resolution === 'resolved');
+    // A conflict that's currently open (mid-merge, not yet aborted or
+    // resolved) is counted in the mergeConflicts/rebaseConflicts KPI above,
+    // but this.conflictRecords only gains an entry once it's aborted or
+    // resolved — so it would otherwise never enter the resolution-rate
+    // denominator, letting a session with one resolved and one still-open
+    // conflict show a "perfect" 100% rate. Synthesizing (not persisting) a
+    // 'pending' record per still-queued conflict keeps the denominator
+    // honest without ever double-counting once that conflict does resolve —
+    // at that point it leaves the queue and gets a real entry instead.
+    const allConflictRecords: MergeConflictRecord[] = [
+      ...this.conflictRecords,
+      ...this.pendingConflicts.map((p) => ({
+        timestamp: p.timestamp,
+        resolution: 'pending' as const,
+        resolutionTimeMs: null,
+        command: p.command,
+        files: p.files,
+      })),
+    ];
+
+    const resolved = allConflictRecords.filter((c) => c.resolution === 'resolved');
     const conflictResolutionRate =
-      this.conflictRecords.length > 0 ? resolved.length / this.conflictRecords.length : null;
+      allConflictRecords.length > 0 ? resolved.length / allConflictRecords.length : null;
 
     const resolutionTimes = resolved
       .filter((c) => c.resolutionTimeMs !== null)
@@ -544,9 +671,17 @@ export class GitEfficiencyTracker {
       // (GitEfficiency.tsx's `[...timeline].reverse().slice(0, 30)`) picks
       // the true newest 30, not whichever 30 happened to be pushed last.
       gitCommandTimeline: [...this.events].sort((a, b) => a.timestamp - b.timestamp).slice(-50),
-      conflictHistory: [...this.conflictRecords].sort((a, b) => a.timestamp - b.timestamp),
-      suggestions,
-      bestPractices,
+      conflictHistory: [...allConflictRecords].sort((a, b) => a.timestamp - b.timestamp),
+      // Both arrays render in whatever order the checks above happen to
+      // .push() in — fixed source-code order, not severity order — so a
+      // critical-severity item could render below a milder one. Sort by
+      // severity (most severe first) before exposing.
+      suggestions: [...suggestions].sort(
+        (a, b) => SUGGESTION_SEVERITY_RANK[a.severity] - SUGGESTION_SEVERITY_RANK[b.severity],
+      ),
+      bestPractices: [...bestPractices].sort(
+        (a, b) => BEST_PRACTICE_STATUS_RANK[a.status] - BEST_PRACTICE_STATUS_RANK[b.status],
+      ),
       preventionScore,
       efficiencyScore,
       riskIndicators,
@@ -560,9 +695,7 @@ export class GitEfficiencyTracker {
   reset(_sessionId: string): void {
     this.events = [];
     this.conflictRecords = [];
-    this.pendingConflictTimestamp = null;
-    this.pendingConflictCommand = '';
-    this.pendingConflictFiles = [];
+    this.pendingConflicts = [];
     this.lastSyncTimestamp = null;
     this.pullsSinceLastConflict = 0;
     this.consecutiveFailedPushes = 0;
@@ -578,6 +711,9 @@ export class GitEfficiencyTracker {
     this.editedFiles.clear();
     this.hasUsedWorktree = false;
     this.hasUsedForceWithLease = false;
+    this.hasUsedBareForcePush = false;
+    this.bareForcePushCount = 0;
+    this.hasForcePushedToDefaultBranch = false;
     this.totalToolCalls = 0;
     this.sessionStartTimestamp = null;
     this.commitTimestamps = [];
@@ -593,7 +729,6 @@ export class GitEfficiencyTracker {
     this.commitsBehindMain = null;
     this.quickConflictResolutions = 0;
     this.prEvents = [];
-    this.firstCommitTimestamp = null;
     this.repoContext = { repoName: null, branch: null, remoteName: null, defaultBranch: null };
   }
 
@@ -646,16 +781,25 @@ export class GitEfficiencyTracker {
   }
 
   private processEvent(event: GitEvent, command: string, record: ToolCallRecord): void {
-    // Track conflict resolution strategies regardless of event type
-    if (GIT_CHECKOUT_OURS_RE.test(command)) this.oursCount++;
-    if (GIT_CHECKOUT_THEIRS_RE.test(command)) this.theirsCount++;
-    if (GIT_CHERRY_PICK_RE.test(command)) this.cherryPickCount++;
+    // Attribute ours/theirs/cherry-pick resolution strategy to the oldest
+    // still-open conflict, not to every matching command — a multi-file
+    // conflict resolved with one `--ours` per file must count once toward
+    // that conflict, not once per file, and a strategy command run with no
+    // conflict pending isn't resolving anything. `--abort` also matches the
+    // bare cherry-pick pattern, so it's excluded explicitly — aborting isn't
+    // a resolution strategy.
+    const oldestPending = this.pendingConflicts[0];
+    if (oldestPending) {
+      if (GIT_CHECKOUT_OURS_RE.test(command)) oldestPending.usedOurs = true;
+      if (GIT_CHECKOUT_THEIRS_RE.test(command)) oldestPending.usedTheirs = true;
+      if (GIT_CHERRY_PICK_RE.test(command) && !CHERRY_PICK_ABORT_RE.test(command)) {
+        oldestPending.usedCherryPick = true;
+      }
+    }
 
     switch (event.type) {
       case 'merge_conflict':
       case 'rebase_conflict': {
-        this.pendingConflictTimestamp = event.timestamp;
-        this.pendingConflictCommand = command;
         const output = (record.error as string) ?? '';
         const files: string[] = [];
         let match: RegExpExecArray | null;
@@ -664,58 +808,62 @@ export class GitEfficiencyTracker {
           files.push(match[1].trim());
           this.conflictedFiles.add(match[1].trim());
         }
-        this.pendingConflictFiles = files;
+        this.pendingConflicts.push({
+          timestamp: event.timestamp,
+          command,
+          files,
+          usedOurs: false,
+          usedTheirs: false,
+          usedCherryPick: false,
+        });
         this.pullsSinceLastConflict = 0;
         break;
       }
 
       case 'merge_abort':
       case 'rebase_abort':
-      case 'cherry_pick_abort':
-        if (this.pendingConflictTimestamp !== null) {
+      case 'cherry_pick_abort': {
+        const pending = this.pendingConflicts.shift();
+        if (pending) {
           this.conflictRecords.push({
-            timestamp: this.pendingConflictTimestamp,
+            timestamp: pending.timestamp,
             resolution: 'aborted',
-            resolutionTimeMs: event.timestamp - this.pendingConflictTimestamp,
-            command: this.pendingConflictCommand,
-            files: this.pendingConflictFiles,
+            resolutionTimeMs: event.timestamp - pending.timestamp,
+            command: pending.command,
+            files: pending.files,
           });
-          this.pendingConflictTimestamp = null;
-          this.pendingConflictCommand = '';
-          this.pendingConflictFiles = [];
         }
         break;
+      }
 
       case 'commit': {
         // git commit --amend fixes a prior commit, not a merge conflict.
-        // Clear the pending conflict on amend so the *next* normal commit
-        // doesn't see a stale pendingConflictTimestamp (potentially hours old).
+        // Drop the oldest pending conflict on amend (without recording a
+        // resolution) so a later, unrelated commit doesn't retroactively
+        // "resolve" it.
         if (command.includes('--amend')) {
-          this.pendingConflictTimestamp = null;
-          this.pendingConflictCommand = '';
-          this.pendingConflictFiles = [];
-        }
-        if (this.pendingConflictTimestamp !== null && !command.includes('--amend')) {
-          const resolutionMs = event.timestamp - this.pendingConflictTimestamp;
-          this.conflictRecords.push({
-            timestamp: this.pendingConflictTimestamp,
-            resolution: 'resolved',
-            resolutionTimeMs: resolutionMs,
-            command: this.pendingConflictCommand,
-            files: this.pendingConflictFiles,
-          });
-          // Under 30s resolution with multiple conflicted files is suspiciously fast
-          if (resolutionMs < 30_000 && this.pendingConflictFiles.length > 1) {
-            this.quickConflictResolutions++;
+          this.pendingConflicts.shift();
+        } else {
+          const pending = this.pendingConflicts.shift();
+          if (pending) {
+            const resolutionMs = event.timestamp - pending.timestamp;
+            this.conflictRecords.push({
+              timestamp: pending.timestamp,
+              resolution: 'resolved',
+              resolutionTimeMs: resolutionMs,
+              command: pending.command,
+              files: pending.files,
+            });
+            if (pending.usedOurs) this.oursCount++;
+            if (pending.usedTheirs) this.theirsCount++;
+            if (pending.usedCherryPick) this.cherryPickCount++;
+            // Under 30s resolution with multiple conflicted files is suspiciously fast
+            if (resolutionMs < 30_000 && pending.files.length > 1) {
+              this.quickConflictResolutions++;
+            }
           }
-          this.pendingConflictTimestamp = null;
-          this.pendingConflictCommand = '';
-          this.pendingConflictFiles = [];
         }
         this.commitTimestamps.push(event.timestamp);
-        if (this.firstCommitTimestamp === null) {
-          this.firstCommitTimestamp = event.timestamp;
-        }
         this.commitsSinceLastSync++;
         this.statusChecksSinceLastAction = 0;
         break;
@@ -761,6 +909,15 @@ export class GitEfficiencyTracker {
         break;
 
       case 'force_push':
+        this.hasUsedBareForcePush = true;
+        this.bareForcePushCount++;
+        if (
+          this.repoContext.branch !== null &&
+          this.repoContext.defaultBranch !== null &&
+          this.repoContext.branch === this.repoContext.defaultBranch
+        ) {
+          this.hasForcePushedToDefaultBranch = true;
+        }
         if (
           this.lastPushRejectedTimestamp !== null &&
           event.timestamp - this.lastPushRejectedTimestamp < 300_000
@@ -798,8 +955,14 @@ export class GitEfficiencyTracker {
         break;
 
       case 'worktree':
-        this.hasUsedWorktree = true;
-        this.worktreeCommands++;
+        // Both the "worktree ops" count and the usesWorktrees/use_worktrees
+        // signal are meant to reflect real worktree usage, not read-only
+        // inspection — `list`/`prune`/`lock`/etc. shouldn't count as evidence
+        // that worktrees were used to isolate parallel work.
+        if (GIT_WORKTREE_ADD_REMOVE_RE.test(command)) {
+          this.worktreeCommands++;
+          this.hasUsedWorktree = true;
+        }
         break;
 
       case 'status':
@@ -812,18 +975,22 @@ export class GitEfficiencyTracker {
     }
   }
 
-  // A pull immediately followed by a conflict means the branch had already
-  // diverged enough that even the act of syncing produced a conflict — a
-  // stronger signal of a stale branch than a conflict from, say, a later
-  // merge or rebase attempted well after the pull.
+  // A pull that diverged enough to conflict is the strongest signal of a
+  // stale branch — checked directly off the conflicting event's own command
+  // (a `git pull` whose own output contains a conflict indicator classifies
+  // as merge_conflict/rebase_conflict, never as 'pull', so this can't rely
+  // on the event's `type`). A pull immediately followed by a *separate*
+  // command that then conflicts is a weaker but still real signal, kept as a
+  // fallback for events that don't match the direct case.
   private countStaleBranchPulls(): number {
     let staleCount = 0;
-    for (let i = 0; i < this.events.length - 1; i++) {
-      if (this.events[i].type === 'pull') {
-        const next = this.events[i + 1];
-        if (next.type === 'merge_conflict' || next.type === 'rebase_conflict') {
-          staleCount++;
-        }
+    for (let i = 0; i < this.events.length; i++) {
+      const event = this.events[i];
+      if (event.type !== 'merge_conflict' && event.type !== 'rebase_conflict') continue;
+      if (GIT_PULL_RE.test(event.command ?? '')) {
+        staleCount++;
+      } else if (i > 0 && this.events[i - 1].type === 'pull') {
+        staleCount++;
       }
     }
     return staleCount;
@@ -994,7 +1161,12 @@ export class GitEfficiencyTracker {
       });
     }
 
-    // 5. Use --force-with-lease instead of --force
+    // 5. Use --force-with-lease instead of --force. Gated on
+    // hasUsedBareForcePush rather than forcePushes/usesForceWithLease alone —
+    // those two count safe and unsafe force-pushes together, so checking
+    // usesForceWithLease alone would let one safe `--force-with-lease` mask a
+    // dangerous bare `--force` in the same session with a fully-passing
+    // status.
     if (stats.forcePushes === 0) {
       practices.push({
         id: 'force_with_lease',
@@ -1002,15 +1174,15 @@ export class GitEfficiencyTracker {
         status: 'unknown',
         detail: 'No force pushes yet.',
       });
-    } else if (risk.usesForceWithLease) {
+    } else if (this.hasUsedBareForcePush && risk.usesForceWithLease) {
       practices.push({
         id: 'force_with_lease',
         label: 'Use --force-with-lease',
-        status: 'pass',
+        status: 'warn',
         detail:
-          "Good — using --force-with-lease which refuses to overwrite remote commits you haven't seen.",
+          'Mixed usage this session — some force pushes used --force-with-lease, but at least one bare --force (unsafe) push also occurred. Always use --force-with-lease; it refuses to push if someone else has pushed to the branch since your last fetch.',
       });
-    } else {
+    } else if (this.hasUsedBareForcePush) {
       practices.push({
         id: 'force_with_lease',
         label: 'Use --force-with-lease',
@@ -1018,26 +1190,17 @@ export class GitEfficiencyTracker {
         detail:
           'Using bare --force instead of --force-with-lease. The --force-with-lease flag is a safety net: it refuses to push if someone else has pushed to the branch since your last fetch. Always prefer it.',
       });
-    }
-
-    // 6. Don't force-push after a rejection without investigating
-    if (risk.forceAfterReject > 0) {
+    } else {
       practices.push({
-        id: 'no_force_after_reject',
-        label: "Don't force-push after rejection",
-        status: 'fail',
-        detail: `Push was rejected ${risk.pushRejections} time(s) and then force-pushed ${risk.forceAfterReject} time(s). When a push is rejected, pull + rebase first to incorporate upstream changes. Force pushing after a rejection overwrites others' work.`,
-      });
-    } else if (risk.pushRejections > 0) {
-      practices.push({
-        id: 'no_force_after_reject',
-        label: "Don't force-push after rejection",
+        id: 'force_with_lease',
+        label: 'Use --force-with-lease',
         status: 'pass',
-        detail: 'Push was rejected but correctly handled without force pushing.',
+        detail:
+          "Good — using --force-with-lease which refuses to overwrite remote commits you haven't seen.",
       });
     }
 
-    // 7. Keep PRs small (proxy: many commits without pushing)
+    // 6. Keep PRs small (proxy: many commits without pushing)
     if (risk.commitsSinceLastSync > 15) {
       practices.push({
         id: 'small_increments',
@@ -1054,7 +1217,7 @@ export class GitEfficiencyTracker {
       });
     }
 
-    // 8. Avoid editing hot files
+    // 7. Avoid editing hot files
     if (risk.hotFiles.length > 0) {
       practices.push({
         id: 'avoid_hot_files',
@@ -1064,7 +1227,7 @@ export class GitEfficiencyTracker {
       });
     }
 
-    // 9. Build/test before pushing
+    // 8. Build/test before pushing
     if (this.buildBeforePush === null && this.lastPushTimestamp === null) {
       practices.push({
         id: 'verify_before_push',
@@ -1123,25 +1286,14 @@ export class GitEfficiencyTracker {
     const suggestions: GitSuggestion[] = [];
 
     // --- Proactive prevention suggestions (fire BEFORE conflicts happen) ---
-
-    if (stats.riskIndicators.syncedBeforeEditing === false) {
-      suggestions.push({
-        severity: 'warning',
-        category: 'no_initial_sync',
-        message:
-          'Started editing without syncing first. Run `git fetch && git rebase origin/main` (or your target branch) at the start of every session. This single habit prevents the majority of AI-assisted coding conflicts.',
-        evidence: 'First file edit occurred before any git pull/fetch',
-      });
-    }
-
-    if (stats.riskIndicators.commitsSinceLastSync > 8) {
-      suggestions.push({
-        severity: 'warning',
-        category: 'drift_risk',
-        message: `${stats.riskIndicators.commitsSinceLastSync} commits without syncing. You're accumulating drift that will compound into painful conflicts. Run \`git fetch && git rebase origin/main\` now — smaller, frequent rebases are far easier than one large one later.`,
-        evidence: `${stats.riskIndicators.commitsSinceLastSync} commits since last pull/fetch/rebase`,
-      });
-    }
+    //
+    // syncedBeforeEditing, commitsSinceLastSync (drift), and hotFiles are
+    // ongoing-state conditions already surfaced as their own Best Practice
+    // checks (sync_before_edit, frequent_sync, avoid_hot_files) — duplicating
+    // them here as one-off suggestions rendered the same fact twice, with a
+    // conflicting severity in the hot-files case. Best Practices is their
+    // canonical home; only force-after-reject (a one-time, reactive event
+    // with actionable remediation) is kept as a suggestion.
 
     if (stats.riskIndicators.forceAfterReject > 0) {
       suggestions.push({
@@ -1150,15 +1302,6 @@ export class GitEfficiencyTracker {
         message:
           'Push was rejected and then force-pushed — this overwrites upstream changes. The correct response to a rejected push is: `git fetch`, then `git rebase origin/<branch>`, resolve any conflicts, then push normally. Force push is a last resort, not a first response.',
         evidence: `${stats.riskIndicators.forceAfterReject} force push(es) within 5 min of a rejection`,
-      });
-    }
-
-    if (stats.riskIndicators.hotFiles.length > 0) {
-      suggestions.push({
-        severity: 'info',
-        category: 'hot_files',
-        message: `You're editing files that previously conflicted (${stats.riskIndicators.hotFiles.slice(0, 3).join(', ')}). These likely have active upstream work. Consider: (1) rebasing immediately to get latest state, (2) coordinating with whoever else is touching these files, or (3) deferring changes until upstream settles.`,
-        evidence: `${stats.riskIndicators.hotFiles.length} previously-conflicted file(s) re-edited`,
       });
     }
 
@@ -1192,21 +1335,40 @@ export class GitEfficiencyTracker {
       });
     }
 
-    if (stats.forcePushes >= 2) {
+    // Severity is gated on hasUsedBareForcePush/bareForcePushCount — the same
+    // shared signal the force_with_lease best-practice check uses — rather
+    // than the raw forcePushes count, which sums bare AND lease-protected
+    // pushes together. Gating (and scaling) on the bare-only count keeps this
+    // suggestion's ranking consistent with the best-practice check: adding a
+    // safe --force-with-lease push on top of an existing bare push must never
+    // raise severity, since only the bare push is actually risky.
+    //
+    // A bare push to the shared default branch is escalated to 'critical'
+    // outright, regardless of count — it can clobber other collaborators'
+    // work, unlike an identical push to a personal feature branch (which
+    // still scales by count, as above).
+    if (this.hasUsedBareForcePush) {
       suggestions.push({
-        severity: 'critical',
+        severity: this.hasForcePushedToDefaultBranch
+          ? 'critical'
+          : this.bareForcePushCount >= 2
+            ? 'critical'
+            : 'warning',
         category: 'force_push',
-        message:
-          'Multiple force pushes this session. Always use --force-with-lease as a safety net. If you need to rewrite history, coordinate with collaborators first and ensure your local refs are up to date with `git fetch` before force pushing.',
-        evidence: `${stats.forcePushes} force pushes this session`,
+        message: this.hasForcePushedToDefaultBranch
+          ? `Bare --force push used on the shared default branch (${this.repoContext.defaultBranch ?? 'default branch'}) — this can overwrite history other collaborators are building on. Always use --force-with-lease, and avoid force-pushing the default branch entirely if possible.`
+          : 'Bare --force push used. Always use --force-with-lease instead — it refuses to push if someone else has pushed to the branch since your last fetch. If you need to rewrite history, coordinate with collaborators first and ensure your local refs are up to date with `git fetch` before force pushing.',
+        evidence: this.hasForcePushedToDefaultBranch
+          ? `${this.bareForcePushCount} bare --force push(es) this session, including at least one on the default branch`
+          : `${this.bareForcePushCount} bare --force push(es) this session`,
       });
-    } else if (stats.forcePushes === 1) {
+    } else if (stats.riskIndicators.usesForceWithLease && stats.forcePushes >= 2) {
       suggestions.push({
         severity: 'info',
         category: 'force_push',
         message:
-          "Force push used. Prefer --force-with-lease for safer force pushes — it refuses to overwrite commits you haven't seen locally.",
-        evidence: '1 force push',
+          'Multiple force pushes this session, all using --force-with-lease — the safe pattern. Repeated history rewrites can still be worth a second look if they indicate a workflow issue upstream.',
+        evidence: `${stats.forcePushes} lease-protected force pushes this session`,
       });
     }
 
@@ -1406,17 +1568,20 @@ export class GitEfficiencyTracker {
   }
 
   private computeConflictStrategy(): ConflictResolutionStrategy {
-    const manualMergeCount =
+    const manualMergeCount = Math.max(
+      0,
       this.conflictRecords.filter((c) => c.resolution === 'resolved').length -
-      this.oursCount -
-      this.theirsCount;
+        this.oursCount -
+        this.theirsCount -
+        this.cherryPickCount,
+    );
 
     return {
       oursCount: this.oursCount,
       theirsCount: this.theirsCount,
-      manualMergeCount: Math.max(0, manualMergeCount),
+      manualMergeCount,
       cherryPickCount: this.cherryPickCount,
-      totalResolutions: this.oursCount + this.theirsCount + Math.max(0, manualMergeCount),
+      totalResolutions: this.oursCount + this.theirsCount + this.cherryPickCount + manualMergeCount,
     };
   }
 }

--- a/src/web/views/GitEfficiency.test.tsx
+++ b/src/web/views/GitEfficiency.test.tsx
@@ -205,8 +205,52 @@ describe('GitEfficiency view — hero KPIs and gated sections', () => {
     });
     expect(await screen.findByText('commits today')).toBeInTheDocument();
     expect(screen.getByText('7')).toBeInTheDocument();
-    expect(screen.getByText('2 merged')).toBeInTheDocument();
     expect(screen.getByText('rebase soon')).toBeInTheDocument();
+  });
+
+  // A `merge` event has no per-PR correlation with `create` — a session that
+  // merges a PR opened on a prior day but hasn't opened anything new today
+  // would otherwise render "PRs opened: 0, 2 merged" directly underneath,
+  // reading as a contradiction. The independent "PRs merged" KPI further
+  // down the page (in the Pull Requests section) already reports this
+  // number without that coupling problem.
+  it('does not present "PRs opened" as if merged were a subset/outcome of it', async () => {
+    renderGitEfficiency({
+      ...BASE_DATA,
+      prMetrics: { ...BASE_DATA.prMetrics, created: 0, merged: 2 },
+    });
+    await screen.findByText('Git Efficiency');
+    expect(screen.queryByText('2 merged')).toBeNull();
+  });
+
+  // `abortedOperations` is a tracker-wide count of every aborted
+  // merge/rebase/cherry-pick this session, unrelated to whether *these*
+  // conflicts were ever resolved. Showing it under "conflicts" without
+  // qualification reads as "0 aborted" even when conflicts were fully
+  // resolved, with no confirmation that resolution actually happened.
+  it('shows a resolved count under "conflicts" instead of the tracker-wide aborted-operations count', async () => {
+    renderGitEfficiency({
+      ...BASE_DATA,
+      mergeConflicts: 2,
+      abortedOperations: 3,
+      conflictHistory: [
+        {
+          timestamp: 1,
+          resolution: 'resolved',
+          resolutionTimeMs: 100,
+          command: 'git commit -m "fix"',
+        },
+        {
+          timestamp: 2,
+          resolution: 'resolved',
+          resolutionTimeMs: 200,
+          command: 'git commit -m "fix2"',
+        },
+      ],
+    });
+    await screen.findByText('Git Efficiency');
+    expect(screen.queryByText('3 aborted')).toBeNull();
+    expect(screen.getByText('2 resolved')).toBeInTheDocument();
   });
 
   it('hides the Conflict Resolution section when there are no conflicts', async () => {

--- a/src/web/views/GitEfficiency.tsx
+++ b/src/web/views/GitEfficiency.tsx
@@ -127,6 +127,9 @@ export function GitEfficiency(): JSX.Element {
     refetchInterval: 30000,
   });
 
+  const resolvedConflictCount =
+    data?.conflictHistory.filter((c) => c.resolution === 'resolved').length ?? 0;
+
   if (isLoading) return <EmptyState icon="clock" variant="loading" title="Loading..." />;
   if (error)
     return <div className="text-accent-red text-xs">Error loading git efficiency data.</div>;
@@ -238,7 +241,6 @@ export function GitEfficiency(): JSX.Element {
               label="PRs opened"
               tone={data.prMetrics.created > 0 ? 'good' : 'neutral'}
               value={String(data.prMetrics.created)}
-              sub={data.prMetrics.merged > 0 ? `${data.prMetrics.merged} merged` : undefined}
               animate
               numericValue={data.prMetrics.created}
             />
@@ -249,7 +251,7 @@ export function GitEfficiency(): JSX.Element {
               sub={
                 data.mergeConflicts + data.rebaseConflicts === 0
                   ? 'clean session'
-                  : `${data.abortedOperations} aborted`
+                  : `${resolvedConflictCount} resolved`
               }
               animate
               numericValue={data.mergeConflicts + data.rebaseConflicts}


### PR DESCRIPTION
## Summary

Fixes 12 correctness bugs in the Git Efficiency dashboard page's tracker (`src/metrics/git-efficiency-tracker.ts`). Ships as v1.14.37.

- **Commit/KPI counter correctness** — commit deduplication after a process restart no longer relies on a hash match that could never succeed; branch-divergence now refreshes periodically instead of freezing at process startup; PR-metrics averaging now pairs each PR with its own preceding commit instead of reflecting only the session's first PR; compound `git ... && gh ...` commands are now recognized instead of silently dropping PR tracking; the worktree-ops counter only counts real `add`/`remove` usage, not read-only inspection like `git worktree list`.
- **Force-push risk assessment** — fixed a genuine severity inversion where a dangerous bare `--force` push could rate safer than two safe `--force-with-lease` pushes. Both the Best Practices check and the Suggestion severity now read one shared signal, and a bare push to the shared default branch is escalated relative to one on a personal feature branch.
- **Conflict/suggestion/best-practice logic** — Best Practices and Suggestions no longer duplicate the same finding with disagreeing severity; both panels now sort by severity before rendering; conflict-resolution-strategy counts are attributed per actual pending conflict instead of per matching command; concurrent pending conflicts are tracked independently instead of one overwriting another; a pull that conflicts directly is now correctly counted as a stale-branch pull.

Fixes #411, Fixes #412, Fixes #414, Fixes #415, Fixes #416, Fixes #417, Fixes #419, Fixes #420, Fixes #421, Fixes #423, Fixes #424, Fixes #425.

## Test plan

- [x] `npm run build`
- [x] `npm test` (5442/5445 passing, 3 pre-existing skips)
- [x] `npx vitest run src/web/views/GitEfficiency.test.tsx` (15/15 passing)
- [x] `npm run lint` (0 errors/warnings)
- [x] New regression tests added for each fix