### PR TITLE
Fix: Sessions live-detection, disclosure/truncation, null/zero conflation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.38] - 2026-08-10
+
+### Fixed
+
+- **The Sessions page now recovers gracefully from a bad session link.** An invalid or stale deep-linked session now shows a real error state with a "clear selection" action, instead of leaving the detail pane permanently blank.
+- **A session that has already ended no longer keeps showing a "live" badge.** The live-session check is now the single source of truth for which session is live, so an ended session's badge disappears instead of lingering indefinitely.
+- **Initial session selection on the Sessions page no longer races ahead of the live-session check.** The page waits for the live-session check to settle before falling back to the most recent session, so a live session is never clobbered by a premature default selection.
+- **Several places that quietly capped or truncated what they showed now disclose that cap where it matters.** The Sessions page's recent-sessions notice, the History page's daily-spend sampling, model-performance and top-tools panel titles, the instruction-file-impact sample size, the collaboration-profile team size, and the Audit page's export button all now say when they're showing a partial view instead of implying completeness. The daily-spend truncation notice itself is now more precise — it only appears when the underlying sample was actually capped, not whenever an account simply doesn't have 30 days of history yet.
+- **A shared KPI display component no longer renders an unknown value as a confident animated zero.** Metrics that are genuinely unavailable now fall through to their placeholder text instead of animating toward "0", and the Git Efficiency page's "behind main" KPI now shows a neutral color for an unknown value instead of a reassuring green.
+- **The Git Efficiency page's worktree best-practice check no longer conflates "not enough data" with "fully evaluated, not applicable."** These are now tracked as distinct outcomes, and both are excluded from the best-practices pass ratio the same way.
+- **Workflow-run duration is no longer reported as zero when it's actually unknown.** A run that's still in progress (or was killed before finishing) now reports its duration as unknown rather than a confirmed instant zero, so it no longer skews duration averages downward.
+
 ## [1.14.37] - 2026-08-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.37",
+  "version": "1.14.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.37",
+      "version": "1.14.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.37",
+  "version": "1.14.38",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1009,6 +1009,45 @@ describe('api-handler GET /api/instruction-drift', () => {
   });
 });
 
+describe('api-handler GET /api/collaboration-profile', () => {
+  it('returns 503 when collaborationProfiler is missing', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/collaboration-profile' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns developerCount from computeTeamBaseline alongside the profile and team deltas', async () => {
+    const handler = createApiHandler({
+      collaborationProfiler: {
+        computeProfile: () => ({
+          classification: 'Power User',
+          dimensions: {
+            specificity: 0.7,
+            autonomy: 0.65,
+            correctionRate: 0.5,
+            taskComplexity: 0.6,
+          },
+          sessionCount: 12,
+        }),
+        compareToTeam: () => ({
+          deltas: { specificity: 0, autonomy: 0, correctionRate: 0, taskComplexity: 0 },
+        }),
+        computeTeamBaseline: () => ({ developerCount: 1 }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['collaborationProfiler'],
+    });
+    const req = { method: 'GET', url: '/api/collaboration-profile' } as IncomingMessage;
+    const { res, status, body, headers } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(headers()['content-type']).toMatch(/application\/json/);
+    const parsed = JSON.parse(body());
+    expect(parsed.developerCount).toBe(1);
+    expect(parsed.classification).toBe('Power User');
+  });
+});
+
 describe('api-handler GET /api/decision-tree', () => {
   it('returns 503 when decisionTracker is missing', async () => {
     const handler = createApiHandler({});
@@ -2844,6 +2883,45 @@ describe('api-handler GET /api/workflows', () => {
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed).toHaveLength(1);
     expect(parsed[0].runId).toBe('wf_abc12345-6dd');
+  });
+
+  // An unfinished/killed run's duration_ms is null (unknown), not 0 — the
+  // DTO must pass that null through unchanged rather than defaulting it.
+  it('passes a null duration_ms through as durationMs: null, not 0', async () => {
+    const fakeRow = {
+      workflow_run_id: 'wf_abc12345-6dd',
+      parent_session_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      task_id: null,
+      workflow_name: 'sample',
+      status: 'running',
+      incomplete: true,
+      error_reason: null,
+      default_model: 'claude-opus-4-7',
+      started_at: 1_781_652_144_959,
+      duration_ms: null,
+      agent_count: 2,
+      total_tokens: 826_463,
+      total_usd: null,
+      declared_phases: null,
+      observed_phases: 1,
+      declared_parallel_widths: [],
+      token_reconciliation_delta: null,
+      run_source: 'script',
+      script_path: null,
+      workflow_json_path: '/tmp/wf_abc12345-6dd.json',
+    };
+    const handler = createApiHandler({
+      workflowStore: {
+        listRuns: () => [fakeRow],
+        getRun: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['workflowStore'],
+    });
+    const req = { method: 'GET', url: '/api/workflows' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body());
+    expect(parsed[0].durationMs).toBeNull();
   });
 });
 

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -127,7 +127,8 @@ interface WorkflowRunDto {
   readonly errorReason: string | null;
   readonly defaultModel: string;
   readonly startedAt: number;
-  readonly durationMs: number;
+  /** `null` for an unfinished/killed run — see `WorkflowRunRow.duration_ms`'s docstring. */
+  readonly durationMs: number | null;
   readonly agentCount: number;
   readonly totalTokens: number;
   readonly totalUsd: number | null;
@@ -461,6 +462,7 @@ export interface ApiHandlerDeps {
         taskComplexity: number;
       };
     };
+    computeTeamBaseline: () => { developerCount: number };
   };
   readonly alertLog?: { readRecent: (limit: number) => Promise<AlertEvent[]> };
   readonly taskDetector?: {
@@ -1947,11 +1949,15 @@ export function createApiHandler(
     const developer = (deps.config?.developer as string | undefined) ?? 'unknown';
     const profile = deps.collaborationProfiler.computeProfile(developer);
     const comparison = deps.collaborationProfiler.compareToTeam(developer);
+    // developerCount lets the dashboard caveat "vs team" when the baseline
+    // is really just this one developer.
+    const baseline = deps.collaborationProfiler.computeTeamBaseline();
     jsonOk(res, {
       classification: profile.classification,
       dimensions: profile.dimensions,
       sessionCount: profile.sessionCount,
       teamDeltas: comparison.deltas,
+      developerCount: baseline.developerCount,
     });
   });
 

--- a/src/dashboard/workflow-store.test.ts
+++ b/src/dashboard/workflow-store.test.ts
@@ -119,6 +119,27 @@ describe('WorkflowStore', () => {
     expect(complete[0].status).toBe('completed');
   });
 
+  // A killed/unfinished run's rollup may have no numeric durationMs at all.
+  // Coercing that to 0 would make it read as a confirmed-instant run and
+  // silently skew any average computed over duration_ms. It must read back
+  // as null (unknown), not 0.
+  it('reports duration_ms as null (not 0) when the rollup has no numeric durationMs', () => {
+    writeFileSync(
+      join(wfDir, 'wf_abc12345-6dd.json'),
+      makeWfJson({ durationMs: undefined, status: 'killed' }),
+    );
+    const store = new WorkflowStore({ projectsDir });
+    const rows = store.listRuns();
+    expect(rows[0].duration_ms).toBeNull();
+  });
+
+  it('still reports a real duration_ms of 0 as 0, not conflated with unknown', () => {
+    writeFileSync(join(wfDir, 'wf_abc12345-6dd.json'), makeWfJson({ durationMs: 0 }));
+    const store = new WorkflowStore({ projectsDir });
+    const rows = store.listRuns();
+    expect(rows[0].duration_ms).toBe(0);
+  });
+
   it('integrates getCostForRun for total_usd', () => {
     writeFileSync(join(wfDir, 'wf_abc12345-6dd.json'), makeWfJson());
     const store = new WorkflowStore({

--- a/src/dashboard/workflow-store.ts
+++ b/src/dashboard/workflow-store.ts
@@ -62,7 +62,13 @@ export interface WorkflowRunRow {
   readonly error_reason: string | null;
   readonly default_model: string;
   readonly started_at: number;
-  readonly duration_ms: number;
+  /**
+   * `null` when the on-disk rollup has no numeric `durationMs` yet (e.g. a
+   * run still in progress or killed before it wrote one) — distinct from a
+   * confirmed 0ms run. Averaging over several runs' `duration_ms` must
+   * filter out nulls rather than let them silently count as zero.
+   */
+  readonly duration_ms: number | null;
   readonly agent_count: number;
   readonly total_tokens: number;
   readonly total_usd: number | null;
@@ -280,7 +286,9 @@ export class WorkflowStore {
     const runId = typeof parsed.runId === 'string' ? parsed.runId : '';
     if (!runId) return null;
     const startTime = typeof parsed.startTime === 'number' ? parsed.startTime : 0;
-    const durationMs = typeof parsed.durationMs === 'number' ? parsed.durationMs : 0;
+    // null (not 0) when absent — an unfinished/killed run's duration is
+    // unknown, not a confirmed instant completion. See WorkflowRunRow's docstring.
+    const durationMs = typeof parsed.durationMs === 'number' ? parsed.durationMs : null;
     const status = typeof parsed.status === 'string' ? parsed.status : 'unknown';
     const wfName = typeof parsed.workflowName === 'string' ? parsed.workflowName : 'unknown';
     const defaultModel = typeof parsed.defaultModel === 'string' ? parsed.defaultModel : 'unknown';

--- a/src/hooks/workflow-watcher.test.ts
+++ b/src/hooks/workflow-watcher.test.ts
@@ -135,6 +135,39 @@ describe('WorkflowWatcher', () => {
     expect(runs[0].status).toBe('killed');
   });
 
+  // A killed/unfinished run's rollup may have no numeric durationMs at all.
+  // Coercing that to 0 would make it read as a confirmed-instant run and
+  // silently skew any average computed over duration_ms. It must emit as
+  // null (unknown), not 0.
+  it('emits duration_ms as null (not 0) when the rollup has no numeric durationMs', () => {
+    writeFileSync(
+      join(wfDir, 'wf_abc12345-6dd.json'),
+      makeWfJson({ durationMs: undefined, status: 'killed' }),
+    );
+    const watcher = new WorkflowWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+    const runs: ScriptWorkflowRunMetrics[] = [];
+    watcher.setOnRun((r) => runs.push(r));
+    watcher.poll();
+    expect(runs[0].duration_ms).toBeNull();
+  });
+
+  it('still emits a real duration_ms of 0 as 0, not conflated with unknown', () => {
+    writeFileSync(join(wfDir, 'wf_abc12345-6dd.json'), makeWfJson({ durationMs: 0 }));
+    const watcher = new WorkflowWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+    const runs: ScriptWorkflowRunMetrics[] = [];
+    watcher.setOnRun((r) => runs.push(r));
+    watcher.poll();
+    expect(runs[0].duration_ms).toBe(0);
+  });
+
   it('matches files with longer suffix (R7: prefix-only filename pattern)', () => {
     // Filename uses an unusually long suffix — watcher must still match on `wf_`.
     writeFileSync(join(wfDir, 'wf_abc12345-6ddXYZ-extralongsuffix.json'), makeWfJson());

--- a/src/hooks/workflow-watcher.ts
+++ b/src/hooks/workflow-watcher.ts
@@ -323,7 +323,10 @@ export class WorkflowWatcher {
 
     const runId = typeof parsed.runId === 'string' ? parsed.runId : file.runId;
     const startTime = typeof parsed.startTime === 'number' ? parsed.startTime : 0;
-    const durationMs = typeof parsed.durationMs === 'number' ? parsed.durationMs : 0;
+    // null (not 0) when absent — an unfinished/killed run's duration is
+    // unknown, not a confirmed instant completion. See
+    // ScriptWorkflowRunMetrics.duration_ms's docstring.
+    const durationMs = typeof parsed.durationMs === 'number' ? parsed.durationMs : null;
     const status = typeof parsed.status === 'string' ? parsed.status : 'unknown';
     const incomplete = status !== 'completed';
     const wfName = typeof parsed.workflowName === 'string' ? parsed.workflowName : 'unknown';

--- a/src/metrics/collaboration-profile.test.ts
+++ b/src/metrics/collaboration-profile.test.ts
@@ -330,6 +330,23 @@ describe('CollaborationProfiler', () => {
     expect(baseline.dimensions.autonomy).toBeCloseTo(0.867, 2);
   });
 
+  // With sessions from only one developer, the "team" baseline is really
+  // just that developer, so the dashboard needs developerCount to know when
+  // to caveat "vs team" comparisons as meaningless. Guards against
+  // computeTeamBaseline silently reporting a count that doesn't reflect a
+  // single-developer SessionStore.
+  it('computeTeamBaseline reports developerCount 1 for a single-developer fixture', () => {
+    const profiler = new CollaborationProfiler({ sessionStore: store });
+
+    store.saveSession(makeSummary({ sessionId: 'solo-1', developer: 'alice', toolCallCount: 60 }));
+    store.saveSession(makeSummary({ sessionId: 'solo-2', developer: 'alice', toolCallCount: 40 }));
+
+    const baseline = profiler.computeTeamBaseline();
+
+    expect(baseline.developerCount).toBe(1);
+    expect(baseline.sessionCount).toBe(2);
+  });
+
   // -------------------------------------------------------------------------
   // 6. compareToTeam — deltas
   // -------------------------------------------------------------------------

--- a/src/metrics/git-efficiency-tracker.test.ts
+++ b/src/metrics/git-efficiency-tracker.test.ts
@@ -506,6 +506,20 @@ describe('GitEfficiencyTracker', () => {
       expect(practice?.status).toBe('unknown');
     });
 
+    // A session with enough activity to judge (3+ commits), no conflicts,
+    // and no worktree usage genuinely doesn't need worktrees — this is a
+    // known, non-violating outcome ('n/a'), distinct from the
+    // insufficient-data 'unknown' case above (which fires below the
+    // commitCount threshold).
+    it('marks use_worktrees as n/a (not unknown) once there is enough activity to judge and no conflicts occurred', () => {
+      for (let i = 0; i < 3; i++) {
+        tracker.recordToolCall(makeRecord({ command: `git commit -m "c${i}"` }));
+      }
+      const metrics = tracker.getMetrics();
+      const practice = metrics.bestPractices.find((p) => p.id === 'use_worktrees');
+      expect(practice?.status).toBe('n/a');
+    });
+
     it('fails force_with_lease check when bare --force is used', () => {
       tracker.recordToolCall(makeRecord({ command: 'git push --force origin feature' }));
       const metrics = tracker.getMetrics();
@@ -796,6 +810,26 @@ describe('GitEfficiencyTracker', () => {
         makeRecord({ command: 'git worktree add ../fix fix', timestamp: t + 600 }),
       );
       const metrics = tracker.getMetrics();
+      expect(metrics.preventionScore).toBe(100);
+    });
+
+    // use_worktrees resolving to 'n/a' (no conflicts, no worktree, enough
+    // activity to judge) must not drag the score down — it's excluded from
+    // the ratio the same way a genuinely-'unknown' check already is.
+    it('excludes an n/a use_worktrees check from the score, same as it excludes unknown checks', () => {
+      const t = Date.now();
+      tracker.recordToolCall(makeRecord({ command: 'git fetch origin', timestamp: t }));
+      tracker.recordToolCall(
+        makeRecord({ toolName: 'Edit', filePath: 'src/a.ts', timestamp: t + 100 }),
+      );
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "a"', timestamp: t + 200 }));
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "b"', timestamp: t + 300 }));
+      tracker.recordToolCall(makeRecord({ command: 'git commit -m "c"', timestamp: t + 400 }));
+      tracker.recordToolCall(makeRecord({ command: 'git rebase origin/main', timestamp: t + 500 }));
+      // No worktree usage, no conflicts.
+      const metrics = tracker.getMetrics();
+      const useWorktrees = metrics.bestPractices.find((p) => p.id === 'use_worktrees');
+      expect(useWorktrees?.status).toBe('n/a');
       expect(metrics.preventionScore).toBe(100);
     });
   });

--- a/src/metrics/git-efficiency-tracker.ts
+++ b/src/metrics/git-efficiency-tracker.ts
@@ -245,7 +245,15 @@ export interface GitSuggestion {
 export interface BestPractice {
   readonly id: string;
   readonly label: string;
-  readonly status: 'pass' | 'fail' | 'warn' | 'unknown';
+  /**
+   * `'n/a'` is distinct from `'unknown'`: `'unknown'` means there isn't
+   * enough signal yet to evaluate the check (genuinely insufficient data);
+   * `'n/a'` means the check is fully evaluated and the practice simply
+   * doesn't apply this session (e.g. no parallel work happened, so worktree
+   * usage was never needed) — a known, non-violating outcome that shouldn't
+   * be conflated with "we don't know" or count against the pass ratio.
+   */
+  readonly status: 'pass' | 'fail' | 'warn' | 'unknown' | 'n/a';
   readonly detail: string;
 }
 
@@ -263,6 +271,7 @@ const BEST_PRACTICE_STATUS_RANK: Record<BestPractice['status'], number> = {
   warn: 1,
   pass: 2,
   unknown: 3,
+  'n/a': 4,
 };
 
 export interface RiskIndicators {
@@ -1152,12 +1161,27 @@ export class GitEfficiencyTracker {
         detail:
           'Conflicts detected without worktree usage. When running multiple AI sessions in parallel (or switching between tasks), use `git worktree add` to give each task its own working directory. This completely eliminates cross-session conflicts.',
       });
-    } else {
+    } else if (stats.commitCount < 3) {
+      // Mirrors frequent_sync's "not enough commits yet" gate above — too
+      // little activity to tell whether this session even involves the kind
+      // of parallel/multi-task work worktrees would protect against.
       practices.push({
         id: 'use_worktrees',
         label: 'Use worktrees for parallel work',
         status: 'unknown',
-        detail: 'No worktree usage detected. Consider worktrees if you run parallel sessions.',
+        detail: 'Not enough activity yet to tell whether this session needs worktrees.',
+      });
+    } else {
+      // Fully known, not a violation: no conflicts occurred and no worktree
+      // was used. Distinct from the 'unknown' branch above — this session
+      // had enough activity to judge, and simply didn't need worktree
+      // isolation, which is a fine outcome, not "we don't know."
+      practices.push({
+        id: 'use_worktrees',
+        label: 'Use worktrees for parallel work',
+        status: 'n/a',
+        detail:
+          "No conflicts and no worktree usage detected this session — parallel-session isolation wasn't needed here.",
       });
     }
 
@@ -1257,7 +1281,10 @@ export class GitEfficiencyTracker {
   }
 
   private computePreventionScore(practices: BestPractice[]): number | null {
-    const scorable = practices.filter((p) => p.status !== 'unknown');
+    // 'n/a' (fully known, not applicable) is excluded the same way 'unknown'
+    // (genuinely insufficient data) is — neither should count for or against
+    // the score. See BestPractice['status']'s docstring for the distinction.
+    const scorable = practices.filter((p) => p.status !== 'unknown' && p.status !== 'n/a');
     if (scorable.length < 2) return null;
 
     let points = 0;

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -1878,6 +1878,26 @@ describe('scriptWorkflowRunToNrEvent()', () => {
     expect(event.incomplete).toBe(true);
     expect(event.status).toBe('killed');
   });
+
+  // An unfinished/killed run's duration is unknown, not a confirmed
+  // 0ms — the event must omit duration_ms entirely (same treatment as the
+  // total_usd-null case above) rather than reporting a false 0.
+  it('omits duration_ms when null (unfinished/killed run), and falls back to started_at alone for the timestamp', () => {
+    const event = scriptWorkflowRunToNrEvent(
+      makeScriptWorkflowRun({ started_at: 1_700_000_000_000, duration_ms: null }),
+      { developer: 'd', appName: 'a' },
+    );
+    expect(event.duration_ms).toBeUndefined();
+    expect(event.timestamp).toBe(1_700_000_000_000);
+  });
+
+  it('still includes a real duration_ms of 0, not conflated with unknown', () => {
+    const event = scriptWorkflowRunToNrEvent(makeScriptWorkflowRun({ duration_ms: 0 }), {
+      developer: 'd',
+      appName: 'a',
+    });
+    expect(event.duration_ms).toBe(0);
+  });
 });
 
 describe('subagentTurnToNrEvent()', () => {

--- a/src/transport/nr-ingest.ts
+++ b/src/transport/nr-ingest.ts
@@ -403,7 +403,13 @@ export interface ScriptWorkflowRunMetrics {
   readonly status: string;
   readonly default_model: string;
   readonly started_at: number;
-  readonly duration_ms: number;
+  /**
+   * `null` when the on-disk rollup has no numeric `durationMs` yet (e.g. a
+   * run still in progress or killed before it wrote one) — distinct from a
+   * confirmed 0ms run. See `WorkflowRunRow.duration_ms`'s docstring
+   * (`workflow-store.ts`) for the same distinction on the read side.
+   */
+  readonly duration_ms: number | null;
   readonly agent_count: number;
   /** Re-derived from sum of subagent JSONL usage; falls back to rollup totalTokens. */
   readonly total_tokens: number;
@@ -548,7 +554,10 @@ export function scriptWorkflowRunToNrEvent(
   const event: NrEventData = {
     eventType: 'AiWorkflowRun',
     event_version: 1,
-    timestamp: metrics.started_at + metrics.duration_ms,
+    // duration_ms can be null (unfinished/killed run); fall back to 0 for
+    // this derived timestamp only — the event's own duration_ms field below
+    // still omits the value entirely rather than reporting a false 0.
+    timestamp: metrics.started_at + (metrics.duration_ms ?? 0),
     run_source: 'script',
     workflow_run_id: metrics.workflow_run_id,
     // Declarative metadata: NOT redacted. meta.name is author-declared
@@ -558,7 +567,6 @@ export function scriptWorkflowRunToNrEvent(
     status: metrics.status,
     default_model: metrics.default_model,
     started_at: metrics.started_at,
-    duration_ms: metrics.duration_ms,
     agent_count: metrics.agent_count,
     total_tokens: metrics.total_tokens,
     observed_phases: metrics.observed_phases,
@@ -568,6 +576,7 @@ export function scriptWorkflowRunToNrEvent(
     developer: attrs.developer,
     app_name: attrs.appName,
   };
+  if (metrics.duration_ms !== null) event.duration_ms = metrics.duration_ms;
   if (metrics.task_id !== null) event.task_id = metrics.task_id;
   if (metrics.declared_phases !== null) event.declared_phases = metrics.declared_phases;
   if (metrics.total_usd !== null) event.total_usd = metrics.total_usd;

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -602,6 +602,10 @@ export interface CollaborationProfileApiResponse {
     readonly correctionRate: number;
     readonly taskComplexity: number;
   };
+  // Number of distinct developers folded into the team baseline `teamDeltas`
+  // was compared against. <= 1 means there's no other developer's data yet,
+  // so "vs team" is really "vs yourself".
+  readonly developerCount: number;
 }
 
 export const fetchCollaborationProfile = (): Promise<CollaborationProfileApiResponse> =>
@@ -685,7 +689,12 @@ export interface GitEvent {
 export interface BestPractice {
   readonly id: string;
   readonly label: string;
-  readonly status: 'pass' | 'fail' | 'warn' | 'unknown';
+  /**
+   * `'n/a'` (fully known, not applicable) is distinct from `'unknown'`
+   * (genuinely insufficient data) — see `BestPractice`'s docstring in
+   * `git-efficiency-tracker.ts` for the full explanation.
+   */
+  readonly status: 'pass' | 'fail' | 'warn' | 'unknown' | 'n/a';
   readonly detail: string;
 }
 

--- a/src/web/components/Kpi.test.tsx
+++ b/src/web/components/Kpi.test.tsx
@@ -38,6 +38,12 @@ describe('Kpi', () => {
     expect(screen.queryByText('WRONG')).not.toBeInTheDocument();
   });
 
+  it('renders the value string, not "0", when numericValue is null (unknown, not zero) even with animate set', () => {
+    render(<Kpi label="behind main" value="—" animate numericValue={null} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
   it('assembles prefix/suffix/decimals around the animated value when no format is given', () => {
     render(
       <Kpi

--- a/src/web/components/Kpi.tsx
+++ b/src/web/components/Kpi.tsx
@@ -18,7 +18,15 @@ export interface KpiProps {
   readonly tone?: KpiTone;
   readonly hero?: boolean;
   readonly animate?: boolean;
-  readonly numericValue?: number;
+  /**
+   * The live numeric value backing the animated count-up. Accepts `null` for
+   * "genuinely unknown/not-yet-available" (as opposed to a confirmed `0`) —
+   * callers should pass the raw nullable metric through rather than
+   * coalescing it to `0` first, or the animate branch below renders a
+   * misleading "0" instead of falling through to the `value` string (e.g.
+   * `value="—"`).
+   */
+  readonly numericValue?: number | null;
   readonly prefix?: string;
   readonly suffix?: string;
   readonly decimals?: number;
@@ -44,18 +52,18 @@ export function Kpi({
   decimals = 0,
   format,
 }: KpiProps): JSX.Element {
+  // `null` means "genuinely unknown", same as `undefined` — neither should
+  // coalesce to a rendered `0`. Only a real number reaches the animate branch.
+  const hasNumericValue = numericValue !== undefined && numericValue !== null;
+
   const animated = useAnimatedValue(numericValue ?? 0, {
     decimals,
-    enabled: animate && numericValue !== undefined,
+    enabled: animate && hasNumericValue,
     format,
   });
 
   const display =
-    animate && numericValue !== undefined
-      ? format
-        ? animated
-        : `${prefix}${animated}${suffix}`
-      : value;
+    animate && hasNumericValue ? (format ? animated : `${prefix}${animated}${suffix}`) : value;
 
   const valueClass = hero
     ? 'text-3xl font-bold mt-1 tabular-nums gradient-text'

--- a/src/web/views/Audit.test.tsx
+++ b/src/web/views/Audit.test.tsx
@@ -115,6 +115,14 @@ describe('Audit view', () => {
     expect(screen.getByRole('button', { name: /export jsonl/i })).toBeInTheDocument();
   });
 
+  it('discloses the 200-row export cap on the export button itself', async () => {
+    renderAudit(SAMPLE);
+    await waitFor(() => expect(screen.getByText('/etc/hosts')).toBeInTheDocument());
+    expect(
+      screen.getByRole('button', { name: /export jsonl \(max 200 rows\)/i }),
+    ).toBeInTheDocument();
+  });
+
   it('caps rendered rows at 200 and shows the "showing first" note when over the limit', async () => {
     const big = Array.from({ length: 500 }, (_, i) => ({
       ts: 1_000_000 + i,

--- a/src/web/views/Audit.tsx
+++ b/src/web/views/Audit.tsx
@@ -64,7 +64,11 @@ export function Audit(): JSX.Element {
       <header className="flex items-baseline justify-between mb-4">
         <h1 className="text-xl font-semibold gradient-text">Audit</h1>
         <Button variant="secondary" size="md" onClick={() => downloadJsonl(visibleSlice)}>
-          Export JSONL
+          {/* Discloses the row cap at the point of action rather than only in
+              the table footer note below — the export always mirrors
+              visibleSlice, so it's silently capped even when the footer note
+              is scrolled out of view. */}
+          Export JSONL (max {VISIBLE_LIMIT} rows)
         </Button>
       </header>
 

--- a/src/web/views/GitEfficiency.test.tsx
+++ b/src/web/views/GitEfficiency.test.tsx
@@ -193,6 +193,26 @@ describe('GitEfficiency view — bestPractices filtering', () => {
     });
     expect(await screen.findByText('No data yet')).toBeInTheDocument();
   });
+
+  // 'n/a' (fully known, not applicable) must be excluded from the
+  // known/passing ratio the same way 'unknown' already is, and still render
+  // visibly as a neutral chip rather than silently disappearing from the list.
+  it('excludes n/a entries from the known/passing ratio and still renders them as a neutral chip', async () => {
+    const practicesWithNA: BestPractice[] = [
+      ...bestPractices,
+      {
+        id: 'use_worktrees',
+        label: 'Use worktrees for parallel work',
+        status: 'n/a',
+        detail: 'No conflicts and no worktree usage detected this session.',
+      },
+    ];
+    renderGitEfficiency({ ...BASE_DATA, bestPractices: practicesWithNA });
+    // known/passing unchanged from the no-n/a case (2/4) — the n/a entry
+    // must not inflate the denominator.
+    expect(await screen.findByText('2/4 passing')).toBeInTheDocument();
+    expect(screen.getByText(/Use worktrees for parallel work/)).toBeInTheDocument();
+  });
 });
 
 describe('GitEfficiency view — hero KPIs and gated sections', () => {
@@ -206,6 +226,30 @@ describe('GitEfficiency view — hero KPIs and gated sections', () => {
     expect(await screen.findByText('commits today')).toBeInTheDocument();
     expect(screen.getByText('7')).toBeInTheDocument();
     expect(screen.getByText('rebase soon')).toBeInTheDocument();
+  });
+
+  // The "behind main" KPI passes `animate`, so it must not coalesce a null
+  // commitsBehindMain to 0 before it reaches Kpi — that would render a
+  // misleading "0" instead of falling through to the "—" (unknown) string.
+  it('shows "—" (not "0") for "behind main" when commitsBehindMain is null — unknown, not a confirmed zero', async () => {
+    renderGitEfficiency({
+      ...BASE_DATA,
+      riskIndicators: { ...BASE_DATA.riskIndicators, commitsBehindMain: null },
+    });
+    const label = await screen.findByText('behind main');
+    expect(label.nextElementSibling?.textContent).toBe('—');
+    // A null value must render with a neutral tone, not the "good" green
+    // that a coalesced-to-0 value would fall through to.
+    expect(label.nextElementSibling?.className).not.toContain('text-accent-green');
+  });
+
+  it('renders the real "behind main" count when commitsBehindMain is a known number', async () => {
+    renderGitEfficiency({
+      ...BASE_DATA,
+      riskIndicators: { ...BASE_DATA.riskIndicators, commitsBehindMain: 12 },
+    });
+    const label = await screen.findByText('behind main');
+    expect(label.nextElementSibling?.textContent).toBe('12');
   });
 
   // A `merge` event has no per-PR correlation with `create` — a session that

--- a/src/web/views/GitEfficiency.tsx
+++ b/src/web/views/GitEfficiency.tsx
@@ -259,11 +259,13 @@ export function GitEfficiency(): JSX.Element {
             <Kpi
               label="behind main"
               tone={
-                (data.riskIndicators.commitsBehindMain ?? 0) > 20
-                  ? 'bad'
-                  : (data.riskIndicators.commitsBehindMain ?? 0) > 5
-                    ? 'warn'
-                    : 'good'
+                data.riskIndicators.commitsBehindMain === null
+                  ? 'neutral'
+                  : data.riskIndicators.commitsBehindMain > 20
+                    ? 'bad'
+                    : data.riskIndicators.commitsBehindMain > 5
+                      ? 'warn'
+                      : 'good'
               }
               value={
                 data.riskIndicators.commitsBehindMain !== null
@@ -279,7 +281,7 @@ export function GitEfficiency(): JSX.Element {
                     : undefined
               }
               animate
-              numericValue={data.riskIndicators.commitsBehindMain ?? 0}
+              numericValue={data.riskIndicators.commitsBehindMain}
             />
           </div>
         </Card>
@@ -294,7 +296,14 @@ export function GitEfficiency(): JSX.Element {
               action={
                 <span className="text-[11px] text-ink-muted">
                   {(() => {
-                    const known = data.bestPractices.filter((bp) => bp.status !== 'unknown').length;
+                    // 'n/a' (fully known, not applicable) is excluded from the
+                    // ratio the same way 'unknown' (insufficient data) is —
+                    // matching computePreventionScore()'s treatment so this
+                    // header and the Prevention score ring never disagree on
+                    // which items count. See BestPractice['status']'s docstring.
+                    const known = data.bestPractices.filter(
+                      (bp) => bp.status !== 'unknown' && bp.status !== 'n/a',
+                    ).length;
                     if (known === 0) return 'No data yet';
                     const passing = data.bestPractices.filter((bp) => bp.status === 'pass').length;
                     return `${passing}/${known} passing`;
@@ -312,7 +321,7 @@ export function GitEfficiency(): JSX.Element {
                   </Pill>
                 ))}
               {data.bestPractices
-                .filter((bp) => bp.status === 'unknown')
+                .filter((bp) => bp.status === 'unknown' || bp.status === 'n/a')
                 .map((bp) => (
                   <Pill key={bp.id} tone="neutral" size="sm" bordered>
                     <span>&#9679;</span> {bp.label}

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -176,6 +176,7 @@ const SAMPLE_COLLAB_PROFILE = {
   dimensions: { specificity: 0.78, autonomy: 0.61, correctionRate: 0.42, taskComplexity: 0.73 },
   sessionCount: 47,
   teamDeltas: { specificity: 0.12, autonomy: 0.03, correctionRate: -0.08, taskComplexity: 0.05 },
+  developerCount: 4,
 };
 
 const SAMPLE_COLLAB_EMPTY = {
@@ -183,6 +184,18 @@ const SAMPLE_COLLAB_EMPTY = {
   dimensions: { specificity: 0, autonomy: 0, correctionRate: 0, taskComplexity: 0 },
   sessionCount: 0,
   teamDeltas: { specificity: 0, autonomy: 0, correctionRate: 0, taskComplexity: 0 },
+  developerCount: 0,
+};
+
+// Single-developer baseline fixture. teamDeltas are ~0 because the "team"
+// baseline is just this one developer compared to itself; the panel must
+// caveat this instead of presenting it as a real team comparison.
+const SAMPLE_COLLAB_SINGLE_DEV = {
+  classification: 'Power User',
+  dimensions: { specificity: 0.7, autonomy: 0.65, correctionRate: 0.5, taskComplexity: 0.6 },
+  sessionCount: 12,
+  teamDeltas: { specificity: 0, autonomy: 0, correctionRate: 0, taskComplexity: 0 },
+  developerCount: 1,
 };
 
 interface FetchOverrides {
@@ -191,6 +204,7 @@ interface FetchOverrides {
   recommendations?: unknown;
   claudemdImpact?: unknown;
   collabProfile?: unknown;
+  sessions?: unknown;
 }
 
 function renderHistory(overrides: FetchOverrides = {}) {
@@ -246,7 +260,7 @@ function renderHistory(overrides: FetchOverrides = {}) {
     }
     if (url.startsWith('/api/sessions')) {
       return Promise.resolve(
-        new Response(JSON.stringify(SAMPLE_SESSIONS), {
+        new Response(JSON.stringify(overrides.sessions ?? SAMPLE_SESSIONS), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         }),
@@ -333,6 +347,69 @@ describe('History view', () => {
       expect(screen.getByText('Top Tools · Most Recent 200 Sessions')).toBeInTheDocument(),
     );
     expect(screen.queryByText('Top Tools · All Sessions')).toBeNull();
+  });
+
+  it('titles the model performance panel with the same 200-session-cap disclosure as the other sampled panels', async () => {
+    renderHistory();
+    await waitFor(() =>
+      expect(screen.getByText('Model Performance · Most Recent 200 Sessions')).toBeInTheDocument(),
+    );
+  });
+
+  it('does not show a "+N more" tools note when there are 8 or fewer distinct tools', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText(/top tools/i)).toBeInTheDocument());
+    expect(screen.queryByText(/more tools? not shown/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a "+N more" tools note when aggregateToolUsage\'s top-8 cap drops entries', async () => {
+    const toolBreakdown: Record<string, number> = {};
+    for (let i = 0; i < 11; i++) toolBreakdown[`tool_${i}`] = 11 - i;
+    renderHistory({ sessions: [{ sessionId: 's1', toolBreakdown }] });
+    // 11 distinct tools, top 8 shown -> 3 hidden. Waits for the session
+    // fetch to resolve — the panel briefly renders its empty state first.
+    await waitFor(() => expect(screen.getByText('+3 more tools not shown')).toBeInTheDocument());
+  });
+
+  it('does not flag the daily spend chart for an account with only a few recent sessions', async () => {
+    // Only 5 sessions total, well under the 200-row cap — nothing was
+    // withheld, so the account's history genuinely started this morning
+    // and the early days of the window are confirmed zero-spend.
+    const recentOnly = Array.from({ length: 5 }, (_, i) => ({
+      sessionId: `recent-${i}`,
+      startTime: new Date(Date.now() - i * 60 * 60 * 1000).toISOString(),
+      estimatedCostUsd: 1,
+      model: 'claude-opus-4-6',
+      toolBreakdown: { Read: 1 },
+    }));
+    renderHistory({ sessions: recentOnly });
+    await waitFor(() => expect(screen.getByText(/daily spend/i)).toBeInTheDocument());
+    expect(screen.queryByText(/sample doesn.t reach back 30 days/i)).not.toBeInTheDocument();
+  });
+
+  it('flags the daily spend chart when a full 200-session sample does not reach back 30 days', async () => {
+    // 200 sessions (hitting the fetch cap) all within the last few hours —
+    // the sample is capped AND doesn't cover the 30-day window, so early
+    // days are genuinely unsampled rather than confirmed zero-spend.
+    const cappedRecentOnly = Array.from({ length: 200 }, (_, i) => ({
+      sessionId: `recent-${i}`,
+      startTime: new Date(Date.now() - i * 60 * 1000).toISOString(),
+      estimatedCostUsd: 1,
+      model: 'claude-opus-4-6',
+      toolBreakdown: { Read: 1 },
+    }));
+    renderHistory({ sessions: cappedRecentOnly });
+    await waitFor(() =>
+      expect(screen.getByText(/sample doesn.t reach back 30 days/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('does not flag the daily spend chart when the session sample already spans the full 30-day window', async () => {
+    // Default SAMPLE_SESSIONS are dated well over 30 days before the
+    // current clock, so the sample already covers the whole window.
+    renderHistory();
+    await waitFor(() => expect(screen.getByText(/daily spend/i)).toBeInTheDocument());
+    expect(screen.queryByText(/sample doesn.t reach back 30 days/i)).not.toBeInTheDocument();
   });
 
   it('uses the real 12-week window in the activity heatmap aria-label', async () => {
@@ -458,6 +535,13 @@ describe('History view', () => {
     expect(within(panel).getByText('Efficiency')).toBeInTheDocument();
   });
 
+  it('renders the before/after sample size next to each ClaudeMdImpactPanel column', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText(/instruction file impact/i)).toBeInTheDocument());
+    expect(screen.getByText('Before (n=8)')).toBeInTheDocument();
+    expect(screen.getByText('After (n=6)')).toBeInTheDocument();
+  });
+
   it('renders no-changes state for ClaudeMdImpactPanel', async () => {
     renderHistory({ claudemdImpact: SAMPLE_CLAUDEMD_NO_CHANGES });
     await waitFor(() =>
@@ -469,6 +553,18 @@ describe('History view', () => {
     renderHistory();
     await waitFor(() => expect(screen.getByText(/collaboration profile/i)).toBeInTheDocument());
     expect(screen.getByText('Explorer')).toBeInTheDocument();
+  });
+
+  it('does not show the no-team-data caveat when developerCount is above 1', async () => {
+    renderHistory();
+    await waitFor(() => expect(screen.getByText('Explorer')).toBeInTheDocument());
+    expect(screen.queryByText(/no team data yet/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a no-team-data caveat on CollaborationProfilePanel when developerCount is 1', async () => {
+    renderHistory({ collabProfile: SAMPLE_COLLAB_SINGLE_DEV });
+    await waitFor(() => expect(screen.getByText('Power User')).toBeInTheDocument());
+    expect(screen.getByText(/no team data yet/i)).toBeInTheDocument();
   });
 
   it('renders no-data state for CollaborationProfilePanel', async () => {

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -232,10 +232,26 @@ export function History(): JSX.Element {
   });
 
   const dailyData = padDailyCostWindow(aggregateDailyCost(sessions.data ?? [], 30), 30);
+  // The 200-session sample can run out before it reaches back the full
+  // 30-day window (a busy account can churn through 200 sessions in far
+  // fewer than 30 days). When it does, the padded $0 days at the start of
+  // the window aren't confirmed zero-spend — they're simply outside the
+  // sample's reach. Flag that instead of presenting them as real zeros.
+  // Only flag it when the sample actually hit the 200-row cap; an account
+  // with fewer than 200 total sessions has nothing withheld, so its early
+  // zero-padded days are confirmed zero-spend rather than unsampled.
+  const dailySpendTruncated =
+    (sessions.data?.length ?? 0) >= 200 && isDailySpendSampleTruncated(sessions.data ?? [], 30);
   const outcomeData = buildOutcomeData(costPerOutcome.data);
   const antiPatternSeries = buildAntiPatternSeries(weeklyChronological);
   const modelPerf = aggregateModelPerformance(sessions.data ?? []);
   const topTools = aggregateToolUsage(sessions.data ?? []);
+  // aggregateToolUsage caps at the top 8 tools; surface how many were
+  // dropped so "Top Tools" doesn't read as an exhaustive list.
+  const totalToolCount = new Set(
+    (sessions.data ?? []).flatMap((r) => (r.toolBreakdown ? Object.keys(r.toolBreakdown) : [])),
+  ).size;
+  const hiddenToolCount = Math.max(0, totalToolCount - topTools.length);
   const concurrencyData = concurrencyHistory.data?.dailyPeaks ?? [];
   const hasConcurrencyData = concurrencyData.some((d) => d.peak > 0);
 
@@ -316,6 +332,12 @@ export function History(): JSX.Element {
               </BarChart>
             </ResponsiveContainer>
           </div>
+          {dailySpendTruncated && (
+            <div className="text-[10px] text-ink-muted italic mt-1">
+              Sample doesn&apos;t reach back 30 days — early days in this chart may undercount
+              actual spend.
+            </div>
+          )}
         </Panel>
 
         <Panel title="Cost Per Outcome · Last 30 Days">
@@ -390,7 +412,7 @@ export function History(): JSX.Element {
           )}
         </Panel>
 
-        <Panel title="Model Performance">
+        <Panel title="Model Performance · Most Recent 200 Sessions">
           {modelPerf.length === 0 ? (
             <EmptyState
               icon="radar"
@@ -483,6 +505,11 @@ export function History(): JSX.Element {
                   </Bar>
                 </BarChart>
               </ResponsiveContainer>
+            </div>
+          )}
+          {hiddenToolCount > 0 && (
+            <div className="text-[10px] text-ink-muted italic mt-1">
+              +{hiddenToolCount} more tool{hiddenToolCount === 1 ? '' : 's'} not shown
             </div>
           )}
         </Panel>
@@ -838,8 +865,10 @@ function ClaudeMdImpactPanel({
       </div>
       <div className="grid grid-cols-4 gap-x-4 gap-y-1 text-xs">
         <span className="text-ink-muted" />
-        <span className="text-ink-muted">Before</span>
-        <span className="text-ink-muted">After</span>
+        {/* Sample size next to each column — a 1-vs-1 session comparison
+            shouldn't read with the same confidence as a 50-vs-50 one. */}
+        <span className="text-ink-muted">Before (n={data.before.sessionCount})</span>
+        <span className="text-ink-muted">After (n={data.after.sessionCount})</span>
         <span className="text-ink-muted">Δ</span>
 
         <span className="text-ink-muted">Efficiency</span>
@@ -952,6 +981,17 @@ function CollaborationProfilePanel({
         <span className="text-sm font-medium text-ink-base">{data.classification}</span>
         <span className="text-ink-muted"> · {data.sessionCount} sessions</span>
       </div>
+      {/* The "vs team" deltas below are computed against a baseline of
+          whatever developers have recorded sessions. With developerCount <= 1
+          that baseline is just this developer, so every delta is trivially
+          ~0 and reads as "right on target" rather than "no comparison data
+          exists yet". */}
+      {data.developerCount <= 1 && (
+        <div className="text-[10px] text-ink-muted italic mb-2">
+          No team data yet — &quot;vs team&quot; comparisons below will reflect other developers
+          once their sessions are recorded.
+        </div>
+      )}
       <div className="min-w-0" style={{ height: `${dims.length * 28 + 40}px` }}>
         <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
           <BarChart data={dims} layout="vertical">
@@ -1065,6 +1105,36 @@ export function aggregateDailyCost(
   }
   const sorted = Array.from(byDay.entries()).sort((a, b) => a[0].localeCompare(b[0]));
   return sorted.slice(-days).map(([day, cost]) => ({ day, cost: Number(cost.toFixed(2)) }));
+}
+
+/**
+ * True when the session sample (already capped upstream, e.g. to the most
+ * recent 200) doesn't reach back the full `days`-day window — i.e. the
+ * oldest session in `rows` is more recent than the window's start date.
+ * When true, `padDailyCostWindow`'s zero-filled early days aren't confirmed
+ * zero-spend; they're simply outside what the sample covers, and the UI
+ * should flag that instead of presenting them as real zeros. Callers should
+ * also confirm the sample actually hit its row cap before using this — a
+ * short window can be genuinely complete rather than truncated.
+ */
+export function isDailySpendSampleTruncated(
+  rows: SessionRow[],
+  days: number,
+  today: Date = new Date(),
+): boolean {
+  if (rows.length === 0) return false;
+  let oldest: number | null = null;
+  for (const r of rows) {
+    if (r.startTime == null) continue;
+    const t = new Date(r.startTime).getTime();
+    if (Number.isNaN(t)) continue;
+    if (oldest === null || t < oldest) oldest = t;
+  }
+  if (oldest === null) return false;
+  const windowStart = new Date(today);
+  windowStart.setDate(windowStart.getDate() - (days - 1));
+  windowStart.setHours(0, 0, 0, 0);
+  return oldest > windowStart.getTime();
 }
 
 export function buildOutcomeData(

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Sessions } from './Sessions';
 
@@ -92,14 +92,44 @@ describe('Sessions view', () => {
     }));
     renderSessions(fullPage);
     await waitFor(() =>
-      expect(screen.getByText(/showing 50 most recent sessions/i)).toBeInTheDocument(),
+      expect(screen.getByText(/only the 50 most recent sessions are loaded/i)).toBeInTheDocument(),
     );
   });
 
   it('hides the cap notice when fewer than the page size are returned', async () => {
     renderSessions(SAMPLE_LIST);
     await waitFor(() => expect(screen.getByText(/s1/)).toBeInTheDocument());
-    expect(screen.queryByText(/showing 50 most recent sessions/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/only the 50 most recent sessions are loaded/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clarifies the cap notice further narrows when a run filter is active', async () => {
+    // A run filter can shrink the visible list to far fewer rows than the
+    // fetch cap; the notice must not read as a description of that
+    // narrowed view.
+    const fullPage = Array.from({ length: 50 }, (_, i) => ({
+      sessionId: `cap-${i}`,
+      startTime: '2026-05-28T09:00:00Z',
+      toolCallCount: 1,
+      estimatedCostUsd: 0,
+    }));
+    renderSessions(fullPage);
+    await waitFor(() =>
+      expect(screen.getByText(/only the 50 most recent sessions are loaded/i)).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/only the 50 most recent sessions are loaded/i).textContent,
+    ).not.toMatch(/narrow/i);
+
+    const statusGroup = screen.getByRole('group', { name: /status filter/i });
+    fireEvent.click(within(statusGroup).getByRole('button', { name: 'Completed' }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/only the 50 most recent sessions are loaded/i).textContent).toMatch(
+        /filters narrow this further/i,
+      ),
+    );
   });
 
   it('auto-selects the first session on load (no manual pick required)', async () => {
@@ -486,6 +516,21 @@ describe('Sessions view — workflow consolidation', () => {
     expect(container.textContent).toMatch(/\$3(\.0+)?/);
   });
 
+  // A run's durationMs being null (unfinished/killed, still upstream in
+  // workflow-store.ts/workflow-watcher.ts) is not the same as a confirmed
+  // 0ms run. Averaging must exclude it rather than let it drag the average
+  // toward zero.
+  it('excludes a null durationMs from the Avg duration KPI average instead of treating it as zero', async () => {
+    const runsWithUnknownDuration = [RUNS[0], { ...RUNS[1], durationMs: null }];
+    const { container } = renderSessionsFull(SESSIONS, runsWithUnknownDuration);
+    await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());
+    // Only run-1's 60_000ms contributes — average of just that one run is
+    // "1m", not (60_000 + 0) / 2 = "30s" (which is what treating the null
+    // run's duration as 0 would produce).
+    expect(container.textContent).toContain('1m');
+    expect(container.textContent).not.toContain('30s');
+  });
+
   // A run's totalUsd being null is ambiguous between "confirmed $0" and "no
   // process ever observed this run's cost". costUnknown distinguishes the
   // two (a partial mitigation); the KPI must disclose when it does.
@@ -628,5 +673,196 @@ describe('Sessions view — subagent fetch failure fallback', () => {
     await waitFor(() => expect(screen.getByText('Parent')).toBeInTheDocument());
     expect(screen.queryByText('Loading subagents')).toBeNull();
     await waitFor(() => expect(subagentsCalls.length).toBeGreaterThan(0));
+  });
+});
+
+describe('Sessions view — live-detection and selection reliability', () => {
+  // A deep link to a non-existent session (e.g., ?session=bad-id) should
+  // show an error state with a "clear selection" action, not blank the detail pane.
+  it('shows error state and clear-selection action when a deep-linked session does not exist', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = ((url: string) => {
+      if (url.startsWith('/api/sessions/')) {
+        const id = decodeURIComponent(url.split('/').pop() ?? '');
+        // Simulate a 404 for the bad deep-linked id
+        if (id === 'bad-id') {
+          return Promise.resolve(new Response('{"error":"not_found"}', { status: 404 }));
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ sessionId: id, timeline: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(SAMPLE_LIST), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as typeof globalThis.fetch;
+
+    const original = window.location;
+    // @ts-expect-error -- test-only reassignment
+    delete window.location;
+    window.location = { ...original, search: '?session=bad-id' } as unknown as string & Location;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <Sessions />
+      </QueryClientProvider>,
+    );
+
+    // The error state should render with the title "Session not found"
+    await waitFor(() => expect(screen.getByText('Session not found')).toBeInTheDocument());
+    // And a "Clear selection" button must be present to dismiss the error
+    const clearBtn = screen.getByRole('button', { name: /clear selection/i });
+    expect(clearBtn).toBeInTheDocument();
+
+    // Clicking the button should clear selectedId. The error state should disappear.
+    fireEvent.click(clearBtn);
+    await waitFor(() => expect(screen.queryByText('Session not found')).not.toBeInTheDocument());
+
+    window.location = original as unknown as string & Location;
+  });
+
+  // When current.data.sessionId is present but liveSessions is empty (a
+  // session has ended), the liveSessionIds derivation should not fall back to
+  // treating the ended session as live. It should return an empty set.
+  it('treats empty liveSessions array as "nothing is live" and does not fall back to current.data.sessionId', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    const sessionList = [
+      {
+        sessionId: 's1',
+        startTime: '2026-05-28T09:00:00Z',
+        toolCallCount: 10,
+      },
+      {
+        sessionId: 's2',
+        startTime: '2026-05-27T09:00:00Z',
+        toolCallCount: 5,
+      },
+    ];
+
+    globalThis.fetch = ((url: string) => {
+      if (url === '/api/session/current') {
+        // Session s1 was active before but has ended: no liveSessions, but sessionId is present
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              sessionId: 's1',
+              liveSessions: [],
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            },
+          ),
+        );
+      }
+      if (url.startsWith('/api/sessions/')) {
+        const id = decodeURIComponent(url.split('/').pop() ?? '');
+        return Promise.resolve(
+          new Response(JSON.stringify({ sessionId: id, timeline: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(sessionList), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as typeof globalThis.fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <Sessions />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText(/s1/)).toBeInTheDocument());
+    // s1 should NOT have the "live" badge because liveSessions is empty (even
+    // though current.data.sessionId = 's1'). Instead, the oldest item (s1)
+    // should be auto-selected by the fallback once current settles.
+    const liveElements = screen.queryAllByText(/live/i);
+    expect(liveElements.length).toBe(0);
+  });
+
+  // Race condition guard: /api/sessions (list) can resolve before
+  // /api/session/current (live check). The auto-select fallback to rows[0]
+  // must wait until current.isLoading has settled to false at least once,
+  // so it never clobbers a potential live-session selection.
+  it('does not auto-select from rows before the live-session check has settled', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    const sessionList = [
+      { sessionId: 's1', startTime: '2026-05-28T09:00:00Z', toolCallCount: 10 },
+      { sessionId: 's2', startTime: '2026-05-27T09:00:00Z', toolCallCount: 5 },
+    ];
+
+    let currentFetchResolved = false;
+    const detailFetchCalls: string[] = [];
+
+    globalThis.fetch = ((url: string) => {
+      if (url === '/api/session/current') {
+        // Simulate a delay: this resolves after /api/sessions
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            currentFetchResolved = true;
+            resolve(
+              new Response(
+                JSON.stringify({
+                  sessionId: 's2',
+                  liveSessions: ['s2'],
+                }),
+                {
+                  status: 200,
+                  headers: { 'content-type': 'application/json' },
+                },
+              ),
+            );
+          }, 100);
+        });
+      }
+      if (url.startsWith('/api/sessions/')) {
+        const id = decodeURIComponent(url.split('/').pop() ?? '');
+        // Track which session detail is fetched to verify correct selection.
+        // Without the fix, s1 would be fetched (buggy early auto-select).
+        // With the fix, s2 is fetched (correct selection after live check settles).
+        detailFetchCalls.push(id);
+        return Promise.resolve(
+          new Response(JSON.stringify({ sessionId: id, timeline: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      // /api/sessions list resolves immediately
+      return Promise.resolve(
+        new Response(JSON.stringify(sessionList), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as typeof globalThis.fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <Sessions />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText(/s1/)).toBeInTheDocument());
+    // Even though s1 loads first from the list, the effect should NOT auto-select
+    // it immediately. Once the live-session check settles (current.isLoading → false),
+    // it should select s2 (the live session), not s1.
+    await waitFor(() => expect(currentFetchResolved).toBe(true), { timeout: 1000 });
+    // Verify that s2's detail was fetched, not s1's. This proves s2 was
+    // selected — if s1 had been selected immediately, the "selectedId is
+    // already set" guard would block ever switching to s2.
+    await waitFor(() => expect(detailFetchCalls).toContain('s2'));
   });
 });

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -247,8 +247,6 @@ export function Sessions(): JSX.Element {
     const set = new Set<string>();
     if (current.data?.liveSessions?.length) {
       for (const id of current.data.liveSessions) set.add(id);
-    } else if (current.data?.sessionId) {
-      set.add(current.data.sessionId);
     }
     return set;
   }, [current.data]);
@@ -323,10 +321,10 @@ export function Sessions(): JSX.Element {
     const firstLiveId = liveSessionIds.size > 0 ? [...liveSessionIds][0]! : null;
     if (firstLiveId) {
       setSelectedId(firstLiveId);
-    } else if (rows.length > 0) {
+    } else if (!current.isLoading && rows.length > 0) {
       setSelectedId(rows[0]!.sessionId);
     }
-  }, [liveSessionIds, rows, selectedId]);
+  }, [liveSessionIds, rows, selectedId, current.isLoading]);
 
   const handleSessionClick = (sessionId: string): void => {
     setSelectedId(sessionId);
@@ -519,10 +517,16 @@ export function Sessions(): JSX.Element {
               sessions exist beyond what's rendered. The cap is enforced
               server-side (api-handler `limit` clamp) and matches the
               `qk.sessionsList(50)` query above; bump both together if the
-              cap ever changes. */}
+              cap ever changes.
+              Worded as "loaded" (not "showing") because this describes the
+              underlying fetch, not the currently visible row count — with a
+              run filter active, visibleRows can be far smaller than
+              SESSIONS_PAGE_SIZE, and "Showing 50" would misleadingly read as
+              a description of the filtered list. */}
             {rows.length >= SESSIONS_PAGE_SIZE && (
               <div className="p-2 text-[10px] text-ink-muted text-center border-t border-border-subtle">
-                Showing {SESSIONS_PAGE_SIZE} most recent sessions.
+                Only the {SESSIONS_PAGE_SIZE} most recent sessions are loaded
+                {filtersActive ? '; filters narrow this further' : ''}.
               </div>
             )}
           </div>
@@ -538,6 +542,22 @@ export function Sessions(): JSX.Element {
           )}
           {selectedId && detail.isLoading && (
             <EmptyState variant="loading" icon="timeline" title="Loading detail" />
+          )}
+          {selectedId && detail.isError && (
+            <div className="flex flex-col items-center justify-center py-8 gap-4">
+              <EmptyState
+                icon="timeline"
+                title="Session not found"
+                subtitle="This session could not be loaded."
+              />
+              <button
+                type="button"
+                onClick={() => setSelectedId(null)}
+                className="text-accent-cyan hover:text-accent-cyan/80 text-sm font-medium"
+              >
+                Clear selection
+              </button>
+            </div>
           )}
           {selectedId && detail.data && (
             <SessionTimeline


### PR DESCRIPTION
## Summary

- **Sessions page live-detection & selection reliability**: an invalid or stale deep-linked session now shows a real error state with a "clear selection" action, instead of leaving the detail pane permanently blank. A session that has already ended no longer keeps showing a "live" badge indefinitely. Initial session selection no longer races ahead of the live-session check.
- **Disclosure of previously-silent caps and truncations**: the Sessions page's recent-sessions notice, the History page's daily-spend sampling, model-performance/top-tools panel titles, the instruction-file-impact sample size, the collaboration-profile team size, and the Audit page's export button now say when they're showing a partial view instead of implying completeness. The daily-spend truncation notice itself is more precise now — it only appears when the underlying sample was actually capped, not whenever an account simply doesn't have 30 days of history yet.
- **Null/zero/"unknown" value conflation**: a shared KPI display component no longer renders an unknown value as a confident animated zero (the Git Efficiency page's "behind main" KPI now shows a neutral color for an unknown value instead of a reassuring green). The Git Efficiency page's worktree best-practice check no longer conflates "not enough data" with "fully evaluated, not applicable." Workflow-run duration is no longer reported as zero when it's actually unknown (still in progress).

Fixes #385
Fixes #386
Fixes #387
Fixes #388
Fixes #395
Fixes #401
Fixes #404
Fixes #406
Fixes #429
Fixes #384
Fixes #413
Fixes #418

## Test plan

- [x] `npm test` — 5454/5457 passing (3 pre-existing skips)
- [x] `npx vitest run` — 493/493 passing
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors/warnings