### PR TITLE
Fix: Today anti-pattern/watcher banners, Sessions panel bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.39] - 2026-08-10
+
+### Fixed
+
+- **Anti-pattern data now keeps its file/command target and real occurrence count all the way to disk.** Persisted anti-patterns no longer collapse into an opaque type/count pair — the Today dashboard's persisted-session banner and the Sessions detail page's anti-pattern pills now show the actual file or command involved instead of "unknown," and a real magnitude (iterations, repeated reads, etc.) instead of a count of unrelated distinct entries. Loading an older session file still works and now expands its count faithfully into the same shape.
+- **The Today dashboard's "tokens wasted" annotation on a thrashing alert no longer silently fails to render.** It compared a file path against a tool name from two unrelated detectors, so it could essentially never match; the broken lookup is now removed.
+- **A nonzero "flags" count on the Today dashboard always shows something explaining it.** Previously the flag count could show a warning with no detail underneath if none of the three data sources backing the banner had loaded yet; a generic fallback message now always appears in that case.
+- **A dead "subagent watcher disabled (lock conflict)" banner on the Today dashboard has been removed** — neither of its two backing signals could ever report true, so it could never actually render.
+- **The Today dashboard's two "subagent watcher disabled" banners no longer contradict the subagent spend KPI shown right above them.** Both now gate on the same combined turn count the KPI uses, instead of a live-only counter that always stayed at zero.
+- **The Sessions detail page's anti-pattern pills no longer show a raw, unlabeled type for over-delegation.**
+- **The Sessions detail page's "Session Quality" and "Tool Selection" cards now render consistently for every session**, including completed sessions and sessions live in a different process — both previously had gaps left by an earlier partial fix.
+- **The Sessions detail page's Context tab now goes through the same typed request path as the rest of the app**, so a backend error shows a real error/retry state instead of silently looking identical to "no data yet."
+- **Switching sessions on the Sessions detail page no longer leaves the Tools panel stuck on a disabled tab.** The panel now resets to the default view when the selected session changes.
+- **The Sessions page's KPI strip now discloses when it's describing sessions outside the currently visible list**, and the disclosed count now matches what's actually shown rather than a fixed page size.
+- **A live session tracked by a different process on the Sessions detail page now scores tool selection using correctly time-ordered records.**
+
 ## [1.14.38] - 2026-08-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.38",
+  "version": "1.14.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.38",
+      "version": "1.14.39",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.38",
+  "version": "1.14.39",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -542,7 +542,7 @@ describe('api-handler GET /api/sessions/:id', () => {
     expect(parsed.toolSelectionScore?.redundantReadCount).toBe(1);
   });
 
-  it('aggregates live-session anti-patterns by type into {type, count} pairs', async () => {
+  it('reports live-session anti-patterns as one entry per incident, preserving file/count detail', async () => {
     const handler = createApiHandler({
       sessionStore: {
         loadTodaySessions: () => [],
@@ -574,14 +574,22 @@ describe('api-handler GET /api/sessions/:id', () => {
     const { res, status, body } = fakeRes();
     await handler(req, res);
     expect(status()).toBe(200);
-    const parsed = JSON.parse(body()) as { antiPatterns?: Array<{ type: string; count: number }> };
+    const parsed = JSON.parse(body()) as {
+      antiPatterns?: Array<{
+        type: string;
+        file?: string;
+        readCount?: number;
+        iterations?: number;
+      }>;
+    };
     expect(parsed.antiPatterns).toEqual([
-      { type: 're_reading', count: 2 },
-      { type: 'thrashing', count: 1 },
+      { type: 're_reading', file: '/a.ts', readCount: 4 },
+      { type: 're_reading', file: '/b.ts', readCount: 5 },
+      { type: 'thrashing', file: '/c.ts', iterations: 3 },
     ]);
   });
 
-  it('attaches toolSelectionScore (but not qualityProxy) to the registry-synthesized branch', async () => {
+  it('attaches toolSelectionScore, antiPatterns, and qualityProxy to the registry-synthesized branch', async () => {
     const handler = createApiHandler({
       sessionStore: {
         loadTodaySessions: () => [],
@@ -614,6 +622,13 @@ describe('api-handler GET /api/sessions/:id', () => {
         }),
       } as unknown as Parameters<typeof createApiHandler>[0]['toolSelectionScorer'],
       toolCallBuffer: {
+        // 3 consecutive failing `npm test` Bash calls on the same session:
+        // enough to trip AntiPatternDetector's stuck_loop threshold AND to
+        // produce 3 test_fail QualityProxyTracker signals. Both fields must
+        // be computed from this branch's own filtered records, using
+        // detector/tracker instances scoped to this one request — not a
+        // shared, stateful instance owned by a different (this process's
+        // own) session.
         getRecords: () => [
           {
             id: '1',
@@ -623,6 +638,30 @@ describe('api-handler GET /api/sessions/:id', () => {
             timestamp: 1,
             durationMs: 1,
             success: false,
+            command: 'npm test',
+            isTestCommand: true,
+          },
+          {
+            id: '2',
+            sessionId: 'concurrent1',
+            toolName: 'Bash',
+            toolUseId: 'u2',
+            timestamp: 2,
+            durationMs: 1,
+            success: false,
+            command: 'npm test',
+            isTestCommand: true,
+          },
+          {
+            id: '3',
+            sessionId: 'concurrent1',
+            toolName: 'Bash',
+            toolUseId: 'u3',
+            timestamp: 3,
+            durationMs: 1,
+            success: false,
+            command: 'npm test',
+            isTestCommand: true,
           },
         ],
       } as unknown as Parameters<typeof createApiHandler>[0]['toolCallBuffer'],
@@ -632,11 +671,86 @@ describe('api-handler GET /api/sessions/:id', () => {
     await handler(req, res);
     expect(status()).toBe(200);
     const parsed = JSON.parse(body()) as {
-      qualityProxy?: unknown;
+      qualityProxy?: { testPassRate: number | null };
+      antiPatterns?: Array<{ type: string; repeatCount?: number }>;
       toolSelectionScore?: { repeatedFailureCount: number };
     };
+    expect(parsed.toolSelectionScore?.repeatedFailureCount).toBe(3);
+    expect(parsed.antiPatterns).toEqual([
+      expect.objectContaining({ type: 'stuck_loop', repeatCount: 3 }),
+    ]);
+    expect(parsed.qualityProxy?.testPassRate).toBe(0);
+  });
+
+  it('leaves antiPatterns empty and qualityProxy absent on the registry-synthesized branch when there are no records to analyze', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      liveSessionRegistry: {
+        getLiveSessions: () => ['concurrent-empty'],
+        getSessionName: () => null,
+      },
+      toolCallBuffer: {
+        getRecords: () => [],
+      } as unknown as Parameters<typeof createApiHandler>[0]['toolCallBuffer'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/concurrent-empty' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { qualityProxy?: unknown; antiPatterns?: unknown[] };
+    expect(parsed.antiPatterns).toEqual([]);
     expect(parsed.qualityProxy).toBeUndefined();
-    expect(parsed.toolSelectionScore?.repeatedFailureCount).toBe(1);
+  });
+
+  it("remaps a persisted session's toolSelectionMetrics onto toolSelectionScore", async () => {
+    const fakeSession = {
+      sessionId: 'sess-tool-selection-1',
+      toolSelectionMetrics: {
+        score: 0.75,
+        totalCalls: 4,
+        penalizedCalls: 1,
+        redundantReadCount: 1,
+        repeatedFailureCount: 0,
+        unusedOutputCount: 0,
+      },
+    };
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: (id: string) => (id === 'sess-tool-selection-1' ? fakeSession : null),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-tool-selection-1' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as {
+      toolSelectionScore?: { score: number; redundantReadCount: number };
+    };
+    expect(parsed.toolSelectionScore?.score).toBe(0.75);
+    expect(parsed.toolSelectionScore?.redundantReadCount).toBe(1);
+  });
+
+  it('does not attach toolSelectionScore to a persisted session with no toolSelectionMetrics (regression guard)', async () => {
+    const fakeSession = { sessionId: 'sess-no-tool-selection', toolCallCount: 3 };
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: (id: string) => (id === 'sess-no-tool-selection' ? fakeSession : null),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-no-tool-selection' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { toolSelectionScore?: unknown };
+    expect(parsed.toolSelectionScore).toBeUndefined();
   });
 
   // session.timeline is append-only in processing order, not timestamp

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -27,7 +27,12 @@ import { computeCacheHealth } from './cache-health-aggregate.js';
 import type { CacheHealthTotals, AggregateCacheHealth } from './cache-health-aggregate.js';
 import { pairToolCallsFromBufferEvents } from './tool-selection-aggregate.js';
 import type { HookEvent, ReplayTimelineEntry, ToolCallRecord } from '../../storage/types.js';
-import type { FullSessionSummary, SessionFileInfo } from '../../storage/session-store.js';
+import type {
+  FullSessionSummary,
+  SessionFileInfo,
+  PersistedAntiPattern,
+} from '../../storage/session-store.js';
+import { toPersistedAntiPatterns } from '../../storage/session-store.js';
 import type { WorkflowRunRow, WorkflowAgentRow } from '../workflow-store.js';
 import type {
   SubagentTimeline,
@@ -50,6 +55,7 @@ import type {
 import {
   combineQualityProxyRawCounts,
   ZERO_QUALITY_PROXY_COUNTS,
+  QualityProxyTracker,
 } from '../../metrics/quality-proxy-tracker.js';
 import type {
   ToolSelectionMetrics,
@@ -63,6 +69,7 @@ import type { ContextReplayEvent, ContextTrackerMetrics } from '../../metrics/co
 import type { ContextCompositionMetrics } from '../../metrics/context-composition-tracker.js';
 import type { ContextWindowMetrics } from '../../metrics/context-window-tracker.js';
 import type { AntiPattern } from '../../metrics/anti-patterns.js';
+import { AntiPatternDetector } from '../../metrics/anti-patterns.js';
 import type { RetryDetectorMetrics } from '../../metrics/retry-detector.js';
 import type { InstructionDriftMetrics } from '../../metrics/instruction-drift-tracker.js';
 import type { DecisionTreeMetrics } from '../../metrics/decision-tracker.js';
@@ -2740,6 +2747,13 @@ export function createApiHandler(
           ]);
           const responseBody: Record<string, unknown> = { ...session };
           if (quality.totalSignals > 0) responseBody.qualityProxy = quality;
+          // The persisted shape's key is `toolSelectionMetrics`, but
+          // Sessions.tsx's SessionTimeline reads `toolSelectionScore` —
+          // remap here so this branch's response uses the same field name
+          // as the other two `/api/sessions/:id` branches.
+          if (session.toolSelectionMetrics) {
+            responseBody.toolSelectionScore = session.toolSelectionMetrics;
+          }
           // `session.timeline` is append-only in processing order, not
           // timestamp order (parallel tool calls can complete out of
           // start-order) — sort before returning, mirroring the identical
@@ -2757,16 +2771,9 @@ export function createApiHandler(
             const costMetrics = deps.costTracker?.getMetrics();
             const costUsd = costMetrics?.sessionTotalCostUsd ?? null;
             const model = costMetrics?.model ?? null;
-            const antiPatterns: Array<{ type: string; count: number }> = [];
-            if (deps.antiPatternDetector) {
-              const grouped = new Map<string, number>();
-              for (const p of deps.antiPatternDetector.getCurrentPatterns()) {
-                grouped.set(p.type, (grouped.get(p.type) ?? 0) + 1);
-              }
-              for (const [type, count] of grouped) {
-                antiPatterns.push({ type, count });
-              }
-            }
+            const antiPatterns: PersistedAntiPattern[] = deps.antiPatternDetector
+              ? toPersistedAntiPatterns(deps.antiPatternDetector.getCurrentPatterns())
+              : [];
             const ownSessionRecords = (deps.toolCallBuffer?.getRecords() ?? []).filter(
               (r) => r.sessionId === sessionId,
             );
@@ -2827,6 +2834,27 @@ export function createApiHandler(
           }
           const startTime = timeline.length > 0 ? timeline[0]!.timestamp : Date.now();
           const lastTs = timeline.length > 0 ? timeline[timeline.length - 1]!.timestamp : startTime;
+          // Chronological order matters for both detectors below (thrashing/
+          // stuck-loop/self-correction all reason about call sequence), but
+          // `records` comes straight from the tool call buffer with no
+          // ordering guarantee — sort a copy, mirroring `timeline` above.
+          const sortedRecords = [...records].sort((a, b) => a.timestamp - b.timestamp);
+          // A fresh AntiPatternDetector instance, not `deps.antiPatternDetector`
+          // — that shared instance belongs to this process's own live session
+          // and caches its last analyze() result for getCurrentPatterns();
+          // reusing it here would clobber that cache with a different
+          // session's patterns.
+          const antiPatternResults =
+            sortedRecords.length > 0 ? new AntiPatternDetector().analyze(sortedRecords) : null;
+          const antiPatterns: PersistedAntiPattern[] = antiPatternResults
+            ? toPersistedAntiPatterns(antiPatternResults.patterns)
+            : [];
+          // Likewise a fresh QualityProxyTracker — it's stateful (tracks the
+          // last edit for backtrack/self-correction detection), so it can't
+          // be a pure function call the way AntiPatternDetector.analyze() is.
+          const qualityTracker = new QualityProxyTracker();
+          for (const r of sortedRecords) qualityTracker.recordToolCall(r);
+          const quality = combineQualityProxyRawCounts([qualityTracker.getRawCounts()]);
           jsonOk(res, {
             sessionId,
             sessionName: deps.liveSessionRegistry.getSessionName(sessionId),
@@ -2837,9 +2865,12 @@ export function createApiHandler(
             model: null,
             outcome: 'in progress',
             toolBreakdown: breakdown,
-            antiPatterns: [],
+            antiPatterns,
+            qualityProxy: quality.totalSignals > 0 ? quality : undefined,
             toolSelectionScore:
-              records.length > 0 ? deps.toolSelectionScorer?.scoreSession(records) : undefined,
+              sortedRecords.length > 0
+                ? deps.toolSelectionScorer?.scoreSession(sortedRecords)
+                : undefined,
             timeline,
           });
           return;

--- a/src/metrics/prompt-feedback.test.ts
+++ b/src/metrics/prompt-feedback.test.ts
@@ -357,7 +357,7 @@ describe('PromptFeedbackEngine', () => {
       store.saveSession(
         makeSummary({
           sessionId: `rr-${i}`,
-          antiPatterns: [{ type: 're_reading', count: 3 }],
+          antiPatterns: [{ type: 're_reading' }],
         }),
       );
     }
@@ -452,7 +452,7 @@ describe('PromptFeedbackEngine', () => {
           sessionId: `s-${i}`,
           userMessages: 20,
           userCorrections: 8,
-          antiPatterns: [{ type: 're_reading', count: 2 }],
+          antiPatterns: [{ type: 're_reading' }],
         }),
       );
     }
@@ -461,7 +461,7 @@ describe('PromptFeedbackEngine', () => {
         sessionId: 's-clean',
         userMessages: 20,
         userCorrections: 8,
-        antiPatterns: [{ type: 're_reading', count: 1 }],
+        antiPatterns: [{ type: 're_reading' }],
       }),
     );
 

--- a/src/metrics/recommendation-engine.test.ts
+++ b/src/metrics/recommendation-engine.test.ts
@@ -120,7 +120,7 @@ describe('RecommendationEngine', () => {
           sessionId: `s-${i}`,
           userMessages: 20,
           userCorrections: 8,
-          antiPatterns: [{ type: 're_reading', count: 3 }],
+          antiPatterns: [{ type: 're_reading' }],
         }),
       );
     }
@@ -129,7 +129,7 @@ describe('RecommendationEngine', () => {
         sessionId: 's-clean',
         userMessages: 20,
         userCorrections: 8,
-        antiPatterns: [{ type: 're_reading', count: 1 }],
+        antiPatterns: [{ type: 're_reading' }],
       }),
     );
 
@@ -180,7 +180,7 @@ describe('RecommendationEngine', () => {
           sessionId: `s-${i}`,
           userMessages: 20,
           userCorrections: 8,
-          antiPatterns: [{ type: 're_reading', count: 2 }],
+          antiPatterns: [{ type: 're_reading' }],
         }),
       );
     }
@@ -189,7 +189,7 @@ describe('RecommendationEngine', () => {
         sessionId: 's-clean',
         userMessages: 20,
         userCorrections: 8,
-        antiPatterns: [{ type: 're_reading', count: 1 }],
+        antiPatterns: [{ type: 're_reading' }],
       }),
     );
 
@@ -219,7 +219,7 @@ describe('RecommendationEngine', () => {
           sessionId: `s-${i}`,
           userMessages: 20,
           userCorrections: 8,
-          antiPatterns: [{ type: 're_reading', count: 3 }],
+          antiPatterns: [{ type: 're_reading' }],
         }),
       );
     }
@@ -228,7 +228,7 @@ describe('RecommendationEngine', () => {
         sessionId: 's-extra',
         userMessages: 20,
         userCorrections: 8,
-        antiPatterns: [{ type: 're_reading', count: 1 }],
+        antiPatterns: [{ type: 're_reading' }],
       }),
     );
 

--- a/src/metrics/trend-analyzer.ts
+++ b/src/metrics/trend-analyzer.ts
@@ -167,7 +167,7 @@ function aggregateWeek(sessions: FullSessionSummary[]): WeekAggregates {
     }
 
     for (const ap of s.antiPatterns) {
-      antiPatterns[ap.type] = (antiPatterns[ap.type] ?? 0) + ap.count;
+      antiPatterns[ap.type] = (antiPatterns[ap.type] ?? 0) + 1;
     }
   }
 

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -13,6 +13,7 @@ import type { SessionTracker } from '../metrics/session-tracker.js';
 import { CostTracker } from '../metrics/cost-tracker.js';
 import type { CostMetrics } from '../metrics/cost-tracker.js';
 import type { TaskDetector } from '../metrics/task-detector.js';
+import type { AntiPatternDetector } from '../metrics/anti-patterns.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
 import type { TranscriptMessageTracker } from '../metrics/transcript-message-tracker.js';
 import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
@@ -162,7 +163,11 @@ describe('sessionSummaryToDriftRecord', () => {
       tokensOutput: 500,
       taskCount: 4,
       efficiencyScore: 0.9,
-      antiPatterns: [{ type: 'thrashing', count: 3 }],
+      antiPatterns: [
+        { type: 'thrashing', file: 'a.ts' },
+        { type: 'thrashing', file: 'b.ts' },
+        { type: 'thrashing', file: 'c.ts' },
+      ],
     });
 
     const record = sessionSummaryToDriftRecord(summary) as SessionOutcomeRecord;
@@ -181,11 +186,176 @@ describe('sessionSummaryToDriftRecord', () => {
   it('defaults thrashingIncidents to 0 when no thrashing anti-pattern is present', () => {
     const summary = makeSummary({
       instructionPromptHash: 'hash-456',
-      antiPatterns: [{ type: 're_reading', count: 2 }],
+      antiPatterns: [{ type: 're_reading', file: 'x.ts' }],
     });
 
     const record = sessionSummaryToDriftRecord(summary) as SessionOutcomeRecord;
     expect(record.thrashingIncidents).toBe(0);
+  });
+});
+
+describe('buildSessionSummary anti-patterns', () => {
+  const mockSessionTracker = {
+    getMetrics: () => ({
+      sessionId: 'ap-session',
+      sessionStartTime: 1_700_000_000_000,
+      sessionDurationMs: 10_000,
+      toolCallCount: 1,
+      toolCallCountByTool: { Edit: 1 },
+      toolDurationMsByTool: {},
+      toolSuccessRate: 1,
+      toolSuccessRateByTool: {},
+      toolErrorCount: 0,
+      toolErrorsByType: {},
+      uniqueFilesRead: 0,
+      uniqueFilesWritten: 1,
+      bashCommandsRun: 0,
+      bashExitCodes: {},
+      searchQueries: 0,
+      toolCallTimeline: [],
+    }),
+  };
+
+  const mockTaskDetector = {
+    getCurrentTask: () => null,
+    getMetrics: () => ({
+      totalTasksCompleted: 1,
+      currentTaskActive: false,
+      currentTaskToolCalls: 0,
+      averageTaskDurationMs: 10_000,
+      averageToolCallsPerTask: 1,
+      completedTasks: [
+        {
+          taskId: 't1',
+          startTime: 1_700_000_000_000,
+          endTime: 1_700_000_010_000,
+          durationMs: 10_000,
+          toolCallCount: 1,
+          toolCallsByType: { Edit: 1 },
+          filesRead: [],
+          filesModified: ['/src/auth.ts'],
+          linesChanged: 2,
+          linesAdded: 2,
+          linesRemoved: 0,
+          bashCommandsRun: 0,
+          testsRun: 0,
+          testsPassed: 0,
+          buildRun: 0,
+          buildPassed: 0,
+          estimatedCostUsd: 0.01,
+          tokensUsed: 100,
+          askedUserQuestions: 0,
+          subAgentsSpawned: 0,
+          toolCalls: [
+            {
+              id: 'tc1',
+              sessionId: 'ap-session',
+              toolName: 'Edit',
+              toolUseId: 'tu1',
+              timestamp: 1_700_000_001_000,
+              durationMs: 20,
+              success: true,
+              filePath: '/src/auth.ts',
+            },
+          ],
+        },
+      ],
+    }),
+  };
+
+  it('persists file and the real per-incident occurrence count', () => {
+    const mockAntiPatternDetector = {
+      analyze: () => ({
+        readEfficiency: null,
+        verifyRate: null,
+        patterns: [
+          {
+            type: 'thrashing',
+            file: '/src/auth.ts',
+            iterations: 4,
+            tokensWasted: 200,
+            suggestion: 'Read the test failure output before editing again.',
+          },
+        ],
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      taskDetector: mockTaskDetector as unknown as TaskDetector,
+      antiPatternDetector: mockAntiPatternDetector as unknown as AntiPatternDetector,
+      developer: 'alice',
+    });
+
+    expect(summary.antiPatterns).toEqual([
+      { type: 'thrashing', file: '/src/auth.ts', iterations: 4 },
+    ]);
+  });
+
+  it('keeps one row per incident when multiple incidents share a type', () => {
+    const mockAntiPatternDetector = {
+      analyze: () => ({
+        readEfficiency: null,
+        verifyRate: null,
+        patterns: [
+          {
+            type: 'thrashing',
+            file: '/src/auth.ts',
+            iterations: 4,
+            tokensWasted: 200,
+            suggestion: 's1',
+          },
+          {
+            type: 'thrashing',
+            file: '/src/session.ts',
+            iterations: 2,
+            tokensWasted: 80,
+            suggestion: 's2',
+          },
+        ],
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      taskDetector: mockTaskDetector as unknown as TaskDetector,
+      antiPatternDetector: mockAntiPatternDetector as unknown as AntiPatternDetector,
+      developer: 'alice',
+    });
+
+    expect(summary.antiPatterns).toHaveLength(2);
+    expect(summary.antiPatterns.map((p) => p.file)).toEqual(['/src/auth.ts', '/src/session.ts']);
+  });
+
+  it('round-trips file/iterations through JSON serialization', () => {
+    const original = makeSummary({
+      antiPatterns: [{ type: 're_reading', file: '/src/config.ts', readCount: 6 }],
+    });
+    const raw = JSON.parse(JSON.stringify(original)) as Record<string, unknown>;
+    const roundTripped = deserializeFullSessionSummary(raw);
+
+    expect(roundTripped.antiPatterns).toEqual([
+      { type: 're_reading', file: '/src/config.ts', readCount: 6 },
+    ]);
+  });
+
+  it('deserializes legacy {type, count} session files into `count` separate incidents of that type', () => {
+    const raw = { sessionId: 'legacy-1', antiPatterns: [{ type: 'thrashing', count: 3 }] };
+    const roundTripped = deserializeFullSessionSummary(raw);
+
+    expect(roundTripped.antiPatterns).toEqual([
+      { type: 'thrashing' },
+      { type: 'thrashing' },
+      { type: 'thrashing' },
+    ]);
+  });
+
+  it('expands a legacy {type, count: 5} entry into 5 rows of that type, matching the historical aggregate', () => {
+    const raw = { sessionId: 'legacy-2', antiPatterns: [{ type: 'thrashing', count: 5 }] };
+    const roundTripped = deserializeFullSessionSummary(raw);
+
+    expect(roundTripped.antiPatterns).toHaveLength(5);
+    expect(roundTripped.antiPatterns.every((p) => p.type === 'thrashing')).toBe(true);
   });
 });
 

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -25,6 +25,7 @@ import type { AntiPatternDetector } from '../metrics/anti-patterns.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
 import type { TranscriptMessageTracker } from '../metrics/transcript-message-tracker.js';
 import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
+import type { AntiPattern } from '../metrics/anti-patterns.js';
 import {
   ToolSelectionScorer,
   toToolSelectionSummary,
@@ -42,6 +43,40 @@ const logger = createLogger('session-store');
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+/**
+ * One detected anti-pattern occurrence, persisted per incident rather than
+ * grouped by type — the target (`file`/`command`) and the detector's own
+ * per-incident occurrence count (`iterations`/`readCount`/etc., matching
+ * `AntiPattern`) both survive the round-trip to disk.
+ */
+export interface PersistedAntiPattern {
+  readonly type: string;
+  readonly file?: string;
+  readonly command?: string;
+  readonly iterations?: number;
+  readonly readCount?: number;
+  readonly repeatCount?: number;
+  readonly editCount?: number;
+  readonly agentCount?: number;
+}
+
+/**
+ * Maps detector-reported anti-pattern incidents into the persisted/API shape,
+ * redacting `file`/`command` targets the same way other persisted fields are.
+ */
+export function toPersistedAntiPatterns(patterns: readonly AntiPattern[]): PersistedAntiPattern[] {
+  return patterns.map((p) => ({
+    type: p.type,
+    file: p.file !== undefined ? redactSensitive(p.file) : undefined,
+    command: p.command !== undefined ? redactSensitive(p.command) : undefined,
+    iterations: p.iterations,
+    readCount: p.readCount,
+    repeatCount: p.repeatCount,
+    editCount: p.editCount,
+    agentCount: p.agentCount,
+  }));
+}
 
 export interface FullSessionSummary extends SessionSummary {
   readonly sessionName: string | null;
@@ -71,7 +106,7 @@ export interface FullSessionSummary extends SessionSummary {
   readonly tokensCacheCreation: number;
   readonly cacheSavingsUsd: number;
   readonly efficiencyScore: number | null;
-  readonly antiPatterns: Array<{ type: string; count: number }>;
+  readonly antiPatterns: PersistedAntiPattern[];
   readonly taskCount: number;
   readonly taskSuccessRate: number | null;
   readonly toolSuccessRate: number | null;
@@ -393,16 +428,9 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
       ? antiPatternDetector.analyze(allToolCalls)
       : null;
 
-  const antiPatterns: Array<{ type: string; count: number }> = [];
-  if (antiPatternResults) {
-    const grouped = new Map<string, number>();
-    for (const p of antiPatternResults.patterns) {
-      grouped.set(p.type, (grouped.get(p.type) ?? 0) + 1);
-    }
-    for (const [type, count] of grouped) {
-      antiPatterns.push({ type, count });
-    }
-  }
+  const antiPatterns: PersistedAntiPattern[] = antiPatternResults
+    ? toPersistedAntiPatterns(antiPatternResults.patterns)
+    : [];
 
   // Tool-selection quality: same allToolCalls used for anti-pattern analysis
   // above, still holding real outputSizeBytes at this point — see the
@@ -507,7 +535,7 @@ export function sessionSummaryToDriftRecord(
     timestamp: summary.endTime,
     successRate: summary.taskSuccessRate,
     totalTokens: summary.tokensInput + summary.tokensOutput,
-    thrashingIncidents: summary.antiPatterns.find((p) => p.type === 'thrashing')?.count ?? 0,
+    thrashingIncidents: summary.antiPatterns.filter((p) => p.type === 'thrashing').length,
     taskCount: summary.taskCount,
     avgEfficiency: summary.efficiencyScore,
   };
@@ -591,14 +619,43 @@ export function deserializeFullSessionSummary(
     }
   }
 
-  const antiPatterns: Array<{ type: string; count: number }> = [];
+  // Legacy on-disk files only ever have the old `{type, count}` shape —
+  // `count` meant "distinct entries of this type" and carried no target
+  // info. Every downstream consumer (trend analysis, weekly summaries,
+  // thrashing-incident counts) counts array entries rather than reading a
+  // magnitude field, so a legacy entry is expanded back into `count`
+  // separate rows of that type here, leaving `file`/`command`/etc.
+  // undefined for those older records — that keeps "one array entry = one
+  // incident" true for both legacy and current on-disk shapes.
+  const antiPatterns: PersistedAntiPattern[] = [];
   if (Array.isArray(obj.antiPatterns)) {
     for (const ap of obj.antiPatterns) {
       if (typeof ap === 'object' && ap !== null) {
         const a = ap;
-        if (typeof a.type === 'string' && typeof a.count === 'number') {
-          antiPatterns.push({ type: a.type, count: a.count });
+        if (typeof a.type !== 'string') continue;
+        const hasMagnitudeField =
+          typeof a.iterations === 'number' ||
+          typeof a.readCount === 'number' ||
+          typeof a.repeatCount === 'number' ||
+          typeof a.editCount === 'number' ||
+          typeof a.agentCount === 'number';
+        if (!hasMagnitudeField && typeof a.count === 'number') {
+          const legacyCount = Math.max(0, Math.trunc(a.count));
+          for (let i = 0; i < legacyCount; i++) {
+            antiPatterns.push({ type: a.type });
+          }
+          continue;
         }
+        antiPatterns.push({
+          type: a.type,
+          file: typeof a.file === 'string' ? a.file : undefined,
+          command: typeof a.command === 'string' ? a.command : undefined,
+          iterations: typeof a.iterations === 'number' ? a.iterations : undefined,
+          readCount: typeof a.readCount === 'number' ? a.readCount : undefined,
+          repeatCount: typeof a.repeatCount === 'number' ? a.repeatCount : undefined,
+          editCount: typeof a.editCount === 'number' ? a.editCount : undefined,
+          agentCount: typeof a.agentCount === 'number' ? a.agentCount : undefined,
+        });
       }
     }
   }

--- a/src/storage/weekly-summary.test.ts
+++ b/src/storage/weekly-summary.test.ts
@@ -149,7 +149,7 @@ describe('WeeklySummaryGenerator', () => {
           testPassCount: 2,
           efficiencyScore: 0.8,
           toolBreakdown: { Read: 4, Edit: 3, Bash: 3 },
-          antiPatterns: [{ type: 'thrashing', count: 1 }],
+          antiPatterns: [{ type: 'thrashing' }],
         }),
       );
     }

--- a/src/storage/weekly-summary.ts
+++ b/src/storage/weekly-summary.ts
@@ -292,7 +292,7 @@ function aggregateSessions(weekId: string, sessions: FullSessionSummary[]): Week
     }
 
     for (const ap of session.antiPatterns) {
-      antiPatternCounts[ap.type] = (antiPatternCounts[ap.type] ?? 0) + ap.count;
+      antiPatternCounts[ap.type] = (antiPatternCounts[ap.type] ?? 0) + 1;
     }
   }
 
@@ -362,7 +362,7 @@ function aggregateDeveloperSessions(sessions: FullSessionSummary[]): DeveloperWe
     }
 
     for (const ap of session.antiPatterns) {
-      antiPatternCounts[ap.type] = (antiPatternCounts[ap.type] ?? 0) + ap.count;
+      antiPatternCounts[ap.type] = (antiPatternCounts[ap.type] ?? 0) + 1;
     }
   }
 

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -170,7 +170,16 @@ export interface SessionListEntry {
   readonly durationMs?: number;
   readonly toolCallCount?: number;
   readonly estimatedCostUsd?: number | null;
-  readonly antiPatterns?: Array<{ type: string; count: number }>;
+  readonly antiPatterns?: Array<{
+    readonly type: string;
+    readonly file?: string;
+    readonly command?: string;
+    readonly iterations?: number;
+    readonly readCount?: number;
+    readonly repeatCount?: number;
+    readonly editCount?: number;
+    readonly agentCount?: number;
+  }>;
   readonly model?: string | null;
   readonly toolSuccessRate?: number | null;
   readonly efficiencyScore?: number | null;
@@ -259,7 +268,16 @@ export interface SessionDetail {
   readonly toolBreakdown?: Record<string, number>;
   readonly filesRead?: string[];
   readonly filesModified?: string[];
-  readonly antiPatterns?: Array<{ type: string; count: number }>;
+  readonly antiPatterns?: Array<{
+    readonly type: string;
+    readonly file?: string;
+    readonly command?: string;
+    readonly iterations?: number;
+    readonly readCount?: number;
+    readonly repeatCount?: number;
+    readonly editCount?: number;
+    readonly agentCount?: number;
+  }>;
   readonly timeline?: ReadonlyArray<ReplayTimelineEntry>;
   readonly qualityProxy?: {
     readonly diffApplyRate: number | null;
@@ -295,24 +313,6 @@ export interface ComputeWasteResponse {
 
 export const fetchComputeWaste = (): Promise<ComputeWasteResponse> =>
   getJson<ComputeWasteResponse>('/api/compute-waste');
-
-export interface ThrashingAlertEntry {
-  readonly toolName: string;
-  readonly occurrences: number;
-  readonly windowSize: number;
-  readonly similarity: number;
-  readonly tokensWastedEstimate: number;
-  readonly timestamp: number;
-}
-
-export interface RetryAlertsResponse {
-  readonly alerts: readonly ThrashingAlertEntry[];
-  readonly totalTokensWasted: number;
-  readonly totalAlertsEmitted: number;
-}
-
-export const fetchRetryAlerts = (): Promise<RetryAlertsResponse> =>
-  getJson<RetryAlertsResponse>('/api/retry-alerts');
 
 export interface DecisionBranchEntry {
   readonly turnNumber: number;

--- a/src/web/store/liveStore.ts
+++ b/src/web/store/liveStore.ts
@@ -308,5 +308,3 @@ export function selectMaxSeverity(state: LiveState): AlertEvent['severity'] | nu
 // keeping the `{ usd, turns }` call-site API intact.
 export const useSubagentStats = (): { usd: number; turns: number } =>
   useLiveStore(useShallow((s) => ({ usd: s.todaySubagentUsd, turns: s.todaySubagentTurnCount })));
-export const useObservabilityHealth = (): ObservabilityHealthState | null =>
-  useLiveStore((s) => s.observabilityHealth);

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -6,7 +6,7 @@ interface DetailMap {
   readonly [sessionId: string]: unknown;
 }
 
-function renderSessions(listData: unknown, detailMap: DetailMap = {}) {
+function renderSessions(listData: unknown, detailMap: DetailMap = {}, workflowsData: unknown = []) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
   globalThis.fetch = ((url: string) => {
     if (url.startsWith('/api/sessions/')) {
@@ -14,6 +14,14 @@ function renderSessions(listData: unknown, detailMap: DetailMap = {}) {
       const detail = detailMap[id] ?? { sessionId: id, timeline: [] };
       return Promise.resolve(
         new Response(JSON.stringify(detail), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }
+    if (url.startsWith('/api/workflows')) {
+      return Promise.resolve(
+        new Response(JSON.stringify(workflowsData), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         }),
@@ -55,6 +63,25 @@ describe('Sessions view', () => {
     renderSessions(SAMPLE_LIST);
     await waitFor(() => expect(screen.getByText(/s1/)).toBeInTheDocument());
     expect(screen.getByText(/s2/)).toBeInTheDocument();
+  });
+
+  it('states the actual number of visible sessions in the runs-outside-page disclosure, not the page-size cap', async () => {
+    // Fewer sessions than the page-size cap are loaded (2), and one run
+    // belongs to a session that isn't among them — the disclosure must
+    // report against the real visible count, not the fetch cap.
+    renderSessions(SAMPLE_LIST, {}, [
+      {
+        runId: 'run-1',
+        parentSessionId: 'missing-session',
+        taskId: null,
+        workflowName: 'wf',
+        status: 'completed',
+        defaultModel: 'claude',
+      },
+    ]);
+    await waitFor(() => expect(screen.getByText(/s1/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/\+1 run above/i)).toBeInTheDocument());
+    expect(screen.getByText(/outside the 2 shown below/i)).toBeInTheDocument();
   });
 
   it('renders the consolidated workflow KPI strip and filter controls', async () => {
@@ -229,21 +256,45 @@ describe('Sessions view', () => {
     expect(screen.queryByText('Files Read')).toBeNull();
   });
 
-  it('renders antiPatterns pills reusing the SEGMENT_LABELS taxonomy, falling back to the raw type for unmapped values', async () => {
+  it('renders antiPatterns pills reusing the SEGMENT_LABELS taxonomy, summing real magnitude across grouped incidents', async () => {
+    // Real API shape: one entry per detected incident, each carrying its
+    // own file/command target.
     const detail = {
       sessionId: 's1',
       timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
       antiPatterns: [
-        { type: 'thrashing', count: 3 },
-        { type: 'over_delegation', count: 1 },
+        { type: 'thrashing', file: 'a.ts', iterations: 3 },
+        { type: 'thrashing', file: 'b.ts', iterations: 2 },
+        { type: 'thrashing', file: 'c.ts', iterations: 4 },
+        { type: 'over_delegation', agentCount: 5 },
       ],
     };
     const { container } = renderSessions(SAMPLE_LIST, { s1: detail });
     await waitFor(() => expect(container.textContent).toContain('Edit/Test Thrashing'));
-    expect(container.textContent).toContain('× 3');
-    // over_delegation has no SEGMENT_LABELS entry — falls back to the raw type string.
-    expect(container.textContent).toContain('over_delegation');
-    expect(container.textContent).toContain('× 1');
+    // Three thrashing incidents (3 + 2 + 4 iterations) sum to the real
+    // magnitude, not the count of incident objects (which would be 3).
+    expect(container.textContent).toContain('× 9');
+    // over_delegation has a SEGMENT_LABELS entry and its own magnitude.
+    expect(container.textContent).toContain('Over-Delegation');
+    expect(container.textContent).not.toContain('over_delegation');
+    expect(container.textContent).toContain('× 5');
+  });
+
+  it('groups same-type anti-pattern incidents into one pill with a stable key, summing to 1 per incident when no magnitude field is present', async () => {
+    const detail = {
+      sessionId: 's1',
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+      antiPatterns: [
+        { type: 'stuck_loop', command: 'npm test' },
+        { type: 'stuck_loop', command: 'npm run build' },
+      ],
+    };
+    const { container } = renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(container.textContent).toContain('× 2'));
+    // Exactly one pill for the type — not two pills sharing a React key,
+    // and no "undefined" from a missing top-level count field.
+    expect(screen.getAllByText(/stuck.loop/i)).toHaveLength(1);
+    expect(container.textContent).not.toContain('undefined');
   });
 
   it('does not render the Anti-Patterns section when antiPatterns is absent or empty', async () => {
@@ -864,5 +915,157 @@ describe('Sessions view — live-detection and selection reliability', () => {
     // selected — if s1 had been selected immediately, the "selectedId is
     // already set" guard would block ever switching to s2.
     await waitFor(() => expect(detailFetchCalls).toContain('s2'));
+  });
+});
+
+describe('Sessions view — Tools panel Context tab', () => {
+  it('fetches Context tab data through fetchContext(sessionId), rendering real contribution data', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    const sessionList = [
+      { sessionId: 'live-sess', startTime: '2026-05-28T09:00:00Z', toolCallCount: 5 },
+    ];
+    const contextRequests: string[] = [];
+
+    globalThis.fetch = ((url: string) => {
+      if (url === '/api/session/current') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ sessionId: 'live-sess', liveSessions: ['live-sess'] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/context')) {
+        contextRequests.push(url);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              turnCount: 3,
+              growth: { startTokens: 0, currentTokens: 1000, deltaTokens: 1000 },
+              currentBreakdown: { system: 100, tools: 500, user: 200, assistant: 200 },
+              fillPercent: 0.5,
+              contextWindow: 200_000,
+              toolContributions: [
+                { tool: 'Read', totalBytes: 2000, estimatedTokens: 500, percentOfToolOutput: 1 },
+              ],
+              history: [],
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            },
+          ),
+        );
+      }
+      if (url.startsWith('/api/sessions/')) {
+        const id = decodeURIComponent(url.split('/').pop() ?? '');
+        return Promise.resolve(
+          new Response(JSON.stringify({ sessionId: id, toolBreakdown: { Bash: 3 } }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(sessionList), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as typeof globalThis.fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <Sessions />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText(/^Tools$/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('tab', { name: 'Context' }));
+    await waitFor(() => expect(screen.getByText('Read')).toBeInTheDocument());
+    // Requesting the exact endpoint shape fetchContext(sessionId) builds
+    // confirms the query goes through the shared client helper, not just
+    // that some request happened to succeed.
+    expect(contextRequests[0]).toBe('/api/context?sessionId=live-sess');
+  });
+
+  // Switching from a live session with the Context tab open to a different,
+  // non-live session must reset the Tools panel to the Calls tab — a
+  // session with real tool-call data should never render as if it has no
+  // data.
+  it('resets the Tools panel back to the Calls tab when switching from a live session to a non-live one', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    const sessionList = [
+      { sessionId: 'live-sess', startTime: '2026-05-28T09:00:00Z', toolCallCount: 5 },
+      { sessionId: 'done-sess', startTime: '2026-05-27T09:00:00Z', toolCallCount: 3 },
+    ];
+
+    globalThis.fetch = ((url: string) => {
+      if (url === '/api/session/current') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ sessionId: 'live-sess', liveSessions: ['live-sess'] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/context')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              turnCount: 0,
+              growth: { startTokens: 0, currentTokens: 0, deltaTokens: 0 },
+              currentBreakdown: { system: 0, tools: 0, user: 0, assistant: 0 },
+              fillPercent: 0,
+              contextWindow: 200_000,
+              toolContributions: [],
+              history: [],
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            },
+          ),
+        );
+      }
+      if (url.startsWith('/api/sessions/')) {
+        const id = decodeURIComponent(url.split('/').pop() ?? '');
+        const toolBreakdown = id === 'live-sess' ? { Bash: 3 } : { Edit: 7 };
+        return Promise.resolve(
+          new Response(JSON.stringify({ sessionId: id, toolBreakdown }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(sessionList), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as typeof globalThis.fetch;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <Sessions />
+      </QueryClientProvider>,
+    );
+
+    // Auto-selects the live session; open its Context tab.
+    await waitFor(() => expect(screen.getByText(/^Tools$/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('tab', { name: 'Context' }));
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: 'Context' })).toHaveAttribute('aria-selected', 'true'),
+    );
+
+    // Switch to the non-live session.
+    fireEvent.click(screen.getAllByText(/done-ses/)[0]);
+    await waitFor(() => expect(screen.getByText('Edit')).toBeInTheDocument());
+    // The non-live session has no tab switcher at all (isLive is false), and
+    // the Calls breakdown — not a stuck "No context data" empty state —
+    // must be what's showing.
+    expect(screen.queryByRole('tab', { name: 'Context' })).toBeNull();
+    expect(screen.queryByText(/no context data/i)).toBeNull();
   });
 });

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -17,6 +17,7 @@ import {
   fetchSessionSubagents,
   fetchWorkflows,
   fetchWorkflowDetail,
+  fetchContext,
   qk,
   type SessionDetail,
   type WorkflowRunInfo,
@@ -76,6 +77,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   stuck_loop: 'Stuck Loop',
   blind_editing: 'Blind Editing',
   re_reading: 'Repeated Reads',
+  over_delegation: 'Over-Delegation',
 };
 
 const WORKFLOW_STATUS_PILL: Record<WorkflowRunInfo['status'], { tone: PillTone; label: string }> = {
@@ -315,6 +317,23 @@ export function Sessions(): JSX.Element {
     () => (filtersActive ? rows.filter((r) => runsBySession.has(r.sessionId)) : rows),
     [filtersActive, rows, runsBySession],
   );
+  // The KPI strip above is built from filteredRuns, which come from
+  // WorkflowStore.listRuns() — a machine-wide, 30-day-window, 500-run scan
+  // with no relationship to `rows` (the session list's own most-recent-50
+  // page from a separate store). Count how many of those runs belong to a
+  // session that isn't even in the visible page, so the UI can disclose
+  // when the two panels describe different populations instead of silently
+  // contradicting each other.
+  const runsOutsideVisibleSessions = useMemo(() => {
+    const visibleSessionIds = new Set(visibleRows.map((r) => r.sessionId));
+    let count = 0;
+    for (const run of filteredRuns) {
+      if (typeof run.parentSessionId === 'string' && !visibleSessionIds.has(run.parentSessionId)) {
+        count++;
+      }
+    }
+    return count;
+  }, [filteredRuns, visibleRows]);
 
   useEffect(() => {
     if (selectedId) return;
@@ -400,6 +419,13 @@ export function Sessions(): JSX.Element {
             />
           </div>
         </div>
+        {runsOutsideVisibleSessions > 0 && (
+          <div className="text-[11px] text-ink-subtle mt-2 pt-2 border-t border-border-subtle">
+            +{runsOutsideVisibleSessions} run{runsOutsideVisibleSessions === 1 ? '' : 's'} above
+            from {runsOutsideVisibleSessions === 1 ? 'a session' : 'sessions'} outside the{' '}
+            {visibleRows.length} shown below
+          </div>
+        )}
       </Card>
 
       <div className="flex items-center gap-3 flex-wrap mb-2 shrink-0">
@@ -900,7 +926,25 @@ function SessionTimeline({
         <div className="mb-4">
           <Eyebrow className="mb-1">Anti-Patterns</Eyebrow>
           <div className="flex flex-wrap gap-1.5">
-            {data.antiPatterns!.map(({ type, count }) => (
+            {/* One pill per type, grouping the per-incident array by `type`
+                so each pill has a stable React key. The pill's number is
+                the summed real magnitude (iterations/readCount/repeatCount/
+                editCount/agentCount, whichever the incident carries) across
+                every incident of that type, not a count of incident
+                objects. */}
+            {Object.entries(
+              (data.antiPatterns ?? []).reduce<Record<string, number>>((counts, ap) => {
+                const magnitude =
+                  ap.iterations ??
+                  ap.readCount ??
+                  ap.repeatCount ??
+                  ap.editCount ??
+                  ap.agentCount ??
+                  1;
+                counts[ap.type] = (counts[ap.type] ?? 0) + magnitude;
+                return counts;
+              }, {}),
+            ).map(([type, count]) => (
               <Pill key={type} tone="warning" size="sm" bordered>
                 {SEGMENT_LABELS[type] ?? type}
                 <span className="opacity-70">× {count}</span>
@@ -973,6 +1017,7 @@ function SessionTimeline({
           so they stay visible without scrolling past the whole gantt/list. */}
       {breakdownEntries.length > 0 && (
         <ToolsSection
+          key={`tools-${data.sessionId}`}
           breakdownEntries={breakdownEntries}
           totalCalls={totalCalls}
           isLive={isLive}
@@ -1173,10 +1218,9 @@ function ToolsSection({
 }): JSX.Element {
   const [tab, setTab] = useState<'calls' | 'context'>('calls');
 
-  const contextUrl = `/api/context?sessionId=${encodeURIComponent(sessionId)}`;
   const { data: contextData } = useQuery<ContextResponse>({
     queryKey: ['context', sessionId],
-    queryFn: () => fetch(contextUrl).then((r) => (r.ok ? r.json() : null)),
+    queryFn: () => fetchContext(sessionId),
     refetchInterval: 10_000,
     enabled: isLive && tab === 'context',
   });

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -80,15 +80,38 @@ describe('Today view', () => {
     expect(screen.queryByText(/thrashing/i)).toBeNull();
   });
 
-  it('shows retry-detector detail on the thrashing banner when a matching alert exists', async () => {
-    useLiveStore.setState({ antiPatterns: [{ type: 'thrashing', target: 'Read', count: 4 }] });
+  it('renders a generic fallback banner when the flags KPI is nonzero but every anti-pattern source is empty', async () => {
+    useLiveStore.setState({ antiPatterns: [] });
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(JSON.stringify({ antiPatternCount: 3 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+    expect(await screen.findByText(/3 flag\(s\) detected today/i)).toBeInTheDocument();
+  });
+
+  it('does not show a retry-detector tokens-wasted annotation on the thrashing banner', async () => {
+    // Even when a retry-alerts entry happens to share a name with the
+    // anti-pattern's file-path target, the banner must not cross-reference
+    // it — RetryDetector groups by literal tool name, an unrelated key.
+    useLiveStore.setState({ antiPatterns: [{ type: 'thrashing', target: 'auth.ts', count: 4 }] });
     globalThis.fetch = vi.fn(async (url: string) => {
       if (url === '/api/retry-alerts') {
         return new Response(
           JSON.stringify({
             alerts: [
               {
-                toolName: 'Read',
+                toolName: 'auth.ts',
                 occurrences: 4,
                 windowSize: 5,
                 similarity: 0.9,
@@ -108,7 +131,8 @@ describe('Today view', () => {
       });
     }) as typeof fetch;
     renderToday();
-    expect(await screen.findByText(/~750 tokens wasted/i)).toBeInTheDocument();
+    expect(await screen.findByText(/thrashing/i)).toBeInTheDocument();
+    expect(screen.queryByText(/tokens wasted/i)).toBeNull();
   });
 
   function stubTurnCostsAndDecisionTree(turnCount = 1): void {
@@ -716,6 +740,41 @@ describe('Today view', () => {
     expect(await screen.findByText(/subagent activity from other sessions/i)).toBeInTheDocument();
     expect(screen.queryByText(/subagent cost tracking is disabled/i)).toBeNull();
     expect(screen.queryByText(/NR_AI_ENABLE_SUBAGENT_WATCHER=0/)).toBeNull();
+  });
+
+  it('does not show the watcher-disabled banner when the cross-session aggregate reports nonzero subagent turns, even though the live SSE turn count is 0', async () => {
+    // The live-only subagentStats.turns stays 0 in this test (no SSE frames
+    // are ever pushed for it) while the polled aggregate endpoint — the same
+    // one the "subagent spend" KPI above these banners already falls back
+    // to — reports turns for today. The gate must agree with that KPI.
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/observability-health')) {
+        return new Response(
+          JSON.stringify({
+            watcherActive: false,
+            watcherDisabledByLock: false,
+            watcherDisabledReason: 'env_var',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(JSON.stringify({ subagentTurnCount: 5 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+    await screen.findByText('5 turns');
+    expect(screen.queryByText(/subagent cost tracking is disabled/i)).toBeNull();
+    expect(screen.queryByText(/subagent activity from other sessions/i)).toBeNull();
   });
 });
 

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -2,12 +2,7 @@ import { useMemo, useState, useRef, useEffect } from 'react';
 import type { JSX } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useLocation } from 'wouter';
-import {
-  useLiveStore,
-  useSubagentStats,
-  useObservabilityHealth,
-  type AlertEvent,
-} from '../store/liveStore';
+import { useLiveStore, useSubagentStats, type AlertEvent } from '../store/liveStore';
 import { Kpi } from '../components/Kpi';
 import { AnimatedCard } from '../components/AnimatedCard';
 import { HourlyCostBlocks, type HourlyCostEntry } from '../components/HourlyCostBlocks';
@@ -31,8 +26,6 @@ import {
   fetchSessionSubagents,
   fetchWorkflows,
   fetchAntiPatterns,
-  fetchRetryAlerts,
-  type RetryAlertsResponse,
   fetchTurnCosts,
   type TurnCostsResponse,
   fetchDecisionTree,
@@ -182,7 +175,6 @@ export function Today(): JSX.Element {
   const cost = useLiveStore((s) => s.cost);
   const antiPatterns = useLiveStore((s) => s.antiPatterns);
   const subagentStats = useSubagentStats();
-  const observabilityHealth = useObservabilityHealth();
   const { data: healthApi } = useQuery<ObservabilityHealthResponse>({
     queryKey: ['observability-health'],
     queryFn: fetchObservabilityHealth,
@@ -206,11 +198,6 @@ export function Today(): JSX.Element {
   const { data: apiAntiPatterns, isPending: antiPatternsPending } = useQuery<SessionAntiPattern[]>({
     queryKey: qk.antiPatterns,
     queryFn: fetchAntiPatterns,
-  });
-  const { data: retryAlerts } = useQuery<RetryAlertsResponse>({
-    queryKey: ['retry-alerts'],
-    queryFn: fetchRetryAlerts,
-    refetchInterval: 10_000,
   });
   const { data: concurrency, isPending: concurrencyPending } = useQuery<ConcurrencyData>({
     queryKey: qk.concurrency,
@@ -367,15 +354,8 @@ export function Today(): JSX.Element {
         </>
       ) : (
         <>
-          {(observabilityHealth?.watcherDisabledByLock === true ||
-            healthApi?.watcherDisabledByLock === true) && (
-            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-300 mb-4">
-              Subagent watcher is disabled (lock conflict). Subagent costs may be undercounted.
-              Check Settings &rarr; Observability health.
-            </div>
-          )}
           {healthApi?.watcherActive === false &&
-            subagentStats.turns === 0 &&
+            subagentTurns === 0 &&
             healthApi?.watcherDisabledReason !== 'mode_mismatch' && (
               <div className="rounded-lg border border-border-subtle bg-surface-5 px-4 py-3 text-sm text-ink-muted mb-4">
                 Subagent cost tracking is disabled (
@@ -385,7 +365,7 @@ export function Today(): JSX.Element {
               </div>
             )}
           {healthApi?.watcherActive === false &&
-            subagentStats.turns === 0 &&
+            subagentTurns === 0 &&
             healthApi?.watcherDisabledReason === 'mode_mismatch' && (
               <div className="rounded-lg border border-border-subtle bg-surface-5 px-4 py-3 text-sm text-ink-muted mb-4">
                 This dashboard process isn&rsquo;t running its own subagent watcher — expected for a
@@ -459,86 +439,73 @@ export function Today(): JSX.Element {
             )}
           </AnimatedCard>
 
-          {flagsCount > 0 &&
-            (antiPatterns.length > 0 ||
-              (apiAntiPatterns && apiAntiPatterns.length > 0) ||
-              persistedAntiPatterns.length > 0) && (
-              <AnimatedCard index={2} className="mb-3">
-                <Card padding="sm" tone="warning" className="text-xs">
-                  {antiPatterns.length > 0 ? (
-                    <>
-                      <Pill tone="warning" size="sm" className="mr-2">
-                        {antiPatterns[0].type}
+          {flagsCount > 0 && (
+            <AnimatedCard index={2} className="mb-3">
+              <Card padding="sm" tone="warning" className="text-xs">
+                {antiPatterns.length > 0 ? (
+                  <>
+                    <Pill tone="warning" size="sm" className="mr-2">
+                      {antiPatterns[0].type}
+                    </Pill>
+                    <span className="text-ink-muted">— </span>
+                    <span>{antiPatterns[0].count}× on </span>
+                    <code className="bg-surface-5 px-1 rounded">{antiPatterns[0].target}</code>
+                    {/* Per-session pill so users can identify
+                        which of N concurrent sessions triggered the alert. */}
+                    {antiPatterns[0].sessionId && (
+                      <Pill tone="neutral" size="sm" className="ml-2">
+                        Session: {sessionPillLabel(antiPatterns[0].sessionId, liveSessions ?? [])}
                       </Pill>
-                      <span className="text-ink-muted">— </span>
-                      <span>{antiPatterns[0].count}× on </span>
-                      <code className="bg-surface-5 px-1 rounded">{antiPatterns[0].target}</code>
-                      {/* Per-session pill so users can identify
-                          which of N concurrent sessions triggered the alert. */}
-                      {antiPatterns[0].sessionId && (
-                        <Pill tone="neutral" size="sm" className="ml-2">
-                          Session: {sessionPillLabel(antiPatterns[0].sessionId, liveSessions ?? [])}
-                        </Pill>
-                      )}
-                      {antiPatterns[0].type === 'thrashing' &&
-                        retryAlerts?.alerts?.find((a) => a.toolName === antiPatterns[0].target)
-                          ?.tokensWastedEstimate !== undefined && (
-                          <span className="text-ink-muted ml-2">
-                            ~
-                            {
-                              retryAlerts.alerts.find((a) => a.toolName === antiPatterns[0].target)!
-                                .tokensWastedEstimate
-                            }{' '}
-                            tokens wasted
-                          </span>
-                        )}
-                    </>
-                  ) : apiAntiPatterns && apiAntiPatterns.length > 0 ? (
-                    <>
-                      <Pill tone="warning" size="sm" className="mr-2">
-                        {apiAntiPatterns[0].type}
-                      </Pill>
-                      <span className="text-ink-muted">— </span>
-                      <span>
-                        {apiAntiPatterns[0].count ??
-                          apiAntiPatterns[0].iterations ??
-                          apiAntiPatterns[0].readCount ??
-                          apiAntiPatterns[0].repeatCount ??
-                          apiAntiPatterns[0].editCount ??
-                          apiAntiPatterns[0].agentCount ??
-                          '?'}
-                        × on{' '}
-                      </span>
-                      <code className="bg-surface-5 px-1 rounded">
-                        {apiAntiPatterns[0].file ?? apiAntiPatterns[0].command ?? 'unknown'}
-                      </code>
-                    </>
-                  ) : persistedAntiPatterns.length > 0 ? (
-                    <>
-                      <Pill tone="warning" size="sm" className="mr-2">
-                        {persistedAntiPatterns[0].type}
-                      </Pill>
-                      <span className="text-ink-muted">— </span>
-                      <span>
-                        {persistedAntiPatterns[0].count ??
-                          persistedAntiPatterns[0].iterations ??
-                          persistedAntiPatterns[0].readCount ??
-                          persistedAntiPatterns[0].repeatCount ??
-                          persistedAntiPatterns[0].editCount ??
-                          persistedAntiPatterns[0].agentCount ??
-                          '?'}
-                        × on{' '}
-                      </span>
-                      <code className="bg-surface-5 px-1 rounded">
-                        {persistedAntiPatterns[0].file ??
-                          persistedAntiPatterns[0].command ??
-                          'unknown'}
-                      </code>
-                    </>
-                  ) : null}
-                </Card>
-              </AnimatedCard>
-            )}
+                    )}
+                  </>
+                ) : apiAntiPatterns && apiAntiPatterns.length > 0 ? (
+                  <>
+                    <Pill tone="warning" size="sm" className="mr-2">
+                      {apiAntiPatterns[0].type}
+                    </Pill>
+                    <span className="text-ink-muted">— </span>
+                    <span>
+                      {apiAntiPatterns[0].count ??
+                        apiAntiPatterns[0].iterations ??
+                        apiAntiPatterns[0].readCount ??
+                        apiAntiPatterns[0].repeatCount ??
+                        apiAntiPatterns[0].editCount ??
+                        apiAntiPatterns[0].agentCount ??
+                        '?'}
+                      × on{' '}
+                    </span>
+                    <code className="bg-surface-5 px-1 rounded">
+                      {apiAntiPatterns[0].file ?? apiAntiPatterns[0].command ?? 'unknown'}
+                    </code>
+                  </>
+                ) : persistedAntiPatterns.length > 0 ? (
+                  <>
+                    <Pill tone="warning" size="sm" className="mr-2">
+                      {persistedAntiPatterns[0].type}
+                    </Pill>
+                    <span className="text-ink-muted">— </span>
+                    <span>
+                      {persistedAntiPatterns[0].count ??
+                        persistedAntiPatterns[0].iterations ??
+                        persistedAntiPatterns[0].readCount ??
+                        persistedAntiPatterns[0].repeatCount ??
+                        persistedAntiPatterns[0].editCount ??
+                        persistedAntiPatterns[0].agentCount ??
+                        '?'}
+                      × on{' '}
+                    </span>
+                    <code className="bg-surface-5 px-1 rounded">
+                      {persistedAntiPatterns[0].file ??
+                        persistedAntiPatterns[0].command ??
+                        'unknown'}
+                    </code>
+                  </>
+                ) : (
+                  <span>{flagsCount} flag(s) detected today — details unavailable.</span>
+                )}
+              </Card>
+            </AnimatedCard>
+          )}
 
           <AnimatedCard index={3} className="grid grid-cols-3 gap-3 mb-3">
             <QualityProxyPanel />


### PR DESCRIPTION
## Summary

- **Today page anti-pattern & watcher banner logic**: anti-pattern data now persists its file/command target and real occurrence count instead of collapsing into an opaque type/count pair. A broken "tokens wasted" annotation that compared unrelated detector outputs is removed. The flags KPI always shows a fallback message when no detail has loaded yet. A dead "subagent watcher disabled (lock conflict)" banner that could never render is removed. The two remaining watcher-disabled banners now gate on the same combined turn count the KPI above them uses, instead of a counter that never leaves zero.
- **Sessions page remaining panel-specific bugs**: anti-pattern pills gained a missing label for over-delegation and now sum real magnitude per type. The Session Quality/Tool Selection cards render consistently across all three response branches instead of two of three silently omitting one or both. The Context tab goes through the shared typed client instead of a raw `fetch`. Switching sessions no longer leaves the Tools panel stuck on a disabled tab. The KPI strip now discloses — accurately — when it describes sessions outside the visible list.
- Also includes: a legacy on-disk anti-pattern format that was silently losing its occurrence count on load, an inaccurate disclosure count, records fed unsorted into an order-dependent scorer, a duplicated mapping helper, and a few dead exports.

Fixes #371
Fixes #372
Fixes #373
Fixes #374
Fixes #375
Fixes #389
Fixes #390
Fixes #391
Fixes #392
Fixes #394

## Test plan

- [x] `npm test` — 5462/5465 passing (3 pre-existing skips)
- [x] `npx vitest run` — 499/499 passing
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors/warnings