### PR TITLE
Fix: Audit export/UX polish, History panel bugs, Today forecast/cache-health/cost-fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.40] - 2026-08-11
+
+### Fixed
+
+- **The Audit page's classification column no longer shows a raw, unlabeled "other" for every routine tool call** — the common, non-flagged case now shows a proper label like every other row.
+- **The Audit page now auto-refreshes and offers a retry action on load failure**, matching the other pages in this dashboard.
+- **The Audit page's session ID is now a link to that session's detail view**, instead of inert text.
+- **Two distinct audit entries that happen to share the same timestamp, tool, and target no longer risk colliding on the same React key** (e.g. two parallel calls landing in the same millisecond) — each entry now carries a stable, unique identifier.
+- **The Audit page's target column no longer silently clips long values** — long targets now wrap and expose the full value on hover.
+- **The "Anti-Pattern Frequency" chart on the History page no longer drops weeks with zero anti-patterns**, keeping its weekly axis aligned with the sibling "Daily Spend" and "Weekly Efficiency" charts — and a history with no anti-patterns at all still shows the "No anti-patterns detected" message instead of an all-zero chart.
+- **The "Model Performance" panel's $/1M-token figure is no longer inflated by sessions with a real cost but no recorded token counts.**
+- **The "Model Performance" panel's "elevated error rates" warning now accounts for how many of a model's sessions were actually measured**, instead of flagging any model with at least one low-success session regardless of sample size.
+- **The "Collaboration Profile" panel's "Correction rate" comparison no longer shows backwards color-coding** — a developer who corrects less than their team now correctly renders as better, not worse, and the dimension is now labeled to match its actual direction.
+- **The "Personal Coach" panel no longer applies full-strength regression/highlight language to a week that's barely started**, avoiding confident-sounding conclusions drawn from too small a sample.
+- **The Today dashboard's "Forecast · End of Day" card's parent/subagent spend breakdown now always sums to the total spend shown above it**, including when the aggregate endpoint briefly reports a legitimate zero while other sources already know about real spend today.
+- **The Cache Health panel's week-over-week trend is now computed against the same today-scoped rate as the headline number it's shown beside**, instead of a separate process's lifetime cache rate.
+- **The Today dashboard's spend figures now also refresh from the `/api/cost` endpoint**, closing a gap where they could otherwise go stale across a day boundary.
+
 ## [1.14.39] - 2026-08-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.39",
+  "version": "1.14.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.39",
+      "version": "1.14.40",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.39",
+  "version": "1.14.40",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1438,6 +1438,31 @@ describe('api-handler GET /api/audit', () => {
     expect(parsed[0]!.severity).toBeUndefined();
   });
 
+  it('passes through the AuditRecord.id as the DTO id field', async () => {
+    const fakeAuditLog = [
+      {
+        id: 'call-abc123',
+        timestamp: 1700000000000,
+        sessionId: 'session-a',
+        action: 'FileRead',
+        tool: 'Read',
+        detail: '/some/file.ts',
+        developer: 'alice',
+      },
+    ];
+    const handler = createApiHandler({
+      auditTrailManager: { getAuditLog: () => fakeAuditLog } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['auditTrailManager'],
+    });
+    const req = { method: 'GET', url: '/api/audit' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as Array<Record<string, unknown>>;
+    expect(parsed[0]!.id).toBe('call-abc123');
+  });
+
   it('returns 503 when auditTrailManager is missing', async () => {
     const handler = createApiHandler({});
     const req = { method: 'GET', url: '/api/audit' } as IncomingMessage;
@@ -4540,11 +4565,35 @@ describe('api-handler GET /api/cache-health', () => {
     expect(result.total_savings_usd).toBe(0.5);
   });
 
-  it('computes week_over_week_delta_pts from the trend, excluding the current ISO week', async () => {
+  it('computes week_over_week_delta_pts against the today-scoped aggregate rate, excluding the current ISO week', async () => {
     const currentWeek = getIsoWeekId(new Date());
+    const now = Date.now();
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+    const startMs = startOfDay.getTime();
+
     const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () => ({ sessionId: 'live-1', sessionStartTime: startMs + 5_000 }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
       costTracker: {
-        getMetrics: () => ({ cacheHitRate: 0.5 }),
+        // Lifetime cacheHitRate (0.99) deliberately disagrees with the
+        // today-scoped totals below (which resolve to a 50% hit rate) —
+        // the delta must be computed from the latter, matching the
+        // aggregate's headline rate, not CostTracker's lifetime rate.
+        getMetrics: () => ({
+          cacheHitRate: 0.99,
+          totalCacheReadTokens: 500,
+          totalCacheCreationTokens: 0,
+          totalInputTokens: 500,
+          totalCacheSavingsUsd: 0,
+        }),
       } as unknown as Parameters<typeof createApiHandler>[0]['costTracker'],
       trendAnalyzer: {
         computeTrends: () => ({
@@ -4560,7 +4609,8 @@ describe('api-handler GET /api/cache-health', () => {
     await handler(req, res);
     expect(status()).toBe(200);
     const result = JSON.parse(body());
-    // cacheHitRatePct = 50, lastWeekEntry (after excluding currentWeek) = 0.3 → 30
+    // today-scoped cacheHitRatePct = 500 / (500 + 500) = 50, lastWeekEntry
+    // (after excluding currentWeek) = 0.3 → 30, delta = 20.
     expect(result.week_over_week_delta_pts).toBe(20);
   });
 

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -76,6 +76,7 @@ import type { DecisionTreeMetrics } from '../../metrics/decision-tracker.js';
 import type { CostAttributionMetrics } from '../../metrics/turn-cost-attributor.js';
 import type { AuditRecord } from '../../security/audit-trail.js';
 interface RawAuditRecord {
+  readonly id: string;
   readonly timestamp: number;
   readonly sessionId: string | null;
   readonly action: string;
@@ -94,6 +95,7 @@ interface RawAuditRecord {
 // alertType chip (sensitive_file/destructive_command/external_network)
 // directly so the SPA's filter chips work without a second mapping.
 interface AuditEntryDto {
+  readonly id: string;
   readonly ts: number;
   readonly sessionId: string | null;
   readonly tool: string;
@@ -111,6 +113,7 @@ function toAuditEntry(entry: unknown): AuditEntryDto {
   // surface only flagged entries.
   const classification = r.securityAlert?.alertType ?? 'other';
   return {
+    id: r.id,
     ts: r.timestamp,
     sessionId: r.sessionId ?? null,
     tool: r.tool,
@@ -1234,14 +1237,10 @@ export function createApiHandler(
   const MAX_AGGREGATE_LATENCY_SAMPLES = 5_000;
   let aggregateCache: { bucket: number; payload: TodayAggregatePayload } | null = null;
 
-  routes.set('GET /api/sessions/today/aggregate', (_req, res) => {
-    const now = Date.now();
-    const currentBucket = Math.floor(now / AGGREGATE_TTL_MS);
-    if (aggregateCache && aggregateCache.bucket === currentBucket) {
-      jsonOk(res, aggregateCache.payload);
-      return;
-    }
-
+  // Extracted so GET /api/cache-health can read the same today-scoped
+  // cacheHitRatePct this computes, instead of falling back to CostTracker's
+  // lifetime cumulative rate — the two would otherwise disagree on scope.
+  function computeTodayAggregatePayload(now: number): TodayAggregatePayload {
     const startMs = localStartOfDay(now);
     const minuteBuckets = Math.max(1, Math.ceil((now - startMs) / 60_000));
     const sparkline = new Array<number>(minuteBuckets).fill(0);
@@ -1617,8 +1616,21 @@ export function createApiHandler(
           ? Math.round(forecast.forecastEndOfDayUsd * 1000) / 1000
           : null,
     };
+    return payload;
+  }
+
+  function getTodayAggregatePayload(now: number): TodayAggregatePayload {
+    const currentBucket = Math.floor(now / AGGREGATE_TTL_MS);
+    if (aggregateCache && aggregateCache.bucket === currentBucket) {
+      return aggregateCache.payload;
+    }
+    const payload = computeTodayAggregatePayload(now);
     aggregateCache = { bucket: currentBucket, payload };
-    jsonOk(res, payload);
+    return payload;
+  }
+
+  routes.set('GET /api/sessions/today/aggregate', (_req, res) => {
+    jsonOk(res, getTodayAggregatePayload(Date.now()));
   });
 
   // Workflow listing (script-driven runs). Reads the workflow
@@ -1847,11 +1859,21 @@ export function createApiHandler(
       (e) => e.week !== currentWeek,
     );
     const lastWeekEntry = trendData.length > 0 ? trendData[trendData.length - 1] : null;
+    // The headline hit-rate the Cache Health panel renders (aggregate.cacheHealth,
+    // from GET /api/sessions/today/aggregate) is today-scoped. Compare against
+    // that same today-scoped rate here — not the lifetime cacheHitRatePct
+    // derived above — so the week-over-week delta is on the same basis as the
+    // number it's displayed alongside.
+    const todayCacheHitRatePct = getTodayAggregatePayload(Date.now()).cacheHealth.cacheHitRatePct;
     const weekOverWeekDeltaPts =
-      cacheHitRatePct !== null && lastWeekEntry !== null
-        ? Math.round(cacheHitRatePct - lastWeekEntry.value * 100)
+      todayCacheHitRatePct !== null && lastWeekEntry !== null
+        ? Math.round(todayCacheHitRatePct - lastWeekEntry.value * 100)
         : null;
 
+    // cache_hit_rate_pct/status reflect this process's lifetime cache
+    // activity; week_over_week_delta_pts is computed against today's scoped
+    // rate to match the headline it's compared against. Mixing scopes here
+    // is intentional — see the comment above weekOverWeekDeltaPts.
     jsonOk(res, {
       status,
       cache_hit_rate_pct: cacheHitRatePct,

--- a/src/metrics/personal-coach.test.ts
+++ b/src/metrics/personal-coach.test.ts
@@ -1,4 +1,5 @@
 import { PersonalCoach } from './personal-coach.js';
+import { getIsoWeekId } from '../storage/weekly-summary.js';
 import type { WeeklySummaryGenerator } from '../storage/weekly-summary.js';
 import type { WeeklySummary } from '../storage/weekly-summary.js';
 
@@ -260,6 +261,76 @@ describe('PersonalCoach', () => {
         result.regressions.some((r) => r.includes('Anti-pattern rate') && r.includes('stuck loop')),
       ).toBe(true);
       expect(result.topRecommendation).toContain('Focus on reducing "stuck loop"');
+    }
+  });
+
+  it('suppresses highlights/regressions and discloses sample size for a low-session in-progress week', () => {
+    const now = new Date('2026-06-10T09:00:00Z');
+    const currentWeekId = getIsoWeekId(now);
+    const summaries = [
+      makeWeeklySummary(currentWeekId, developer, {
+        sessionCount: 1,
+        totalCostUsd: 50.0,
+        avgEfficiencyScore: 0.2,
+      }),
+      makeWeeklySummary('2026-W01', developer, { totalCostUsd: 5.0, avgEfficiencyScore: 0.8 }),
+      makeWeeklySummary('2026-W02', developer, { totalCostUsd: 5.0, avgEfficiencyScore: 0.8 }),
+    ];
+    const gen = makeSummaryGenerator(summaries);
+    const coach = new PersonalCoach(gen, developer);
+    const result = coach.generate(now);
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.thisWeek.weekId).toBe(currentWeekId);
+      expect(result.thisWeek.sessionsCount).toBe(1);
+      expect(result.highlights).toEqual([]);
+      expect(result.regressions).toEqual([]);
+      expect(result.topRecommendation).toContain('1 session');
+      expect(result.topRecommendation).toContain('check back');
+    }
+  });
+
+  it('applies normal comparisons to an in-progress week once it has enough sessions', () => {
+    const now = new Date('2026-06-10T09:00:00Z');
+    const currentWeekId = getIsoWeekId(now);
+    const summaries = [
+      makeWeeklySummary(currentWeekId, developer, {
+        sessionCount: 10,
+        totalCostUsd: 20.0,
+        avgEfficiencyScore: 0.5,
+      }),
+      makeWeeklySummary('2026-W01', developer, { totalCostUsd: 5.0, avgEfficiencyScore: 0.75 }),
+      makeWeeklySummary('2026-W02', developer, { totalCostUsd: 5.0, avgEfficiencyScore: 0.75 }),
+    ];
+    const gen = makeSummaryGenerator(summaries);
+    const coach = new PersonalCoach(gen, developer);
+    const result = coach.generate(now);
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.regressions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('does not gate a fully-elapsed low-session week even when it is the most recent one loaded', () => {
+    // "now" is far after every loaded week, so none of them are the
+    // in-progress current week — a genuinely quiet past week should still
+    // surface its real regressions.
+    const now = new Date('2026-09-01T09:00:00Z');
+    const summaries = [
+      makeWeeklySummary('2026-W02', developer, {
+        sessionCount: 1,
+        totalCostUsd: 50.0,
+        avgEfficiencyScore: 0.2,
+      }),
+      makeWeeklySummary('2026-W01', developer, { totalCostUsd: 5.0, avgEfficiencyScore: 0.8 }),
+      makeWeeklySummary('2025-W52', developer, { totalCostUsd: 5.0, avgEfficiencyScore: 0.8 }),
+    ];
+    const gen = makeSummaryGenerator(summaries);
+    const coach = new PersonalCoach(gen, developer);
+    const result = coach.generate(now);
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.regressions.length).toBeGreaterThan(0);
     }
   });
 

--- a/src/metrics/personal-coach.ts
+++ b/src/metrics/personal-coach.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '../shared/index.js';
+import { getIsoWeekId } from '../storage/weekly-summary.js';
 import type { WeeklySummaryGenerator } from '../storage/weekly-summary.js';
 import type { DeveloperWeeklyStats } from '../storage/weekly-summary.js';
 
@@ -52,6 +53,10 @@ const WEEKS_REQUIRED = 2;
 // ~2 months of history — enough for a meaningful baseline mean without
 // diluting it with data old enough to no longer reflect current habits.
 const WEEKS_TO_LOAD = 8;
+// Below this many sessions, a still-in-progress week hasn't accumulated
+// enough signal to be diffed against a baseline of fully-elapsed weeks —
+// see hasSufficientSample in generate().
+const MIN_SESSIONS_FOR_WEEKLY_COMPARISON = 3;
 
 export class PersonalCoach {
   private readonly summaryGenerator: WeeklySummaryGenerator;
@@ -62,7 +67,7 @@ export class PersonalCoach {
     this.developer = developer;
   }
 
-  generate(): PersonalInsightsResult {
+  generate(now: Date = new Date()): PersonalInsightsResult {
     const weeks = this.loadDeveloperWeeks();
 
     if (weeks.length < WEEKS_REQUIRED) {
@@ -88,10 +93,28 @@ export class PersonalCoach {
     const thisWeek = this.toPersonalWeekMetrics(thisWeekData);
     const lastWeek = lastWeekData ? this.toPersonalWeekMetrics(lastWeekData) : null;
 
-    const highlights = this.buildHighlights(thisWeek, lastWeek, baseline);
-    const regressions = this.buildRegressions(thisWeek, lastWeek, baseline);
+    // Weekly summaries for the current, still-running ISO week are
+    // regenerated on demand from whatever sessions exist so far (see the
+    // various generate(getIsoWeekId(new Date())) call sites), so "this
+    // week" can be a handful of hours of data. Diffing that against a
+    // baseline built from fully-elapsed weeks produces a comparison the
+    // sample can't actually support, so full-strength highlight/regression
+    // language and the top recommendation are held back until the current
+    // week has accumulated a minimum amount of signal.
+    const isCurrentWeekInProgress = thisWeekData.weekId === getIsoWeekId(now);
+    const hasSufficientSample =
+      !isCurrentWeekInProgress || thisWeek.sessionsCount >= MIN_SESSIONS_FOR_WEEKLY_COMPARISON;
+
+    const highlights = hasSufficientSample
+      ? this.buildHighlights(thisWeek, lastWeek, baseline)
+      : [];
+    const regressions = hasSufficientSample
+      ? this.buildRegressions(thisWeek, lastWeek, baseline)
+      : [];
     const streaks = this.buildStreaks(weeks);
-    const topRecommendation = this.buildTopRecommendation(regressions, thisWeek, baseline);
+    const topRecommendation = hasSufficientSample
+      ? this.buildTopRecommendation(regressions, thisWeek, baseline)
+      : `Only ${thisWeek.sessionsCount} session${thisWeek.sessionsCount === 1 ? '' : 's'} logged so far this week — check back once more sessions land before drawing week-over-week comparisons.`;
 
     logger.debug('Personal insights generated', {
       developer: this.developer,

--- a/src/security/audit-trail.test.ts
+++ b/src/security/audit-trail.test.ts
@@ -567,6 +567,28 @@ describe('AuditTrailManager', () => {
     const mgr = makeManager();
     expect(() => mgr.recordToolCall(makeRecord())).not.toThrow();
   });
+
+  // 21. carries ToolCallRecord.id through to AuditRecord.id
+  it('carries the ToolCallRecord id through to AuditRecord.id on recordToolCall', () => {
+    const mgr = makeManager();
+    const audit = mgr.recordToolCall(makeRecord({ id: 'tool-call-xyz' }));
+    expect(audit.id).toBe('tool-call-xyz');
+  });
+
+  // 22. carries ProxyToolCallRecord.id through to AuditRecord.id
+  it('carries the ProxyToolCallRecord id through to AuditRecord.id on recordProxyCall', () => {
+    const mgr = makeManager();
+    const audit = mgr.recordProxyCall(makeProxyRecord({ id: 'proxy-call-xyz' }));
+    expect(audit.id).toBe('proxy-call-xyz');
+  });
+
+  // 23. persists id to disk
+  it('includes id in the object persisted to disk', () => {
+    const { store, appendSpy } = makeLocalStore();
+    const mgr = makeManager({ localStore: store });
+    mgr.recordToolCall(makeRecord({ id: 'tool-call-persisted' }));
+    expect(appendSpy.mock.calls[0][0]).toMatchObject({ id: 'tool-call-persisted' });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -673,6 +695,42 @@ describe('AuditTrailManager.getAuditLog() disk read-back', () => {
     ]);
 
     expect(mgr.getAuditLog()).toHaveLength(1);
+  });
+
+  it("round-trips a disk entry's id unchanged", () => {
+    const { store } = makeLocalStoreWithDisk([
+      {
+        id: 'disk-entry-id',
+        timestamp: 555,
+        sessionId: 'sess-other',
+        action: 'FileRead',
+        tool: 'Read',
+        detail: 'Read src/old.ts',
+        developer: 'alice',
+      },
+    ]);
+    const mgr = makeManager({ localStore: store });
+
+    const log = mgr.getAuditLog();
+    expect(log[0]?.id).toBe('disk-entry-id');
+  });
+
+  it('falls back to a generated id for a legacy disk entry with no id', () => {
+    const { store } = makeLocalStoreWithDisk([
+      {
+        timestamp: 555,
+        sessionId: 'sess-other',
+        action: 'FileRead',
+        tool: 'Read',
+        detail: 'Read src/old.ts',
+        developer: 'alice',
+      },
+    ]);
+    const mgr = makeManager({ localStore: store });
+
+    const log = mgr.getAuditLog();
+    expect(typeof log[0]?.id).toBe('string');
+    expect(log[0]?.id.length).toBeGreaterThan(0);
   });
 
   it('drops a disk entry missing required fields instead of surfacing a broken row', () => {

--- a/src/security/audit-trail.ts
+++ b/src/security/audit-trail.ts
@@ -37,6 +37,10 @@ export interface SecurityAlert {
 }
 
 export interface AuditRecord {
+  /** Stable per-call id, sourced from `ToolCallRecord.id`/`ProxyToolCallRecord.id` — lets
+   * consumers (e.g. the Audit page's React key) distinguish two entries that otherwise
+   * share the same timestamp/tool/detail. */
+  readonly id: string;
   readonly timestamp: number;
   readonly sessionId: string | null;
   readonly action: AuditAction;
@@ -341,6 +345,15 @@ function auditEntryToRecord(entry: AuditEntry): AuditRecord | null {
     typeof rawSessionId === 'string' && !isSyntheticSessionId(rawSessionId) ? rawSessionId : null;
   const filePath = typeof entry.filePath === 'string' ? entry.filePath : undefined;
   const command = typeof entry.command === 'string' ? entry.command : undefined;
+  // Disk entries written before this field was introduced have no `id`; fall
+  // back to the same content fingerprint used for cross-process dedup below.
+  // That fingerprint isn't guaranteed unique across two distinct legacy
+  // entries that happen to share timestamp/tool/detail — an inherent limit
+  // of identifying such entries by content alone.
+  const id =
+    typeof entry.id === 'string' && entry.id.length > 0
+      ? entry.id
+      : auditIdentityKey({ timestamp, sessionId, tool, detail });
 
   let securityAlert: SecurityAlert | undefined;
   const rawAlert = entry.securityAlert;
@@ -356,6 +369,7 @@ function auditEntryToRecord(entry: AuditEntry): AuditRecord | null {
   }
 
   return {
+    id,
     timestamp,
     sessionId,
     action,
@@ -437,6 +451,7 @@ export class AuditTrailManager {
     const rawFilePath = record.filePath as string | undefined;
     const rawCommand = record.command as string | undefined;
     const auditRecord: AuditRecord = {
+      id: record.id,
       timestamp: record.timestamp,
       sessionId: resolveAuditSessionId(record.sessionId, this.sessionId),
       action,
@@ -481,6 +496,7 @@ export class AuditTrailManager {
     );
 
     const auditRecord: AuditRecord = {
+      id: record.id,
       timestamp: record.timestamp,
       sessionId: resolveAuditSessionId(record.sessionId, this.sessionId),
       action: 'McpToolCall',
@@ -588,6 +604,7 @@ export class AuditTrailManager {
   private persistToDisk(record: AuditRecord): void {
     if (!this.localStore) return;
     this.localStore.appendAuditLog({
+      id: record.id,
       timestamp: record.timestamp,
       sessionId: record.sessionId,
       action: record.action,

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -151,6 +151,8 @@ export interface AuditEntry {
   readonly action: string;
   readonly tool?: string;
   readonly detail?: string;
+  // Optional because legacy on-disk records predate this field.
+  readonly id?: string;
   readonly [key: string]: unknown;
 }
 

--- a/src/transport/log-ingest.test.ts
+++ b/src/transport/log-ingest.test.ts
@@ -9,6 +9,7 @@ import type { AuditRecord } from '../security/audit-trail.js';
 
 function makeAuditRecord(overrides?: Partial<AuditRecord>): AuditRecord {
   return {
+    id: 'audit-001',
     timestamp: 1_700_000_000_000,
     sessionId: 'sess-001',
     action: 'FileRead',

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -428,8 +428,12 @@ export interface ToolSelectionMetrics {
 // Mirrors AuditEntryDto in src/dashboard/routes/api-handler.ts (not importable —
 // tsconfig.web.json excludes server source). sessionId is `string | null` at
 // runtime (never `undefined`) — the real handler's toAuditEntry() always sets it,
-// falling back to null when the underlying audit record has none.
+// falling back to null when the underlying audit record has none. id is a stable
+// per-call identifier (sourced from AuditRecord.id) — use it as the React key
+// instead of deriving one from ts/tool/target, which collide when two distinct
+// calls share a timestamp.
 export interface AuditEntry {
+  readonly id: string;
   readonly ts: number;
   readonly sessionId: string | null;
   readonly tool: string;

--- a/src/web/views/Audit.test.tsx
+++ b/src/web/views/Audit.test.tsx
@@ -21,8 +21,16 @@ function renderAudit(data: unknown) {
 }
 
 const SAMPLE = [
-  { ts: 1, tool: 'Read', target: '/etc/hosts', classification: 'sensitive_file', sessionId: 's1' },
   {
+    id: 'call-1',
+    ts: 1,
+    tool: 'Read',
+    target: '/etc/hosts',
+    classification: 'sensitive_file',
+    sessionId: 's1',
+  },
+  {
+    id: 'call-2',
     ts: 2,
     tool: 'Bash',
     target: 'rm -rf /tmp/x',
@@ -30,6 +38,7 @@ const SAMPLE = [
     sessionId: 's1',
   },
   {
+    id: 'call-3',
     ts: 3,
     tool: 'Bash',
     target: 'curl evil.com',
@@ -49,6 +58,7 @@ describe('Audit view', () => {
   it('colors the classification Pill by severity instead of always neutral', async () => {
     const withSeverity = [
       {
+        id: 'call-1',
         ts: 1,
         tool: 'Bash',
         target: 'rm -rf /tmp/x',
@@ -57,6 +67,7 @@ describe('Audit view', () => {
         sessionId: 's1',
       },
       {
+        id: 'call-2',
         ts: 2,
         tool: 'Read',
         target: '/etc/hosts',
@@ -65,6 +76,7 @@ describe('Audit view', () => {
         sessionId: 's1',
       },
       {
+        id: 'call-3',
         ts: 3,
         tool: 'Read',
         target: '/home/alice/notes.txt',
@@ -82,7 +94,7 @@ describe('Audit view', () => {
       .find((td) => td.textContent?.includes('Sensitive files'))
       ?.querySelector('span');
     const otherPills = Array.from(table.querySelectorAll('td'))
-      .find((td) => td.textContent?.includes('other'))
+      .find((td) => td.textContent?.includes('Other'))
       ?.querySelector('span');
     expect(destructivePills?.className).toMatch(/bg-accent-red/);
     expect(sensitivePills?.className).toMatch(/bg-accent-amber/);
@@ -98,6 +110,22 @@ describe('Audit view', () => {
     expect(screen.queryByText('sensitive_file')).toBeNull();
     expect(screen.queryByText('destructive_command')).toBeNull();
     expect(screen.queryByText('external_network')).toBeNull();
+  });
+
+  it('renders a friendly label for the unflagged "other" classification, not the raw key', async () => {
+    renderAudit([
+      {
+        id: 'call-1',
+        ts: 1,
+        tool: 'Read',
+        target: '/home/alice/notes.txt',
+        classification: 'other',
+        sessionId: 's1',
+      },
+    ]);
+    await waitFor(() => expect(screen.getByText('/home/alice/notes.txt')).toBeInTheDocument());
+    expect(screen.getByText('Other')).toBeInTheDocument();
+    expect(screen.queryByText('other')).toBeNull();
   });
 
   it('filters by classification when a chip is clicked', async () => {
@@ -125,6 +153,7 @@ describe('Audit view', () => {
 
   it('caps rendered rows at 200 and shows the "showing first" note when over the limit', async () => {
     const big = Array.from({ length: 500 }, (_, i) => ({
+      id: `call-${i}`,
       ts: 1_000_000 + i,
       tool: 'Read',
       target: `/file/${i}`,
@@ -145,16 +174,26 @@ describe('Audit view', () => {
     expect(screen.queryByText(/showing first/i)).toBeNull();
   });
 
-  it('shows an error message when the audit log fetch fails', async () => {
+  it('shows an error message and a retry button when the audit log fetch fails', async () => {
+    const user = userEvent.setup();
     const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
-    globalThis.fetch = (() =>
-      Promise.resolve(new Response('Internal Server Error', { status: 500 }))) as typeof fetch;
+    let callCount = 0;
+    globalThis.fetch = (() => {
+      callCount++;
+      return Promise.resolve(new Response('Internal Server Error', { status: 500 }));
+    }) as typeof fetch;
     render(
       <QueryClientProvider client={qc}>
         <Audit />
       </QueryClientProvider>,
     );
     expect(await screen.findByText('Error loading audit log.')).toBeInTheDocument();
+    const retryButton = screen.getByRole('button', { name: /retry/i });
+    const callsBeforeRetry = callCount;
+
+    await user.click(retryButton);
+
+    await waitFor(() => expect(callCount).toBeGreaterThan(callsBeforeRetry));
   });
 
   it('shows "No matching entries." for a genuinely empty dataset', async () => {
@@ -165,6 +204,7 @@ describe('Audit view', () => {
   it('exports only the filtered and capped rows, not the full unfiltered set', async () => {
     const user = userEvent.setup();
     const sensitiveRows = Array.from({ length: 250 }, (_, i) => ({
+      id: `call-${i}`,
       ts: 1_000_000 + i,
       tool: 'Read',
       target: `/sensitive/${i}`,
@@ -172,6 +212,7 @@ describe('Audit view', () => {
       sessionId: `s-${i}`,
     }));
     const destructiveRow = {
+      id: 'call-destructive',
       ts: 1,
       tool: 'Bash',
       target: 'rm -rf /tmp/x',
@@ -213,6 +254,97 @@ describe('Audit view', () => {
       clickSpy.mockRestore();
     }
   });
+
+  it("links a row's session id to the Sessions view using the ?session= param", async () => {
+    renderAudit([
+      {
+        id: 'call-1',
+        ts: 1,
+        tool: 'Read',
+        target: '/etc/hosts',
+        classification: 'sensitive_file',
+        sessionId: 's1',
+      },
+    ]);
+    await waitFor(() => expect(screen.getByText('/etc/hosts')).toBeInTheDocument());
+    const sessionLink = screen.getByRole('link', { name: 's1' });
+    expect(sessionLink).toHaveAttribute('href', '/sessions?session=s1');
+  });
+
+  it('renders "—" instead of a link when a row has no session id', async () => {
+    renderAudit([
+      {
+        id: 'call-1',
+        ts: 1,
+        tool: 'Read',
+        target: '/etc/hosts',
+        classification: 'sensitive_file',
+        sessionId: null,
+      },
+    ]);
+    await waitFor(() => expect(screen.getByText('/etc/hosts')).toBeInTheDocument());
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('lets a long target wrap instead of overflowing, and exposes the full value via title', async () => {
+    const longTarget = `/very/long/path/${'segment/'.repeat(20)}file.ts`;
+    renderAudit([
+      {
+        id: 'call-1',
+        ts: 1,
+        tool: 'Read',
+        target: longTarget,
+        classification: 'sensitive_file',
+        sessionId: 's1',
+      },
+    ]);
+    const targetCell = await screen.findByTitle(longTarget);
+    expect(targetCell.tagName).toBe('TD');
+    expect(targetCell.className).toMatch(/break-all/);
+  });
+
+  // Two entries with the same ts/tool/target (e.g. parallel tool calls that
+  // finish in the same millisecond) must still render as two distinct rows,
+  // each keyed by its own unique id, with no React duplicate-key warning.
+  it('renders two entries sharing the same ts/tool/target as distinct rows, keyed by id', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const duplicateContent = [
+      {
+        id: 'call-1',
+        ts: 100,
+        tool: 'Read',
+        target: '/etc/hosts',
+        classification: 'sensitive_file',
+        sessionId: 's1',
+      },
+      {
+        id: 'call-2',
+        ts: 100,
+        tool: 'Read',
+        target: '/etc/hosts',
+        classification: 'sensitive_file',
+        sessionId: 's2',
+      },
+    ];
+
+    try {
+      renderAudit(duplicateContent);
+      await waitFor(() => expect(screen.getAllByText('/etc/hosts')).toHaveLength(2));
+
+      const table = screen.getByRole('table');
+      expect(table.querySelectorAll('tbody tr')).toHaveLength(2);
+      expect(screen.getByRole('link', { name: 's1' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 's2' })).toBeInTheDocument();
+
+      const duplicateKeyWarning = consoleErrorSpy.mock.calls.some((args) =>
+        args.some((arg) => String(arg).toLowerCase().includes('same key')),
+      );
+      expect(duplicateKeyWarning).toBe(false);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
 });
 
 describe('Audit downloadJsonl', () => {
@@ -236,6 +368,7 @@ describe('Audit downloadJsonl', () => {
     try {
       downloadJsonl([
         {
+          id: 'call-1',
           ts: 1,
           tool: 'Read',
           target: '/etc/hosts',
@@ -275,6 +408,7 @@ describe('Audit downloadJsonl', () => {
     try {
       downloadJsonl([
         {
+          id: 'call-1',
           ts: 1,
           tool: 'Read',
           target: '/etc/hosts',
@@ -320,6 +454,7 @@ describe('Audit downloadJsonl', () => {
       expect(() =>
         downloadJsonl([
           {
+            id: 'call-1',
             ts: 1,
             tool: 'Read',
             target: '/etc/hosts',

--- a/src/web/views/Audit.tsx
+++ b/src/web/views/Audit.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { JSX } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Link } from 'wouter';
 import { fetchAuditLog, qk, type AuditEntry } from '../api/client';
 import { EmptyState } from '../components/EmptyState';
 import { GeoBanner } from '../components/GeoBanner';
@@ -19,6 +20,17 @@ const SEVERITY_TONE: Record<string, 'danger' | 'warning' | 'info'> = {
   critical: 'danger',
   high: 'warning',
   medium: 'info',
+};
+
+// Labels for the classification Pill, distinct from FILTERS above (which only
+// covers the filter chips — 'all' isn't a real classification, and 'other'
+// isn't a filter). Every classification toAuditEntry() can produce needs an
+// entry here so the Pill never falls back to rendering the raw key.
+const CLASSIFICATION_LABELS: Record<string, string> = {
+  sensitive_file: 'Sensitive files',
+  destructive_command: 'Destructive',
+  external_network: 'External network',
+  other: 'Other',
 };
 
 export function downloadJsonl(rows: AuditEntry[]): void {
@@ -45,9 +57,10 @@ export function downloadJsonl(rows: AuditEntry[]): void {
 
 export function Audit(): JSX.Element {
   const [filter, setFilter] = useState<FilterKey>('all');
-  const { data, isLoading, error } = useQuery<AuditEntry[]>({
+  const { data, isLoading, error, refetch } = useQuery<AuditEntry[]>({
     queryKey: qk.audit,
     queryFn: () => fetchAuditLog(),
+    refetchInterval: 10_000,
   });
 
   const rows = data ?? [];
@@ -86,7 +99,17 @@ export function Audit(): JSX.Element {
       </div>
 
       {isLoading && <EmptyState icon="clock" variant="loading" title="Loading..." />}
-      {error && <div className="text-accent-red text-xs">Error loading audit log.</div>}
+      {error && (
+        <div className="text-accent-red text-xs flex items-center gap-2">
+          <span>Error loading audit log.</span>
+          <button
+            onClick={() => void refetch()}
+            className="text-[10px] text-ink-muted hover:text-ink-base transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      )}
 
       {!isLoading && !error && visible.length > VISIBLE_LIMIT && (
         <div className="text-[11px] text-ink-muted mb-2">
@@ -115,7 +138,7 @@ export function Audit(): JSX.Element {
                 </tr>
               )}
               {visibleSlice.map((r) => (
-                <tr key={`${r.ts}-${r.tool}-${r.target}`} className="border-t border-border-subtle">
+                <tr key={r.id} className="border-t border-border-subtle">
                   <td className="p-2 tabular-nums">
                     {new Date(r.ts).toLocaleString(undefined, {
                       month: 'short',
@@ -125,16 +148,29 @@ export function Audit(): JSX.Element {
                     })}
                   </td>
                   <td className="p-2">{r.tool}</td>
-                  <td className="p-2 font-mono text-[11px]">{r.target}</td>
+                  <td className="p-2 font-mono text-[11px] break-all" title={r.target}>
+                    {r.target}
+                  </td>
                   <td className="p-2">
                     <Pill
                       tone={r.severity ? (SEVERITY_TONE[r.severity] ?? 'neutral') : 'neutral'}
                       size="sm"
                     >
-                      {FILTERS.find((f) => f.key === r.classification)?.label ?? r.classification}
+                      {CLASSIFICATION_LABELS[r.classification] ?? r.classification}
                     </Pill>
                   </td>
-                  <td className="p-2 text-ink-subtle">{r.sessionId ?? '—'}</td>
+                  <td className="p-2 text-ink-subtle">
+                    {r.sessionId ? (
+                      <Link
+                        href={`/sessions?session=${encodeURIComponent(r.sessionId)}`}
+                        className="text-accent-cyan hover:underline transition-colors duration-150"
+                      >
+                        {r.sessionId}
+                      </Link>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/src/web/views/History.test.tsx
+++ b/src/web/views/History.test.tsx
@@ -198,6 +198,19 @@ const SAMPLE_COLLAB_SINGLE_DEV = {
   developerCount: 1,
 };
 
+// The backend `correctionRate` dimension is a correction-free score — higher
+// means fewer corrections were needed. A developer who needs fewer
+// corrections than their team has a HIGHER correctionRate than the team, so
+// this fixture's positive teamDeltas.correctionRate represents a developer
+// with a lower (better) real-world correction rate than their team.
+const SAMPLE_COLLAB_FEWER_CORRECTIONS = {
+  classification: 'Power User',
+  dimensions: { specificity: 0.7, autonomy: 0.65, correctionRate: 0.88, taskComplexity: 0.6 },
+  sessionCount: 20,
+  teamDeltas: { specificity: 0.02, autonomy: 0.01, correctionRate: 0.15, taskComplexity: 0.03 },
+  developerCount: 5,
+};
+
 interface FetchOverrides {
   outcome?: unknown;
   coach?: unknown;
@@ -561,6 +574,23 @@ describe('History view', () => {
     expect(screen.queryByText(/no team data yet/i)).not.toBeInTheDocument();
   });
 
+  it('renders the correction-rate delta in the "better" color when the developer corrects less than their team', async () => {
+    renderHistory({ collabProfile: SAMPLE_COLLAB_FEWER_CORRECTIONS });
+    await waitFor(() => expect(screen.getByText('Power User')).toBeInTheDocument());
+    // "Correction-free rate" also appears as a Y-axis tick label inside the
+    // SVG chart above the delta list; only the label in the delta row itself
+    // has a sibling "% vs team" span, so filter to that row.
+    const row = screen
+      .getAllByText(/Correction-free rate/)
+      .map((el) => el.closest('div'))
+      .find((el) => el && within(el).queryByText(/vs team/) !== null);
+    expect(row).toBeTruthy();
+    const deltaEl = within(row!).getByText(/vs team/);
+    expect(deltaEl.className).toContain('text-accent-green');
+    expect(deltaEl.className).not.toContain('text-accent-amber');
+    expect(within(row!).getByText(/\(higher = better\)/)).toBeInTheDocument();
+  });
+
   it('shows a no-team-data caveat on CollaborationProfilePanel when developerCount is 1', async () => {
     renderHistory({ collabProfile: SAMPLE_COLLAB_SINGLE_DEV });
     await waitFor(() => expect(screen.getByText('Power User')).toBeInTheDocument());
@@ -582,6 +612,71 @@ describe('History view', () => {
                 week: '2026-05-05',
                 avgEfficiencyScore: 0.91,
                 totalCostUsd: 12.75,
+                antiPatternCounts: {},
+              },
+            ]),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        );
+      }
+      return null;
+    };
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    globalThis.fetch = ((url: string) => {
+      const override = fetchOverrides(url);
+      if (override) return override;
+      if (url.startsWith('/api/cost-per-outcome')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_OUTCOME), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/personal-coach')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_COACH_OK), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.startsWith('/api/sessions')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(SAMPLE_SESSIONS), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('null', { status: 200 }));
+    }) as typeof globalThis.fetch;
+    render(
+      <QueryClientProvider client={qc}>
+        <History />
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getAllByText(/no anti-patterns detected/i).length).toBeGreaterThanOrEqual(1),
+    );
+  });
+
+  it('skips the anti-pattern panel chart when multiple loaded weeks all have zero anti-patterns', async () => {
+    const fetchOverrides = (url: string) => {
+      if (url.startsWith('/api/weekly')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                week: '2026-05-05',
+                avgEfficiencyScore: 0.91,
+                totalCostUsd: 12.75,
+                antiPatternCounts: {},
+              },
+              {
+                week: '2026-05-12',
+                avgEfficiencyScore: 0.88,
+                totalCostUsd: 10.5,
                 antiPatternCounts: {},
               },
             ]),
@@ -1075,7 +1170,7 @@ describe('History data helpers', () => {
   });
 
   describe('buildAntiPatternSeries', () => {
-    it('sums anti-pattern counts per week and skips weeks with zero', () => {
+    it('sums anti-pattern counts per week and zero-fills weeks with none', () => {
       const out = buildAntiPatternSeries([
         {
           week: '2026-04-21',
@@ -1099,18 +1194,21 @@ describe('History data helpers', () => {
       ]);
       // Keep the full ISO date in chart data so cross-year ticks
       // remain unique; the XAxis tickFormatter shortens to MM-DD on render.
+      // The zero-count week stays in the series (like padDailyCostWindow's
+      // zero-fill) so the chart's x-axis reflects a continuous timeline.
       expect(out).toEqual([
         { week: '2026-04-21', count: 3 },
         { week: '2026-04-28', count: 3 },
+        { week: '2026-05-05', count: 0 },
         { week: '2026-05-12', count: 4 },
       ]);
     });
 
-    it('treats missing antiPatternCounts as empty', () => {
+    it('treats missing antiPatternCounts as a zero-count week', () => {
       const out = buildAntiPatternSeries([
         { week: '2026-05-05', avgEfficiencyScore: 0.9, totalCostUsd: 10, antiPatternCounts: {} },
       ]);
-      expect(out).toEqual([]);
+      expect(out).toEqual([{ week: '2026-05-05', count: 0 }]);
     });
 
     it('returns an empty array when given no weeks', () => {
@@ -1229,7 +1327,7 @@ describe('History helpers with real API data shapes', () => {
       expect(out[0].week).toBe('2026-W22');
     });
 
-    it('handles empty antiPatternCounts (skips the week)', () => {
+    it('handles empty antiPatternCounts (zero-fills the week)', () => {
       const out = buildAntiPatternSeries([
         {
           week: '2026-W22',
@@ -1238,7 +1336,7 @@ describe('History helpers with real API data shapes', () => {
           antiPatternCounts: {},
         },
       ]);
-      expect(out).toEqual([]);
+      expect(out).toEqual([{ week: '2026-W22', count: 0 }]);
     });
   });
 
@@ -1345,6 +1443,31 @@ describe('aggregateModelPerformance', () => {
     expect(result[0].costPerMillionTokens).toBeCloseTo(9.0);
   });
 
+  it('excludes a session with explicit zero token counts but real cost from costPerMillionTokens', () => {
+    const sessions = [
+      {
+        sessionId: 's1',
+        model: 'claude-opus-4-6',
+        estimatedCostUsd: 9.0,
+        tokensInput: 800_000,
+        tokensOutput: 200_000,
+      },
+      // Reports a real cost but the schema's non-null token defaults happen
+      // to both be 0 (e.g. a token-count write failure) — a null-check
+      // guard would treat this as "has tokens" and let the cost inflate the
+      // blended rate above the true 9.0.
+      {
+        sessionId: 's2-zero-tokens',
+        model: 'claude-opus-4-6',
+        estimatedCostUsd: 5.0,
+        tokensInput: 0,
+        tokensOutput: 0,
+      },
+    ];
+    const result = aggregateModelPerformance(sessions);
+    expect(result[0].costPerMillionTokens).toBeCloseTo(9.0);
+  });
+
   it('flags models that have sessions below 85% success rate', () => {
     const sessions = [
       { sessionId: 's1', model: 'claude-opus-4-6', toolSuccessRate: 0.95 },
@@ -1353,6 +1476,58 @@ describe('aggregateModelPerformance', () => {
     ];
     const result = aggregateModelPerformance(sessions);
     expect(result[0].flagged).toBe(true);
+  });
+
+  it('does not flag a model when only a small proportion of its many sessions have low success', () => {
+    const sessions = [
+      { sessionId: 's1', model: 'claude-opus-4-6', toolSuccessRate: 0.6 },
+      ...Array.from({ length: 49 }, (_, i) => ({
+        sessionId: `s${i + 2}`,
+        model: 'claude-opus-4-6',
+        toolSuccessRate: 0.95,
+      })),
+    ];
+    const result = aggregateModelPerformance(sessions);
+    expect(result[0].sessions).toBe(50);
+    expect(result[0].flagged).toBe(false);
+  });
+
+  it('flags a model when a large proportion of a small sample has low success', () => {
+    const sessions = [
+      { sessionId: 's1', model: 'claude-opus-4-6', toolSuccessRate: 0.5 },
+      { sessionId: 's2', model: 'claude-opus-4-6', toolSuccessRate: 0.95 },
+    ];
+    const result = aggregateModelPerformance(sessions);
+    expect(result[0].sessions).toBe(2);
+    expect(result[0].flagged).toBe(true);
+  });
+
+  it('flags a model based on the proportion of measured sessions with low success, not the proportion of all sessions', () => {
+    const sessions = [
+      { sessionId: 's1', model: 'claude-opus-4-6', toolSuccessRate: 0.5 },
+      { sessionId: 's2', model: 'claude-opus-4-6', toolSuccessRate: 0.6 },
+      // These sessions have no recorded success rate at all — they must not
+      // dilute the flagged proportion, which is a fraction of measured
+      // sessions only.
+      ...Array.from({ length: 8 }, (_, i) => ({
+        sessionId: `s${i + 3}`,
+        model: 'claude-opus-4-6',
+      })),
+    ];
+    const result = aggregateModelPerformance(sessions);
+    expect(result[0].sessions).toBe(10);
+    expect(result[0].avgSuccessRate).toBeCloseTo(0.55);
+    expect(result[0].flagged).toBe(true);
+  });
+
+  it('does not flag a model with no measured sessions', () => {
+    const sessions = [
+      { sessionId: 's1', model: 'claude-opus-4-6' },
+      { sessionId: 's2', model: 'claude-opus-4-6' },
+    ];
+    const result = aggregateModelPerformance(sessions);
+    expect(result[0].avgSuccessRate).toBeNull();
+    expect(result[0].flagged).toBe(false);
   });
 
   it('returns empty array for empty input', () => {

--- a/src/web/views/History.tsx
+++ b/src/web/views/History.tsx
@@ -380,7 +380,7 @@ export function History(): JSX.Element {
         </Panel>
 
         <Panel title="Anti-Pattern Frequency · Weekly">
-          {antiPatternSeries.length === 0 ? (
+          {antiPatternSeries.length === 0 || antiPatternSeries.every((d) => d.count === 0) ? (
             <EmptyState
               icon="checkmark"
               title="No anti-patterns detected"
@@ -952,6 +952,7 @@ function CollaborationProfilePanel({
       value: Math.round(data.dimensions.specificity * 100),
       delta: data.teamDeltas.specificity,
       lowerIsBetter: false,
+      note: '',
     },
     {
       name: 'Autonomy',
@@ -959,13 +960,19 @@ function CollaborationProfilePanel({
       value: Math.round(data.dimensions.autonomy * 100),
       delta: data.teamDeltas.autonomy,
       lowerIsBetter: false,
+      note: '',
     },
     {
-      name: 'Correction rate',
+      // The backend dimension is a correction-free score — higher means
+      // fewer corrections were needed — so the label spells that out
+      // directly instead of reading as a raw "rate of corrections" (which
+      // would suggest the opposite direction).
+      name: 'Correction-free rate',
       key: 'correctionRate',
       value: Math.round(data.dimensions.correctionRate * 100),
       delta: data.teamDeltas.correctionRate,
-      lowerIsBetter: true,
+      lowerIsBetter: false,
+      note: ' (higher = better)',
     },
     {
       name: 'Task complexity',
@@ -973,6 +980,7 @@ function CollaborationProfilePanel({
       value: Math.round(data.dimensions.taskComplexity * 100),
       delta: data.teamDeltas.taskComplexity,
       lowerIsBetter: false,
+      note: '',
     },
   ];
   return (
@@ -1022,7 +1030,7 @@ function CollaborationProfilePanel({
           const color =
             d.delta === 0 ? 'text-ink-muted' : positive ? 'text-accent-green' : 'text-accent-amber';
           const sign = d.delta > 0 ? '+' : d.delta < 0 ? '-' : '';
-          const note = d.lowerIsBetter ? ' (lower = better)' : '';
+          const note = d.lowerIsBetter ? ' (lower = better)' : d.note;
           return (
             <div key={d.key} className="flex items-center justify-between text-[10px]">
               <span className="text-ink-muted">
@@ -1185,9 +1193,7 @@ export function buildAntiPatternSeries(weeks: WeeklyRow[]): Array<{ week: string
   for (const w of weeks) {
     const counts = w.antiPatternCounts ?? {};
     const total = Object.values(counts).reduce((a, b) => a + b, 0);
-    if (total > 0) {
-      out.push({ week: w.week || '?', count: total });
-    }
+    out.push({ week: w.week || '?', count: total });
   }
   return out;
 }
@@ -1210,6 +1216,10 @@ export interface ModelPerformanceRow {
 }
 
 const FLAGGED_SUCCESS_THRESHOLD = 0.85;
+// A single low-success session shouldn't carry the same visual weight for a
+// model with 50 sessions as it does for a model with 2 — flag a model only
+// once a meaningful share of its sessions fall below FLAGGED_SUCCESS_THRESHOLD.
+const FLAGGED_LOW_SUCCESS_PROPORTION = 0.3;
 
 export function aggregateModelPerformance(rows: SessionRow[]): ModelPerformanceRow[] {
   const byModel = new Map<
@@ -1264,10 +1274,14 @@ export function aggregateModelPerformance(rows: SessionRow[]): ModelPerformanceR
       // Only blend cost and tokens from the same session — a live session row
       // can carry a cost before its token counts have been persisted, which
       // would otherwise inflate costPerMillionTokens by counting cost against
-      // fewer tokens than were actually spent.
-      if (r.tokensInput != null || r.tokensOutput != null) {
+      // fewer tokens than were actually spent. The schema guarantees non-null
+      // token defaults, so guard on an actual positive token count rather
+      // than null-ness (a session with real cost but zero recorded tokens
+      // would otherwise pass the null check and inflate the blended rate).
+      const sessionTokens = (r.tokensInput ?? 0) + (r.tokensOutput ?? 0);
+      if (sessionTokens > 0) {
         entry.blendedCostSum += r.estimatedCostUsd;
-        entry.blendedTokensSum += (r.tokensInput ?? 0) + (r.tokensOutput ?? 0);
+        entry.blendedTokensSum += sessionTokens;
       }
     }
   }
@@ -1282,7 +1296,9 @@ export function aggregateModelPerformance(rows: SessionRow[]): ModelPerformanceR
       avgCost: e.costCount > 0 ? e.costSum / e.costCount : null,
       costPerMillionTokens:
         e.blendedTokensSum > 0 ? (e.blendedCostSum / e.blendedTokensSum) * 1_000_000 : null,
-      flagged: e.lowSuccessSessions > 0,
+      flagged:
+        e.successCount > 0 &&
+        e.lowSuccessSessions / e.successCount > FLAGGED_LOW_SUCCESS_PROPORTION,
     });
   }
 

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -776,6 +776,187 @@ describe('Today view', () => {
     expect(screen.queryByText(/subagent cost tracking is disabled/i)).toBeNull();
     expect(screen.queryByText(/subagent activity from other sessions/i)).toBeNull();
   });
+
+  it('keeps the ForecastEodCard parent+subagent breakdown summing to the displayed total even when the page-wide todayTotal/subagentUsd would disagree', async () => {
+    // A fresh live SSE subagent tick (todaySubagentUsd) has landed while the
+    // SSE total-spend push is stale-low and the polled aggregate hasn't
+    // caught up to that subagent tick either. Maxing todayTotal and
+    // subagentUsd independently across their own, different endpoint pairs
+    // would let subagentUsd (15) exceed todayTotal (10), clamping "parent"
+    // to $0 even though aggregate.totalCostUsd (10) and aggregate.subagentUsd
+    // (8) — sourced together in one request — agree that parent is $2.
+    useLiveStore.setState({
+      cost: { sessionTotalUsd: 3, todayTotalUsd: 5, forecastEodUsd: 20 },
+      todaySubagentUsd: 15,
+      todaySubagentTurnCount: 3,
+    });
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(
+          JSON.stringify({ totalCostUsd: 10, subagentUsd: 8, forecastEndOfDayUsd: 20 }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions?limit=')) {
+        return new Response(
+          JSON.stringify([
+            {
+              sessionId: 's1',
+              startTime: Date.now() - 60_000,
+              estimatedCostUsd: 5,
+              toolCallCount: 3,
+            },
+          ]),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+
+    // All four assertions must hold together in the same settled render —
+    // splitting them across separate waitFor/synchronous checks risks
+    // observing a transitional DOM state where only some values have
+    // committed.
+    await waitFor(() => {
+      expect(screen.getByText(/parent \$2\.00/)).toBeInTheDocument();
+      expect(screen.getByText(/subagent \$8\.00/)).toBeInTheDocument();
+      // Must never clamp "parent" to $0 just because the page-wide
+      // todayTotal/subagentUsd picked different underlying sources.
+      expect(screen.queryByText(/parent \$0\.00/)).toBeNull();
+      // parent ($2.00) + subagent ($8.00) sums to the $10.00 the "spend today"
+      // KPI shows for the same aggregate-sourced total.
+      const spendTile = screen.getByText('spend today').closest('.px-1') as HTMLElement;
+      expect(within(spendTile).getByText('$10.00')).toBeInTheDocument();
+    });
+  });
+
+  it('does not let a legitimate zero from the aggregate override the forecast breakdown total when other sources already know about real spend', async () => {
+    // The aggregate endpoint can legitimately resolve to 0 while its
+    // disk-only sources haven't yet seen any events from today, even though
+    // the SSE push and a persisted session both already know about real
+    // spend. The Forecast card's breakdown must still be computed against
+    // that already-higher total, not the aggregate's zero, or it would
+    // contradict the "spend today" KPI shown directly above it.
+    useLiveStore.setState({
+      cost: { sessionTotalUsd: 8, todayTotalUsd: 8, forecastEodUsd: 12 },
+      todaySubagentUsd: 2,
+      todaySubagentTurnCount: 1,
+    });
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(JSON.stringify({ totalCostUsd: 0, subagentUsd: 0 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/sessions?limit=')) {
+        return new Response(
+          JSON.stringify([
+            {
+              sessionId: 's1',
+              startTime: Date.now() - 60_000,
+              estimatedCostUsd: 6,
+              toolCallCount: 3,
+            },
+          ]),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+
+    // All assertions must hold together in the same settled render — see
+    // the sibling test above for why these aren't split across separate
+    // waitFor/synchronous checks.
+    await waitFor(() => {
+      const spendTile = screen.getByText('spend today').closest('.px-1') as HTMLElement;
+      expect(within(spendTile).getByText('$8.00')).toBeInTheDocument();
+      expect(screen.getByText(/parent \$6\.00/)).toBeInTheDocument();
+      expect(screen.getByText(/subagent \$2\.00/)).toBeInTheDocument();
+      expect(screen.queryByText(/parent \$0\.00/)).toBeNull();
+      expect(screen.queryByText(/parent \$8\.00/)).toBeNull();
+    });
+  });
+
+  it('folds the /api/cost REST fallback into todayTotal so the KPI does not flash $0.00 before the first SSE frame arrives', async () => {
+    // No SSE cost frame has arrived yet, and the aggregate endpoint has
+    // legitimately resolved to 0 (no disk-backed data yet from this
+    // process) — only the /api/cost REST payload has this session's actual
+    // today-scoped spend.
+    useLiveStore.setState({ cost: null });
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url === '/api/cost') {
+        return new Response(
+          JSON.stringify({ cost: { sessionTotalCostUsd: 7 }, forecast: null, sessionTodayUsd: 7 }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(JSON.stringify({ totalCostUsd: 0 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+
+    await waitFor(() => {
+      const spendTile = screen.getByText('spend today').closest('.px-1') as HTMLElement;
+      expect(within(spendTile).getByText('$7.00')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/No activity yet today/)).toBeNull();
+  });
+
+  it('falls back to the /api/cost REST forecast when neither SSE nor the aggregate has one', async () => {
+    useLiveStore.setState({ cost: null });
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url === '/api/cost') {
+        return new Response(
+          JSON.stringify({
+            cost: { sessionTotalCostUsd: 5 },
+            forecast: { forecastEndOfDayUsd: 12 },
+            sessionTodayUsd: 5,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url.includes('/api/sessions/today/aggregate')) {
+        return new Response(JSON.stringify({ totalCostUsd: 5 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+
+    await waitFor(() => expect(screen.getByText('$12.00')).toBeInTheDocument());
+    // delta = 12 - 5 = 7
+    expect(screen.getByText(/\+\$7\.00/)).toBeInTheDocument();
+  });
 });
 
 describe('Today view — empty state', () => {

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -181,9 +181,10 @@ export function Today(): JSX.Element {
     refetchInterval: 30_000,
   });
 
-  const { isPending: costPending } = useQuery<CostApiResponse>({
+  const { data: costApi, isPending: costPending } = useQuery<CostApiResponse>({
     queryKey: qk.cost,
     queryFn: fetchCost,
+    refetchInterval: 10_000,
   });
   const { data: aggregate, isPending: aggregatePending } = useQuery<TodayAggregateResponse>({
     queryKey: qk.sessionsTodayAggregate,
@@ -248,7 +249,11 @@ export function Today(): JSX.Element {
   // disk-only data sources see no events from today (e.g., the live
   // session's events are in the in-memory tool-call buffer of a different
   // MCP, not in any drained buffer-*.jsonl file). Matches the spend +
-  // flags formulas just below.
+  // flags formulas just below. `costApi?.sessionTodayUsd` (the REST
+  // fallback for this process's own today-scoped spend) is folded in
+  // alongside the SSE and aggregate sources so the KPI reflects real spend
+  // as soon as any one source resolves, instead of waiting on the first SSE
+  // frame while the aggregate still legitimately reads 0.
   const calls = Math.max(aggregate?.toolCallCount ?? 0, persistedTodayCalls);
   const spendLoading =
     (costPending || sessionsPending || aggregatePending) &&
@@ -259,6 +264,7 @@ export function Today(): JSX.Element {
     cost?.todayTotalUsd ?? 0,
     aggregate?.totalCostUsd ?? 0,
     persistedTodaySpend,
+    costApi?.sessionTodayUsd ?? 0,
   );
 
   // Aggregate flags = anti-patterns from every live + persisted session today.
@@ -282,6 +288,24 @@ export function Today(): JSX.Element {
   // Distinguish "no data yet" (aggregate still loading and no live ticks) from
   // a genuine zero so the KPI shows the em-dash empty state instead of $0.00.
   const subagentHasData = aggregate !== undefined || subagentStats.turns > 0;
+  // The Forecast card's parent/subagent breakdown must always sum to the
+  // total it displays. aggregate.totalCostUsd and aggregate.subagentUsd come
+  // from the same request and are guaranteed consistent (subagent cost is
+  // already a subset of total cost by construction), whereas todayTotal and
+  // subagentUsd above are each independently maxed across sources that don't
+  // share that guarantee (e.g. a live SSE subagent tick can outrun a
+  // stale-low SSE/aggregate total). Prefer the aggregate's own pair for the
+  // breakdown, but only when the aggregate is actually the dominant source —
+  // aggregate.totalCostUsd can legitimately read 0 while a fresher SSE/REST
+  // source already knows about real spend (its disk-only sources see no
+  // events from today yet), and switching to the aggregate pair in that case
+  // would present a stale-zero breakdown under an already-higher KPI. When
+  // the aggregate isn't dominant, fall back to the independently-maxed
+  // page-wide values instead.
+  const forecastBreakdownTotalUsd =
+    aggregate && aggregate.totalCostUsd >= todayTotal ? aggregate.totalCostUsd : todayTotal;
+  const forecastBreakdownSubagentUsd =
+    aggregate && aggregate.totalCostUsd >= todayTotal ? (aggregate.subagentUsd ?? 0) : subagentUsd;
   const [headerTimestamp, setHeaderTimestamp] = useState(() =>
     new Date().toLocaleString(undefined, HEADER_TIMESTAMP_FORMAT),
   );
@@ -418,14 +442,17 @@ export function Today(): JSX.Element {
 
           <AnimatedCard index={1} className="grid grid-cols-2 gap-3 mb-3">
             <ForecastEodCard
-              todayTotal={todayTotal}
+              todayTotal={forecastBreakdownTotalUsd}
               forecastEod={
                 spendLoading
                   ? null
-                  : (cost?.forecastEodUsd ?? aggregate?.forecastEndOfDayUsd ?? null)
+                  : (cost?.forecastEodUsd ??
+                    aggregate?.forecastEndOfDayUsd ??
+                    costApi?.forecast?.forecastEndOfDayUsd ??
+                    null)
               }
               hourlySpend={hourlySpend}
-              subagentUsd={subagentUsd}
+              subagentUsd={forecastBreakdownSubagentUsd}
             />
             {concurrency && concurrency.buckets && (
               <ConcurrencyIndicator
@@ -1644,9 +1671,10 @@ function ForecastEodCard({
   const delta = hasForecast ? effectiveForecast - todayTotal : 0;
   const pct = hasForecast && todayTotal > 0 ? (delta / todayTotal) * 100 : 0;
   const hasSpend = hourlySpend.some((h) => h.cost > 0);
-  // todayTotal and subagentUsd are each a Math.max over different endpoints, so
-  // the subtraction can momentarily go negative when they pick different
-  // sources; clamp to 0 (the server clamps its own parentUsd the same way).
+  // The caller passes todayTotal/subagentUsd from the same source whenever
+  // possible, so subagentUsd is normally guaranteed <= todayTotal. Clamp to 0
+  // defensively anyway (the server clamps its own parentUsd the same way) for
+  // the brief window before that shared source has resolved.
   const parentUsd = subagentUsd > 0 ? Math.max(0, todayTotal - subagentUsd) : 0;
 
   return (


### PR DESCRIPTION
## Summary

Final release of the 5-release dashboard-audit series. This closes out the entire audit epic.

- **Audit page**: classification label for the routine/"other" case, auto-refresh + retry, sessionId deep-link to Sessions, a stable per-entry ID fixing a React key collision risk, and target-cell wrapping/tooltip for long values.
- **History page**: zero-filled weekly anti-pattern series (with the empty state preserved when every week is zero), a cost-per-token guard no longer inflated by zero-token sessions, a sample-size-aware "elevated error rate" flag, a fixed sign-inversion in the Collaboration Profile's "Correction rate" delta coloring (plus a relabel to match its actual direction), and a sample-size gate on Personal Coach's week-over-week language.
- **Today page**: the Forecast card's parent/subagent breakdown now always sums to the displayed total, Cache Health's week-over-week delta now uses the same today-scoped rate as its headline, and the `/api/cost` REST response now feeds the same fallback chains the SSE/aggregate sources do.

A final whole-branch review found and fixed 5 additional issues that only surfaced at cross-task/integration scope, plus a flaky test found during final verification (fixed and confirmed clean across 10+ repeated full-suite runs).

Fixes #370
Fixes #377
Fixes #380
Fixes #397
Fixes #398
Fixes #400
Fixes #405
Fixes #407
Fixes #428
Fixes #431
Fixes #432
Fixes #433
Fixes #434

## Test plan

- [x] `npm test` (Jest) — 5471 passing, 3 pre-existing skips, 0 failures
- [x] Vitest suite — 515/515 passing, verified clean across multiple repeated full-suite runs
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors/warnings