### PR TITLE
Fix #381: activity heatmap uses browser timezone, not the server's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.41] - 2026-08-11
+
+### Fixed
+
+- **The "Activity Today" heatmap now uses the viewing browser's timezone instead of the dashboard server's**, so its day boundary agrees with the rest of the page even when the server and browser run in different timezones (a cloud-hosted or containerized dashboard, or a dev box viewed from a different region). Applies to both the "today" and "history" views of the heatmap.
+
 ## [1.14.40] - 2026-08-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -5998,6 +5998,198 @@ describe('api-handler GET /api/activity-heatmap', () => {
     expect(todayEntry?.count).toBe(5);
   });
 
+  it("uses the tz query param, not the server process's own timezone, for view=today", async () => {
+    jest.useFakeTimers();
+    try {
+      const now = Date.UTC(2026, 5, 10, 12, 0, 0);
+      jest.setSystemTime(now);
+
+      // Asia/Kolkata (UTC+5:30), computed via the same shared helper the
+      // route itself calls, so this test is not tied to any one host
+      // timezone. Guard against a vacuous scenario by checking Kolkata
+      // against an explicit UTC computation — not against "whatever this
+      // test process's own default timezone happens to be" (that would
+      // itself go vacuous, and wrongly fail this guard, if the suite ever
+      // ran with TZ=Asia/Kolkata or an equal-offset zone like Asia/Colombo).
+      const kolkataStart = localStartOfDay(now, 'Asia/Kolkata');
+      expect(kolkataStart).not.toBe(localStartOfDay(now, 'UTC'));
+      const defaultStart = localStartOfDay(now);
+
+      const recordTs = kolkataStart + 60_000;
+      const handler = createApiHandler({
+        toolCallBuffer: {
+          getRecords: () =>
+            [
+              {
+                id: 'r1',
+                sessionId: 's1',
+                toolName: 'Read',
+                toolUseId: 't1',
+                timestamp: recordTs,
+                durationMs: 10,
+                success: true,
+              },
+            ] as unknown as ReturnType<
+              NonNullable<Parameters<typeof createApiHandler>[0]['toolCallBuffer']>['getRecords']
+            >,
+        },
+        sessionStore: {
+          loadTodaySessions: () => [],
+          loadAllSessions: () => [],
+          listSessions: () => [],
+          loadSession: () => null,
+        } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      });
+
+      const reqWithTz = {
+        method: 'GET',
+        url: '/api/activity-heatmap?view=today&tz=Asia%2FKolkata',
+      } as IncomingMessage;
+      const { res: resWithTz, status: statusWithTz, body: bodyWithTz } = fakeRes();
+      await handler(reqWithTz, resWithTz);
+      expect(statusWithTz()).toBe(200);
+      const resultWithTz = JSON.parse(bodyWithTz());
+      expect(resultWithTz.startTimestamp).toBe(kolkataStart);
+      expect((resultWithTz.buckets as number[]).reduce((sum, n) => sum + n, 0)).toBe(1);
+
+      const reqWithoutTz = {
+        method: 'GET',
+        url: '/api/activity-heatmap?view=today',
+      } as IncomingMessage;
+      const { res: resNoTz, status: statusNoTz, body: bodyNoTz } = fakeRes();
+      await handler(reqWithoutTz, resNoTz);
+      expect(statusNoTz()).toBe(200);
+      const resultNoTz = JSON.parse(bodyNoTz());
+      expect(resultNoTz.startTimestamp).toBe(defaultStart);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("uses the tz query param, not the server process's own timezone, for view=history day-keying", async () => {
+    jest.useFakeTimers();
+    try {
+      const now = Date.UTC(2026, 5, 10, 12, 0, 0);
+      jest.setSystemTime(now);
+
+      const kolkataStart = localStartOfDay(now, 'Asia/Kolkata');
+      // See the view=today test above for why this guards against UTC
+      // specifically rather than against this process's own default tz.
+      expect(kolkataStart).not.toBe(localStartOfDay(now, 'UTC'));
+
+      const entryTs = kolkataStart + 60_000;
+      const kolkataKey = localDateKey(entryTs, 'Asia/Kolkata');
+      const defaultKey = localDateKey(entryTs);
+      const handler = createApiHandler({
+        sessionStore: {
+          loadTodaySessions: () => [],
+          loadAllSessions: () => [
+            {
+              startTime: entryTs,
+              toolCallCount: 1,
+              timeline: [{ timestamp: entryTs }],
+            },
+          ],
+          listSessions: () => [],
+          loadSession: () => null,
+        } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      });
+
+      const reqWithTz = {
+        method: 'GET',
+        url: '/api/activity-heatmap?view=history&weeks=1&tz=Asia%2FKolkata',
+      } as IncomingMessage;
+      const { res: resWithTz, status: statusWithTz, body: bodyWithTz } = fakeRes();
+      await handler(reqWithTz, resWithTz);
+      expect(statusWithTz()).toBe(200);
+      const resultWithTz = JSON.parse(bodyWithTz());
+      const kolkataDay = (resultWithTz.days as Array<{ date: string; count: number }>).find(
+        (d) => d.date === kolkataKey,
+      );
+      expect(kolkataDay?.count).toBe(1);
+
+      const reqWithoutTz = {
+        method: 'GET',
+        url: '/api/activity-heatmap?view=history&weeks=1',
+      } as IncomingMessage;
+      const { res: resNoTz, status: statusNoTz, body: bodyNoTz } = fakeRes();
+      await handler(reqWithoutTz, resNoTz);
+      expect(statusNoTz()).toBe(200);
+      const resultNoTz = JSON.parse(bodyNoTz());
+      const defaultDay = (resultNoTz.days as Array<{ date: string; count: number }>).find(
+        (d) => d.date === defaultKey,
+      );
+      expect(defaultDay?.count).toBe(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("falls back to the server's own timezone (200, not 500) when tz is not a recognized IANA name", async () => {
+    // Intl.DateTimeFormat throws a RangeError on an unrecognized timeZone —
+    // reachable without any client bug via ICU version skew between the
+    // browser and this server's Node/ICU. That must degrade to the default
+    // behavior for the whole panel, not surface as a 500.
+    jest.useFakeTimers();
+    try {
+      const now = Date.UTC(2026, 5, 10, 12, 0, 0);
+      jest.setSystemTime(now);
+      const handler = createApiHandler({
+        toolCallBuffer: { getRecords: () => [] },
+        sessionStore: {
+          loadTodaySessions: () => [],
+          loadAllSessions: () => [],
+          listSessions: () => [],
+          loadSession: () => null,
+        } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      });
+      const req = {
+        method: 'GET',
+        url: '/api/activity-heatmap?view=today&tz=Not%2FARealZone',
+      } as IncomingMessage;
+      const { res, status, body } = fakeRes();
+      await handler(req, res);
+      expect(status()).toBe(200);
+      expect(JSON.parse(body()).startTimestamp).toBe(localStartOfDay(now));
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('trims whitespace from tz before validating and forwarding it', async () => {
+    jest.useFakeTimers();
+    try {
+      const now = Date.UTC(2026, 5, 10, 12, 0, 0);
+      jest.setSystemTime(now);
+      const kolkataStart = localStartOfDay(now, 'Asia/Kolkata');
+
+      const handler = createApiHandler({
+        toolCallBuffer: { getRecords: () => [] },
+        sessionStore: {
+          loadTodaySessions: () => [],
+          loadAllSessions: () => [],
+          listSessions: () => [],
+          loadSession: () => null,
+        } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      });
+      // Leading space (`%20`) is inside the emptiness check but must not
+      // survive into what's actually forwarded to localStartOfDay — a
+      // space-padded IANA name would otherwise fail Intl.DateTimeFormat's
+      // validation and silently fall back to the server's own timezone
+      // instead of Kolkata.
+      const req = {
+        method: 'GET',
+        url: '/api/activity-heatmap?view=today&tz=%20Asia%2FKolkata',
+      } as IncomingMessage;
+      const { res, status, body } = fakeRes();
+      await handler(req, res);
+      expect(status()).toBe(200);
+      expect(JSON.parse(body()).startTimestamp).toBe(kolkataStart);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('returns 400 invalid_view for an unrecognized view param', async () => {
     const handler = createApiHandler({});
     const req = { method: 'GET', url: '/api/activity-heatmap?view=bogus' } as IncomingMessage;

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -2228,19 +2228,34 @@ export function createApiHandler(
     try {
       const url = new URL(req.url ?? '/', 'http://localhost');
       const view = url.searchParams.get('view') ?? 'today';
+      // The browser sends its own IANA timezone (Intl.DateTimeFormat().
+      // resolvedOptions().timeZone) as `tz` — see fetchActivityHeatmap in
+      // src/web/api/client.ts. When present and recognized, `tz` is used
+      // instead of this dashboard *server* process's own OS/Intl timezone to
+      // draw the day boundary, so a cloud-hosted or containerized dashboard
+      // viewed from a different timezone than the server still buckets
+      // "today" the way the viewing browser expects. Falls back to the
+      // server's own timezone when `tz` is absent, blank, or not a name this
+      // server's ICU recognizes — Intl.DateTimeFormat throws a RangeError on
+      // an unrecognized IANA name, which can happen from ICU version skew
+      // alone (e.g. a browser reporting a newer alias like
+      // "America/Ciudad_Juarez" that this server's Node/ICU doesn't have),
+      // with no malice or client bug required; probing it here keeps that
+      // case a graceful fallback instead of a 500 for the whole panel.
+      const tzParam = url.searchParams.get('tz')?.trim();
+      let tz: string | undefined;
+      if (tzParam) {
+        try {
+          new Intl.DateTimeFormat('en-US', { timeZone: tzParam });
+          tz = tzParam;
+        } catch {
+          tz = undefined;
+        }
+      }
 
       if (view === 'today') {
-        // localStartOfDay() draws "today" using this dashboard *server*
-        // process's own OS/Intl timezone. The browser calls the same helper
-        // client-side (src/lib/date.ts) for its own "today" filtering, so
-        // this endpoint is only guaranteed to agree with the client when
-        // server and browser share a timezone — the common single-machine
-        // `--local`/`--stdio` deployment. A cloud-hosted or containerized
-        // dashboard viewed from a different timezone can see this bucket
-        // range anchored to the wrong midnight; neither side is ever
-        // told the other's offset today.
         const now = Date.now();
-        const startMs = localStartOfDay(now);
+        const startMs = localStartOfDay(now, tz);
         const bucketSizeMs = 900_000;
         const bucketCount = Math.ceil((now - startMs) / bucketSizeMs) || 1;
         const buckets = new Array<number>(bucketCount).fill(0);
@@ -2292,17 +2307,28 @@ export function createApiHandler(
         // developer's evening session commonly straddles UTC midnight, which
         // would otherwise land that activity on the wrong calendar day for
         // anyone not in UTC.
-        const todayStart = localStartOfDay();
-        const startDate = new Date(todayStart);
-        startDate.setDate(startDate.getDate() - weeks * 7);
+        const todayStart = localStartOfDay(undefined, tz);
 
-        const sessions = deps.sessionStore?.loadAllSessions?.({ since: startDate }) ?? [];
+        // Walk backward from today to the start of the window, one day at a
+        // time, snapping each step to that day's actual local midnight via
+        // localStartOfDay rather than subtracting a fixed 86_400_000ms — a
+        // local day can be 23h or 25h across a DST transition. Subtracting
+        // 12h before re-snapping is always enough to land within the
+        // previous day (the shortest possible local day is 23h) and never
+        // enough to skip past it (the longest is 25h).
+        const totalDays = weeks * 7;
+        const dayBoundaries = new Array<number>(totalDays + 1);
+        dayBoundaries[totalDays] = todayStart;
+        for (let i = totalDays - 1; i >= 0; i--) {
+          dayBoundaries[i] = localStartOfDay(dayBoundaries[i + 1] - 12 * 3_600_000, tz);
+        }
+        const startMs = dayBoundaries[0];
+
+        const sessions = deps.sessionStore?.loadAllSessions?.({ since: new Date(startMs) }) ?? [];
 
         const dayMap = new Map<string, number>();
-        const cursor = new Date(startDate);
-        while (cursor.getTime() <= todayStart) {
-          dayMap.set(localDateKey(cursor.getTime()), 0);
-          cursor.setDate(cursor.getDate() + 1);
+        for (const boundary of dayBoundaries) {
+          dayMap.set(localDateKey(boundary, tz), 0);
         }
 
         // Bucket by each timeline entry's own timestamp, mirroring the
@@ -2319,7 +2345,6 @@ export function createApiHandler(
         // start-day/toolCallCount attribution so that older history doesn't
         // silently drop to zero; only sessions that *do* have a timeline get
         // the per-entry walk.
-        const startMs = startDate.getTime();
         for (const s of sessions) {
           const session = s as {
             startTime?: number;
@@ -2329,7 +2354,7 @@ export function createApiHandler(
           if (session.timeline) {
             for (const entry of session.timeline) {
               if (entry.timestamp < startMs) continue;
-              const key = localDateKey(entry.timestamp);
+              const key = localDateKey(entry.timestamp, tz);
               if (dayMap.has(key)) {
                 dayMap.set(key, (dayMap.get(key) ?? 0) + 1);
               }
@@ -2337,7 +2362,7 @@ export function createApiHandler(
             continue;
           }
           if (!session.startTime || session.startTime < startMs) continue;
-          const key = localDateKey(session.startTime);
+          const key = localDateKey(session.startTime, tz);
           if (dayMap.has(key)) {
             dayMap.set(key, (dayMap.get(key) ?? 0) + (session.toolCallCount ?? 0));
           }

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -25,6 +25,104 @@ describe('localStartOfDay', () => {
     expect(start).toBeLessThanOrEqual(after);
     expect(new Date(start).getHours()).toBe(0);
   });
+
+  it('computes midnight in a given IANA tz with a non-whole-hour UTC offset', () => {
+    // Asia/Kolkata is UTC+5:30 year-round (no DST). Noon UTC on 2026-06-10 is
+    // 17:30 Kolkata time on the same calendar day, so Kolkata midnight for
+    // that day is 2026-06-09T18:30:00Z.
+    const noonUtc = Date.UTC(2026, 5, 10, 12, 0, 0);
+    const start = localStartOfDay(noonUtc, 'Asia/Kolkata');
+    expect(start).toBe(Date.UTC(2026, 5, 9, 18, 30, 0));
+  });
+
+  it('computes midnight in a given IANA tz across a spring-forward DST transition', () => {
+    // America/New_York springs forward on 2026-03-08 (02:00 -> 03:00 local),
+    // making that a 23h local day. A timestamp just after that day's local
+    // midnight must still resolve to that same day's midnight, not drift
+    // into the previous day because of the shortened day length.
+    // 2026-03-08T05:00:00Z = 00:00 EST (UTC-5, DST not yet in effect at
+    // midnight local time on transition day).
+    const justAfterMidnight = Date.UTC(2026, 2, 8, 5, 30, 0);
+    const start = localStartOfDay(justAfterMidnight, 'America/New_York');
+    expect(start).toBe(Date.UTC(2026, 2, 8, 5, 0, 0));
+
+    // The following day (2026-03-09) is a normal 24h day, now at UTC-4 (EDT).
+    const nextDayNoon = Date.UTC(2026, 2, 9, 16, 0, 0);
+    const nextDayStart = localStartOfDay(nextDayNoon, 'America/New_York');
+    expect(nextDayStart).toBe(Date.UTC(2026, 2, 9, 4, 0, 0));
+  });
+
+  it('computes midnight in a given IANA tz across a fall-back DST transition', () => {
+    // America/New_York falls back on 2026-11-01 (02:00 -> 01:00 local),
+    // making that a 25h local day.
+    // 2026-11-01T04:00:00Z = 00:00 EDT (UTC-4, DST still in effect at
+    // midnight local time on transition day).
+    const justAfterMidnight = Date.UTC(2026, 10, 1, 4, 30, 0);
+    const start = localStartOfDay(justAfterMidnight, 'America/New_York');
+    expect(start).toBe(Date.UTC(2026, 10, 1, 4, 0, 0));
+
+    // The following day (2026-11-02) is a normal 24h day, now at UTC-5 (EST).
+    const nextDayNoon = Date.UTC(2026, 10, 2, 17, 0, 0);
+    const nextDayStart = localStartOfDay(nextDayNoon, 'America/New_York');
+    expect(nextDayStart).toBe(Date.UTC(2026, 10, 2, 5, 0, 0));
+  });
+
+  it('resolves to the first instant of the target day, not the previous day, for zones that spring forward at or near midnight', () => {
+    // These three zones spring forward exactly at (or immediately touching)
+    // local midnight, so local midnight itself doesn't exist on the
+    // transition day — the day instead begins at the first instant after
+    // the gap. The offset re-read after the first correction belongs to the
+    // transition that skipped midnight, so applying it a second time without
+    // validation walks the candidate back onto the *previous* day.
+    //
+    // America/Havana springs forward 2026-03-08: 00:00 CST -> 01:00 CDT.
+    expect(localStartOfDay(Date.UTC(2026, 2, 8, 12), 'America/Havana')).toBe(
+      Date.UTC(2026, 2, 8, 5, 0, 0),
+    );
+    // America/Santiago springs forward 2026-09-06: 00:00 -04:00 -> 01:00 -03:00.
+    expect(localStartOfDay(Date.UTC(2026, 8, 6, 15), 'America/Santiago')).toBe(
+      Date.UTC(2026, 8, 6, 4, 0, 0),
+    );
+    // Atlantic/Azores springs forward 2026-03-29: 00:00 -01:00 -> 01:00 +00:00.
+    expect(localStartOfDay(Date.UTC(2026, 2, 29, 12), 'Atlantic/Azores')).toBe(
+      Date.UTC(2026, 2, 29, 1, 0, 0),
+    );
+  });
+});
+
+describe('localStartOfDay / localDateKey round-trip invariant', () => {
+  it('localDateKey(localStartOfDay(ts, tz), tz) always equals localDateKey(ts, tz)', () => {
+    // The start of "ts"'s local day must, by definition, fall back on the
+    // same local calendar day as ts itself. This is a stronger check than
+    // asserting a specific epoch value: it fails for *any* zone/date where
+    // localStartOfDay resolves to the wrong side of a DST transition,
+    // including zones this suite doesn't otherwise name explicitly.
+    const zones = [
+      'UTC',
+      'America/New_York',
+      'Asia/Kolkata',
+      'America/Havana',
+      'America/Santiago',
+      'Atlantic/Azores',
+    ];
+    const timestamps = [
+      Date.UTC(2026, 0, 1, 6),
+      Date.UTC(2026, 2, 8, 12),
+      Date.UTC(2026, 2, 29, 12),
+      Date.UTC(2026, 5, 15, 6),
+      Date.UTC(2026, 8, 6, 15),
+      Date.UTC(2026, 10, 1, 12),
+      Date.UTC(2026, 11, 31, 23),
+    ];
+    for (const tz of zones) {
+      for (const ts of timestamps) {
+        const start = localStartOfDay(ts, tz);
+        expect(`${tz} @ ${new Date(ts).toISOString()}: ${localDateKey(start, tz)}`).toBe(
+          `${tz} @ ${new Date(ts).toISOString()}: ${localDateKey(ts, tz)}`,
+        );
+      }
+    }
+  });
 });
 
 describe('isSameLocalDay', () => {
@@ -46,6 +144,26 @@ describe('isSameLocalDay', () => {
     const oneWeekAgo = now - 7 * 24 * 60 * 60 * 1000;
     expect(isSameLocalDay(oneWeekAgo)).toBe(false);
   });
+
+  it('compares Y/M/D in a given IANA tz with a non-whole-hour UTC offset', () => {
+    // 2026-06-10T18:00:00Z is 23:30 Kolkata (UTC+5:30) on 2026-06-10, and
+    // 2026-06-10T19:00:00Z is 00:30 Kolkata on 2026-06-11 — different
+    // Kolkata calendar days despite being only 1h apart in UTC.
+    const beforeMidnightKolkata = Date.UTC(2026, 5, 10, 18, 0, 0);
+    const afterMidnightKolkata = Date.UTC(2026, 5, 10, 19, 0, 0);
+    expect(isSameLocalDay(beforeMidnightKolkata, afterMidnightKolkata, 'Asia/Kolkata')).toBe(false);
+    // But in UTC itself both instants fall on 2026-06-10.
+    expect(isSameLocalDay(beforeMidnightKolkata, afterMidnightKolkata, 'UTC')).toBe(true);
+  });
+
+  it('compares Y/M/D in a given IANA tz across a DST transition', () => {
+    // Both instants fall on the same America/New_York calendar day
+    // (2026-03-08) even though the 2:00-3:00 local spring-forward jump
+    // happens in between them.
+    const earlyMorning = Date.UTC(2026, 2, 8, 6, 0, 0); // 01:00 EST, pre-transition
+    const lateMorning = Date.UTC(2026, 2, 8, 15, 0, 0); // 11:00 EDT, post-transition
+    expect(isSameLocalDay(earlyMorning, lateMorning, 'America/New_York')).toBe(true);
+  });
 });
 
 describe('localDateKey', () => {
@@ -66,6 +184,20 @@ describe('localDateKey', () => {
     expect(localDateKey(lateNight)).toBe('2026-06-10');
     const earlyMorning = new Date(2026, 5, 11, 0, 30).getTime();
     expect(localDateKey(earlyMorning)).toBe('2026-06-11');
+  });
+
+  it('produces the key for a given IANA tz with a non-whole-hour UTC offset', () => {
+    // 2026-06-10T19:00:00Z is 00:30 on 2026-06-11 in Asia/Kolkata (UTC+5:30).
+    const ts = Date.UTC(2026, 5, 10, 19, 0, 0);
+    expect(localDateKey(ts, 'Asia/Kolkata')).toBe('2026-06-11');
+    expect(localDateKey(ts, 'UTC')).toBe('2026-06-10');
+  });
+
+  it('produces the key for a given IANA tz across a DST transition', () => {
+    // 2026-11-01T05:00:00Z is 01:00 EDT on 2026-11-01, before that day's
+    // fall-back transition at 06:00 UTC (02:00 EDT -> 01:00 EST).
+    const ts = Date.UTC(2026, 10, 1, 5, 0, 0);
+    expect(localDateKey(ts, 'America/New_York')).toBe('2026-11-01');
   });
 });
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -8,28 +8,178 @@
  * sides drew the day boundary at different moments and visible inconsistencies
  * appeared (chart shows session active, sidebar filter drops it, etc.).
  *
- * These helpers operate in the host process's local timezone — same as the
- * previous inline implementations. Both sides should call them so any future
- * tz/DST handling change lands in one place.
+ * These helpers operate in the host process's own local timezone by default —
+ * same as the previous inline implementations. Each also accepts an optional
+ * trailing IANA `tz` (e.g. `"America/New_York"`); when given, Y/M/D is
+ * computed in that zone instead of the host's. Callers that need "today" to
+ * mean the *browser's* today (rather than the server process's) thread the
+ * browser's `Intl.DateTimeFormat().resolvedOptions().timeZone` through to
+ * these functions.
  */
+
+// Intl.DateTimeFormat construction is measurably more expensive than
+// formatToParts() itself, and the `history` branch of the activity-heatmap
+// route calls into these helpers a few times per day boundary across up to
+// 52 weeks in a single request on a single-threaded server. Today, the only
+// caller that ever passes a `tz` (the activity-heatmap route) validates it
+// against Intl.DateTimeFormat first — but these helpers themselves don't
+// enforce that, so the cache key can't just be the raw `tz` string: distinct
+// spellings of the same zone ('Asia/Kolkata', 'asia/kolkata', '+0530', ...)
+// all construct successfully and would otherwise become distinct,
+// never-evicted Map entries. Resolving each input to Intl's canonical zone
+// name before touching the cache collapses those spelling variants onto one
+// key, so the cache only grows with the number of *distinct* zones/offsets
+// actually seen — not with every raw string a caller happens to send.
+function canonicalTz(tz: string): string {
+  return new Intl.DateTimeFormat('en-US', { timeZone: tz }).resolvedOptions().timeZone;
+}
+
+const ymdFormatterCache = new Map<string, Intl.DateTimeFormat>();
+function ymdFormatterFor(tz: string): Intl.DateTimeFormat {
+  const canonical = canonicalTz(tz);
+  let formatter = ymdFormatterCache.get(canonical);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: canonical,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    ymdFormatterCache.set(canonical, formatter);
+  }
+  return formatter;
+}
+
+const offsetFormatterCache = new Map<string, Intl.DateTimeFormat>();
+function offsetFormatterFor(tz: string): Intl.DateTimeFormat {
+  const canonical = canonicalTz(tz);
+  let formatter = offsetFormatterCache.get(canonical);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: canonical,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+    offsetFormatterCache.set(canonical, formatter);
+  }
+  return formatter;
+}
+
+/**
+ * Y/M/D as observed in `tz` for the instant `ts`.
+ */
+function zonedYMD(ts: number, tz: string): { year: number; month: number; day: number } {
+  const parts = ymdFormatterFor(tz).formatToParts(ts);
+  let year = 0;
+  let month = 0;
+  let day = 0;
+  for (const part of parts) {
+    if (part.type === 'year') year = Number(part.value);
+    else if (part.type === 'month') month = Number(part.value);
+    else if (part.type === 'day') day = Number(part.value);
+  }
+  return { year, month, day };
+}
+
+/**
+ * `tz`'s UTC offset in ms (positive east of UTC) at the instant `ts`. Derived
+ * by reading `tz`'s wall-clock Y/M/D/H/M/S at `ts` and re-interpreting those
+ * same numbers as UTC — the gap between the two is the offset. This varies by
+ * date for zones that observe DST, so it must be read near the instant in
+ * question rather than assumed fixed.
+ */
+function zonedOffsetMs(ts: number, tz: string): number {
+  const parts = offsetFormatterFor(tz).formatToParts(ts);
+  const values: Record<string, number> = {};
+  for (const part of parts) {
+    if (part.type !== 'literal') values[part.type] = Number(part.value);
+  }
+  // Some ICU configurations render midnight as hour "24" under hour12: false.
+  const hour = values.hour === 24 ? 0 : values.hour;
+  const wallClockAsUtc = Date.UTC(
+    values.year,
+    values.month - 1,
+    values.day,
+    hour,
+    values.minute,
+    values.second,
+  );
+  return wallClockAsUtc - ts;
+}
+
+/**
+ * Epoch ms of local midnight for Y/M/D in `tz`. A first guess treats Y/M/D as
+ * if they were UTC, then that guess is corrected by `tz`'s actual offset at
+ * (approximately) that instant. Because the correction itself can move the
+ * candidate instant across a DST transition — landing on a moment where the
+ * offset is different from the one used to compute it — the offset is read
+ * again at the corrected instant and, if it changed, a second correction is
+ * computed using that re-read offset.
+ *
+ * The second correction is only trustworthy if it actually lands back on the
+ * target Y/M/D — re-reading the offset can itself land on the far side of
+ * *another* transition (this happens for zones that spring forward at or
+ * near midnight, e.g. America/Havana, America/Santiago, Atlantic/Azores: the
+ * re-read offset belongs to the transition that skipped local midnight
+ * entirely, and blindly applying it walks the candidate back onto the
+ * *previous* day instead of forward onto the first real instant of the
+ * target day). So the second correction is validated against the target
+ * Y/M/D before being trusted, falling back to the first correction — the
+ * earliest instant whose wall-clock date is on or after the target — when it
+ * isn't.
+ */
+function zonedStartOfDayMs(year: number, month: number, day: number, tz: string): number {
+  const guess = Date.UTC(year, month - 1, day);
+  const offset = zonedOffsetMs(guess, tz);
+  const firstCorrection = guess - offset;
+  const offsetAtFirstCorrection = zonedOffsetMs(firstCorrection, tz);
+  if (offsetAtFirstCorrection === offset) return firstCorrection;
+  const secondCorrection = guess - offsetAtFirstCorrection;
+  const secondCorrectionYmd = zonedYMD(secondCorrection, tz);
+  const secondCorrectionMatchesTarget =
+    secondCorrectionYmd.year === year &&
+    secondCorrectionYmd.month === month &&
+    secondCorrectionYmd.day === day;
+  return secondCorrectionMatchesTarget ? secondCorrection : firstCorrection;
+}
 
 /**
  * Epoch ms at local midnight of the day containing `refTs`.
  * Defaults to `Date.now()` when `refTs` is omitted.
+ * Computed in the host's own local timezone unless `tz` (an IANA timezone
+ * name) is given, in which case midnight is computed in that zone instead.
  */
-export function localStartOfDay(refTs?: number): number {
+export function localStartOfDay(refTs?: number, tz?: string): number {
+  if (tz) {
+    const ts = refTs == null ? Date.now() : refTs;
+    const { year, month, day } = zonedYMD(ts, tz);
+    return zonedStartOfDayMs(year, month, day, tz);
+  }
   const d = refTs == null ? new Date() : new Date(refTs);
   d.setHours(0, 0, 0, 0);
   return d.getTime();
 }
 
 /**
- * True iff `ts` and `refTs` (or now) fall on the same local-time calendar day.
+ * True iff `ts` and `refTs` (or now) fall on the same calendar day.
  * Uses Y/M/D comparison so DST transitions don't introduce off-by-one bugs
  * (a "day" can be 23 h or 25 h on DST boundaries; raw ts-range arithmetic
  * gets that wrong, Y/M/D comparison doesn't).
+ * Compares Y/M/D in the host's own local timezone unless `tz` (an IANA
+ * timezone name) is given, in which case both `ts` and `refTs` are compared
+ * as observed in that same zone.
  */
-export function isSameLocalDay(ts: number, refTs?: number): boolean {
+export function isSameLocalDay(ts: number, refTs?: number, tz?: string): boolean {
+  if (tz) {
+    const a = zonedYMD(ts, tz);
+    const b = zonedYMD(refTs == null ? Date.now() : refTs, tz);
+    return a.year === b.year && a.month === b.month && a.day === b.day;
+  }
   const a = new Date(ts);
   const b = refTs == null ? new Date() : new Date(refTs);
   return (
@@ -43,8 +193,14 @@ export function isSameLocalDay(ts: number, refTs?: number): boolean {
  * Local-time YYYY-MM-DD key for `ts` (or now). Used as a Map key for per-day
  * cost buckets. Must agree with localStartOfDay/isSameLocalDay so server-side
  * bucketing and client-side filters draw the day boundary at the same instant.
+ * Computed in the host's own local timezone unless `tz` (an IANA timezone
+ * name) is given, in which case the key reflects Y/M/D in that zone instead.
  */
-export function localDateKey(ts?: number): string {
+export function localDateKey(ts?: number, tz?: string): string {
+  if (tz) {
+    const { year, month, day } = zonedYMD(ts == null ? Date.now() : ts, tz);
+    return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  }
   const d = ts == null ? new Date() : new Date(ts);
   const year = d.getFullYear();
   const month = String(d.getMonth() + 1).padStart(2, '0');

--- a/src/web/api/client.test.ts
+++ b/src/web/api/client.test.ts
@@ -6,6 +6,7 @@ import {
   fetchGitEfficiency,
   fetchWorkflowDetail,
   fetchSessionReplay,
+  fetchActivityHeatmap,
   patchSettings,
   postDigestSend,
   qk,
@@ -287,5 +288,40 @@ describe('api/client', () => {
     const result = await fetchSessionReplay('sess-1');
     expect(calledWith).toBe('/api/sessions/sess-1/replay');
     expect(result).toEqual(payload);
+  });
+
+  it('fetchActivityHeatmap sends the browser IANA timezone as a tz query param', async () => {
+    let calledWith = '';
+    const payload = { buckets: [1, 2], bucketSizeMs: 900_000, startTimestamp: 0, maxCount: 2 };
+    globalThis.fetch = ((u: string) => {
+      calledWith = u;
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as unknown as typeof globalThis.fetch;
+    const result = await fetchActivityHeatmap('today');
+    const expectedTz = encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    expect(calledWith).toBe(`/api/activity-heatmap?view=today&tz=${expectedTz}`);
+    expect(result).toEqual(payload);
+  });
+
+  it('fetchActivityHeatmap includes both weeks and tz for the history view', async () => {
+    let calledWith = '';
+    const payload = { days: [{ date: '2026-06-10', count: 3 }], maxCount: 3 };
+    globalThis.fetch = ((u: string) => {
+      calledWith = u;
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    }) as unknown as typeof globalThis.fetch;
+    await fetchActivityHeatmap('history', 12);
+    const expectedTz = encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    expect(calledWith).toBe(`/api/activity-heatmap?view=history&weeks=12&tz=${expectedTz}`);
   });
 });

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -876,8 +876,12 @@ export function fetchActivityHeatmap(
   view: string,
   weeks?: number,
 ): Promise<ActivityHeatmapTodayResponse | ActivityHeatmapHistoryResponse> {
+  // The server has no way to know the viewing browser's timezone on its own —
+  // send it explicitly so "today"/each day's boundary is drawn where the
+  // browser is, not where the dashboard server process happens to run.
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
   return getJson<ActivityHeatmapTodayResponse | ActivityHeatmapHistoryResponse>(
-    `/api/activity-heatmap?view=${encodeURIComponent(view)}${weeks ? `&weeks=${weeks}` : ''}`,
+    `/api/activity-heatmap?view=${encodeURIComponent(view)}${weeks ? `&weeks=${weeks}` : ''}&tz=${encodeURIComponent(tz)}`,
   );
 }
 // Mirrors ContextTrackerMetrics in src/metrics/context-tracker.ts (not


### PR DESCRIPTION
## Summary

Fixes a genuine gap that survived the 5-release dashboard-audit epic: issue #381 was scoped into Release 1's fix batch but was silently dropped from that PR's closing-issue list and never actually implemented — confirmed by reading the current code, where the exact bug (and a self-documenting comment describing it) was still present.

`GET /api/activity-heatmap` computed "today"'s day boundary using the dashboard *server's* own OS timezone, while the browser computes "today" in its own timezone using the same shared helpers. When server and browser run in different timezones, the heatmap's day boundary could disagree with the rest of the page.

- The browser now sends its IANA timezone name (`Intl.DateTimeFormat().resolvedOptions().timeZone`) as a `tz` query param to `/api/activity-heatmap`.
- `src/lib/date.ts`'s shared day-boundary helpers (`localStartOfDay`, `isSameLocalDay`, `localDateKey`) gained an optional trailing `tz` parameter — when omitted, behavior is unchanged (verified against ~40 existing call sites); when provided, Y/M/D and local-midnight are computed in that IANA zone instead of the host's own.
- Both the `today` and `history` branches of the route now use the client-supplied `tz` when present.
- An invalid/unrecognized `tz` value degrades gracefully to the server's own timezone rather than 500ing the panel.

This went through two independent review rounds. The first found a real DST-correctness bug in the offset-correction math (confirmed via an exhaustive 418-timezone × 365-day sweep — 3 zones, including `America/Havana` and `America/Santiago`, returned the wrong calendar day on their spring-forward-at-midnight transition date) plus 3 more issues (missing test coverage of that exact code path, unvalidated `tz` query param that could 500 the panel on ICU version skew, and a test assertion fragile to the test host's own timezone). All four were fixed and independently re-verified with the reviewer's own from-scratch DST trace and a fresh 418-zone sweep against the corrected code (0 failures). A second, smaller round addressed 2 minor cache-keying/test-flake cleanups.

Scope note: several other routes in `api-handler.ts` share this same server-vs-browser timezone gap for their own "today" computations (not part of issue #381, which named only the activity-heatmap endpoint) — intentionally left untouched; worth a follow-up issue if it should be swept more broadly.

Fixes #381

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` (Jest) — 5486 passing, 3 pre-existing skips, 0 failures, run 3x consecutively with identical results
- [x] Vitest suite — 517/517 passing, run 3x consecutively with identical results
- [x] `npm run lint` — 0 errors/warnings