### PR TITLE
Feat: cost deep dive — forecast chips + Cost by Tool panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.0] - 2026-08-12
+
+### Added
+
+- **The Today dashboard now shows a "Cost by Tool" panel** breaking down spend by tool type (Read, Edit, Bash, Agent, etc.), with call counts, so you can see which tools are driving cost without leaving the Today view.
+- **The cost forecast card now shows end-of-session and end-of-week cost estimates** alongside the existing end-of-day forecast, giving a longer-range view of where spend is headed.
+
 ## [1.14.41] - 2026-08-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.41",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.14.41",
+      "version": "1.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.14.41",
+  "version": "1.15.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1884,6 +1884,15 @@ export function createApiHandler(
     });
   });
 
+  routes.set('GET /api/cost-per-tool', (req, res) => {
+    if (!deps.turnCostAttributor) return unavailable(res, 'turnCostAttributor');
+    // Same reasoning as /api/turn-costs above — optional ?sessionId= scopes
+    // this process-global tracker's data to one session.
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const sessionId = url.searchParams.get('sessionId') ?? undefined;
+    jsonOk(res, deps.turnCostAttributor.getMetrics(sessionId));
+  });
+
   routes.set('GET /api/cost-per-outcome', (req, res) => {
     if (!deps.sessionStore?.loadAllSessions)
       return unavailable(res, 'sessionStore.loadAllSessions');

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -1008,6 +1008,15 @@ export const fetchModelUsage = (): Promise<ModelUsageMetrics> =>
   getJson<ModelUsageMetrics>('/api/model-usage');
 export const fetchCacheHealth = (): Promise<CacheHealthResponse> =>
   getJson<CacheHealthResponse>('/api/cache-health');
+// Same underlying tracker/shape as fetchTurnCosts (both read
+// TurnCostAttributor.getMetrics()) — reuses TurnCostsResponse rather than
+// duplicating an identical interface. sessionId scopes the same way.
+export const fetchCostPerTool = (sessionId?: string): Promise<TurnCostsResponse> =>
+  getJson<TurnCostsResponse>(
+    sessionId
+      ? `/api/cost-per-tool?sessionId=${encodeURIComponent(sessionId)}`
+      : '/api/cost-per-tool',
+  );
 
 // Mirrors the real GET /api/settings handler response in
 // src/dashboard/routes/api-handler.ts (not importable — tsconfig.web.json
@@ -1234,6 +1243,7 @@ export const qk = {
   context: ['context'] as const,
   modelUsage: ['model-usage'] as const,
   cacheHealth: ['cache-health'] as const,
+  costPerTool: ['cost-per-tool'] as const,
   settings: ['settings'] as const,
   sessionsLive: ['sessions', 'live'] as const,
   sessionsTodayAggregate: ['sessions', 'today', 'aggregate'] as const,

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -2109,3 +2109,135 @@ describe('Today view — traceWindow ignores the no-subagent sentinel window', (
     expect(screen.queryByText(/^\d{4,}:\d{2}$/)).toBeNull();
   });
 });
+
+describe('Today view — forecast end-of-week and session chips', () => {
+  beforeEach(() => {
+    useLiveStore.setState({
+      connected: true,
+      recentToolCalls: [],
+      cost: { sessionTotalUsd: 1.2, todayTotalUsd: 4.8, forecastEodUsd: null },
+      antiPatterns: [],
+      firingAlerts: new Map(),
+      dismissedAlerts: new Set(),
+    });
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/api/cost')) {
+        return new Response(
+          JSON.stringify({
+            cost: { sessionTotalCostUsd: 1.2, model: null },
+            forecast: {
+              forecastEndOfDayUsd: 4.8,
+              forecastEndOfWeekUsd: 18.4,
+              forecastSessionEndUsd: 2.1,
+              confidenceNote: 'Reasonable confidence — based on 30+ minutes of data.',
+            },
+            sessionTodayUsd: 1.2,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify(null), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders end-of-week and end-of-session forecast chips when API returns them', async () => {
+    renderToday();
+    await waitFor(() => expect(screen.getByText('End of week')).toBeInTheDocument());
+    expect(screen.getByText('End of session')).toBeInTheDocument();
+  });
+});
+
+describe('Today view — Cost by Tool panel', () => {
+  beforeEach(() => {
+    useLiveStore.setState({
+      connected: true,
+      recentToolCalls: [],
+      cost: { sessionTotalUsd: 0, todayTotalUsd: 0, forecastEodUsd: null },
+      antiPatterns: [],
+      firingAlerts: new Map(),
+      dismissedAlerts: new Set(),
+    });
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/api/cost-per-tool')) {
+        return new Response(
+          JSON.stringify({
+            costByToolType: {
+              Agent: { totalCost: 4.2, callCount: 8, avgCost: 0.525 },
+              Read: { totalCost: 0.52, callCount: 61, avgCost: 0.0085 },
+            },
+            totalAttributedCost: 4.72,
+            attributionRate: 0.88,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify(null), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders Cost by Tool panel with a chart instead of the empty state', async () => {
+    // Recharts' ResponsiveContainer measures 0x0 under jsdom, so bar/axis
+    // content doesn't render meaningfully in tests — assert the panel
+    // rendered its chart branch (no empty state), matching the same
+    // convention History.test.tsx uses for its own Recharts panels.
+    renderToday();
+    await waitFor(() => expect(screen.queryByText('No cost data yet')).toBeNull());
+    expect(screen.getByText('Cost by Tool')).toBeInTheDocument();
+  });
+
+  it('renders Cost attribution unavailable when /api/cost-per-tool returns 503', async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/api/cost-per-tool')) {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      return new Response(JSON.stringify(null), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    renderToday();
+    await waitFor(() =>
+      expect(screen.getByText('Cost attribution unavailable')).toBeInTheDocument(),
+    );
+  });
+
+  it('renders the empty state instead of crashing when the query settles with a null value', async () => {
+    // A 200 response whose body is the JSON literal `null` (distinct from a
+    // request that errors) resolves the query successfully with `data` set
+    // to `null`, not `undefined` — asserting against the pending state's
+    // identical "No cost data yet" text wouldn't distinguish the two, so
+    // seed the cache directly with the already-settled value instead of
+    // waiting on the mocked fetch to resolve.
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    qc.setQueryData(qk.costPerTool, null);
+    renderToday(qc);
+    expect(screen.getByText('No cost data yet')).toBeInTheDocument();
+  });
+
+  it('shows the low-attribution footnote when attributionRate is below 50%', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+    qc.setQueryData(qk.costPerTool, {
+      costByToolType: {
+        Agent: { totalCost: 4.2, callCount: 8, avgCost: 0.525 },
+      },
+      totalAttributedCost: 4.2,
+      attributionRate: 0.3,
+    });
+    renderToday(qc);
+    expect(screen.getByText('Based on 30% of session cost')).toBeInTheDocument();
+  });
+});

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -1,6 +1,16 @@
 import { useMemo, useState, useRef, useEffect } from 'react';
 import type { JSX } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+  ResponsiveContainer,
+} from 'recharts';
 import { useLocation } from 'wouter';
 import { useLiveStore, useSubagentStats, type AlertEvent } from '../store/liveStore';
 import { Kpi } from '../components/Kpi';
@@ -20,6 +30,7 @@ import {
   fetchRecentAlerts,
   fetchCacheHealth,
   fetchCost,
+  fetchCostPerTool,
   fetchSessionCurrent,
   fetchSessionsList,
   fetchSessionReplay,
@@ -83,7 +94,12 @@ const SEVERITY_DOT: Record<AlertEvent['severity'], string> = {
 
 interface CostApiResponse {
   readonly cost: { readonly sessionTotalCostUsd?: number | null; readonly model?: string | null };
-  readonly forecast: { readonly forecastEndOfDayUsd?: number | null } | null;
+  readonly forecast: {
+    readonly forecastEndOfDayUsd?: number | null;
+    readonly forecastEndOfWeekUsd?: number | null;
+    readonly forecastSessionEndUsd?: number | null;
+    readonly confidenceNote?: string | null;
+  } | null;
   readonly sessionTodayUsd?: number | null;
 }
 
@@ -170,6 +186,27 @@ interface ToolSelectionMetrics {
 }
 
 const QUALITY_REFETCH_MS = 10_000;
+
+const CHART_TICK_STYLE = { fill: 'var(--color-ink-muted)', fontSize: 10 };
+const CHART_GRID_STROKE = 'var(--color-border-subtle)';
+const CHART_TOOLTIP_STYLE = {
+  background: 'var(--color-bg-elevated)',
+  border: '1px solid var(--color-border-medium)',
+  borderRadius: 8,
+  fontSize: 12,
+  color: 'var(--color-ink-base)',
+};
+
+// Mirrors History.tsx's toolFillColor — same tool-name-keyed palette, so a
+// tool's color is consistent whether viewed here (by cost) or in the Top
+// Tools panel (by call count).
+function toolFillColor(toolName: string): string {
+  if (toolName === 'Read') return 'var(--color-accent-blue)';
+  if (toolName === 'Edit' || toolName === 'Write') return 'var(--color-accent-green)';
+  if (toolName === 'Bash') return 'var(--color-accent-purple)';
+  if (toolName === 'Agent') return 'var(--color-accent-teal)';
+  return 'var(--color-ink-muted)';
+}
 
 export function Today(): JSX.Element {
   const cost = useLiveStore((s) => s.cost);
@@ -372,7 +409,11 @@ export function Today(): JSX.Element {
             />
           </AnimatedCard>
 
-          <AnimatedCard index={1}>
+          <AnimatedCard index={1} className="mb-3">
+            <CostByToolPanel />
+          </AnimatedCard>
+
+          <AnimatedCard index={2}>
             <RecentAlertsPanel />
           </AnimatedCard>
         </>
@@ -453,6 +494,9 @@ export function Today(): JSX.Element {
               }
               hourlySpend={hourlySpend}
               subagentUsd={forecastBreakdownSubagentUsd}
+              forecastSessionEnd={costApi?.forecast?.forecastSessionEndUsd ?? null}
+              forecastWeek={costApi?.forecast?.forecastEndOfWeekUsd ?? null}
+              confidenceNote={costApi?.forecast?.confidenceNote ?? null}
             />
             {concurrency && concurrency.buckets && (
               <ConcurrencyIndicator
@@ -538,9 +582,12 @@ export function Today(): JSX.Element {
             <QualityProxyPanel />
             <ToolSelectionPanel />
             <LatencyPanel aggregate={aggregate} />
+            <ComputeWastePanel />
             <ModelUsagePanel />
             <CacheHealthPanel aggregate={aggregate} />
-            <ComputeWastePanel />
+            <div className="col-span-3">
+              <CostByToolPanel />
+            </div>
           </AnimatedCard>
 
           <AnimatedCard index={4}>
@@ -572,6 +619,105 @@ export function Today(): JSX.Element {
         </>
       )}
     </section>
+  );
+}
+
+function CostByToolPanel(): JSX.Element {
+  const { data, isError } = useQuery<TurnCostsResponse>({
+    queryKey: qk.costPerTool,
+    queryFn: () => fetchCostPerTool(),
+    refetchInterval: QUALITY_REFETCH_MS,
+    retry: false,
+  });
+
+  const tools = data?.costByToolType
+    ? Object.entries(data.costByToolType)
+        .filter(([, e]) => e.totalCost > 0)
+        .sort((a, b) => b[1].totalCost - a[1].totalCost)
+        .map(([tool, e]) => ({ tool, totalCost: e.totalCost, callCount: e.callCount }))
+    : [];
+
+  const lowAttribution = data != null && (data.attributionRate ?? 1) < 0.5;
+
+  if (isError) {
+    return (
+      <Card padding="sm" className="h-full">
+        <Eyebrow className="mb-2">Cost by Tool</Eyebrow>
+        <EmptyState
+          icon="radar"
+          title="Cost attribution unavailable"
+          subtitle="Start a Claude Code session to enable cost attribution."
+        />
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Card padding="sm" className="h-full">
+        <Eyebrow className="mb-2">Cost by Tool</Eyebrow>
+        <EmptyState
+          icon="radar"
+          title="No cost data yet"
+          subtitle="Cost attribution appears after token data is recorded."
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <Card padding="sm" className="h-full">
+      <Eyebrow className="mb-2">Cost by Tool</Eyebrow>
+      {tools.length === 0 ? (
+        <EmptyState
+          icon="radar"
+          title="No cost data yet"
+          subtitle="Cost attribution appears after token data is recorded."
+        />
+      ) : (
+        <>
+          <div className="min-w-0" style={{ height: `${Math.max(96, tools.length * 28 + 24)}px` }}>
+            <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
+              <BarChart data={tools} layout="vertical">
+                <CartesianGrid stroke={CHART_GRID_STROKE} strokeDasharray="3 3" />
+                <XAxis type="number" tick={CHART_TICK_STYLE} stroke={CHART_GRID_STROKE} unit="$" />
+                <YAxis
+                  type="category"
+                  dataKey="tool"
+                  tick={CHART_TICK_STYLE}
+                  tickFormatter={(value: string) => {
+                    const match = tools.find((t) => t.tool === value);
+                    const label = shortToolName(value);
+                    return match ? `${label} (${match.callCount})` : label;
+                  }}
+                  stroke={CHART_GRID_STROKE}
+                  width={90}
+                  interval={0}
+                />
+                <Tooltip
+                  contentStyle={CHART_TOOLTIP_STYLE}
+                  labelFormatter={(label) => shortToolName(String(label))}
+                />
+                <Bar dataKey="totalCost" name="Cost ($)" radius={[0, 3, 3, 0]}>
+                  {tools.map((entry) => (
+                    <Cell
+                      key={entry.tool}
+                      fill={toolFillColor(shortToolName(entry.tool))}
+                      fillOpacity={0.8}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          {lowAttribution && (
+            <div className="text-[10px] text-ink-muted italic mt-1">
+              Based on {Math.round((data.attributionRate ?? 0) * 100)}% of session cost
+            </div>
+          )}
+        </>
+      )}
+    </Card>
   );
 }
 
@@ -1660,11 +1806,17 @@ function ForecastEodCard({
   forecastEod,
   hourlySpend,
   subagentUsd = 0,
+  forecastSessionEnd,
+  forecastWeek,
+  confidenceNote,
 }: {
   todayTotal: number;
   forecastEod: number | null;
   hourlySpend: HourlyCostEntry[];
   subagentUsd?: number;
+  forecastSessionEnd: number | null;
+  forecastWeek: number | null;
+  confidenceNote: string | null;
 }): JSX.Element {
   const hasForecast = forecastEod !== null && Number.isFinite(forecastEod);
   const effectiveForecast = hasForecast ? Math.max(forecastEod, todayTotal) : 0;
@@ -1711,6 +1863,25 @@ function ForecastEodCard({
                 </div>
               )}
             </div>
+          )}
+          {(forecastSessionEnd !== null || forecastWeek !== null) && (
+            <div className="grid grid-cols-2 gap-x-3 mt-2 pt-2 border-t border-border-subtle text-xs">
+              {forecastSessionEnd !== null && (
+                <div>
+                  <div className="text-ink-muted">End of session</div>
+                  <div className="font-mono tabular-nums">~${forecastSessionEnd.toFixed(2)}</div>
+                </div>
+              )}
+              {forecastWeek !== null && (
+                <div>
+                  <div className="text-ink-muted">End of week</div>
+                  <div className="font-mono tabular-nums">~${forecastWeek.toFixed(2)}</div>
+                </div>
+              )}
+            </div>
+          )}
+          {confidenceNote && (
+            <div className="text-[10px] text-ink-muted italic mt-1">{confidenceNote}</div>
           )}
         </>
       ) : (


### PR DESCRIPTION
## Summary
- Adds end-of-session and end-of-week cost forecast chips to the Today dashboard's forecast card, alongside the existing end-of-day estimate.
- Adds a new "Cost by Tool" panel to the Today dashboard, breaking down spend by tool type (Read, Edit, Bash, Agent, etc.) with call counts, backed by a new `GET /api/cost-per-tool` route.

Fixes #34

## Test plan
- [x] `npm run lint` / `npm run format:check` clean
- [x] `npm run build` clean
- [x] Full Jest suite passing
- [x] Full Vitest suite passing