### PR TITLE
Patch release v1.15.1: #331, #332, #350, #362, #363

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2026-08-13
+
+### Fixed
+
+- **The Sessions page now shows the LIVE badge and a placeholder row for sessions running in a different Claude Code window**, not just the window the dashboard happens to be attached to — previously such sessions were invisible entirely. (Full activity detail for a cross-process session — call counts, timeline — is not yet available; only its live status and identity are.)
+- **The Sessions page's Today/7-days/30-days tabs no longer hide sessions that never spawned a subagent** — most sessions — regardless of how recently they actually happened. Only "All" reliably showed every session before this fix.
+- **The session-backfill script (`scripts/backfill-sessions.ts`) now writes every `FullSessionSummary` field**, so sessions it reconstructs from historical New Relic telemetry no longer permanently report zero/null for model breakdown, cache-token, and quality-proxy data that later dashboard views expect.
+
+### Changed
+
+- **A dashboard-only dead code path (`fetchLatency`) was removed** — no user-visible change; latency data continues to be served via the Today dashboard's aggregate endpoint.
+- **Region host configuration (events-ingest host, NerdGraph URL, license-key auto-detect, deploy CLI flags) is now consolidated into one internal registry**, instead of being hand-maintained separately in four places — no change in behavior, this only reduces the risk of the four copies drifting out of sync when a region is added or changed in the future.
+
 ## [1.15.0] - 2026-08-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/scripts/backfill-sessions.ts
+++ b/scripts/backfill-sessions.ts
@@ -13,17 +13,18 @@
  *
  * Requires a New Relic User API key (NRAK-...), not a license key.
  *
- * Note: filesRead / filesModified and token breakdowns cannot be recovered
- * from NR event data and are left empty. All fields used by PersonalCoach
- * (efficiencyScore, estimatedCostUsd, antiPatterns, taskCount, toolBreakdown)
- * are fully recoverable.
+ * Note: filesRead / filesModified, per-model/cache token breakdowns,
+ * sessionName, and repoName cannot be recovered from NR event data and are
+ * left at their FullSessionSummary legacy-file defaults. All fields used by
+ * PersonalCoach (efficiencyScore, estimatedCostUsd, antiPatterns, taskCount,
+ * toolBreakdown) are fully recoverable.
  */
 
 import 'dotenv/config';
 
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { SessionStore, buildSessionSummary } from '../src/storage/session-store.js';
+import { SessionStore } from '../src/storage/session-store.js';
 import {
   WeeklySummaryGenerator,
   getIsoWeekId,
@@ -31,6 +32,7 @@ import {
 } from '../src/storage/weekly-summary.js';
 import type { FullSessionSummary } from '../src/storage/session-store.js';
 import { normalizeDeveloperName } from '../src/config.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from '../src/metrics/quality-proxy-tracker.js';
 
 const NERDGRAPH_URL = 'https://api.newrelic.com/graphql';
 
@@ -315,6 +317,8 @@ async function main(): Promise<void> {
 
     const summary: FullSessionSummary = {
       sessionId,
+      sessionName: null, // not recoverable from NR event data
+      repoName: null, // not recoverable from NR event data
       startTime: base.startTime,
       endTime: base.endTime,
       durationMs: base.endTime - base.startTime,
@@ -332,9 +336,13 @@ async function main(): Promise<void> {
       buildRunCount: tasks?.buildRunCount ?? 0,
       buildPassCount: tasks?.buildPassCount ?? 0,
       estimatedCostUsd: typeof estimatedCostUsd === 'number' ? estimatedCostUsd : null,
+      subagentCostUsd: 0, // not recoverable from NR event data
       tokensInput: 0, // not recoverable from NR event data
       tokensOutput: 0,
       tokensThinking: 0,
+      tokensCacheRead: 0, // not recoverable from NR event data
+      tokensCacheCreation: 0, // not recoverable from NR event data
+      cacheSavingsUsd: 0, // not recoverable from NR event data
       efficiencyScore: efficiencyScores.get(sessionId) ?? null,
       antiPatterns: antiPatterns.get(sessionId) ?? [],
       taskCount: tasks?.taskCount ?? 0,
@@ -346,6 +354,9 @@ async function main(): Promise<void> {
       assistantMessages: 0,
       userCorrections: 0,
       outcome: 'completed',
+      toolSelectionMetrics: null, // not recoverable from NR event data
+      modelBreakdown: {}, // not recoverable from NR event data
+      qualityProxy: ZERO_QUALITY_PROXY_COUNTS,
     };
 
     const weekId = getIsoWeekId(new Date(base.startTime));

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -97,6 +97,31 @@ describe('api-handler GET /api/session/current', () => {
     expect(JSON.parse(body())).toEqual({ ...fake, efficiencyScore: null, liveSessions: [] });
   });
 
+  it('includes a session live only in another process (via localStore buffer) in liveSessions', async () => {
+    const fake = { id: 'sess-cross-process', toolCallCount: 2 };
+    const now = Date.now();
+    const handler = createApiHandler({
+      sessionTracker: { getMetrics: () => fake } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['sessionTracker'],
+      liveSessionRegistry: {
+        getLiveSessions: () => [],
+        getSessionName: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['liveSessionRegistry'],
+      localStore: {
+        peekAllBuffers: () => [
+          { mode: 'post', sessionId: 'other-process-session', timestamp: now - 1_000 },
+        ],
+      } as unknown as Parameters<typeof createApiHandler>[0]['localStore'],
+    });
+    const req = { method: 'GET', url: '/api/session/current' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { liveSessions: string[] };
+    expect(parsed.liveSessions).toContain('other-process-session');
+  });
+
   it('returns 503 with { error, what } body when sessionTracker is missing', async () => {
     const handler = createApiHandler({});
     const req = { method: 'GET', url: '/api/session/current' } as IncomingMessage;
@@ -342,6 +367,34 @@ describe('api-handler GET /api/sessions', () => {
     expect(live).toBeDefined();
     expect(live?.model ?? null).toBeNull();
   });
+
+  it('injects a stub row for a session live only in another process', async () => {
+    const now = Date.now();
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadAllSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      liveSessionRegistry: {
+        getLiveSessions: () => [],
+        getLastActivity: () => null,
+        getSessionName: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['liveSessionRegistry'],
+      localStore: {
+        peekAllBuffers: () => [
+          { mode: 'post', sessionId: 'other-process-session', timestamp: now - 1_000 },
+        ],
+      } as unknown as Parameters<typeof createApiHandler>[0]['localStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const result = JSON.parse(body()) as Array<{ sessionId: string }>;
+    expect(result.some((s) => s.sessionId === 'other-process-session')).toBe(true);
+  });
 });
 
 describe('api-handler GET /api/sessions/:id', () => {
@@ -402,6 +455,36 @@ describe('api-handler GET /api/sessions/:id', () => {
     const { res, status } = fakeRes();
     await handler(req, res);
     expect(status()).toBe(404);
+  });
+
+  it('returns an in-progress shell instead of 404 for a session live only in another process', async () => {
+    const now = Date.now();
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      liveSessionRegistry: {
+        getLiveSessions: () => [],
+        getSessionName: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['liveSessionRegistry'],
+      localStore: {
+        peekAllBuffers: () => [
+          { mode: 'post', sessionId: 'other-process-session', timestamp: now - 1_000 },
+        ],
+      } as unknown as Parameters<typeof createApiHandler>[0]['localStore'],
+    });
+    const req = {
+      method: 'GET',
+      url: '/api/sessions/other-process-session',
+    } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { sessionId: string; outcome: string };
+    expect(parsed.sessionId).toBe('other-process-session');
+    expect(parsed.outcome).toBe('in progress');
   });
 
   it('attaches qualityProxy (derived from persisted raw counts) to a persisted session with real signals', async () => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1040,7 +1040,7 @@ export function createApiHandler(
     // SPA Today KPI can render it without a second round-trip. `null` when
     // no tasks have been scored yet (or when the scorer wasn't wired in).
     const efficiencyScore = deps.efficiencyScorer?.getSessionAverage()?.score ?? null;
-    const liveSessions = deps.liveSessionRegistry?.getLiveSessions() ?? [];
+    const liveSessions = computeCrossProcessLiveSessionIds(deps);
     jsonOk(res, { ...deps.sessionTracker.getMetrics(), efficiencyScore, liveSessions });
   });
 
@@ -1124,7 +1124,7 @@ export function createApiHandler(
           perSession.set(sid, { count: 1, firstTs: ts || Date.now(), lastTs: ts || Date.now() });
         }
       }
-      for (const id of deps.liveSessionRegistry.getLiveSessions()) {
+      for (const id of computeCrossProcessLiveSessionIds(deps)) {
         if (!knownIds.has(id)) {
           const stats = perSession.get(id);
           // getLastActivity is registry-maintained and survives buffer drains,
@@ -2869,7 +2869,7 @@ export function createApiHandler(
         }
         // Concurrent live session tracked by the registry but not this server's
         // own session — synthesize from tool call buffer records.
-        if (deps.liveSessionRegistry?.getLiveSessions().includes(sessionId)) {
+        if (computeCrossProcessLiveSessionIds(deps).includes(sessionId)) {
           const allRecords = deps.toolCallBuffer?.getRecords() ?? [];
           const records = allRecords.filter(
             (r) => (r as { sessionId?: string | null }).sessionId === sessionId,
@@ -2913,7 +2913,7 @@ export function createApiHandler(
           const quality = combineQualityProxyRawCounts([qualityTracker.getRawCounts()]);
           jsonOk(res, {
             sessionId,
-            sessionName: deps.liveSessionRegistry.getSessionName(sessionId),
+            sessionName: deps.liveSessionRegistry?.getSessionName(sessionId) ?? null,
             startTime,
             durationMs: lastTs - startTime,
             toolCallCount: records.length,

--- a/src/deploy/deploy-alerts.ts
+++ b/src/deploy/deploy-alerts.ts
@@ -18,6 +18,7 @@ import type {
 import { DEFAULT_PERSONAL_THRESHOLDS } from '../alerts/types.js';
 import { normalizeDeveloperName } from '../config.js';
 import { resolveDataDir } from './data-paths.js';
+import { getRegionByDeployFlags } from '../install/regions.js';
 
 export const CREATE_POLICY_MUTATION = `
 mutation CreateAlertPolicy($accountId: Int!, $name: String!, $incidentPreference: AlertsIncidentPreference!) {
@@ -410,9 +411,7 @@ async function syncConditions(
 
 function pickNerdgraphUrl(opts: AlertsDeployOptions): string {
   if (opts.nerdgraphUrlOverride) return opts.nerdgraphUrlOverride;
-  if (opts.eu) return 'https://api.eu.newrelic.com/graphql';
-  if (opts.jp) return 'https://api.jp.newrelic.com/graphql';
-  return 'https://api.newrelic.com/graphql';
+  return getRegionByDeployFlags(opts).nerdgraphUrl;
 }
 
 /**

--- a/src/deploy/deploy-dashboards.ts
+++ b/src/deploy/deploy-dashboards.ts
@@ -12,6 +12,7 @@ import { resolve, sep } from 'node:path';
 
 import { normalizeDeveloperName } from '../config.js';
 import { resolveDataDir } from './data-paths.js';
+import { getRegionByDeployFlags } from '../install/regions.js';
 
 export const CREATE_MUTATION = `
 mutation DashboardCreate($accountId: Int!, $dashboard: DashboardInput!) {
@@ -350,9 +351,7 @@ async function teardownDashboard(
 
 function pickNerdgraphUrl(opts: DashboardDeployOptions): string {
   if (opts.nerdgraphUrlOverride) return opts.nerdgraphUrlOverride;
-  if (opts.eu) return 'https://api.eu.newrelic.com/graphql';
-  if (opts.jp) return 'https://api.jp.newrelic.com/graphql';
-  return 'https://api.newrelic.com/graphql';
+  return getRegionByDeployFlags(opts).nerdgraphUrl;
 }
 
 /**

--- a/src/install/key-validator.ts
+++ b/src/install/key-validator.ts
@@ -1,29 +1,16 @@
 import { createLogger } from '../shared/index.js';
 import { validateSsrfUrl } from '../security/index.js';
+import { getRegion } from './regions.js';
 
 const logger = createLogger('key-validator');
 
-const EVENTS_API_HOSTS: Record<string, string> = {
-  eu: 'insights-collector.eu01.nr-data.net',
-  gov: 'gov-insights-collector.newrelic.com',
-  jp: 'insights-collector.jp.nr-data.net',
-  us: 'insights-collector.newrelic.com',
-};
-
-const NERDGRAPH_URLS: Record<string, string> = {
-  eu: 'https://api.eu.newrelic.com/graphql',
-  gov: 'https://api.newrelic.com/graphql',
-  jp: 'https://api.jp.newrelic.com/graphql',
-  us: 'https://api.newrelic.com/graphql',
-};
-
 export function getEventsApiUrl(accountId: string, collectorHost: string | null): string {
-  const host = EVENTS_API_HOSTS[collectorHost ?? 'us'] ?? EVENTS_API_HOSTS['us'];
+  const host = getRegion(collectorHost).eventsApiHost;
   return `https://${host}/v1/accounts/${accountId}/events`;
 }
 
 export function getNerdgraphUrl(collectorHost: string | null): string {
-  return NERDGRAPH_URLS[collectorHost ?? 'us'] ?? NERDGRAPH_URLS['us'];
+  return getRegion(collectorHost).nerdgraphUrl;
 }
 
 export interface ValidationResult {

--- a/src/install/regions.test.ts
+++ b/src/install/regions.test.ts
@@ -1,0 +1,92 @@
+import {
+  REGIONS,
+  getRegion,
+  getRegionByDeployFlags,
+  detectRegionFromLicenseKeyStrict,
+  suggestRegionFromLicenseKey,
+} from './regions.js';
+
+describe('REGIONS', () => {
+  it('is ordered us, eu, gov, jp', () => {
+    expect(REGIONS.map((r) => r.key)).toEqual(['us', 'eu', 'gov', 'jp']);
+  });
+});
+
+describe('getRegion', () => {
+  it('returns the us region for null', () => {
+    expect(getRegion(null).key).toBe('us');
+  });
+
+  it('returns the us region for undefined', () => {
+    expect(getRegion(undefined).key).toBe('us');
+  });
+
+  it('returns the us region for an unrecognized key', () => {
+    expect(getRegion('not-a-real-region').key).toBe('us');
+  });
+
+  it('returns the matching region for a known key', () => {
+    expect(getRegion('eu').eventsApiHost).toBe('insights-collector.eu01.nr-data.net');
+    expect(getRegion('jp').nerdgraphUrl).toBe('https://api.jp.newrelic.com/graphql');
+    expect(getRegion('gov').eventsApiHost).toBe('gov-insights-collector.newrelic.com');
+    expect(getRegion('gov').nerdgraphUrl).toBe('https://api.newrelic.com/graphql');
+  });
+});
+
+describe('getRegionByDeployFlags', () => {
+  it('returns us when no flag is set', () => {
+    expect(getRegionByDeployFlags({}).key).toBe('us');
+  });
+
+  it('returns eu when eu is set', () => {
+    expect(getRegionByDeployFlags({ eu: true }).nerdgraphUrl).toBe(
+      'https://api.eu.newrelic.com/graphql',
+    );
+  });
+
+  it('returns jp when jp is set', () => {
+    expect(getRegionByDeployFlags({ jp: true }).nerdgraphUrl).toBe(
+      'https://api.jp.newrelic.com/graphql',
+    );
+  });
+});
+
+describe('detectRegionFromLicenseKeyStrict', () => {
+  it('detects eu01 prefix', () => {
+    expect(detectRegionFromLicenseKeyStrict('eu01xx-license')).toBe('eu');
+  });
+
+  it('detects gov01 prefix', () => {
+    expect(detectRegionFromLicenseKeyStrict('gov01xx-license')).toBe('gov');
+  });
+
+  it('detects us01 prefix', () => {
+    expect(detectRegionFromLicenseKeyStrict('us01xx-license')).toBe('us');
+  });
+
+  it('detects jp prefix', () => {
+    expect(detectRegionFromLicenseKeyStrict('jpxx-license')).toBe('jp');
+  });
+
+  it('returns null for a legacy key with no recognized prefix', () => {
+    expect(detectRegionFromLicenseKeyStrict('NRLIC-legacykey')).toBeNull();
+  });
+
+  it('is case-insensitive', () => {
+    expect(detectRegionFromLicenseKeyStrict('EU01XX-LICENSE')).toBe('eu');
+  });
+});
+
+describe('suggestRegionFromLicenseKey', () => {
+  it('suggests eu for an eu01-prefixed key', () => {
+    expect(suggestRegionFromLicenseKey('eu01xx-license')).toBe('eu');
+  });
+
+  it('defaults to us for a key with no recognized prefix', () => {
+    expect(suggestRegionFromLicenseKey('NRLIC-legacykey')).toBe('us');
+  });
+
+  it('defaults to us for a nonsense key', () => {
+    expect(suggestRegionFromLicenseKey('nope')).toBe('us');
+  });
+});

--- a/src/install/regions.ts
+++ b/src/install/regions.ts
@@ -1,0 +1,93 @@
+/**
+ * Single source of truth for New Relic region host mappings — events-ingest
+ * host, NerdGraph URL, license-key auto-detect prefix, and deploy-CLI flag —
+ * consumed by key-validator.ts, setup-wizard.ts, and the deploy CLI files.
+ * Previously each of those maintained its own copy of this table; adding or
+ * changing a region meant updating all of them in lockstep with no
+ * compiler-enforced sync.
+ */
+
+export type RegionKey = 'us' | 'eu' | 'gov' | 'jp';
+
+export interface RegionDefinition {
+  readonly key: RegionKey;
+  readonly menuLabel: string;
+  readonly displayHost: string;
+  readonly eventsApiHost: string;
+  readonly nerdgraphUrl: string;
+  readonly licenseKeyPrefix: string | null;
+  readonly cliFlag: '--eu' | '--jp' | null;
+}
+
+// Order is load-bearing: setup-wizard's regenerated region menu numbers its
+// options 1-4 by this array's index.
+export const REGIONS: readonly RegionDefinition[] = [
+  {
+    key: 'us',
+    menuLabel: 'US',
+    displayHost: 'api.newrelic.com',
+    eventsApiHost: 'insights-collector.newrelic.com',
+    nerdgraphUrl: 'https://api.newrelic.com/graphql',
+    licenseKeyPrefix: 'us01',
+    cliFlag: null,
+  },
+  {
+    key: 'eu',
+    menuLabel: 'EU',
+    displayHost: 'api.eu.newrelic.com',
+    eventsApiHost: 'insights-collector.eu01.nr-data.net',
+    nerdgraphUrl: 'https://api.eu.newrelic.com/graphql',
+    licenseKeyPrefix: 'eu01',
+    cliFlag: '--eu',
+  },
+  {
+    key: 'gov',
+    menuLabel: 'FedRAMP',
+    displayHost: 'api.newrelic.com (FedRAMP/GovCloud)',
+    eventsApiHost: 'gov-insights-collector.newrelic.com',
+    // FedRAMP/GovCloud uses the same NerdGraph API as US, only the
+    // events-ingest host differs — there is no --gov deploy CLI flag
+    // because deploy commands never need a different NerdGraph URL for it.
+    nerdgraphUrl: 'https://api.newrelic.com/graphql',
+    licenseKeyPrefix: 'gov01',
+    cliFlag: null,
+  },
+  {
+    key: 'jp',
+    menuLabel: 'Japan',
+    displayHost: 'api.jp.newrelic.com',
+    eventsApiHost: 'insights-collector.jp.nr-data.net',
+    nerdgraphUrl: 'https://api.jp.newrelic.com/graphql',
+    licenseKeyPrefix: 'jp',
+    cliFlag: '--jp',
+  },
+];
+
+export function getRegion(key: string | null | undefined): RegionDefinition {
+  return REGIONS.find((r) => r.key === key) ?? REGIONS[0]!;
+}
+
+export function getRegionByDeployFlags(opts: { eu?: boolean; jp?: boolean }): RegionDefinition {
+  if (opts.eu) return getRegion('eu');
+  if (opts.jp) return getRegion('jp');
+  return getRegion('us');
+}
+
+// Strict prefix match — returns null when the key has no recognized region
+// prefix (e.g. a legacy key), so callers can distinguish "no opinion" from
+// "detected us". Used for the setup wizard's key/environment-mismatch warning.
+export function detectRegionFromLicenseKeyStrict(licenseKey: string): RegionKey | null {
+  const keyLower = licenseKey.toLowerCase();
+  for (const region of REGIONS) {
+    if (region.licenseKeyPrefix && keyLower.startsWith(region.licenseKeyPrefix)) {
+      return region.key;
+    }
+  }
+  return null;
+}
+
+// Same prefix match as above, but defaults to 'us' instead of null — used to
+// pre-select a default answer in the setup wizard's environment picker.
+export function suggestRegionFromLicenseKey(licenseKey: string): RegionKey {
+  return detectRegionFromLicenseKeyStrict(licenseKey) ?? 'us';
+}

--- a/src/install/setup-wizard.ts
+++ b/src/install/setup-wizard.ts
@@ -18,6 +18,12 @@ import { writeJsonFile } from './json-utils.js';
 import { installSchedule, installDashboardDaemon, resolveBinaryPath } from './schedule.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
 import { validateLicenseKey, validateApiKey } from './key-validator.js';
+import {
+  REGIONS,
+  getRegion,
+  suggestRegionFromLicenseKey,
+  detectRegionFromLicenseKeyStrict,
+} from './regions.js';
 import { getDashboardAddress, waitForHealthyDashboard } from './dashboard-health.js';
 
 const CONFIG_PATH = resolve(DEFAULT_STORAGE_PATH, 'config.json');
@@ -265,20 +271,13 @@ export async function runSetupWizard(): Promise<void> {
       // Step 2b: Environment / region
       const existingCollectorHost =
         typeof existing.collectorHost === 'string' ? existing.collectorHost : null;
-      const keyLower = licenseKey.toLowerCase();
-      const autoEnv = keyLower.startsWith('eu01')
-        ? 'eu'
-        : keyLower.startsWith('gov01')
-          ? 'gov'
-          : keyLower.startsWith('jp')
-            ? 'jp'
-            : 'us';
+      const autoEnv = suggestRegionFromLicenseKey(licenseKey);
       const defaultEnv = existingCollectorHost ?? autoEnv;
       print('Environment:');
-      print('  1) US      — api.newrelic.com');
-      print('  2) EU      — api.eu.newrelic.com');
-      print('  3) FedRAMP — api.newrelic.com (FedRAMP/GovCloud)');
-      print('  4) Japan   — api.jp.newrelic.com');
+      const menuLabelWidth = Math.max(...REGIONS.map((r) => r.menuLabel.length));
+      REGIONS.forEach((region, i) => {
+        print(`  ${i + 1}) ${region.menuLabel.padEnd(menuLabelWidth)} — ${region.displayHost}`);
+      });
       const envRaw = (await rl.question(`Which environment? [${defaultEnv}]: `))
         .trim()
         .toLowerCase();
@@ -297,15 +296,7 @@ export async function runSetupWizard(): Promise<void> {
       collectorHost = resolvedEnv === 'us' ? null : resolvedEnv;
 
       // Warn if license key prefix contradicts selected environment.
-      const keyRegion = keyLower.startsWith('eu01')
-        ? 'eu'
-        : keyLower.startsWith('gov01')
-          ? 'gov'
-          : keyLower.startsWith('us01')
-            ? 'us'
-            : keyLower.startsWith('jp')
-              ? 'jp'
-              : null;
+      const keyRegion = detectRegionFromLicenseKeyStrict(licenseKey);
       if (keyRegion && keyRegion !== resolvedEnv) {
         print(
           `  ⚠ Your license key looks like a ${keyRegion.toUpperCase()} key but you selected ${resolvedEnv.toUpperCase()}. Verify this is intentional.`,
@@ -688,7 +679,8 @@ export async function runSetupWizard(): Promise<void> {
 
     // Step 8: Dashboard deploy — show manual command
     if (mode !== 'local') {
-      const regionFlag = collectorHost === 'eu' ? ' --eu' : collectorHost === 'jp' ? ' --jp' : '';
+      const regionCliFlag = getRegion(collectorHost ?? 'us').cliFlag;
+      const regionFlag = regionCliFlag ? ` ${regionCliFlag}` : '';
       // Mask the API key in printed commands — users copy these snippets to
       // terminals, docs, and chat messages, and the raw key could be captured.
       const apiKeyVar = nrApiKey

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -86,17 +86,6 @@ export interface LatencyPercentiles {
   readonly count: number;
 }
 
-export interface LatencyMetrics {
-  readonly overall: LatencyPercentiles | null;
-  readonly byTool: Readonly<Record<string, LatencyPercentiles | null>>;
-  readonly slowestCalls: ReadonlyArray<{
-    readonly toolName: string;
-    readonly durationMs: number;
-    readonly timestamp: number;
-    readonly filePath?: string;
-  }>;
-}
-
 export interface ReplayTimelineEntry {
   readonly timestamp: number;
   readonly toolName: string;
@@ -484,7 +473,6 @@ export interface BudgetStatus {
 }
 
 export const fetchBudget = (): Promise<BudgetStatus> => getJson<BudgetStatus>('/api/budget');
-export const fetchLatency = (): Promise<LatencyMetrics> => getJson<LatencyMetrics>('/api/latency');
 
 // Mirrors CostAttribution in src/metrics/cost-per-outcome.ts (not importable).
 export interface CostPerOutcomeResponse {
@@ -1221,7 +1209,6 @@ export const qk = {
   audit: ['audit'] as const,
   weekly: ['weekly'] as const,
   budget: ['budget'] as const,
-  latency: ['latency'] as const,
   costPerOutcome: (days: number) => ['cost-per-outcome', days] as const,
   personalCoach: ['personal-coach'] as const,
   instructionDrift: ['instruction-drift'] as const,

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -582,6 +582,35 @@ describe('Sessions view — workflow consolidation', () => {
     expect(container.textContent).not.toContain('30s');
   });
 
+  it('shows a session with no workflow runs under the Today tab when it started today', async () => {
+    // sessionId kept to 8 chars: SessionListRow renders `sessionId.slice(0, 8)`,
+    // so a longer id would never render in full and this assertion would be
+    // vacuous regardless of the filtering fix under test.
+    const todaySession = {
+      sessionId: 'sess-tdy',
+      startTime: new Date().toISOString(),
+      toolCallCount: 3,
+      estimatedCostUsd: 0.1,
+    };
+    const { container } = renderSessionsFull([...SESSIONS, todaySession], RUNS);
+    await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('tab', { name: 'Today' }));
+    await waitFor(() => expect(within(container).getByText(/sess-tdy/)).toBeInTheDocument());
+  });
+
+  it('hides a session under the Today tab when it did not start today, even with no workflow runs', async () => {
+    const oldSession = {
+      sessionId: 'sess-old',
+      startTime: '2020-01-01T00:00:00Z',
+      toolCallCount: 3,
+      estimatedCostUsd: 0.1,
+    };
+    const { container } = renderSessionsFull([...SESSIONS, oldSession], RUNS);
+    await waitFor(() => expect(screen.getByText(/sess-a/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('tab', { name: 'Today' }));
+    await waitFor(() => expect(container.textContent).not.toContain('sess-old'));
+  });
+
   // A run's totalUsd being null is ambiguous between "confirmed $0" and "no
   // process ever observed this run's cost". costUnknown distinguishes the
   // two (a partial mitigation); the KPI must disclose when it does.

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -91,8 +91,9 @@ const WORKFLOW_STATUS_PILL: Record<WorkflowRunInfo['status'], { tone: PillTone; 
 type SortKey = 'date' | 'lastActive' | 'cost' | 'calls';
 
 // Run-level filters consolidated from the former Workflows view. They scope the
-// KPI strip AND the master list (a non-default filter shows only sessions that
-// own a matching run).
+// KPI strip AND the master list — see the `visibleRows` computation below for
+// how each filter narrows the master list (the time window and the run
+// source/status filters apply differently).
 type TimeWindow = 'today' | '7d' | '30d' | 'all';
 type RunSource = 'all' | 'script' | 'agent_tool';
 type StatusFilter = 'all' | 'running' | 'completed' | 'failed' | 'cancelled';
@@ -312,11 +313,30 @@ export function Sessions(): JSX.Element {
   }, [filteredRuns]);
   const filtersActive =
     activeWindow !== 'all' || runSourceFilter !== 'all' || statusFilter !== 'all';
-  // When a filter is active, show only sessions that own a matching run.
-  const visibleRows = useMemo(
-    () => (filtersActive ? rows.filter((r) => runsBySession.has(r.sessionId)) : rows),
-    [filtersActive, rows, runsBySession],
-  );
+  // Run-specific filters (source/status) still narrow to sessions owning a
+  // matching run — that's the whole point of those two filters. The time
+  // window, however, must filter sessions by their OWN startTime: most
+  // sessions never spawn a subagent and so have no entry in runsBySession at
+  // all, and joining them out via that map hid every such session the moment
+  // any tab but "All" was active, regardless of when it actually happened.
+  const runFiltersActive = runSourceFilter !== 'all' || statusFilter !== 'all';
+  const visibleRows = useMemo(() => {
+    let result = rows;
+    if (activeWindow !== 'all') {
+      // A session is in-window if its own startTime falls inside it, OR it
+      // owns a run that does (runsBySession is built from filteredRuns, which
+      // is already window-filtered) — this keeps a session visible when it
+      // started just before the window but spawned a subagent run just after
+      // the boundary.
+      result = result.filter(
+        (r) => isWithinWindow(startTimeMs(r), activeWindow) || runsBySession.has(r.sessionId),
+      );
+    }
+    if (runFiltersActive) {
+      result = result.filter((r) => runsBySession.has(r.sessionId));
+    }
+    return result;
+  }, [rows, activeWindow, runFiltersActive, runsBySession]);
   // The KPI strip above is built from filteredRuns, which come from
   // WorkflowStore.listRuns() — a machine-wide, 30-day-window, 500-run scan
   // with no relationship to `rows` (the session list's own most-recent-50
@@ -518,7 +538,9 @@ export function Sessions(): JSX.Element {
                 title={filtersActive ? 'No matching sessions' : 'No sessions yet'}
                 subtitle={
                   filtersActive
-                    ? 'No sessions own a workflow run matching these filters.'
+                    ? runFiltersActive
+                      ? 'No sessions own a workflow run matching these filters.'
+                      : 'No sessions in this time window.'
                     : 'Start coding with Claude to see your sessions here.'
                 }
               />


### PR DESCRIPTION
Fixes #331, Fixes #332, Fixes #350, Fixes #362, Fixes #363

## Summary

Bundles five already-filed issues into one patch release (1.15.0 → 1.15.1):

- **#331** — removed dead `fetchLatency`/`LatencyMetrics`/`qk.latency` code from the web dashboard's API client (zero remaining references; latency data is still served via the Today dashboard's aggregate endpoint).
- **#362** — Sessions page live-session detection is now cross-process-aware. Three call sites in `api-handler.ts` (`/api/session/current`, the `/api/sessions` stub injection, and the `/api/sessions/:id` detail route) now source liveness from a shared cross-process helper instead of the single-process registry, so a session running in a different Claude Code window shows its LIVE badge and a placeholder row instead of being invisible. (Full activity detail for that cross-process case — call counts, timeline — isn't available yet; only its live status and identity are.)
- **#363** — the Sessions page's Today/7-days/30-days tabs no longer hide sessions that never spawned a subagent (most sessions), regardless of how recently they actually happened. The time-window filter now also keeps a session visible if it owns a run inside the window, so sessions that started just before the window boundary aren't newly hidden either.
- **#332** — `scripts/backfill-sessions.ts` now writes all 9 previously-missing `FullSessionSummary` fields (sessionName, repoName, subagentCostUsd, cache-token fields, toolSelectionMetrics, modelBreakdown, qualityProxy), matching the production deserializer's legacy-file defaults.
- **#350** — consolidated region-host configuration (events-ingest host, NerdGraph URL, license-key auto-detect prefix, deploy CLI flag) into a single new registry module (`src/install/regions.ts`), previously hand-duplicated across `key-validator.ts`, `setup-wizard.ts`, and both deploy CLI files. Behavior-preserving — no public signature or CLI/output changes.

Plus a version bump to 1.15.1 and the corresponding CHANGELOG entry.

## Test plan

- [x] `npm test` — 5506 passed, 3 skipped (pre-existing), 0 failed
- [x] `npm run test:web` — 524 passed
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run format:check` — clean
- [x] `npm run build && npm run build:web` — both succeed

🤖 Generated with Claude Sonnet 5