### PR TITLE
Chore: add claude-opus-5 to the built-in pricing table

### DIFF
--- a/src/shared/pricing-data.test.ts
+++ b/src/shared/pricing-data.test.ts
@@ -2,6 +2,17 @@ import { DEFAULT_PRICING_TABLE } from './pricing-data.js';
 
 describe('DEFAULT_PRICING_TABLE', () => {
   describe('Anthropic models', () => {
+    it('has claude-opus-5 (current gen) with correct rates', () => {
+      const p = DEFAULT_PRICING_TABLE['claude-opus-5'];
+      expect(p).toBeDefined();
+      expect(p.inputPerMTok).toBe(5);
+      expect(p.outputPerMTok).toBe(25);
+      expect(p.thinkingPerMTok).toBe(25);
+      expect(p.cacheReadPerMTok).toBe(0.5);
+      expect(p.cacheCreationPerMTok).toBe(6.25);
+      expect(p.contextWindow).toBe(1_000_000);
+    });
+
     it('has claude-opus-4-7 (current gen) with correct rates', () => {
       const p = DEFAULT_PRICING_TABLE['claude-opus-4-7'];
       expect(p).toBeDefined();

--- a/src/shared/pricing-data.ts
+++ b/src/shared/pricing-data.ts
@@ -39,7 +39,8 @@ export const MODEL_ALIASES: Record<string, string> = {
 // ---------------------------------------------------------------------------
 // Built-in pricing table — USD per million tokens
 //
-// Rates last verified against vendor public pricing pages on 2026-07-01:
+// Rates last verified against vendor public pricing pages on 2026-07-01
+// (Anthropic re-checked 2026-08-14 for the Claude Opus 5 entries):
 //   - Anthropic   https://www.anthropic.com/pricing
 //   - Google      https://cloud.google.com/vertex-ai/generative-ai/pricing
 //   - OpenAI      https://openai.com/api/pricing/
@@ -64,6 +65,14 @@ export const DEFAULT_PRICING_TABLE: Record<string, ModelPricing> = {
     thinkingPerMTok: 50,
     cacheReadPerMTok: 1,
     cacheCreationPerMTok: 12.5,
+    contextWindow: 1_000_000,
+  },
+  'claude-opus-5': {
+    inputPerMTok: 5,
+    outputPerMTok: 25,
+    thinkingPerMTok: 25,
+    cacheReadPerMTok: 0.5,
+    cacheCreationPerMTok: 6.25,
     contextWindow: 1_000_000,
   },
   'claude-opus-4-8': {
@@ -387,6 +396,11 @@ export const DEFAULT_PRICING_TABLE: Record<string, ModelPricing> = {
   'anthropic.claude-sonnet-5': {
     inputPerMTok: 2,
     outputPerMTok: 10,
+    contextWindow: 1_000_000,
+  },
+  'anthropic.claude-opus-5': {
+    inputPerMTok: 5,
+    outputPerMTok: 25,
     contextWindow: 1_000_000,
   },
   'anthropic.claude-opus-4-8': {


### PR DESCRIPTION
Claude Opus 5 shipped after the 2026-07-01 pricing sync (#20), so it has no entry in `DEFAULT_PRICING_TABLE`.

`resolveModelPricing()` logs `Unknown model, pricing not available` and returns `null`, so every cost surface reports **$0.00** for sessions on that model — Spend Today, Model Usage, Cost by Tool, Cost per Outcome, and the forecast chips. Token counts, tool-selection scores, and every other metric record normally, so the dashboard looks healthy while cost silently reads zero. Budget alerts (`budget.session` / `budget.daily` / `budget.weekly`) also never fire for these sessions.

Reproduce by running a session on `claude-opus-5` and opening the dashboard: `MODEL USAGE` shows `$0.00/1M tok`.

## What changed

### New models

| Model | Input | Output | Notes |
|---|---|---|---|
| `claude-opus-5` | \$5 / MTok | \$25 / MTok | Cache read \$0.5, cache creation \$6.25, 1M context |
| `anthropic.claude-opus-5` (Bedrock) | \$5 / MTok | \$25 / MTok | No cache rates, per the existing Bedrock convention |

Rates are from Anthropic's public pricing page and match the existing `claude-opus-4-8` entry — Opus 5 is priced identically to Opus 4.8. Cache rates follow the same multipliers used throughout the table (read 0.1x input, creation 1.25x input for the 5-minute TTL).

### Verification comment

The header comment keeps its `2026-07-01` date for the other vendors and notes that only Anthropic was re-checked (2026-08-14) for these entries — I didn't re-verify Google, OpenAI, Cohere, Mistral, or the rest of the Bedrock table, so bumping the shared date would have overstated it.

## Notes

- No alias change. `claude-opus-4` still resolves to `claude-opus-4-8`; Opus 5 is a new family and matches exactly.
- Historical sessions already recorded at \$0 stay as recorded — only new sessions pick up the rates. Same behavior as #20.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors/warnings
- [x] `npm run format:check` — clean
- [x] `npm test` — added a `claude-opus-5` case to `pricing-data.test.ts` alongside the existing per-model rate assertions; 5506 passing

One pre-existing failure in `src/dashboard/routes/api-handler.test.ts` (`does not inflate the next bucket when a session ends exactly at a bucket boundary`) is unrelated to this change — it reproduces on a clean `main` checkout when the full suite runs, and passes when that file is run on its own, so it looks order- or clock-dependent rather than caused by this PR.