### PR TITLE
Patch release v1.15.2: doctor diagnostics + local --stdio visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.2] - 2026-08-13
+
+### Added
+
+- **`preflight doctor` now includes three additional checks**: whether the running Node.js version meets the minimum supported version, whether a newer version of Preflight is available on npm, and whether the Node.js binary colocated with the installed Claude Code hook matches the Node currently running `doctor` (catches an nvm default that changed after install).
+- **`preflight local` now also lists live `--stdio` MCP processes** (one per Claude Code window), not just `--local` dashboard processes, and `--clean` auto-flags `--stdio` processes whose recorded binary no longer exists on disk for cleanup.
+
 ## [1.15.1] - 2026-08-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ You'll need a **license key** (telemetry ingest) and your **account ID**, plus a
 ## Other Commands
 
 ```bash
-preflight doctor               # Run 7 diagnostic checks and print actionable fix commands
+preflight doctor               # Run 10 diagnostic checks and print actionable fix commands
 preflight validate             # Check config for syntax errors and unknown keys
 preflight update               # Pull latest version, rebuild, and offer to restart a running dashboard (source installs only — npm installs: npm install -g @newrelic/preflight@latest)
-preflight local                # List running --local dashboard processes
-preflight local --clean        # Kill orphaned --local processes (prompts for confirmation)
+preflight local                # List running --local dashboard processes and live --stdio MCP processes
+preflight local --clean        # Kill orphaned --local processes and --stdio processes with a missing binary (prompts for confirmation)
 preflight uninstall            # Remove hooks and MCP config (prompts with a summary first)
 preflight uninstall --yes      # Skip the confirmation prompt (for scripts and CI)
 preflight uninstall --daemon   # Remove only the background dashboard daemon

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.15.1",
+      "version": "1.15.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/dashboard-server.ts
+++ b/src/dashboard/dashboard-server.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { createLogger } from '../shared/index.js';
 import { VERSION } from '../version.js';
+import { isNewerVersion, fetchLatestNpmVersion } from '../install/npm-version-check.js';
 import { LiveEventBus } from './live-event-bus.js';
 import { createStaticHandler } from './routes/static-handler.js';
 import { createApiHandler, ApiHandlerDeps } from './routes/api-handler.js';
@@ -12,37 +13,6 @@ import type { LocalAlertEngine } from '../alerts/local-alert-engine.js';
 import type { AlertLog } from '../alerts/alert-log.js';
 
 const logger = createLogger('dashboard-server');
-
-function isNewerVersion(candidate: string, installed: string): boolean {
-  const parse = (v: string): [number, number, number] => {
-    const parts = v.replace(/^v/, '').replace(/-.*$/, '').split('.').map(Number);
-    return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
-  };
-  const [ca, cb, cc] = parse(candidate);
-  const [ia, ib, ic] = parse(installed);
-  if (ca !== ia) return ca > ia;
-  if (cb !== ib) return cb > ib;
-  return cc > ic;
-}
-
-interface NpmRegistryLatestResponse {
-  readonly version?: unknown;
-}
-
-async function defaultNpmFetcher(): Promise<string | null> {
-  try {
-    const res = await fetch('https://registry.npmjs.org/@newrelic/preflight/latest', {
-      headers: { accept: 'application/json' },
-      signal: AbortSignal.timeout(5000),
-    });
-    if (!res.ok) return null;
-    const data = (await res.json()) as NpmRegistryLatestResponse;
-    const v = data.version;
-    return typeof v === 'string' ? v : null;
-  } catch {
-    return null;
-  }
-}
 
 export interface DashboardServerOptions {
   readonly port: number;
@@ -122,7 +92,7 @@ export class DashboardServer {
       res.on('close', () => this.activeSseResponses.delete(res));
       sseHandler(req, res);
     });
-    const fetcher = opts.npmFetcher ?? defaultNpmFetcher;
+    const fetcher = opts.npmFetcher ?? fetchLatestNpmVersion;
     void fetcher().then((v) => {
       if (v !== null) {
         this.latestVersion = v;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,7 +26,6 @@ import {
   DEFAULT_PENDING_CONFIRMATION_CAP_MS,
   startRetentionSweep,
   startMaintenanceGc,
-  checkNodeVersion,
 } from './index.js';
 import type { DashboardServer } from './dashboard/dashboard-server.js';
 import type { LocalStore } from './storage/index.js';
@@ -468,26 +467,6 @@ describe('getPendingConfirmationCapMs()', () => {
     expect(getPendingConfirmationCapMs()).toBe(DEFAULT_PENDING_CONFIRMATION_CAP_MS);
     process.env.NR_AI_PENDING_CONFIRMATION_CAP_MS = '-100';
     expect(getPendingConfirmationCapMs()).toBe(DEFAULT_PENDING_CONFIRMATION_CAP_MS);
-  });
-});
-
-describe('checkNodeVersion()', () => {
-  it('returns null when the running Node version meets the floor', () => {
-    expect(checkNodeVersion('v22.0.0')).toBeNull();
-    expect(checkNodeVersion('v24.18.0')).toBeNull();
-  });
-
-  it('returns a diagnostic message when Node is below the floor', () => {
-    const message = checkNodeVersion('v16.20.0');
-    expect(message).not.toBeNull();
-    expect(message).toContain('v16.20.0');
-    expect(message).toContain('v22');
-    expect(message).toContain('TROUBLESHOOTING.md');
-  });
-
-  it('defaults to process.version when no argument is given', () => {
-    // The test runner itself must satisfy engines.node (>=22), so this is null.
-    expect(checkNodeVersion()).toBeNull();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { resolve } from 'node:path';
 import { Command } from 'commander';
 import { createLogger } from './shared/index.js';
 import { VERSION } from './version.js';
+import { checkNodeVersion } from './install/node-version-check.js';
 import { createServer } from './server.js';
 import { loadMcpConfig, DEFAULT_STORAGE_PATH } from './config.js';
 import type { McpServerConfig } from './config.js';
@@ -625,37 +626,6 @@ export function parseArgs(argv: string[]): CliOptions {
     local,
     validate,
   };
-}
-
-// Must track package.json's `engines.node` floor.
-export const MIN_SUPPORTED_NODE_MAJOR = 22;
-
-/**
- * Returns a diagnostic message when the running Node major version is below
- * MIN_SUPPORTED_NODE_MAJOR, or null when it's fine. Checked at the very start
- * of main() so an MCP client resolving a stale/unintended Node binary (e.g.
- * via nvm — see docs/TROUBLESHOOTING.md) fails with a clear message instead
- * of an opaque deep-in-the-stack error or silent connection failure.
- *
- * This only actually catches Node 20-21: on those versions the static import
- * graph still loads fine, so this check's own code gets a chance to run
- * before failing on the version floor. On Node 16-19 the process crashes
- * earlier, during ESM's evaluation of the whole static import graph — before
- * main() (and this check) ever runs — with a less clear error, e.g.
- * `ReferenceError: structuredClone is not defined` (Node 16, from
- * src/shared/pricing.ts) or `ReferenceError: File is not defined` (Node 18,
- * from undici). Still valuable for the most common real-world case: a stale
- * nvm default resolving to a merely-slightly-old Node.
- */
-export function checkNodeVersion(nodeVersion: string = process.version): string | null {
-  const major = parseInt(nodeVersion.replace(/^v/, '').split('.')[0], 10);
-  if (!Number.isFinite(major) || major >= MIN_SUPPORTED_NODE_MAJOR) return null;
-  return (
-    `preflight requires Node.js v${MIN_SUPPORTED_NODE_MAJOR}+, but is running under ${nodeVersion}. ` +
-    'This usually means your MCP client resolved a stale or unintended Node binary (e.g. via nvm). ' +
-    'See docs/TROUBLESHOOTING.md, "MCP server won\'t start (wrong Node version)", for how to pin the ' +
-    'exact Node path in ~/.mcp.json.'
-  );
 }
 
 async function main(): Promise<void> {

--- a/src/install/cli.test.ts
+++ b/src/install/cli.test.ts
@@ -1770,8 +1770,10 @@ describe('preflight local', () => {
     (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
       getLiveLocalDashboardProcess: jest.fn(() => null),
       listLocalInstances: jest.fn(() => []),
+      listActiveStdioInstances: jest.fn(() => []),
       gcDeadLocalInstances: jest.fn(() => 0),
       unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
     }));
     const readlineMod = await import('node:readline/promises');
     (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
@@ -1788,17 +1790,19 @@ describe('preflight local', () => {
     return stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
   }
 
-  it('prints "No --local processes running" when the registry is empty', async () => {
+  it('prints "No --local or --stdio processes running" when the registry is empty', async () => {
     await runInstallCli(['local']);
-    expect(getOutput()).toContain('No --local processes running');
+    expect(getOutput()).toContain('No --local or --stdio processes running');
   });
 
   it('cleans up dead entries silently before listing', async () => {
     (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
       getLiveLocalDashboardProcess: jest.fn(() => null),
       listLocalInstances: jest.fn(() => []),
+      listActiveStdioInstances: jest.fn(() => []),
       gcDeadLocalInstances: jest.fn(() => 2),
       unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
     }));
     await runInstallCli(['local']);
     expect(getOutput()).toContain('Cleaned up 2 stale registry entries');
@@ -1811,8 +1815,10 @@ describe('preflight local', () => {
         { pid: 100, argv: [], cwd: '/owner', startedAt: Date.now() - 1000, alive: true },
         { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now() - 2000, alive: true },
       ]),
+      listActiveStdioInstances: jest.fn(() => []),
       gcDeadLocalInstances: jest.fn(() => 0),
       unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
     }));
     await runInstallCli(['local']);
     const output = getOutput();
@@ -1829,8 +1835,10 @@ describe('preflight local', () => {
       listLocalInstances: jest.fn(() => [
         { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now(), alive: true },
       ]),
+      listActiveStdioInstances: jest.fn(() => []),
       gcDeadLocalInstances: jest.fn(() => 0),
       unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
     }));
     const killSpy = jest.spyOn(process, 'kill');
     await runInstallCli(['local']);
@@ -1847,8 +1855,10 @@ describe('preflight local', () => {
         { pid: 200, argv: [], cwd: '/orphan-a', startedAt: Date.now(), alive: true },
         { pid: 201, argv: [], cwd: '/orphan-b', startedAt: Date.now(), alive: true },
       ]),
+      listActiveStdioInstances: jest.fn(() => []),
       gcDeadLocalInstances: jest.fn(() => 0),
       unregisterLocalInstance,
+      removeStdioHeartbeat: jest.fn(),
     }));
     const readlineMod = await import('node:readline/promises');
     const questionMock = jest.fn(async (_prompt: string) => 'y');
@@ -1884,8 +1894,10 @@ describe('preflight local', () => {
       listLocalInstances: jest.fn(() => [
         { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now(), alive: true },
       ]),
+      listActiveStdioInstances: jest.fn(() => []),
       gcDeadLocalInstances: jest.fn(() => 0),
       unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
     }));
     const readlineMod = await import('node:readline/promises');
     (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
@@ -1911,8 +1923,10 @@ describe('preflight local', () => {
       listLocalInstances: jest.fn(() => [
         { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now(), alive: true },
       ]),
+      listActiveStdioInstances: jest.fn(() => []),
       gcDeadLocalInstances: jest.fn(() => 0),
       unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
     }));
     const readlineMod = await import('node:readline/promises');
     (readlineMod.createInterface as unknown as jest.Mock).mockReturnValue({
@@ -1953,8 +1967,10 @@ describe('preflight local', () => {
       listLocalInstances: jest.fn(() => [
         { pid: 200, argv: [], cwd: '/orphan', startedAt: Date.now(), alive: true },
       ]),
+      listActiveStdioInstances: jest.fn(() => []),
       gcDeadLocalInstances: jest.fn(() => 0),
       unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
     }));
     const killSpy = jest.spyOn(process, 'kill');
     await runInstallCli(['local', '--clean']);
@@ -1968,14 +1984,121 @@ describe('preflight local', () => {
       listLocalInstances: jest.fn(() => [
         { pid: 100, argv: [], cwd: '/owner', startedAt: Date.now(), alive: true },
       ]),
+      listActiveStdioInstances: jest.fn(() => []),
       gcDeadLocalInstances: jest.fn(() => 0),
       unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
     }));
     const killSpy = jest.spyOn(process, 'kill');
     await runInstallCli(['local', '--clean']);
     expect(getOutput()).toContain('No orphaned processes to clean up');
     expect(killSpy).not.toHaveBeenCalled();
     killSpy.mockRestore();
+  });
+
+  it('lists live --stdio processes alongside --local ones', async () => {
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+      listLocalInstances: jest.fn(() => []),
+      listActiveStdioInstances: jest.fn(() => [
+        {
+          pid: 300,
+          sessionId: 'sess-a',
+          argv: ['/opt/preflight/dist/index.js', '--stdio'],
+          cwd: '/home/user/project',
+          startedAt: Date.now() - 5000,
+          alive: true,
+        },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
+    }));
+    await runInstallCli(['local']);
+    const output = getOutput();
+    expect(output).toContain('1 --stdio MCP process(es) running');
+    expect(output).toContain('PID 300');
+    expect(output).toContain('sess-a');
+    expect(output).toContain('/home/user/project');
+    expect(output).toContain('restart Claude Code');
+  });
+
+  it('does not list a --stdio process whose heartbeat PID is dead', async () => {
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+      listLocalInstances: jest.fn(() => []),
+      listActiveStdioInstances: jest.fn(() => [
+        {
+          pid: 999999,
+          sessionId: 'sess-dead',
+          argv: [],
+          cwd: null,
+          startedAt: Date.now(),
+          alive: false,
+        },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
+    }));
+    await runInstallCli(['local']);
+    expect(getOutput()).toContain('No --local or --stdio processes running');
+  });
+
+  it('--clean auto-kills a --stdio process whose recorded binary no longer exists on disk', async () => {
+    const removeStdioHeartbeat = jest.fn();
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+      listLocalInstances: jest.fn(() => []),
+      listActiveStdioInstances: jest.fn(() => [
+        {
+          pid: 300,
+          sessionId: 'sess-orphan',
+          argv: ['/opt/preflight-uninstalled/dist/index.js', '--stdio'],
+          cwd: '/home/user/project',
+          startedAt: Date.now(),
+          alive: true,
+        },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat,
+    }));
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' });
+    });
+    await runInstallCli(['local', '--clean']);
+    expect(killSpy).toHaveBeenCalledWith(300, 'SIGTERM');
+    expect(removeStdioHeartbeat).toHaveBeenCalledWith('sess-orphan');
+    killSpy.mockRestore();
+  });
+
+  it('--clean does not touch a live --stdio process whose recorded binary still exists on disk', async () => {
+    (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
+      getLiveLocalDashboardProcess: jest.fn(() => null),
+      listLocalInstances: jest.fn(() => []),
+      listActiveStdioInstances: jest.fn(() => [
+        {
+          // process.execPath is always a real, existing file — a safe stand-in
+          // for "the binary is still on disk".
+          pid: 300,
+          sessionId: 'sess-fine',
+          argv: [process.execPath],
+          cwd: '/home/user/project',
+          startedAt: Date.now(),
+          alive: true,
+        },
+      ]),
+      gcDeadLocalInstances: jest.fn(() => 0),
+      unregisterLocalInstance: jest.fn(),
+      removeStdioHeartbeat: jest.fn(),
+    }));
+    (fsMod.existsSync as jest.Mock).mockImplementation((p: unknown) => p === process.execPath);
+    const killSpy = jest.spyOn(process, 'kill');
+    await runInstallCli(['local', '--clean']);
+    expect(killSpy).not.toHaveBeenCalledWith(300, 'SIGTERM');
+    killSpy.mockRestore();
+    (fsMod.existsSync as jest.Mock).mockImplementation(() => false);
   });
 });
 

--- a/src/install/cli.ts
+++ b/src/install/cli.ts
@@ -368,12 +368,14 @@ function formatAge(ms: number): string {
 /**
  * `preflight local` — lists every `--local` process preflight has
  * registered (see `LocalStore.registerLocalInstance()`), marking whichever
- * one currently owns the dashboard port. `--clean` additionally offers to
- * kill every live, non-owning entry (a single combined prompt, default
- * yes) — these are processes that lost the dashboard port race and have
- * been running headless ever since, with no other way to detect them
- * short of scanning the OS process table, which this feature deliberately
- * avoids.
+ * one currently owns the dashboard port, and every live `--stdio` MCP
+ * process (one per Claude Code window, see `LocalStore.writeHeartbeat()`).
+ * `--clean` additionally offers to kill every live, non-owning `--local`
+ * entry (processes that lost the dashboard port race and have been running
+ * headless ever since) plus any `--stdio` process whose recorded binary no
+ * longer exists on disk (a high-confidence sign it was uninstalled or moved
+ * out from under a still-running session) — a single combined prompt,
+ * default yes.
  */
 async function handleLocal(options: { clean?: boolean }): Promise<void> {
   const localStore = new LocalStore(DEFAULT_STORAGE_PATH);
@@ -385,25 +387,56 @@ async function handleLocal(options: { clean?: boolean }): Promise<void> {
 
   const owner = localStore.getLiveLocalDashboardProcess();
   const instances = localStore.listLocalInstances().filter((i) => i.alive);
+  const stdioInstances = localStore.listActiveStdioInstances().filter((i) => i.alive);
 
-  if (instances.length === 0) {
-    print('No --local processes running.');
+  if (instances.length === 0 && stdioInstances.length === 0) {
+    print('No --local or --stdio processes running.');
     return;
   }
 
-  print(`${instances.length} --local process(es) running:`);
-  print();
-  for (const inst of instances) {
-    const status = inst.pid === owner?.pid ? 'dashboard owner' : 'idle';
+  if (instances.length > 0) {
+    print(`${instances.length} --local process(es) running:`);
+    print();
+    for (const inst of instances) {
+      const status = inst.pid === owner?.pid ? 'dashboard owner' : 'idle';
+      print(
+        `  PID ${inst.pid}  (${status}, started ${formatAge(Date.now() - inst.startedAt)} ago)  ${inst.cwd}`,
+      );
+    }
+    print();
+  }
+
+  // High-confidence --stdio orphans: the recorded binary (argv[0]) no longer
+  // exists on disk — e.g. it was uninstalled or moved after Claude Code
+  // spawned this process. Unlike a --local process that lost the dashboard
+  // port race, a live --stdio process with an intact binary is the normal
+  // case (one per Claude Code window) — only the binary-missing ones are
+  // auto-flagged.
+  const stdioOrphans = stdioInstances.filter((i) => i.argv[0] && !existsSync(i.argv[0]));
+
+  if (stdioInstances.length > 0) {
+    print(`${stdioInstances.length} --stdio MCP process(es) running:`);
+    print();
+    for (const inst of stdioInstances) {
+      const orphanTag = stdioOrphans.includes(inst) ? ', binary missing' : '';
+      print(
+        `  PID ${inst.pid}  (session ${inst.sessionId}, started ${formatAge(Date.now() - inst.startedAt)} ago${orphanTag})  ${inst.cwd ?? 'unknown cwd'}`,
+      );
+    }
+    print();
     print(
-      `  PID ${inst.pid}  (${status}, started ${formatAge(Date.now() - inst.startedAt)} ago)  ${inst.cwd}`,
+      '  Note: a --stdio process is spawned once by Claude Code over stdio pipes — killing it will not',
+    );
+    print(
+      '  make Claude Code respawn a replacement; restart Claude Code (or that window) afterward.',
     );
   }
 
   if (!options.clean) return;
 
-  const orphans = instances.filter((i) => i.pid !== owner?.pid);
-  if (orphans.length === 0) {
+  const localOrphans = instances.filter((i) => i.pid !== owner?.pid);
+  const totalOrphans = localOrphans.length + stdioOrphans.length;
+  if (totalOrphans === 0) {
     print('\nNo orphaned processes to clean up.');
     return;
   }
@@ -413,7 +446,7 @@ async function handleLocal(options: { clean?: boolean }): Promise<void> {
   try {
     answer = (
       await rl.question(
-        `\nKill ${orphans.length} orphaned process${orphans.length > 1 ? 'es' : ''}? [Y/n]: `,
+        `\nKill ${totalOrphans} orphaned process${totalOrphans > 1 ? 'es' : ''}? [Y/n]: `,
       )
     )
       .trim()
@@ -423,11 +456,21 @@ async function handleLocal(options: { clean?: boolean }): Promise<void> {
   }
   if (answer === 'n' || answer === 'no') return;
 
-  for (const orphan of orphans) {
+  for (const orphan of localOrphans) {
     try {
       await killProcessGracefully(orphan.pid);
       localStore.unregisterLocalInstance(orphan.pid);
       print(`✓ Killed PID ${orphan.pid}.`);
+    } catch (err) {
+      print(`⚠ Could not kill PID ${orphan.pid}: ${errMsg(err)}`);
+    }
+  }
+
+  for (const orphan of stdioOrphans) {
+    try {
+      await killProcessGracefully(orphan.pid);
+      localStore.removeStdioHeartbeat(orphan.sessionId);
+      print(`✓ Killed PID ${orphan.pid} (session ${orphan.sessionId}).`);
     } catch (err) {
       print(`⚠ Could not kill PID ${orphan.pid}: ${errMsg(err)}`);
     }

--- a/src/install/diagnostics.test.ts
+++ b/src/install/diagnostics.test.ts
@@ -138,7 +138,9 @@ describe('runDiagnostics', () => {
     });
     mockedDetectSettingsPath.mockReturnValue('/test-home/.claude/settings.json');
     mockedIsWsl.mockReturnValue(false);
-    mockFetch.mockResolvedValue({ ok: true } as Response);
+    mockFetch.mockImplementation(async () => {
+      return { ok: true, json: async () => ({ version: '0.0.0' }) } as unknown as Response;
+    });
     mockedStatSync.mockImplementation(() => {
       throw new Error('ENOENT');
     });
@@ -200,7 +202,16 @@ describe('runDiagnostics', () => {
     });
   });
 
-  describe('Check 2: Daemon installed', () => {
+  describe('Check 2: Node version', () => {
+    it('returns ok on a supported Node version', async () => {
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Node version')!;
+      expect(c.status).toBe('ok');
+      expect(c.detail).toContain(process.version);
+    });
+  });
+
+  describe('Check 3: Daemon installed', () => {
     it('returns skip on non-macOS', async () => {
       mockedPlatform.mockReturnValue('linux');
       const checks = await runDiagnostics(makeOpts());
@@ -225,7 +236,7 @@ describe('runDiagnostics', () => {
     });
   });
 
-  describe('Check 3: Daemon node path', () => {
+  describe('Check 4: Daemon node path', () => {
     it('returns skip when daemon not installed', async () => {
       mockedGetDaemonStatus.mockReturnValue({ installed: false, readable: false });
       const checks = await runDiagnostics(makeOpts());
@@ -301,7 +312,7 @@ describe('runDiagnostics', () => {
     });
   });
 
-  describe('Check 4: Hooks wired', () => {
+  describe('Check 5: Hooks wired', () => {
     it('returns fail when settings file does not exist', async () => {
       mockedExistSync.mockImplementation((p) => p !== '/test-home/.claude/settings.json');
       const checks = await runDiagnostics(makeOpts());
@@ -494,7 +505,81 @@ describe('runDiagnostics', () => {
     });
   });
 
-  describe('Check 5: Storage writable', () => {
+  describe('Check 6: Hook node path', () => {
+    function settingsWithHookCommand(command: string) {
+      mockedExistSync.mockImplementation((p) => p === '/test-home/.claude/settings.json');
+      mockedReadFileSync.mockImplementation((p) => {
+        if (p === '/test-home/.claude/settings.json') {
+          return JSON.stringify({
+            hooks: {
+              PreToolUse: [{ matcher: '', hooks: [{ type: 'command', command }] }],
+              PostToolUse: [{ matcher: '', hooks: [{ type: 'command', command }] }],
+            },
+          });
+        }
+        return '{}';
+      });
+    }
+
+    it('skips when no NR hook is installed', async () => {
+      mockedExistSync.mockImplementation((p) => p === '/test-home/.claude/settings.json');
+      mockedReadFileSync.mockImplementation(() => JSON.stringify({ hooks: {} }));
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hook node path')!;
+      expect(c.status).toBe('skip');
+    });
+
+    it('skips when the installed hook uses a bare command name (no absolute path)', async () => {
+      settingsWithHookCommand('preflight-collector pre-tool');
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hook node path')!;
+      expect(c.status).toBe('skip');
+      expect(c.detail).toContain('bare command name');
+    });
+
+    it('fails when no node binary is found next to the installed hook', async () => {
+      settingsWithHookCommand('"/opt/stale-node/bin/preflight-collector" pre-tool');
+      mockedFindExecutableNodeDir.mockReturnValue({ dir: null, hasNonExecutable: false });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hook node path')!;
+      expect(c.status).toBe('fail');
+      expect(c.fix).toBeDefined();
+    });
+
+    it('fails with permission error when node binary exists but is not executable', async () => {
+      settingsWithHookCommand('"/opt/node/bin/preflight-collector" pre-tool');
+      mockedFindExecutableNodeDir.mockReturnValue({ dir: null, hasNonExecutable: true });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hook node path')!;
+      expect(c.status).toBe('fail');
+      expect(c.detail).toContain('not executable');
+      expect(c.fix).toContain('chmod +x');
+    });
+
+    it('returns ok when the colocated node binary matches the current Node install', async () => {
+      const currentNodeDir = dirname(process.execPath);
+      settingsWithHookCommand(`"${currentNodeDir}/preflight-collector" pre-tool`);
+      mockedFindExecutableNodeDir.mockReturnValue({ dir: currentNodeDir, hasNonExecutable: false });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hook node path')!;
+      expect(c.status).toBe('ok');
+    });
+
+    it('warns when the colocated node binary differs from the current Node install', async () => {
+      settingsWithHookCommand('"/opt/other-node/bin/preflight-collector" pre-tool');
+      mockedFindExecutableNodeDir.mockReturnValue({
+        dir: '/opt/other-node/bin',
+        hasNonExecutable: false,
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Hook node path')!;
+      expect(c.status).toBe('warn');
+      expect(c.detail).toContain('/opt/other-node/bin');
+      expect(c.fix).toBeDefined();
+    });
+  });
+
+  describe('Check 7: Storage writable', () => {
     it('returns fail when directory does not exist', async () => {
       mockedExistSync.mockImplementation((p) => p !== '/test-home/.newrelic-preflight');
       const checks = await runDiagnostics(makeOpts());
@@ -533,7 +618,7 @@ describe('runDiagnostics', () => {
     });
   });
 
-  describe('Check 6: NR reachable', () => {
+  describe('Check 10: NR reachable', () => {
     beforeEach(() => {
       mockedValidateConfig.mockReturnValue({
         fileExists: true,
@@ -662,7 +747,7 @@ describe('runDiagnostics', () => {
     });
   });
 
-  describe('Check 7: Local instances', () => {
+  describe('Check 8: Local instances', () => {
     it('reports ok with no --local processes running', async () => {
       (LocalStore as unknown as jest.Mock).mockImplementation(() => ({
         getLiveLocalDashboardProcess: jest.fn(() => null),
@@ -719,9 +804,9 @@ describe('runDiagnostics', () => {
         throw new Error('registry file is corrupt');
       });
       const checks = await runDiagnostics({ configPath: '/tmp/does-not-exist.json' });
-      // All 7 checks must still be present — one throwing dependency must not
+      // All 10 checks must still be present — one throwing dependency must not
       // take down the rest of the diagnostic run.
-      expect(checks).toHaveLength(7);
+      expect(checks).toHaveLength(10);
       const check = checks.find((c) => c.check === 'Local instances');
       expect(check?.status).toBe('warn');
       expect(check?.detail).toContain('registry file is corrupt');
@@ -729,8 +814,49 @@ describe('runDiagnostics', () => {
     });
   });
 
-  it('returns exactly 7 checks on macOS', async () => {
+  describe('Check 9: Preflight version', () => {
+    it('returns ok when the installed version is the latest', async () => {
+      const mod = await import('../version.js');
+      mockFetch.mockImplementation(async (url: string | URL | Request) => {
+        if (String(url).includes('registry.npmjs.org')) {
+          return { ok: true, json: async () => ({ version: mod.VERSION }) } as unknown as Response;
+        }
+        return { ok: true, json: async () => ({}) } as unknown as Response;
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Preflight version')!;
+      expect(c.status).toBe('ok');
+    });
+
+    it('returns warn with an upgrade fix command when a newer version is on npm', async () => {
+      mockFetch.mockImplementation(async (url: string | URL | Request) => {
+        if (String(url).includes('registry.npmjs.org')) {
+          return { ok: true, json: async () => ({ version: '99.0.0' }) } as unknown as Response;
+        }
+        return { ok: true, json: async () => ({}) } as unknown as Response;
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Preflight version')!;
+      expect(c.status).toBe('warn');
+      expect(c.detail).toContain('99.0.0');
+      expect(c.fix).toBe('npm install -g @newrelic/preflight@latest');
+    });
+
+    it('returns skip when the npm registry is unreachable', async () => {
+      mockFetch.mockImplementation(async (url: string | URL | Request) => {
+        if (String(url).includes('registry.npmjs.org')) {
+          return { ok: false } as unknown as Response;
+        }
+        return { ok: true, json: async () => ({}) } as unknown as Response;
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Preflight version')!;
+      expect(c.status).toBe('skip');
+    });
+  });
+
+  it('returns exactly 10 checks on macOS', async () => {
     const checks = await runDiagnostics(makeOpts());
-    expect(checks).toHaveLength(7);
+    expect(checks).toHaveLength(10);
   });
 });

--- a/src/install/diagnostics.test.ts
+++ b/src/install/diagnostics.test.ts
@@ -818,7 +818,7 @@ describe('runDiagnostics', () => {
     it('returns ok when the installed version is the latest', async () => {
       const mod = await import('../version.js');
       mockFetch.mockImplementation(async (url: string | URL | Request) => {
-        if (String(url).includes('registry.npmjs.org')) {
+        if (new URL(String(url)).hostname === 'registry.npmjs.org') {
           return { ok: true, json: async () => ({ version: mod.VERSION }) } as unknown as Response;
         }
         return { ok: true, json: async () => ({}) } as unknown as Response;
@@ -830,7 +830,7 @@ describe('runDiagnostics', () => {
 
     it('returns warn with an upgrade fix command when a newer version is on npm', async () => {
       mockFetch.mockImplementation(async (url: string | URL | Request) => {
-        if (String(url).includes('registry.npmjs.org')) {
+        if (new URL(String(url)).hostname === 'registry.npmjs.org') {
           return { ok: true, json: async () => ({ version: '99.0.0' }) } as unknown as Response;
         }
         return { ok: true, json: async () => ({}) } as unknown as Response;
@@ -844,7 +844,7 @@ describe('runDiagnostics', () => {
 
     it('returns skip when the npm registry is unreachable', async () => {
       mockFetch.mockImplementation(async (url: string | URL | Request) => {
-        if (String(url).includes('registry.npmjs.org')) {
+        if (new URL(String(url)).hostname === 'registry.npmjs.org') {
           return { ok: false } as unknown as Response;
         }
         return { ok: true, json: async () => ({}) } as unknown as Response;

--- a/src/install/diagnostics.ts
+++ b/src/install/diagnostics.ts
@@ -1,8 +1,11 @@
 import { accessSync, constants, existsSync, readFileSync, statSync } from 'node:fs';
 import { platform } from 'node:os';
-import { resolve } from 'node:path';
+import { dirname, isAbsolute, resolve } from 'node:path';
 
 import { createLogger } from '../shared/index.js';
+import { checkNodeVersion, MIN_SUPPORTED_NODE_MAJOR } from './node-version-check.js';
+import { isNewerVersion, fetchLatestNpmVersion } from './npm-version-check.js';
+import { VERSION } from '../version.js';
 
 import { validateConfigFile, DEFAULT_STORAGE_PATH } from '../config.js';
 import { getDashboardDaemonStatus, findExecutableNodeDir } from './schedule.js';
@@ -10,6 +13,7 @@ import {
   detectSettingsPath,
   entryContainsNrObserve,
   entryHasAnyCommandHook,
+  NR_HOOK_RE,
 } from './install-helper.js';
 import { isWsl, resolveWindowsHome } from './platform.js';
 import { LocalStore } from '../storage/index.js';
@@ -196,6 +200,12 @@ interface ClaudeSettingsHooks {
   readonly PostToolUse?: unknown;
 }
 
+// Captures the binary path portion of an installed NR hook command, e.g.
+// `"/Users/x/.nvm/.../bin/preflight-collector" pre-tool` -> group 1 =
+// `/Users/x/.nvm/.../bin/preflight-collector`. Handles both quoted and
+// unquoted forms (see generateHookEntries() in install-helper.ts).
+const HOOK_COMMAND_PATH_RE = /^"?(.+?)"?\s+(?:pre|post)-tool$/;
+
 function checkHooksWired(settingsPaths: string[], platform: string | undefined): DiagnosticCheck {
   if (platform !== undefined && platform !== 'claude-code') {
     const registry = createDefaultRegistry();
@@ -311,6 +321,112 @@ function checkHooksWired(settingsPaths: string[], platform: string | undefined):
     status: 'fail',
     detail: `${trulyMissingEvents.join(' and ')} not found in ${searched}${customNote}${malformedNote}`,
     fix: 'preflight install',
+  };
+}
+
+/**
+ * Returns the raw installed hook command string (e.g.
+ * `"/abs/path/preflight-collector" pre-tool`) from the first settings file
+ * that has one, or null if no NR hook is installed anywhere. Mirrors the
+ * parsing checkHooksWired() already does, but returns the command text
+ * itself instead of a boolean — checkHooksWired() only needs booleans.
+ */
+function extractInstalledHookCommand(settingsPaths: string[]): string | null {
+  for (const sp of settingsPaths) {
+    if (!existsSync(sp)) continue;
+    let settings: Record<string, unknown>;
+    try {
+      settings = JSON.parse(readFileSync(sp, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const hooks = settings.hooks as ClaudeSettingsHooks | undefined;
+    for (const hookType of ['PreToolUse', 'PostToolUse'] as const) {
+      const entries = hooks?.[hookType];
+      if (!Array.isArray(entries)) continue;
+      for (const entry of entries) {
+        if (typeof entry !== 'object' || entry === null) continue;
+        const commandHooks = (entry as Record<string, unknown>).hooks;
+        if (!Array.isArray(commandHooks)) continue;
+        for (const h of commandHooks) {
+          if (typeof h !== 'object' || h === null) continue;
+          const command = (h as Record<string, unknown>).command;
+          if (typeof command === 'string' && NR_HOOK_RE.test(command)) {
+            return command;
+          }
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function checkHookNodePath(settingsPaths: string[], platform: string | undefined): DiagnosticCheck {
+  if (platform !== undefined && platform !== 'claude-code') {
+    return {
+      check: 'Hook node path',
+      status: 'skip',
+      detail: `This check only validates Claude Code's settings.json — not applicable to "${platform}"`,
+    };
+  }
+
+  const command = extractInstalledHookCommand(settingsPaths);
+  if (command === null) {
+    return {
+      check: 'Hook node path',
+      status: 'skip',
+      detail: 'No installed preflight hook found — see the "Hooks wired" check above.',
+    };
+  }
+
+  const match = HOOK_COMMAND_PATH_RE.exec(command);
+  const hookPath = match?.[1] ?? null;
+  if (hookPath === null || !isAbsolute(hookPath)) {
+    return {
+      check: 'Hook node path',
+      status: 'skip',
+      detail:
+        'Installed hook uses a bare command name (not an absolute path) — cannot check for a colocated node binary.',
+    };
+  }
+
+  const hookDir = dirname(hookPath);
+  const { dir: nodeDir, hasNonExecutable } = findExecutableNodeDir([hookDir]);
+
+  if (nodeDir === null && hasNonExecutable) {
+    return {
+      check: 'Hook node path',
+      status: 'fail',
+      detail: `node binary found next to the installed hook (${hookDir}) but is not executable`,
+      fix: 'Check node permissions (chmod +x <node>), or reinstall: preflight setup',
+    };
+  } else if (nodeDir === null) {
+    return {
+      check: 'Hook node path',
+      status: 'fail',
+      detail: `No executable node binary found next to the installed hook (${hookDir}) — the hook may fail to start.`,
+      fix: 'preflight setup (re-run install to refresh the hook path)',
+    };
+  }
+
+  const currentNodeDir = dirname(process.execPath);
+  if (resolve(nodeDir) !== resolve(currentNodeDir)) {
+    return {
+      check: 'Hook node path',
+      status: 'warn',
+      detail:
+        `Hook's colocated node binary (${nodeDir}) differs from the Node currently running doctor ` +
+        `(${currentNodeDir}) — the nvm default may have changed since install. This is a proxy check ` +
+        "based on where nvm/Homebrew colocate binaries, not a guarantee of what Claude Code's own hook " +
+        'subprocess resolves at runtime.',
+      fix: 'preflight setup (re-run install to refresh the hook path)',
+    };
+  }
+
+  return {
+    check: 'Hook node path',
+    status: 'ok',
+    detail: `node binary found next to the installed hook (${nodeDir}), matching the current Node install`,
   };
 }
 
@@ -436,6 +552,44 @@ function checkLocalInstances(storagePath: string): DiagnosticCheck {
   }
 }
 
+function checkNodeVersionDiagnostic(): DiagnosticCheck {
+  const error = checkNodeVersion();
+  if (error !== null) {
+    return {
+      check: 'Node version',
+      status: 'fail',
+      detail: `Running Node.js ${process.version}, but preflight requires v${MIN_SUPPORTED_NODE_MAJOR}+.`,
+      fix: `Install/select Node v${MIN_SUPPORTED_NODE_MAJOR}+ (e.g. via nvm), then re-run preflight setup.`,
+    };
+  }
+  return {
+    check: 'Node version',
+    status: 'ok',
+    detail: `Running Node.js ${process.version} (requires v${MIN_SUPPORTED_NODE_MAJOR}+)`,
+  };
+}
+
+async function checkPreflightVersion(): Promise<DiagnosticCheck> {
+  const latest = await fetchLatestNpmVersion();
+  if (latest === null) {
+    return {
+      check: 'Preflight version',
+      status: 'skip',
+      detail:
+        'Could not reach the npm registry to check for updates (offline, or npm unreachable).',
+    };
+  }
+  if (isNewerVersion(latest, VERSION)) {
+    return {
+      check: 'Preflight version',
+      status: 'warn',
+      detail: `Update available: v${VERSION} installed, v${latest} on npm.`,
+      fix: 'npm install -g @newrelic/preflight@latest',
+    };
+  }
+  return { check: 'Preflight version', status: 'ok', detail: `v${VERSION} is the latest version.` };
+}
+
 export async function runDiagnostics(opts?: {
   configPath?: string;
   storagePath?: string;
@@ -452,10 +606,13 @@ export async function runDiagnostics(opts?: {
 
   return [
     configCheck,
+    checkNodeVersionDiagnostic(),
     ...checkDaemon(),
     checkHooksWired(settingsPaths, opts?.platform),
+    checkHookNodePath(settingsPaths, opts?.platform),
     checkStorageWritable(context.storagePath),
     checkLocalInstances(context.storagePath),
+    await checkPreflightVersion(),
     await checkNrReachable(context.nrSkipReason),
   ];
 }

--- a/src/install/node-version-check.test.ts
+++ b/src/install/node-version-check.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from '@jest/globals';
+import { checkNodeVersion } from './node-version-check.js';
+
+describe('checkNodeVersion()', () => {
+  it('returns null when the running Node version meets the floor', () => {
+    expect(checkNodeVersion('v22.0.0')).toBeNull();
+    expect(checkNodeVersion('v24.18.0')).toBeNull();
+  });
+
+  it('returns a diagnostic message when Node is below the floor', () => {
+    const message = checkNodeVersion('v16.20.0');
+    expect(message).not.toBeNull();
+    expect(message).toContain('v16.20.0');
+    expect(message).toContain('v22');
+    expect(message).toContain('TROUBLESHOOTING.md');
+  });
+
+  it('defaults to process.version when no argument is given', () => {
+    // The test runner itself must satisfy engines.node (>=22), so this is null.
+    expect(checkNodeVersion()).toBeNull();
+  });
+});

--- a/src/install/node-version-check.ts
+++ b/src/install/node-version-check.ts
@@ -1,0 +1,29 @@
+export const MIN_SUPPORTED_NODE_MAJOR = 22;
+
+/**
+ * Returns a diagnostic message when the running Node major version is below
+ * MIN_SUPPORTED_NODE_MAJOR, or null when it's fine. Checked at the very start
+ * of main() (src/index.ts) and reused as a `doctor` diagnostic check
+ * (src/install/diagnostics.ts) so a stale/unintended Node binary (commonly an
+ * nvm resolution issue) is reported consistently in both places.
+ *
+ * This only actually catches Node 20-21: on those versions the static import
+ * graph still loads fine, so this check's own code gets a chance to run
+ * before failing on the version floor. On Node 16-19 the process crashes
+ * earlier, during ESM's evaluation of the whole static import graph — before
+ * this check ever runs — with a less clear error, e.g.
+ * `ReferenceError: structuredClone is not defined` (Node 16, from
+ * src/shared/pricing.ts) or `ReferenceError: File is not defined` (Node 18,
+ * from undici). Still valuable for the most common real-world case: a stale
+ * nvm default resolving to a merely-slightly-old Node.
+ */
+export function checkNodeVersion(nodeVersion: string = process.version): string | null {
+  const major = parseInt(nodeVersion.replace(/^v/, '').split('.')[0], 10);
+  if (!Number.isFinite(major) || major >= MIN_SUPPORTED_NODE_MAJOR) return null;
+  return (
+    `preflight requires Node.js v${MIN_SUPPORTED_NODE_MAJOR}+, but is running under ${nodeVersion}. ` +
+    'This usually means your MCP client resolved a stale or unintended Node binary (e.g. via nvm). ' +
+    'See docs/TROUBLESHOOTING.md, "MCP server won\'t start (wrong Node version)", for how to pin the ' +
+    'exact Node path in ~/.mcp.json.'
+  );
+}

--- a/src/install/npm-version-check.test.ts
+++ b/src/install/npm-version-check.test.ts
@@ -1,0 +1,63 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { isNewerVersion, fetchLatestNpmVersion } from './npm-version-check.js';
+
+describe('isNewerVersion()', () => {
+  it('detects a newer major version', () => {
+    expect(isNewerVersion('2.0.0', '1.15.1')).toBe(true);
+    expect(isNewerVersion('1.15.1', '2.0.0')).toBe(false);
+  });
+
+  it('detects a newer minor version', () => {
+    expect(isNewerVersion('1.16.0', '1.15.1')).toBe(true);
+    expect(isNewerVersion('1.15.1', '1.16.0')).toBe(false);
+  });
+
+  it('detects a newer patch version', () => {
+    expect(isNewerVersion('1.15.2', '1.15.1')).toBe(true);
+    expect(isNewerVersion('1.15.1', '1.15.2')).toBe(false);
+  });
+
+  it('returns false for equal versions', () => {
+    expect(isNewerVersion('1.15.1', '1.15.1')).toBe(false);
+  });
+
+  it('tolerates a leading "v" and a pre-release suffix', () => {
+    expect(isNewerVersion('v1.15.2', '1.15.1')).toBe(true);
+    expect(isNewerVersion('1.15.2-beta.1', '1.15.1')).toBe(true);
+  });
+});
+
+describe('fetchLatestNpmVersion()', () => {
+  const mockFetch = jest.fn<typeof fetch>();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  it('returns the version string on a successful response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: '9.9.9' }),
+    } as unknown as Response);
+    expect(await fetchLatestNpmVersion()).toBe('9.9.9');
+  });
+
+  it('returns null on a non-ok response', async () => {
+    mockFetch.mockResolvedValue({ ok: false } as Response);
+    expect(await fetchLatestNpmVersion()).toBeNull();
+  });
+
+  it('returns null when the response body has no string version field', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: 12345 }),
+    } as unknown as Response);
+    expect(await fetchLatestNpmVersion()).toBeNull();
+  });
+
+  it('returns null on a network error', async () => {
+    mockFetch.mockRejectedValue(new Error('network error'));
+    expect(await fetchLatestNpmVersion()).toBeNull();
+  });
+});

--- a/src/install/npm-version-check.ts
+++ b/src/install/npm-version-check.ts
@@ -1,0 +1,32 @@
+/** True when `candidate` (e.g. an npm registry "latest" version) is a newer semver than `installed`. */
+export function isNewerVersion(candidate: string, installed: string): boolean {
+  const parse = (v: string): [number, number, number] => {
+    const parts = v.replace(/^v/, '').replace(/-.*$/, '').split('.').map(Number);
+    return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+  };
+  const [ca, cb, cc] = parse(candidate);
+  const [ia, ib, ic] = parse(installed);
+  if (ca !== ia) return ca > ia;
+  if (cb !== ib) return cb > ib;
+  return cc > ic;
+}
+
+interface NpmRegistryLatestResponse {
+  readonly version?: unknown;
+}
+
+/** Fetches @newrelic/preflight's "latest" version from the npm registry, or null if unreachable/malformed. */
+export async function fetchLatestNpmVersion(): Promise<string | null> {
+  try {
+    const res = await fetch('https://registry.npmjs.org/@newrelic/preflight/latest', {
+      headers: { accept: 'application/json' },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as NpmRegistryLatestResponse;
+    const v = data.version;
+    return typeof v === 'string' ? v : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -978,6 +978,34 @@ describe('LocalStore', () => {
       // Should not throw
       expect(() => store.removeHeartbeat()).not.toThrow();
     });
+
+    it('also writes a sidecar meta file with argv and cwd', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const store = new LocalStore(tmpDir, 'sess-hb-3');
+      store.writeHeartbeat(
+        12345,
+        ['/opt/preflight/dist/index.js', '--stdio'],
+        '/home/user/project',
+      );
+
+      const metaPath = resolve(tmpDir, 'active-sess-hb-3.meta.json');
+      expect(existsSync(metaPath)).toBe(true);
+      const meta = JSON.parse(readFileSync(metaPath, 'utf-8'));
+      expect(meta).toEqual({
+        argv: ['/opt/preflight/dist/index.js', '--stdio'],
+        cwd: '/home/user/project',
+      });
+    });
+
+    it('removeHeartbeat also removes the sidecar meta file', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const store = new LocalStore(tmpDir, 'sess-hb-4');
+      store.writeHeartbeat(67890, ['/opt/preflight/dist/index.js'], '/home/user/project');
+      expect(existsSync(resolve(tmpDir, 'active-sess-hb-4.meta.json'))).toBe(true);
+
+      store.removeHeartbeat();
+      expect(existsSync(resolve(tmpDir, 'active-sess-hb-4.meta.json'))).toBe(false);
+    });
   });
 
   describe('gcOrphanBuffers()', () => {
@@ -1014,6 +1042,23 @@ describe('LocalStore', () => {
         /^buffer-sess-dead\.jsonl\.archived-\d+$/.test(n),
       );
       expect(archives).toHaveLength(1);
+    });
+
+    it('also removes the sidecar meta.json when archiving a dead-heartbeat buffer', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      makeBufferFile('buffer-sess-dead-meta.jsonl');
+      writeFileSync(resolve(tmpDir, 'active-sess-dead-meta.pid'), String(DEAD_PID));
+      writeFileSync(
+        resolve(tmpDir, 'active-sess-dead-meta.meta.json'),
+        JSON.stringify({ argv: ['/opt/preflight/dist/index.js'], cwd: '/home/user/project' }),
+      );
+
+      const store = new LocalStore(tmpDir);
+      const result = store.gcOrphanBuffers(new Set());
+
+      expect(result.archived).toBe(1);
+      expect(existsSync(resolve(tmpDir, 'active-sess-dead-meta.pid'))).toBe(false);
+      expect(existsSync(resolve(tmpDir, 'active-sess-dead-meta.meta.json'))).toBe(false);
     });
 
     it('preserves a buffer whose heartbeat PID is alive (this process)', () => {
@@ -1314,6 +1359,54 @@ describe('LocalStore', () => {
       mkdirSync(tmpDir, { recursive: true });
       const store = new LocalStore(tmpDir);
       expect(store.getActiveSessionIdsFromHeartbeats().size).toBe(0);
+    });
+  });
+
+  describe('listActiveStdioInstances()', () => {
+    it('returns live instances with argv/cwd from the sidecar meta file', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const store = new LocalStore(tmpDir, 'sess-stdio-1');
+      store.writeHeartbeat(
+        process.pid,
+        ['/opt/preflight/dist/index.js', '--stdio'],
+        '/home/user/project',
+      );
+
+      const [inst] = new LocalStore(tmpDir).listActiveStdioInstances();
+      expect(inst.pid).toBe(process.pid);
+      expect(inst.sessionId).toBe('sess-stdio-1');
+      expect(inst.argv).toEqual(['/opt/preflight/dist/index.js', '--stdio']);
+      expect(inst.cwd).toBe('/home/user/project');
+      expect(inst.alive).toBe(true);
+      expect(typeof inst.startedAt).toBe('number');
+    });
+
+    it('marks a dead PID as not alive', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const DEAD_PID = 999999;
+      writeFileSync(resolve(tmpDir, 'active-sess-stdio-dead.pid'), String(DEAD_PID));
+      const [inst] = new LocalStore(tmpDir).listActiveStdioInstances();
+      expect(inst.pid).toBe(DEAD_PID);
+      expect(inst.alive).toBe(false);
+    });
+
+    it('defaults argv to [] and cwd to null when the sidecar meta file is missing (pre-upgrade heartbeat)', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(resolve(tmpDir, 'active-sess-stdio-nometa.pid'), String(process.pid));
+      const [inst] = new LocalStore(tmpDir).listActiveStdioInstances();
+      expect(inst.argv).toEqual([]);
+      expect(inst.cwd).toBeNull();
+    });
+
+    it('returns an empty array when no heartbeats exist', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      expect(new LocalStore(tmpDir).listActiveStdioInstances()).toEqual([]);
+    });
+
+    it('skips a heartbeat file with a malformed sessionId', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(resolve(tmpDir, 'active-bad session id!.pid'), String(process.pid));
+      expect(new LocalStore(tmpDir).listActiveStdioInstances()).toEqual([]);
     });
   });
 

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -316,35 +316,71 @@ export class LocalStore {
    * resolving its session_id, and remove it on graceful shutdown via
    * `removeHeartbeat()`.
    *
+   * Also writes a sidecar `active-<sessionId>.meta.json` file with `argv`
+   * and `cwd`, consumed by `listActiveStdioInstances()`. `argv`/`cwd`
+   * default to the current process's own argv/cwd.
+   *
    * No-op if the LocalStore is not bound to a sessionId (e.g. --local mode).
    */
-  writeHeartbeat(pid: number = process.pid): void {
+  writeHeartbeat(
+    pid: number = process.pid,
+    argv: readonly string[] = process.argv.slice(1),
+    cwd: string = process.cwd(),
+  ): void {
     if (!this.sessionId) return;
     if (!Number.isFinite(pid) || pid <= 0) return;
     const heartbeatPath = resolve(this.storagePath, `active-${this.sessionId}.pid`);
+    const metaPath = resolve(this.storagePath, `active-${this.sessionId}.meta.json`);
     try {
       if (!existsSync(this.storagePath)) {
         mkdirSync(this.storagePath, { recursive: true, mode: 0o700 });
       }
       writeFileSync(heartbeatPath, String(pid), { mode: 0o600 });
+      // Sidecar metadata for listActiveStdioInstances() — kept separate from
+      // the heartbeat's own bare-PID content so hasLiveOwner(),
+      // getActiveSessionIdsFromHeartbeats(), and gcOrphanBuffers() (which all
+      // parse active-<sessionId>.pid as a bare PID) are unaffected.
+      writeFileSync(metaPath, JSON.stringify({ argv: Array.from(argv), cwd }), { mode: 0o600 });
     } catch (err) {
       logger.warn('Failed to write heartbeat file', { error: String(err) });
     }
   }
 
   /**
-   * Remove this MCP's heartbeat file. Called from the shutdown handler so the
-   * next maintenance GC pass knows the buffer is up for adoption.
+   * Remove this MCP's heartbeat file (and its sidecar metadata, if present).
+   * Called from the shutdown handler so the next maintenance GC pass knows
+   * the buffer is up for adoption.
    *
    * No-op if no heartbeat was ever written or if the file is already gone.
    */
   removeHeartbeat(): void {
     if (!this.sessionId) return;
     const heartbeatPath = resolve(this.storagePath, `active-${this.sessionId}.pid`);
+    const metaPath = resolve(this.storagePath, `active-${this.sessionId}.meta.json`);
     try {
       if (existsSync(heartbeatPath)) unlinkSync(heartbeatPath);
+      if (existsSync(metaPath)) unlinkSync(metaPath);
     } catch (err) {
       logger.debug('Failed to remove heartbeat file', { error: String(err) });
+    }
+  }
+
+  /**
+   * Remove another session's heartbeat + sidecar metadata by explicit
+   * sessionId. Unlike removeHeartbeat() (which only ever acts on `this`
+   * LocalStore's own bound sessionId), this lets a caller — the `preflight
+   * local --clean` CLI command, which isn't scoped to any one session —
+   * clean up a *different* session's files after killing that session's
+   * process. Safe to call even if the files are already gone.
+   */
+  removeStdioHeartbeat(sessionId: string): void {
+    const heartbeatPath = resolve(this.storagePath, `active-${sessionId}.pid`);
+    const metaPath = resolve(this.storagePath, `active-${sessionId}.meta.json`);
+    try {
+      if (existsSync(heartbeatPath)) unlinkSync(heartbeatPath);
+      if (existsSync(metaPath)) unlinkSync(metaPath);
+    } catch (err) {
+      logger.debug('Failed to remove stdio heartbeat/sidecar', { error: String(err) });
     }
   }
 
@@ -671,6 +707,18 @@ export class LocalStore {
               error: String(err),
             });
           }
+          // Sidecar metadata written by writeHeartbeat() alongside the
+          // heartbeat — removed separately so a missing/unlinkable sidecar
+          // never blocks the heartbeat cleanup above.
+          const metaPath = resolve(this.storagePath, `active-${sessionId}.meta.json`);
+          try {
+            if (existsSync(metaPath)) unlinkSync(metaPath);
+          } catch (err) {
+            logger.debug('Failed to remove sidecar metadata after archive', {
+              sessionId,
+              error: String(err),
+            });
+          }
         }
       } catch (err) {
         logger.warn('Failed to archive orphan buffer', { sessionId, error: String(err) });
@@ -815,6 +863,80 @@ export class LocalStore {
       }
     }
     return active;
+  }
+
+  /**
+   * List every live `--stdio` MCP process from `active-<sessionId>.pid`
+   * heartbeats — the same files `getActiveSessionIdsFromHeartbeats()` and
+   * `hasLiveOwner()` already read, scanned here for user-facing detail
+   * (`preflight local`) instead of internal GC/ownership bookkeeping.
+   * `argv`/`cwd` come from the sidecar `active-<sessionId>.meta.json`
+   * written by `writeHeartbeat()`; a heartbeat from a pre-upgrade build that
+   * predates the sidecar reports `argv: []`, `cwd: null`. `startedAt` is the
+   * heartbeat file's mtime — `writeHeartbeat()` is called exactly once at
+   * process startup (never refreshed), so mtime is an accurate proxy for
+   * process start time. Malformed entries are skipped silently.
+   */
+  listActiveStdioInstances(): Array<{
+    pid: number;
+    sessionId: string;
+    argv: string[];
+    cwd: string | null;
+    startedAt: number;
+    alive: boolean;
+  }> {
+    if (!existsSync(this.storagePath)) return [];
+    let entries: string[];
+    try {
+      entries = readdirSync(this.storagePath);
+    } catch (err) {
+      logger.warn('Failed to enumerate storage path for listActiveStdioInstances', {
+        error: String(err),
+      });
+      return [];
+    }
+    const result: Array<{
+      pid: number;
+      sessionId: string;
+      argv: string[];
+      cwd: string | null;
+      startedAt: number;
+      alive: boolean;
+    }> = [];
+    for (const name of entries) {
+      if (!name.startsWith('active-') || !name.endsWith('.pid')) continue;
+      const sessionId = name.slice('active-'.length, -'.pid'.length);
+      if (!SESSION_ID_RE.test(sessionId)) continue;
+      const heartbeatPath = resolve(this.storagePath, name);
+      let pid: number;
+      let startedAt: number;
+      try {
+        pid = Number.parseInt(readFileSync(heartbeatPath, 'utf-8').trim(), 10);
+        startedAt = statSync(heartbeatPath).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (!Number.isFinite(pid) || pid <= 0) continue;
+
+      let argv: string[] = [];
+      let cwd: string | null = null;
+      try {
+        const metaPath = resolve(this.storagePath, `active-${sessionId}.meta.json`);
+        const meta = JSON.parse(readFileSync(metaPath, 'utf-8')) as {
+          argv?: unknown;
+          cwd?: unknown;
+        };
+        if (Array.isArray(meta.argv) && meta.argv.every((a) => typeof a === 'string')) {
+          argv = meta.argv as string[];
+        }
+        if (typeof meta.cwd === 'string') cwd = meta.cwd;
+      } catch {
+        // No sidecar (pre-upgrade heartbeat) or unreadable — leave argv/cwd at their defaults.
+      }
+
+      result.push({ pid, sessionId, argv, cwd, startedAt, alive: isPidAlive(pid) });
+    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
## Summary
- `preflight doctor` gains three new diagnostic checks: **Node version**, **Preflight version** (checks npm for a newer release), and **Hook node path** (detects an nvm-default change between the installed Claude Code hook and the current shell) — 10 checks total, up from 7.
- `preflight local` now also lists live `--stdio` MCP processes (one per Claude Code window) alongside the existing `--local` dashboard-process listing, and `--clean` auto-flags/kills `--stdio` processes whose recorded binary no longer exists on disk.

Fixes #364
Fixes #365
Fixes #366
Fixes #367

## Test plan
- [x] `npm run build && npm test && npm run lint` — all passing (165/166 suites, 5537/5540 tests, skips pre-existing, 0 lint errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)