### PR TITLE
Chore: v1.15.4 — cost/token restart data-loss fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.4] - 2026-08-14
+
+### Fixed
+
+- **Local session cost and token totals no longer reset to zero when the MCP server process restarts mid-session** — closing and reopening a terminal, a laptop sleep/wake, `claude --resume`, or a crash all restart the process. Previously only activity observed since the most recent restart was ever counted; a long or repeatedly-interrupted session could silently lose most of its real cost and token totals, well beyond anything explained by subagent-tracking gaps.
+- **A resumed session's per-model and per-workflow-run cost breakdowns no longer lag behind its now-correct overall total** — both are restored from the same pre-restart checkpoint as the fix above, so the Model Performance panel and per-workflow-run spend stay consistent with the session total instead of only reflecting post-restart activity.
+- **A session's restored cost/token total can no longer be attributed to the wrong session.** The restart-recovery fix above only re-attaches a session's own prior totals once its identity is confirmed — previously, an unconfirmed, ambiguous session-id guess could import a different session's cost/token total before that guess was verified.
+
 ## [1.15.3] - 2026-08-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.15.3",
+      "version": "1.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/scripts/compare-cost-with-ccusage-claude-code.ts
+++ b/scripts/compare-cost-with-ccusage-claude-code.ts
@@ -1,0 +1,308 @@
+#!/usr/bin/env npx tsx
+/**
+ * Compare Preflight's tracked cost/tokens for a CLAUDE CODE session against
+ * ccusage's independent re-parse of the same session's raw .jsonl transcript.
+ *
+ * Claude Code only. This is verified only for sessions Preflight tracked via
+ * its claude-code platform adapter, because the comparison depends on both
+ * tools reading the exact same underlying transcript under the exact same
+ * session id — true for Claude Code (ccusage's `claude` reader parses
+ * `~/.claude/projects/**\/*.jsonl`, the same file Preflight's session id
+ * resolves to), unverified for anything else. Preflight also supports
+ * Codex CLI and Gemini CLI sessions (ccusage has readers for both too), but
+ * nobody has confirmed the two tools' session-id schemes actually line up
+ * for those — this script warns rather than silently producing misleading
+ * deltas if it's pointed at a non-claude-code session.
+ *
+ * Decomposes any $ gap into two independently-checkable causes by re-pricing
+ * ccusage's raw token counts through Preflight's own pricing table:
+ *
+ *   - repricedUsd ≈ preflightCostUsd, far from ccusageCostUsd
+ *       → pricing-table mismatch (same tokens, different $/Mtok rates)
+ *   - repricedUsd ≈ ccusageCostUsd, far from preflightCostUsd
+ *       → token-capture mismatch (Preflight is missing/undercounting tokens
+ *         that the transcript actually contains)
+ *   - repricedUsd matches neither
+ *       → both are contributing
+ *
+ * Usage:
+ *   npx tsx scripts/compare-cost-with-ccusage-claude-code.ts --session-id <id> [--json]
+ *   npx tsx scripts/compare-cost-with-ccusage-claude-code.ts --session-id <id> \
+ *     --preflight-cost-json <path>   # for a still-live session: save the
+ *                                    # output of nr_observe_get_cost_breakdown
+ *                                    # to a file and point at it here, since a
+ *                                    # live session has no persisted file yet
+ *
+ * Requires `npx ccusage` to be resolvable (installs on first run if absent).
+ * Reads only local files already on disk — no network calls, no NR ingest.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+import { SessionStore } from '../src/storage/session-store.js';
+import { calculateCost } from '../src/shared/pricing.js';
+import type { TokenUsage } from '../src/shared/tokens.js';
+
+interface CcusageEntry {
+  readonly model: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheCreationTokens: number;
+  readonly costUSD: number;
+}
+
+interface CcusageSessionReport {
+  readonly sessionId: string;
+  readonly totalCost: number;
+  readonly totalTokens: number;
+  readonly entries: CcusageEntry[];
+}
+
+// Shape of nr_observe_get_cost_breakdown's MCP tool response — accepted via
+// --preflight-cost-json as an alternative source for a still-live session.
+interface PreflightCostJson {
+  readonly total_usd: number;
+  readonly tokens: {
+    readonly input: number;
+    readonly output: number;
+    readonly thinking: number;
+    readonly cache_read: number;
+    readonly cache_creation: number;
+  };
+}
+
+interface PreflightTotals {
+  readonly costUsd: number;
+  readonly input: number;
+  readonly output: number;
+  readonly thinking: number;
+  readonly cacheRead: number;
+  readonly cacheCreation: number;
+  /**
+   * Undefined when loaded via --preflight-cost-json (that MCP tool response
+   * carries no platform field) or for a pre-fix session file predating it —
+   * in both cases we simply can't warn, not a signal the session is fine.
+   */
+  readonly platform: string | undefined;
+}
+
+function parseArgs(argv: string[]): {
+  sessionId: string | null;
+  json: boolean;
+  preflightCostJsonPath: string | null;
+  storagePath: string | undefined;
+} {
+  let sessionId: string | null = null;
+  let json = false;
+  let preflightCostJsonPath: string | null = null;
+  let storagePath: string | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--session-id') sessionId = argv[++i] ?? null;
+    else if (arg === '--json') json = true;
+    else if (arg === '--preflight-cost-json') preflightCostJsonPath = argv[++i] ?? null;
+    else if (arg === '--storage-path') storagePath = argv[++i];
+  }
+
+  return { sessionId, json, preflightCostJsonPath, storagePath };
+}
+
+function runCcusage(sessionId: string): CcusageSessionReport {
+  const raw = execFileSync(
+    'npx',
+    ['--yes', 'ccusage@latest', 'session', '--id', sessionId, '--json'],
+    { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] },
+  );
+  return JSON.parse(raw) as CcusageSessionReport;
+}
+
+function loadPreflightTotals(
+  sessionId: string,
+  storagePath: string | undefined,
+  preflightCostJsonPath: string | null,
+): PreflightTotals {
+  if (preflightCostJsonPath) {
+    const parsed = JSON.parse(readFileSync(preflightCostJsonPath, 'utf-8')) as PreflightCostJson;
+    return {
+      costUsd: parsed.total_usd,
+      input: parsed.tokens.input,
+      output: parsed.tokens.output,
+      thinking: parsed.tokens.thinking,
+      cacheRead: parsed.tokens.cache_read,
+      cacheCreation: parsed.tokens.cache_creation,
+      platform: undefined,
+    };
+  }
+
+  const store = new SessionStore({
+    storagePath: storagePath ?? `${process.env.HOME}/.newrelic-preflight`,
+  });
+  const summary = store.loadSession(sessionId);
+  if (!summary) {
+    throw new Error(
+      `No persisted Preflight session file found for ${sessionId}. ` +
+        `Either the session hasn't ended yet (pass --preflight-cost-json with the ` +
+        `output of nr_observe_get_cost_breakdown instead), or it's under a ` +
+        `different --storage-path.`,
+    );
+  }
+  return {
+    costUsd: summary.estimatedCostUsd ?? 0,
+    input: summary.tokensInput,
+    output: summary.tokensOutput,
+    thinking: summary.tokensThinking,
+    cacheRead: summary.tokensCacheRead,
+    cacheCreation: summary.tokensCacheCreation,
+    platform: summary.platform,
+  };
+}
+
+function sumCcusageTokens(
+  entries: CcusageEntry[],
+): Omit<TokenUsage, 'totalTokens' | 'thinkingTokens'> {
+  return entries.reduce(
+    (acc, e) => ({
+      inputTokens: acc.inputTokens + e.inputTokens,
+      outputTokens: acc.outputTokens + e.outputTokens,
+      cacheReadTokens: acc.cacheReadTokens + e.cacheReadTokens,
+      cacheCreationTokens: acc.cacheCreationTokens + e.cacheCreationTokens,
+    }),
+    { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+  );
+}
+
+// Re-prices ccusage's raw token counts through Preflight's own pricing table,
+// grouped by model since different entries in one session can carry
+// different model ids (e.g. a mid-session upgrade).
+function repriceThroughPreflightTable(entries: CcusageEntry[]): number {
+  const byModel = new Map<string, CcusageEntry[]>();
+  for (const e of entries) {
+    const list = byModel.get(e.model) ?? [];
+    list.push(e);
+    byModel.set(e.model, list);
+  }
+
+  let total = 0;
+  for (const [model, modelEntries] of byModel) {
+    const tokens = sumCcusageTokens(modelEntries);
+    const usage: TokenUsage = {
+      ...tokens,
+      thinkingTokens: 0, // ccusage entries carry no thinking-token split
+      totalTokens: tokens.inputTokens + tokens.outputTokens,
+    };
+    total += calculateCost(model, usage).totalUsd;
+  }
+  return total;
+}
+
+function pctDelta(a: number, b: number): string {
+  if (b === 0) return a === 0 ? '0%' : '∞';
+  return `${(((a - b) / b) * 100).toFixed(1)}%`;
+}
+
+function main(): void {
+  const { sessionId, json, preflightCostJsonPath, storagePath } = parseArgs(process.argv.slice(2));
+  if (!sessionId) {
+    console.error(
+      'Usage: compare-cost-with-ccusage-claude-code.ts --session-id <id> [--json] ' +
+        '[--preflight-cost-json <path>] [--storage-path <path>]',
+    );
+    process.exit(1);
+  }
+
+  const preflight = loadPreflightTotals(sessionId, storagePath, preflightCostJsonPath);
+  if (preflight.platform !== undefined && preflight.platform !== 'claude-code') {
+    console.error(
+      `WARNING: this session was tracked via Preflight's "${preflight.platform}" platform ` +
+        `adapter, not claude-code. This script's ccusage comparison is only verified for ` +
+        `Claude Code sessions — ccusage may have no reader for this platform at all, in ` +
+        `which case the deltas below are meaningless (comparing real Preflight totals ` +
+        `against an empty/unrelated ccusage result), not evidence of a real gap.\n`,
+    );
+  }
+
+  const ccusage = runCcusage(sessionId);
+  const ccusageTokens = sumCcusageTokens(ccusage.entries);
+  const repricedUsd = repriceThroughPreflightTable(ccusage.entries);
+
+  const report = {
+    sessionId,
+    tokens: {
+      input: {
+        preflight: preflight.input,
+        ccusage: ccusageTokens.inputTokens,
+        delta: pctDelta(preflight.input, ccusageTokens.inputTokens),
+      },
+      output: {
+        preflight: preflight.output,
+        ccusage: ccusageTokens.outputTokens,
+        delta: pctDelta(preflight.output, ccusageTokens.outputTokens),
+      },
+      cacheRead: {
+        preflight: preflight.cacheRead,
+        ccusage: ccusageTokens.cacheReadTokens,
+        delta: pctDelta(preflight.cacheRead, ccusageTokens.cacheReadTokens),
+      },
+      cacheCreation: {
+        preflight: preflight.cacheCreation,
+        ccusage: ccusageTokens.cacheCreationTokens,
+        delta: pctDelta(preflight.cacheCreation, ccusageTokens.cacheCreationTokens),
+      },
+      thinking_preflightOnly: preflight.thinking, // ccusage reports no thinking-token split; not comparable
+    },
+    cost: {
+      preflightReportedUsd: preflight.costUsd,
+      ccusageReportedUsd: ccusage.totalCost,
+      preflightTableAppliedToCcusageTokensUsd: repricedUsd,
+    },
+    diagnosis: {
+      matchesPricingTableHypothesis:
+        Math.abs(repricedUsd - preflight.costUsd) < Math.abs(repricedUsd - ccusage.totalCost),
+      note:
+        'If preflightTableAppliedToCcusageTokensUsd is close to preflightReportedUsd, the ' +
+        'gap is a pricing-table rate difference (same tokens, different $/Mtok). If it is ' +
+        'close to ccusageReportedUsd instead, the gap is token-capture (Preflight is missing ' +
+        'tokens the transcript actually contains — check subagent/parent transcript coverage).',
+    },
+  };
+
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  console.log(`\nSession ${sessionId}`);
+  console.log('─'.repeat(60));
+  console.log('Token counts (Preflight vs ccusage):');
+  for (const [label, v] of Object.entries(report.tokens)) {
+    if (label === 'thinking_preflightOnly') {
+      console.log(`  thinking (Preflight-only, no ccusage split): ${v}`);
+      continue;
+    }
+    const t = v as { preflight: number; ccusage: number; delta: string };
+    console.log(
+      `  ${label.padEnd(14)} preflight=${t.preflight}  ccusage=${t.ccusage}  delta=${t.delta}`,
+    );
+  }
+  console.log('\nCost:');
+  console.log(
+    `  Preflight reported:                       $${report.cost.preflightReportedUsd.toFixed(4)}`,
+  );
+  console.log(
+    `  ccusage reported:                         $${report.cost.ccusageReportedUsd.toFixed(4)}`,
+  );
+  console.log(
+    `  Preflight pricing × ccusage's tokens:      $${report.cost.preflightTableAppliedToCcusageTokensUsd.toFixed(4)}`,
+  );
+  console.log(`\n${report.diagnosis.note}`);
+  console.log(
+    report.diagnosis.matchesPricingTableHypothesis
+      ? '  → Looks like a PRICING-TABLE gap.'
+      : '  → Looks like a TOKEN-CAPTURE gap.',
+  );
+}
+
+main();

--- a/src/dashboard/workflow-store.ts
+++ b/src/dashboard/workflow-store.ts
@@ -77,9 +77,11 @@ export interface WorkflowRunRow {
    * observed this run's cost (no `hasCostForRun` callback, or it returned
    * false), as opposed to a confirmed $0. Lets a KPI summing several runs'
    * `total_usd` flag its total as partial instead of silently treating
-   * "unknown" the same as "zero". A full fix — persisting per-run cost
-   * somewhere readable across process restarts/instances — is deferred as
-   * a follow-up; this is a partial mitigation in the meantime.
+   * "unknown" the same as "zero". As of CostTracker.seedFromPersisted()
+   * restoring costByWorkflowRunId across a process restart, this should now
+   * only be true for a run a different, concurrently-running process is
+   * paying for (e.g. a `--local` dashboard reading a `--stdio` process's
+   * run) — not for a run whose owning process simply restarted.
    */
   readonly cost_unknown: boolean;
   readonly declared_phases: number | null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { purgeOldSessions, purgeOldWeeklySummaries } from './storage/retention.j
 import { HookEventProcessor } from './hooks/index.js';
 import { SessionTracker } from './metrics/session-tracker.js';
 import { CostTracker } from './metrics/cost-tracker.js';
+import { buildCostTrackerSeed } from './metrics/cost-tracker-seed.js';
 import { buildCostForecastFromInputs } from './metrics/cost-forecast.js';
 import { BudgetTracker } from './metrics/budget-tracker.js';
 import { TaskDetector } from './metrics/task-detector.js';
@@ -1059,6 +1060,38 @@ async function main(): Promise<void> {
     sessionStore = new SessionStore({ storagePath: config.storagePath });
     const currentSessionId = sessionTracker.getMetrics().sessionId;
     let currentRepoName: string | null = null;
+
+    // Recover a resumed session's pre-restart cost/token totals — see
+    // CostTracker.seedFromPersisted()'s doc comment for the bug this fixes.
+    // Also seeds ModelUsageTracker, which has the identical in-memory-only,
+    // resets-on-restart problem for its own per-model breakdown — without
+    // this, its numbers would stay inconsistent with (short of) CostTracker's
+    // now-correct session total after a restart.
+    // Guarded per-id (not a single fired-once flag) because adoptRealSessionId
+    // below can call this again for a *different* id after a pending->real
+    // transition or a PPID correction.
+    const rehydratedTrackerSessionIds = new Set<string>();
+    const rehydrateTrackersIfResumed = (sessionId: string): void => {
+      if (isSyntheticSessionId(sessionId)) return;
+      if (rehydratedTrackerSessionIds.has(sessionId)) return;
+      rehydratedTrackerSessionIds.add(sessionId);
+      try {
+        const persisted = sessionStore!.loadSession(sessionId);
+        if (!persisted) return;
+        costTracker.seedFromPersisted(buildCostTrackerSeed(persisted));
+        modelUsageTracker.seedFromPersisted(persisted.modelBreakdown);
+        logger.info('Rehydrated trackers from a prior checkpoint for this session', {
+          sessionId,
+          estimatedCostUsd: persisted.estimatedCostUsd,
+        });
+      } catch (err) {
+        logger.warn('Failed to rehydrate trackers from a prior checkpoint', {
+          sessionId,
+          error: String(err),
+        });
+      }
+    };
+    if (!isProvisional && !resolvedViaCwdOnly) rehydrateTrackersIfResumed(currentSessionId);
 
     // Each command is isolated so a slow/missing git or remote doesn't block
     // the others. Uses spawnSync (no shell) to avoid injection; stderr is
@@ -2257,7 +2290,7 @@ async function main(): Promise<void> {
     // stopped first so its harvest interval never leaks on a second call.
     const adoptRealSessionId = async (
       realId: string,
-      opts?: { isCorrection?: boolean },
+      opts?: { isCorrection?: boolean; viaCwdOnly?: boolean },
     ): Promise<void> => {
       if (opts?.isCorrection) {
         // A real correction means the previously-adopted id was wrong, and
@@ -2276,6 +2309,15 @@ async function main(): Promise<void> {
       }
       sessionTraceId = realId;
       sessionTracker!.adoptSessionId(realId);
+      // viaCwdOnly means this id came from the collision-prone cwd fallback
+      // and hasn't been confirmed by the PPID breadcrumb yet — mirrors the
+      // resolvedViaCwdOnly gate on the synchronous resolution path's own
+      // eager-seed call. Seeding here would import a DIFFERENT session's
+      // real cost/token total on an unconfirmed guess; the caller arms
+      // startPpidCorrectionWatch right after this returns, whose
+      // confirmation branch (ppidId === staleId) calls
+      // rehydrateTrackersIfResumed itself once the guess is confirmed.
+      if (!opts?.viaCwdOnly) rehydrateTrackersIfResumed(realId);
 
       // Replace the current LocalStore with one scoped to the real id.
       const realLocalStore = new LocalStore(config!.storagePath, realId);
@@ -2434,7 +2476,11 @@ async function main(): Promise<void> {
           if (ppidId === staleId) {
             // The cwd guess turned out to be correct — no correction needed,
             // so no reason to keep suppressing checkpoints for the rest of
-            // the cap window.
+            // the cap window. It was NOT seeded eagerly (see the
+            // resolvedViaCwdOnly gate on rehydrateTrackersIfResumed's first
+            // call site) precisely because it wasn't confirmed yet — seed it
+            // now that it is.
+            rehydrateTrackersIfResumed(staleId);
             clearPendingConfirmation();
             return;
           }
@@ -2504,8 +2550,11 @@ async function main(): Promise<void> {
             }
 
             // Adopt the real session ID without clearing accumulated
-            // metrics — see adoptRealSessionId's own comment above.
-            await adoptRealSessionId(realId);
+            // metrics — see adoptRealSessionId's own comment above. Skip the
+            // eager cost/token seed for a cwd-resolved id (see viaCwdOnly's
+            // doc comment there) — startPpidCorrectionWatch below seeds it
+            // once confirmed, exactly like the synchronous resolution path.
+            await adoptRealSessionId(realId, { viaCwdOnly: resolvedSource === 'cwd' });
 
             logger.info('Session ID resolved, full initialization complete', {
               sessionTraceId: realId,

--- a/src/metrics/claudemd-tracker.test.ts
+++ b/src/metrics/claudemd-tracker.test.ts
@@ -63,6 +63,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    costByWorkflowRunId: {},
     qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,

--- a/src/metrics/collaboration-profile.test.ts
+++ b/src/metrics/collaboration-profile.test.ts
@@ -60,6 +60,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    costByWorkflowRunId: {},
     qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,

--- a/src/metrics/cost-tracker-seed.test.ts
+++ b/src/metrics/cost-tracker-seed.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildCostTrackerSeed } from './cost-tracker-seed.js';
+import { localDateKey } from '../lib/date.js';
+import type { FullSessionSummary } from '../storage/session-store.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from './quality-proxy-tracker.js';
+
+function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummary {
+  const now = Date.now();
+  return {
+    sessionId: `sess-${now}`,
+    sessionName: 'my-project',
+    repoName: null,
+    startTime: now - 60_000,
+    endTime: now,
+    durationMs: 60_000,
+    toolCallCount: 10,
+    developer: 'alice',
+    model: 'claude-sonnet-4-20250514',
+    toolBreakdown: {},
+    filesRead: [],
+    filesModified: [],
+    linesAdded: 0,
+    linesRemoved: 0,
+    bashCommandCount: 0,
+    testRunCount: 0,
+    testPassCount: 0,
+    buildRunCount: 0,
+    buildPassCount: 0,
+    estimatedCostUsd: 56.02,
+    subagentCostUsd: 12.5,
+    tokensInput: 143_758,
+    tokensOutput: 383_743,
+    tokensThinking: 0,
+    tokensCacheRead: 171_800_083,
+    tokensCacheCreation: 3_409_635,
+    cacheSavingsUsd: 4.2,
+    efficiencyScore: null,
+    toolSelectionMetrics: null,
+    modelBreakdown: {
+      'claude-sonnet-5': {
+        requestCount: 44,
+        totalInputTokens: 143_758,
+        totalOutputTokens: 383_743,
+        totalCostUsd: 56.02,
+      },
+    },
+    costByWorkflowRunId: { wf_abc: { [localDateKey()]: 12.5 } },
+    qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
+    antiPatterns: [],
+    taskCount: 1,
+    taskSuccessRate: null,
+    toolSuccessRate: null,
+    contextCompressions: 0,
+    agentSpawns: 1,
+    userMessages: 0,
+    assistantMessages: 0,
+    userCorrections: 0,
+    outcome: 'completed',
+    ...overrides,
+  };
+}
+
+describe('buildCostTrackerSeed', () => {
+  it('maps every FullSessionSummary field onto the seed correctly, entirely-today session', () => {
+    const summary = makeSummary();
+    const seed = buildCostTrackerSeed(summary);
+
+    expect(seed.totalCostUsd).toBe(56.02);
+    expect(seed.subagentCostUsd).toBe(12.5);
+    expect(seed.parentCostUsd).toBeCloseTo(43.52, 6); // 56.02 - 12.5
+    expect(seed.totalInputTokens).toBe(143_758);
+    expect(seed.totalOutputTokens).toBe(383_743);
+    expect(seed.totalThinkingTokens).toBe(0);
+    expect(seed.totalCacheReadTokens).toBe(171_800_083);
+    expect(seed.totalCacheCreationTokens).toBe(3_409_635);
+    expect(seed.totalCacheSavingsUsd).toBe(4.2);
+    expect(seed.costByModel).toEqual({ 'claude-sonnet-5': 56.02 });
+    expect(seed.costByWorkflowRunId).toEqual({ wf_abc: { [localDateKey()]: 12.5 } });
+    expect(seed.dayKey).toBe(localDateKey());
+    // Session is entirely within today (startTime/endTime both `now`-relative),
+    // so todayPortionRatio is exactly 1 — the full totals book to today.
+    expect(seed.dayCostUsd).toBeCloseTo(56.02, 6);
+    expect(seed.daySubagentCostUsd).toBeCloseTo(12.5, 6);
+  });
+
+  it('derives parentCostUsd as totalCostUsd minus subagentCostUsd, not a separate field', () => {
+    const seed = buildCostTrackerSeed(makeSummary({ estimatedCostUsd: 10, subagentCostUsd: 3 }));
+    expect(seed.parentCostUsd).toBeCloseTo(7, 6);
+  });
+
+  it('defaults totalCostUsd to 0 when estimatedCostUsd is null', () => {
+    const seed = buildCostTrackerSeed(makeSummary({ estimatedCostUsd: null, subagentCostUsd: 0 }));
+    expect(seed.totalCostUsd).toBe(0);
+    expect(seed.parentCostUsd).toBe(0);
+  });
+
+  it('passes costByWorkflowRunId through unchanged', () => {
+    const raw = { wf_x: { [localDateKey()]: 1.1 }, wf_y: { [localDateKey()]: 2.2 } };
+    const seed = buildCostTrackerSeed(makeSummary({ costByWorkflowRunId: raw }));
+    expect(seed.costByWorkflowRunId).toEqual(raw);
+  });
+
+  it('builds an empty costByModel from an empty modelBreakdown', () => {
+    const seed = buildCostTrackerSeed(makeSummary({ modelBreakdown: {} }));
+    expect(seed.costByModel).toEqual({});
+  });
+});

--- a/src/metrics/cost-tracker-seed.ts
+++ b/src/metrics/cost-tracker-seed.ts
@@ -1,0 +1,37 @@
+import type { FullSessionSummary } from '../storage/session-store.js';
+import type { CostTrackerSeed } from './cost-tracker.js';
+import { localDateKey, todayPortionOfSessionCost, todayPortionRatio } from '../lib/date.js';
+
+// Builds the seed a freshly-started process's CostTracker needs to recover a
+// resumed session's pre-restart totals — see CostTracker.seedFromPersisted()
+// for why this exists (ParentTranscriptWatcher's read cursor durably survives
+// a restart; CostTracker's totals do not, without this).
+//
+// dayCostUsd/daySubagentCostUsd use todayPortion*() rather than booking the
+// whole persisted total to `dayKey` so a persisted session whose own prior
+// activity already spanned a midnight doesn't over-attribute to today.
+export function buildCostTrackerSeed(persisted: FullSessionSummary): CostTrackerSeed {
+  const totalCostUsd = persisted.estimatedCostUsd ?? 0;
+  const costByModel: Record<string, number> = {};
+  for (const [model, entry] of Object.entries(persisted.modelBreakdown)) {
+    costByModel[model] = entry.totalCostUsd;
+  }
+  const dayKey = localDateKey();
+  const todayRatio = todayPortionRatio(persisted);
+  return {
+    totalCostUsd,
+    subagentCostUsd: persisted.subagentCostUsd,
+    parentCostUsd: totalCostUsd - persisted.subagentCostUsd,
+    totalInputTokens: persisted.tokensInput,
+    totalOutputTokens: persisted.tokensOutput,
+    totalThinkingTokens: persisted.tokensThinking,
+    totalCacheReadTokens: persisted.tokensCacheRead,
+    totalCacheCreationTokens: persisted.tokensCacheCreation,
+    totalCacheSavingsUsd: persisted.cacheSavingsUsd,
+    costByModel,
+    costByWorkflowRunId: persisted.costByWorkflowRunId,
+    dayKey,
+    dayCostUsd: todayPortionOfSessionCost(persisted),
+    daySubagentCostUsd: persisted.subagentCostUsd * todayRatio,
+  };
+}

--- a/src/metrics/cost-tracker.test.ts
+++ b/src/metrics/cost-tracker.test.ts
@@ -1,6 +1,6 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { CostTracker } from './cost-tracker.js';
-import type { TokenRecordContext } from './cost-tracker.js';
+import type { TokenRecordContext, CostTrackerSeed } from './cost-tracker.js';
 import { localDateKey } from '../lib/date.js';
 import { SessionTracker } from './session-tracker.js';
 import { MetricAggregator } from '../shared/index.js';
@@ -1099,5 +1099,200 @@ describe('subagent token support', () => {
     // 0.06 / (0.06 + 0.03) * 100 ≈ 66.7%
     expect(sub.subagentSharePct).toBeCloseTo(66.67, 1);
     expect(sub.reconciliationDeltaPct).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seedFromPersisted() — restart data-loss fix
+// ---------------------------------------------------------------------------
+
+function makeSeed(overrides?: Partial<CostTrackerSeed>): CostTrackerSeed {
+  return {
+    totalCostUsd: 0,
+    subagentCostUsd: 0,
+    parentCostUsd: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalThinkingTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheCreationTokens: 0,
+    totalCacheSavingsUsd: 0,
+    costByModel: {},
+    dayKey: localDateKey(),
+    dayCostUsd: 0,
+    daySubagentCostUsd: 0,
+    costByWorkflowRunId: {},
+    ...overrides,
+  };
+}
+
+describe('seedFromPersisted()', () => {
+  it('adds seeded totals into a fresh tracker — reproduces the pre-fix bug directly', () => {
+    const tracker = new CostTracker();
+
+    tracker.seedFromPersisted(
+      makeSeed({
+        totalCostUsd: 56.02,
+        subagentCostUsd: 0,
+        parentCostUsd: 56.02,
+        totalInputTokens: 143_758,
+        totalOutputTokens: 383_743,
+        totalCacheReadTokens: 171_800_083,
+        totalCacheCreationTokens: 3_409_635,
+        costByModel: { 'claude-sonnet-5': 56.02 },
+        dayCostUsd: 56.02,
+      }),
+    );
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.sessionTotalCostUsd).toBeCloseTo(56.02, 4);
+    expect(metrics.totalInputTokens).toBe(143_758);
+    expect(metrics.totalOutputTokens).toBe(383_743);
+    expect(metrics.totalCacheReadTokens).toBe(171_800_083);
+    expect(metrics.totalCacheCreationTokens).toBe(3_409_635);
+    expect(metrics.costByModel['claude-sonnet-5']).toBeCloseTo(56.02, 4);
+    expect(tracker.getCostForDay(localDateKey())).toBeCloseTo(56.02, 4);
+  });
+
+  it('adds on top of totals already recorded by this process, rather than overwriting', () => {
+    const tracker = new CostTracker();
+    tracker.recordTokenUsage(
+      makeUsage({ inputTokens: 1_000, outputTokens: 500, totalTokens: 1_500 }),
+      'claude-sonnet-4',
+    );
+    const beforeSeed = tracker.getMetrics().sessionTotalCostUsd!;
+
+    tracker.seedFromPersisted(makeSeed({ totalCostUsd: 10, dayCostUsd: 10 }));
+
+    expect(tracker.getMetrics().sessionTotalCostUsd).toBeCloseTo(beforeSeed + 10, 4);
+  });
+
+  it('books dayCostUsd/daySubagentCostUsd separately from the session-cumulative totals', () => {
+    const tracker = new CostTracker();
+    const yesterday = localDateKey(Date.now() - 86_400_000);
+
+    // A persisted session whose $10 total is entirely from a prior day — the
+    // caller (buildCostTrackerSeed) is expected to compute dayCostUsd as the
+    // *today* portion only (0 here), even though the session-cumulative
+    // total must still reflect the full $10.
+    tracker.seedFromPersisted(
+      makeSeed({
+        totalCostUsd: 10,
+        subagentCostUsd: 4,
+        parentCostUsd: 6,
+        dayKey: yesterday,
+        dayCostUsd: 0,
+        daySubagentCostUsd: 0,
+      }),
+    );
+
+    expect(tracker.getMetrics().sessionTotalCostUsd).toBeCloseTo(10, 4);
+    expect(tracker.getSubagentMetrics().subagentUsd).toBeCloseTo(4, 4);
+    expect(tracker.getCostForDay(yesterday)).toBe(0);
+    expect(tracker.getCostForDay(localDateKey())).toBe(0);
+  });
+
+  it('is a no-op for an all-zero seed (no persisted session found)', () => {
+    const tracker = new CostTracker();
+    tracker.seedFromPersisted(makeSeed());
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.sessionTotalCostUsd).toBeNull();
+    expect(metrics.reportCount).toBe(0);
+  });
+
+  it('makes sessionTotalCostUsd non-null even if no real activity has been recorded yet this process', () => {
+    const tracker = new CostTracker();
+    tracker.seedFromPersisted(makeSeed({ totalCostUsd: 3.1, dayCostUsd: 3.1 }));
+
+    expect(tracker.getMetrics().sessionTotalCostUsd).toBeCloseTo(3.1, 4);
+  });
+
+  it('additively seeds costByWorkflowRunId from a persisted checkpoint', () => {
+    const tracker = new CostTracker();
+    tracker.recordTokenUsage(
+      makeUsage({ inputTokens: 1_000, outputTokens: 500, totalTokens: 1_500 }),
+      'claude-sonnet-4',
+      { workflowRunId: 'wf_live_run' },
+    );
+
+    tracker.seedFromPersisted(
+      makeSeed({
+        totalCostUsd: 10,
+        dayCostUsd: 10,
+        costByWorkflowRunId: {
+          wf_persisted_run: { '2026-08-13': 0.5, '2026-08-14': 1.25 },
+        },
+      }),
+    );
+
+    // The run this process already observed live is untouched...
+    expect(tracker.getCostForWorkflowRun('wf_live_run')).toBeGreaterThan(0);
+    // ...and the persisted run's total is restored, summed across its days.
+    expect(tracker.getCostForWorkflowRun('wf_persisted_run')).toBeCloseTo(1.75, 4);
+    expect(tracker.hasCostForWorkflowRun('wf_persisted_run')).toBe(true);
+  });
+
+  it('merges costByWorkflowRunId day-buckets for a run already partially observed by this process, same day', () => {
+    const tracker = new CostTracker();
+    tracker.recordTokenUsage(
+      makeUsage({ inputTokens: 1_000, outputTokens: 500, totalTokens: 1_500 }),
+      'claude-sonnet-4',
+      { workflowRunId: 'wf_resumed_run' },
+    );
+    const liveCostBefore = tracker.getCostForWorkflowRun('wf_resumed_run');
+    const today = localDateKey();
+
+    tracker.seedFromPersisted(
+      makeSeed({
+        totalCostUsd: 2,
+        dayCostUsd: 2,
+        costByWorkflowRunId: { wf_resumed_run: { [today]: 2 } },
+      }),
+    );
+
+    expect(tracker.getCostForWorkflowRun('wf_resumed_run')).toBeCloseTo(liveCostBefore + 2, 4);
+    // Assert the actual day-bucket placement, not just the summed total —
+    // a merge bug that filed the seeded amount under the wrong dayKey would
+    // still pass the assertion above, since getCostForWorkflowRun() sums
+    // across every day.
+    const entries = [...tracker.iterCostByWorkflowRun()].filter(
+      (e) => e.runId === 'wf_resumed_run',
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.dayKey).toBe(today);
+    expect(entries[0]!.usd).toBeCloseTo(liveCostBefore + 2, 4);
+  });
+
+  it('keeps a persisted run day-bucket separate from a different day already live-observed by this process', () => {
+    const tracker = new CostTracker();
+    const today = localDateKey();
+    const otherDay = '2020-01-01'; // fixed past date used ONLY as a distinct key, not as "today" — never asserted to be relative to now
+
+    tracker.recordTokenUsage(
+      makeUsage({ inputTokens: 1_000, outputTokens: 500, totalTokens: 1_500 }),
+      'claude-sonnet-4',
+      { workflowRunId: 'wf_cross_day_run' },
+    );
+    const liveCostToday = tracker.getCostForWorkflowRun('wf_cross_day_run');
+
+    tracker.seedFromPersisted(
+      makeSeed({
+        totalCostUsd: 5,
+        dayCostUsd: 0, // the seed's day-portion for TODAY's costByDayUsd bucket is unrelated to this test
+        costByWorkflowRunId: { wf_cross_day_run: { [otherDay]: 5 } },
+      }),
+    );
+
+    const entries = [...tracker.iterCostByWorkflowRun()].filter(
+      (e) => e.runId === 'wf_cross_day_run',
+    );
+    expect(entries).toHaveLength(2);
+    const todayEntry = entries.find((e) => e.dayKey === today);
+    const otherEntry = entries.find((e) => e.dayKey === otherDay);
+    expect(todayEntry?.usd).toBeCloseTo(liveCostToday, 4);
+    expect(otherEntry?.usd).toBeCloseTo(5, 4);
+    // Total across both days still sums correctly.
+    expect(tracker.getCostForWorkflowRun('wf_cross_day_run')).toBeCloseTo(liveCostToday + 5, 4);
   });
 });

--- a/src/metrics/cost-tracker.ts
+++ b/src/metrics/cost-tracker.ts
@@ -84,6 +84,36 @@ export interface CostMetrics {
   readonly costByWorkflowRunId: Record<string, Record<string, number>>;
 }
 
+/**
+ * Cumulative totals to seed into a freshly-constructed tracker, derived from
+ * a previous process's last checkpoint for the SAME session — see
+ * `seedFromPersisted()` for why this exists.
+ */
+export interface CostTrackerSeed {
+  readonly totalCostUsd: number;
+  readonly subagentCostUsd: number;
+  readonly parentCostUsd: number;
+  readonly totalInputTokens: number;
+  readonly totalOutputTokens: number;
+  readonly totalThinkingTokens: number;
+  readonly totalCacheReadTokens: number;
+  readonly totalCacheCreationTokens: number;
+  readonly totalCacheSavingsUsd: number;
+  readonly costByModel: Readonly<Record<string, number>>;
+  /** Local-day key (see `localDateKey`) `dayCostUsd`/`daySubagentCostUsd` book against. */
+  readonly dayKey: string;
+  /** Portion of `totalCostUsd`/`subagentCostUsd` attributable to `dayKey` (see `todayPortionOfSessionCost`). */
+  readonly dayCostUsd: number;
+  readonly daySubagentCostUsd: number;
+  /**
+   * Per-workflow-run cost, split by local-day, from the persisted checkpoint
+   * — see `seedFromPersisted()`'s doc comment for why this is seeded (unlike
+   * `reset()`, which still clears this map for the unrelated "wrong session
+   * id" correction case).
+   */
+  readonly costByWorkflowRunId: Readonly<Record<string, Readonly<Record<string, number>>>>;
+}
+
 export interface SubagentMetrics {
   readonly subagentUsd: number;
   readonly parentUsd: number;
@@ -125,9 +155,9 @@ export class CostTracker implements Resettable {
   /**
    * Per-workflow-run cost attribution split by local-day so a run that crosses
    * midnight contributes to each day's bucket independently. Two-level map:
-   * `costByWorkflowRunId.get(runId).get(dayKey) → usd`. Restart-resets to empty
-   * (intentional: per-day totals remain correct even if run-level attribution
-   * is lost across restarts).
+   * `costByWorkflowRunId.get(runId).get(dayKey) → usd`. Restart-resets to
+   * empty UNLESS `seedFromPersisted()` restores it from a persisted
+   * checkpoint for this same session (see that method's doc comment).
    */
   private costByWorkflowRunId = new Map<string, Map<string, number>>();
   /** Per-day mutation counter so dashboards can invalidate cached day cards. */
@@ -274,6 +304,80 @@ export class CostTracker implements Resettable {
     return breakdown;
   }
 
+  /**
+   * Seeds cumulative totals from a previous process's last checkpoint for
+   * this same session. Adds to current state rather than overwriting, so
+   * callers must invoke this at most once per (re)adopted session id, before
+   * any real activity for that id has been recorded here — see the call
+   * sites in `index.ts` for the once-per-id guard.
+   *
+   * Restart data-loss fix: `ParentTranscriptWatcher`'s transcript-read cursor
+   * is durably persisted across process restarts so a resumed session never
+   * re-reads old transcript lines — but this tracker's totals are pure
+   * in-memory state with no equivalent persistence. Without this seed, every
+   * dollar/token attributed to lines a now-dead prior process already
+   * consumed is silently and permanently lost the moment a session gets
+   * paused and resumed (sleep, closing a terminal, `claude --resume`,
+   * a crash) — the longer/more-interrupted the session, the worse the loss.
+   *
+   * `costByWorkflowRunId` IS seeded (additively, per run+day) — this used to
+   * be the one dimension left to reset on restart, but `WorkflowStore`'s
+   * `cost_unknown` flag (see its doc comment in `src/dashboard/workflow-store.ts`)
+   * depends on `hasCostForWorkflowRun()` staying accurate across a restart
+   * too, so it gets the same treatment as everything else here.
+   */
+  seedFromPersisted(seed: CostTrackerSeed): void {
+    const hasAnyTotal =
+      seed.totalCostUsd !== 0 ||
+      seed.totalInputTokens !== 0 ||
+      seed.totalOutputTokens !== 0 ||
+      seed.totalThinkingTokens !== 0 ||
+      seed.totalCacheReadTokens !== 0 ||
+      seed.totalCacheCreationTokens !== 0;
+    if (!hasAnyTotal) return;
+
+    this.totalCostUsd += seed.totalCostUsd;
+    this.subagentCostUsd += seed.subagentCostUsd;
+    this.parentCostUsd += seed.parentCostUsd;
+    this.totalInputTokens += seed.totalInputTokens;
+    this.totalOutputTokens += seed.totalOutputTokens;
+    this.totalThinkingTokens += seed.totalThinkingTokens;
+    this.totalCacheReadTokens += seed.totalCacheReadTokens;
+    this.totalCacheCreationTokens += seed.totalCacheCreationTokens;
+    this.totalCacheSavingsUsd += seed.totalCacheSavingsUsd;
+    this.reportCount += 1;
+
+    for (const [model, usd] of Object.entries(seed.costByModel)) {
+      this.costByModel.set(model, (this.costByModel.get(model) ?? 0) + usd);
+    }
+
+    if (seed.dayCostUsd !== 0) {
+      this.costByDayUsd.set(
+        seed.dayKey,
+        (this.costByDayUsd.get(seed.dayKey) ?? 0) + seed.dayCostUsd,
+      );
+      this.lastMutationMsByDay.set(seed.dayKey, Date.now());
+      const existingFirst = this.firstActivityMsByDay.get(seed.dayKey);
+      if (existingFirst === undefined) {
+        this.firstActivityMsByDay.set(seed.dayKey, Date.now());
+      }
+    }
+    if (seed.daySubagentCostUsd !== 0) {
+      this.subagentCostByDayUsd.set(
+        seed.dayKey,
+        (this.subagentCostByDayUsd.get(seed.dayKey) ?? 0) + seed.daySubagentCostUsd,
+      );
+    }
+
+    for (const [runId, days] of Object.entries(seed.costByWorkflowRunId)) {
+      const runMap = this.costByWorkflowRunId.get(runId) ?? new Map<string, number>();
+      for (const [dayKey, usd] of Object.entries(days)) {
+        runMap.set(dayKey, (runMap.get(dayKey) ?? 0) + usd);
+      }
+      this.costByWorkflowRunId.set(runId, runMap);
+    }
+  }
+
   private computeCacheHitRate(): number | null {
     const denominator =
       this.totalInputTokens + this.totalCacheReadTokens + this.totalCacheCreationTokens;
@@ -334,17 +438,15 @@ export class CostTracker implements Resettable {
    * Whether THIS process's live CostTracker has ever observed a token event
    * for `runId` at all, distinct from `getCostForWorkflowRun()` returning 0.
    * That 0 is ambiguous: it means either "confirmed $0 spend" or "this
-   * process never personally observed this run's cost" (e.g. after a
-   * process restart, or in a `--local` standalone dashboard reading rollups
-   * from disk for a run a different `--stdio` process actually paid for) —
+   * process never personally observed this run's cost" — e.g. in a
+   * `--local` standalone dashboard reading rollups from disk for a run a
+   * different, concurrently-running `--stdio` process is the one actually
+   * paying for. (A sequential process restart for the SAME session no
+   * longer hits this ambiguity — `seedFromPersisted()` rehydrates
+   * `costByWorkflowRunId` from the session's own last checkpoint.)
    * `WorkflowStore` uses this to distinguish the two so the "Workflow
    * spend" KPI can flag a total as partial instead of silently treating
-   * "unknown" as "zero". A partial mitigation.
-   *
-   * This is a read-only accessor over existing state — it does not change
-   * what `costByWorkflowRunId` tracks or how. A full fix would persist
-   * per-run cost somewhere `WorkflowStore` can read across process
-   * restarts/instances; that's out of scope here.
+   * "unknown" as "zero".
    */
   hasCostForWorkflowRun(runId: string): boolean {
     return this.costByWorkflowRunId.has(runId);

--- a/src/metrics/model-usage-tracker.test.ts
+++ b/src/metrics/model-usage-tracker.test.ts
@@ -230,3 +230,85 @@ describe('ModelUsageTracker.combineBreakdowns', () => {
     expect(t.combineBreakdowns([t.getRawBreakdown()])).toEqual(t.getMetrics());
   });
 });
+
+describe('ModelUsageTracker.seedFromPersisted', () => {
+  it('adds a persisted breakdown into an empty tracker', () => {
+    const t = new ModelUsageTracker();
+    t.seedFromPersisted({
+      'claude-sonnet-5': {
+        requestCount: 12,
+        totalInputTokens: 502,
+        totalOutputTokens: 6642,
+        totalCostUsd: 3.0984488,
+      },
+    });
+
+    const raw = t.getRawBreakdown();
+    expect(raw['claude-sonnet-5']).toEqual({
+      requestCount: 12,
+      totalInputTokens: 502,
+      totalOutputTokens: 6642,
+      totalCostUsd: 3.0984488,
+    });
+  });
+
+  it('adds on top of usage already recorded by this process, rather than overwriting', () => {
+    const t = new ModelUsageTracker();
+    t.recordUsage('claude-sonnet-5', 100, 50, 0.01);
+
+    t.seedFromPersisted({
+      'claude-sonnet-5': {
+        requestCount: 12,
+        totalInputTokens: 502,
+        totalOutputTokens: 6642,
+        totalCostUsd: 3.0984488,
+      },
+    });
+
+    const raw = t.getRawBreakdown();
+    expect(raw['claude-sonnet-5']?.requestCount).toBe(13);
+    expect(raw['claude-sonnet-5']?.totalInputTokens).toBe(602);
+    expect(raw['claude-sonnet-5']?.totalOutputTokens).toBe(6692);
+    expect(raw['claude-sonnet-5']?.totalCostUsd).toBeCloseTo(3.1084488, 6);
+  });
+
+  it('merges a model already partially recorded and adds a new model not yet seen', () => {
+    const t = new ModelUsageTracker();
+    t.recordUsage('claude-sonnet-5', 100, 50, 0.01);
+
+    t.seedFromPersisted({
+      'claude-sonnet-5': {
+        requestCount: 1,
+        totalInputTokens: 200,
+        totalOutputTokens: 100,
+        totalCostUsd: 0.02,
+      },
+      'claude-opus-5': {
+        requestCount: 5,
+        totalInputTokens: 1000,
+        totalOutputTokens: 500,
+        totalCostUsd: 0.5,
+      },
+    });
+
+    const raw = t.getRawBreakdown();
+    expect(raw['claude-sonnet-5']).toEqual({
+      requestCount: 2,
+      totalInputTokens: 300,
+      totalOutputTokens: 150,
+      totalCostUsd: 0.03,
+    });
+    expect(raw['claude-opus-5']).toEqual({
+      requestCount: 5,
+      totalInputTokens: 1000,
+      totalOutputTokens: 500,
+      totalCostUsd: 0.5,
+    });
+  });
+
+  it('is a no-op for an empty breakdown (no persisted session found)', () => {
+    const t = new ModelUsageTracker();
+    t.seedFromPersisted({});
+    expect(t.getRawBreakdown()).toEqual({});
+  });
+});

--- a/src/metrics/model-usage-tracker.ts
+++ b/src/metrics/model-usage-tracker.ts
@@ -110,6 +110,36 @@ export class ModelUsageTracker implements Resettable {
     stats.totalCostUsd += costUsd;
   }
 
+  /**
+   * Seeds cumulative per-model counters from a previous process's last
+   * checkpoint for this same session — mirrors
+   * `CostTracker.seedFromPersisted()`, which this tracker has the identical
+   * in-memory-only, resets-on-restart problem alongside (see that method's
+   * doc comment for why): a process restart mid-session (sleep, closing a
+   * terminal, `claude --resume`, a crash) otherwise silently discards every
+   * request/token/dollar a now-dead prior process already attributed to a
+   * model, even after CostTracker's own totals are correctly restored —
+   * leaving this tracker's per-model breakdown inconsistent with (short of)
+   * the session total.
+   *
+   * Adds to current per-model state rather than overwriting, so callers must
+   * invoke this at most once per (re)adopted session id, before any real
+   * activity for that id has reached this tracker.
+   */
+  seedFromPersisted(breakdown: Readonly<Record<string, ModelBreakdownEntry>>): void {
+    for (const [model, entry] of Object.entries(breakdown)) {
+      let stats = this.byModel.get(model);
+      if (!stats) {
+        stats = { requestCount: 0, totalInputTokens: 0, totalOutputTokens: 0, totalCostUsd: 0 };
+        this.byModel.set(model, stats);
+      }
+      stats.requestCount += entry.requestCount;
+      stats.totalInputTokens += entry.totalInputTokens;
+      stats.totalOutputTokens += entry.totalOutputTokens;
+      stats.totalCostUsd += entry.totalCostUsd;
+    }
+  }
+
   // Raw per-model counters only — no derived ratios. This is the shape
   // persisted onto FullSessionSummary.modelBreakdown (session-store.ts) so a
   // session file never stores a stale derived ratio; ratios are always

--- a/src/metrics/prompt-feedback.test.ts
+++ b/src/metrics/prompt-feedback.test.ts
@@ -65,6 +65,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    costByWorkflowRunId: {},
     qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,

--- a/src/metrics/recommendation-engine.test.ts
+++ b/src/metrics/recommendation-engine.test.ts
@@ -66,6 +66,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    costByWorkflowRunId: {},
     qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,

--- a/src/metrics/trend-analyzer.test.ts
+++ b/src/metrics/trend-analyzer.test.ts
@@ -65,6 +65,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    costByWorkflowRunId: {},
     qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -74,6 +74,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    costByWorkflowRunId: {},
     qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,
@@ -1163,6 +1164,47 @@ describe('buildSessionSummary', () => {
     expect(summary.subagentCostUsd).toBe(0.021);
   });
 
+  it('includes costByWorkflowRunId from CostTracker', () => {
+    const sessionTracker = makeSessionTracker();
+    const costTracker = new CostTracker();
+    jest.spyOn(costTracker, 'getMetrics').mockReturnValue({
+      sessionTotalCostUsd: 0.05,
+      costByTask: null,
+      costByModel: {},
+      costPerLineOfCode: null,
+      costPerFileModified: null,
+      costPerMillionTokens: null,
+      model: 'claude-sonnet-4-6',
+      totalInputTokens: 3_000,
+      totalOutputTokens: 1_000,
+      totalThinkingTokens: 0,
+      totalCacheReadTokens: 5_000,
+      totalCacheCreationTokens: 1_500,
+      cacheHitRate: 0.526,
+      totalCacheSavingsUsd: 0.018,
+      reportCount: 2,
+      estimationCount: 0,
+      latestCostBreakdown: null,
+      subagentCostUsd: 0.021,
+      parentCostUsd: 0.029,
+      costByWorkflowRunId: { wf_test_run: { '2026-08-14': 0.05 } },
+    } satisfies CostMetrics);
+    const summary = buildSessionSummary({
+      sessionTracker,
+      costTracker,
+      developer: 'dev',
+    });
+    expect(summary.costByWorkflowRunId).toEqual({ wf_test_run: { '2026-08-14': 0.05 } });
+  });
+
+  it('defaults costByWorkflowRunId to {} when no CostTracker is provided', () => {
+    const summary = buildSessionSummary({
+      sessionTracker: makeSessionTracker(),
+      developer: 'dev',
+    });
+    expect(summary.costByWorkflowRunId).toEqual({});
+  });
+
   it('defaults subagentCostUsd to 0 when no CostTracker is provided', () => {
     const summary = buildSessionSummary({
       sessionTracker: makeSessionTracker(),
@@ -1274,6 +1316,53 @@ describe('buildSessionSummary', () => {
     };
     const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
     expect(result.subagentCostUsd).toBe(0);
+  });
+
+  it('deserializeFullSessionSummary round-trips costByWorkflowRunId', () => {
+    const raw = {
+      sessionId: 'sess-wf',
+      startTime: 1_700_000_000_000,
+      endTime: 1_700_003_600_000,
+      durationMs: 3_600_000,
+      toolCallCount: 5,
+      developer: 'dev',
+      costByWorkflowRunId: { wf_abc: { '2026-08-14': 0.5, '2026-08-15': 1.25 } },
+    };
+    const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
+    expect(result.costByWorkflowRunId).toEqual({
+      wf_abc: { '2026-08-14': 0.5, '2026-08-15': 1.25 },
+    });
+  });
+
+  it('deserializeFullSessionSummary defaults costByWorkflowRunId to {} for pre-fix session files', () => {
+    const raw = {
+      sessionId: 'sess-old',
+      startTime: 1_700_000_000_000,
+      endTime: 1_700_003_600_000,
+      durationMs: 3_600_000,
+      toolCallCount: 5,
+      developer: 'dev',
+    };
+    const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
+    expect(result.costByWorkflowRunId).toEqual({});
+  });
+
+  it('deserializeFullSessionSummary drops non-numeric values inside costByWorkflowRunId rather than throwing', () => {
+    const raw = {
+      sessionId: 'sess-malformed',
+      startTime: 1_700_000_000_000,
+      endTime: 1_700_003_600_000,
+      durationMs: 3_600_000,
+      toolCallCount: 5,
+      developer: 'dev',
+      costByWorkflowRunId: {
+        wf_ok: { '2026-08-14': 0.5 },
+        wf_bad_day: { '2026-08-14': 'not-a-number' },
+        wf_not_an_object: 'not-an-object',
+      },
+    };
+    const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
+    expect(result.costByWorkflowRunId).toEqual({ wf_ok: { '2026-08-14': 0.5 }, wf_bad_day: {} });
   });
 
   it('handles missing optional trackers gracefully', () => {

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -136,6 +136,14 @@ export interface FullSessionSummary extends SessionSummary {
    */
   readonly modelBreakdown: Readonly<Record<string, ModelBreakdownEntry>>;
   /**
+   * Per-workflow-run cost, split by local-day, keyed by workflow_run_id then
+   * day key — the exact shape `CostMetrics.costByWorkflowRunId` already
+   * produces. Captured once at save time so a resumed session's per-run
+   * spend survives a process restart (see CostTracker.seedFromPersisted()).
+   * `{}` for pre-fix session files and for sessions with no workflow runs.
+   */
+  readonly costByWorkflowRunId: Record<string, Record<string, number>>;
+  /**
    * Raw quality-proxy signal counts for this session, captured once at save
    * time from QualityProxyTracker.getRawCounts(). Raw counts only, no derived
    * rates — see combineQualityProxyRawCounts for why rates are always
@@ -510,6 +518,7 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     timeline: timeline.length > 0 ? timeline : undefined,
     toolSelectionMetrics: toolSelectionResult,
     modelBreakdown: sources.modelUsageTracker?.getRawBreakdown() ?? {},
+    costByWorkflowRunId: costMetrics?.costByWorkflowRunId ?? {},
     qualityProxy: sources.qualityProxyTracker?.getRawCounts() ?? ZERO_QUALITY_PROXY_COUNTS,
   };
 }
@@ -601,6 +610,7 @@ interface SerializedFullSessionSummary {
   readonly timeline?: Array<Record<string, unknown>>;
   readonly toolSelectionMetrics?: unknown;
   readonly modelBreakdown?: Record<string, unknown>;
+  readonly costByWorkflowRunId?: Record<string, unknown>;
   readonly qualityProxy?: Record<string, unknown>;
 }
 
@@ -705,6 +715,18 @@ export function deserializeFullSessionSummary(
     }
   }
 
+  const costByWorkflowRunId: Record<string, Record<string, number>> = {};
+  if (typeof obj.costByWorkflowRunId === 'object' && obj.costByWorkflowRunId !== null) {
+    for (const [runId, dayMap] of Object.entries(obj.costByWorkflowRunId)) {
+      if (typeof dayMap !== 'object' || dayMap === null) continue;
+      const days: Record<string, number> = {};
+      for (const [dayKey, usd] of Object.entries(dayMap)) {
+        if (typeof usd === 'number') days[dayKey] = usd;
+      }
+      costByWorkflowRunId[runId] = days;
+    }
+  }
+
   const qualityProxy: QualityProxyRawCounts = (() => {
     const q = obj.qualityProxy;
     if (typeof q !== 'object' || q === null) return ZERO_QUALITY_PROXY_COUNTS;
@@ -802,6 +824,7 @@ export function deserializeFullSessionSummary(
       : undefined,
     toolSelectionMetrics,
     modelBreakdown,
+    costByWorkflowRunId,
     qualityProxy,
   };
 }

--- a/src/storage/weekly-summary.test.ts
+++ b/src/storage/weekly-summary.test.ts
@@ -65,6 +65,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    costByWorkflowRunId: {},
     qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -93,6 +93,7 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
     efficiencyScore: 0.75,
     toolSelectionMetrics: null,
     modelBreakdown: {},
+    costByWorkflowRunId: {},
     qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
     antiPatterns: [],
     taskCount: 1,


### PR DESCRIPTION
Fixes #451

## Summary

- Local session cost and token totals reset to zero when the MCP server process restarted mid-session — closing and reopening a terminal, a laptop sleep/wake, `claude --resume`, or a crash all restart the process. Previously only activity observed since the most recent restart was ever counted; a long or repeatedly-interrupted session could silently lose most of its real cost and token totals.
- Confirmed against a real session with a 178-minute gap: Preflight reported $3.10 where an independent `ccusage` read of the same transcript reported $56.02.
- `CostTracker.seedFromPersisted()` now additively restores cumulative totals and today's day-bucket from the session's own periodic on-disk checkpoint (already written every ~30s, but never read back on restart). The same fix covers `ModelUsageTracker`'s per-model breakdown and `CostTracker`'s per-workflow-run cost attribution, so neither lags behind the now-correct session total.
- A resumed session's restored total can no longer be attributed to the wrong session either — seeding now only happens once a session's identity is confirmed, not on an unconfirmed, ambiguous session-id guess.
- Adds `scripts/compare-cost-with-ccusage-claude-code.ts`, a reusable Claude-Code-specific diagnostic for local cost-discrepancy reports — diffs Preflight's tracked tokens/cost against an independent `ccusage` read of the same session, and re-prices `ccusage`'s raw tokens through Preflight's own pricing table to separate a token-capture gap from a pricing-table gap.

## Test plan

- [x] `npm run build && npm test` — 5561/5564 tests passing (166/167 suites; 3 skipped, pre-existing/unrelated)
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run format:check` — clean