### PR TITLE
Fix #452-#455: close out tracker restart-recovery audit (v1.15.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.5] - 2026-08-17
+
+### Fixed
+
+- **A resumed session's file/line/test/build/agent-spawn counts, quality-proxy signal counts, and efficiency-score average no longer reset to zero when the MCP server process restarts mid-session** — closing and reopening a terminal, a laptop sleep/wake, `claude --resume`, or a crash all restart the process. These are the same restart-recovery gap fixed for cost/token totals and per-model/per-workflow-run breakdowns in 1.15.4, now closed for the remaining stateful trackers found in that same audit.
+- **Session-budget threshold alerts (50%/80%/100%) no longer re-fire after a process restart.** Once the fix above correctly restores a session's pre-restart spend immediately on restart, the budget tracker now also recognizes any threshold that total already implies as already-fired, instead of alerting again for spend that isn't new.
+
 ## [1.15.4] - 2026-08-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.15.4",
+      "version": "1.15.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { HookEventProcessor } from './hooks/index.js';
 import { SessionTracker } from './metrics/session-tracker.js';
 import { CostTracker } from './metrics/cost-tracker.js';
 import { buildCostTrackerSeed } from './metrics/cost-tracker-seed.js';
+import { buildTaskDetectorSeed } from './metrics/task-detector-seed.js';
 import { buildCostForecastFromInputs } from './metrics/cost-forecast.js';
 import { BudgetTracker } from './metrics/budget-tracker.js';
 import { TaskDetector } from './metrics/task-detector.js';
@@ -1061,11 +1062,17 @@ async function main(): Promise<void> {
     const currentSessionId = sessionTracker.getMetrics().sessionId;
     let currentRepoName: string | null = null;
 
+    const budgetTracker = new BudgetTracker({
+      sessionBudgetUsd: config.sessionBudgetUsd,
+      dailyBudgetUsd: config.dailyBudgetUsd,
+      weeklyBudgetUsd: config.weeklyBudgetUsd,
+    });
+
     // Recover a resumed session's pre-restart cost/token totals — see
     // CostTracker.seedFromPersisted()'s doc comment for the bug this fixes.
-    // Also seeds ModelUsageTracker, which has the identical in-memory-only,
-    // resets-on-restart problem for its own per-model breakdown — without
-    // this, its numbers would stay inconsistent with (short of) CostTracker's
+    // Also seeds ModelUsageTracker and BudgetTracker, which have the identical
+    // in-memory-only, resets-on-restart problem for their own metrics — without
+    // this, their numbers would stay inconsistent with (short of) CostTracker's
     // now-correct session total after a restart.
     // Guarded per-id (not a single fired-once flag) because adoptRealSessionId
     // below can call this again for a *different* id after a pending->real
@@ -1079,7 +1086,28 @@ async function main(): Promise<void> {
         const persisted = sessionStore!.loadSession(sessionId);
         if (!persisted) return;
         costTracker.seedFromPersisted(buildCostTrackerSeed(persisted));
+        budgetTracker.seedFiredThresholdsFromSessionTotal(
+          costTracker.getMetrics().sessionTotalCostUsd ?? 0,
+        );
         modelUsageTracker.seedFromPersisted(persisted.modelBreakdown);
+        qualityProxyTracker.seedFromPersisted(persisted.qualityProxy);
+        // Non-null: taskDetector is assigned unconditionally earlier in this
+        // same setup path (see line ~980), before rehydrateTrackersIfResumed
+        // can be invoked — same pattern as the other `taskDetector!` use
+        // below, needed because its declared type stays `| undefined` for
+        // callers outside this path.
+        taskDetector!.seedFromPersisted(buildTaskDetectorSeed(persisted));
+        if (
+          persisted.efficiencyScore !== null &&
+          persisted.efficiencyScoreComponents &&
+          (persisted.efficiencyScoreSampleCount ?? 0) > 0
+        ) {
+          efficiencyScorer.seedFromPersisted({
+            score: persisted.efficiencyScore,
+            components: persisted.efficiencyScoreComponents,
+            sampleCount: persisted.efficiencyScoreSampleCount ?? 0,
+          });
+        }
         logger.info('Rehydrated trackers from a prior checkpoint for this session', {
           sessionId,
           estimatedCostUsd: persisted.estimatedCostUsd,
@@ -1290,12 +1318,6 @@ async function main(): Promise<void> {
     const sessionStartMs = Date.now();
 
     const liveBus = new LiveEventBus();
-
-    const budgetTracker = new BudgetTracker({
-      sessionBudgetUsd: config.sessionBudgetUsd,
-      dailyBudgetUsd: config.dailyBudgetUsd,
-      weeklyBudgetUsd: config.weeklyBudgetUsd,
-    });
 
     // Construct AuditTrailManager once and share it across NrIngestManager and the
     // DashboardServer. In local mode there is no NrIngestManager, but the dashboard

--- a/src/metrics/budget-tracker.test.ts
+++ b/src/metrics/budget-tracker.test.ts
@@ -185,4 +185,51 @@ describe('BudgetTracker', () => {
 
     jest.useRealTimers();
   });
+
+  it('seedFiredThresholdsFromSessionTotal marks thresholds already implied by a restored total as fired, without emitting alerts', () => {
+    const events: unknown[] = [];
+    const t = new BudgetTracker({
+      sessionBudgetUsd: 10,
+      dailyBudgetUsd: null,
+      weeklyBudgetUsd: null,
+      onThreshold: (e) => events.push(e),
+    });
+
+    // Simulate CostTracker.seedFromPersisted() having just restored an 85%-spent total.
+    t.seedFiredThresholdsFromSessionTotal(8.5);
+    expect(events).toHaveLength(0); // no alert emitted for pre-existing spend
+
+    // A tiny bit of NEW spend should not re-fire the 50%/80% thresholds already seeded.
+    t.updateCost(8.6, 0, 0);
+    expect(events).toHaveLength(0);
+
+    // Crossing 100% for the first time (session-scoped) should still fire.
+    t.updateCost(10.1, 0, 0);
+    expect(events).toHaveLength(1);
+    expect((events[0] as { thresholdPct: number }).thresholdPct).toBe(100);
+  });
+
+  it('seedFiredThresholdsFromSessionTotal is a no-op when there is no session budget configured', () => {
+    const t = new BudgetTracker({
+      sessionBudgetUsd: null,
+      dailyBudgetUsd: null,
+      weeklyBudgetUsd: null,
+    });
+    expect(() => t.seedFiredThresholdsFromSessionTotal(1000)).not.toThrow();
+    expect(t.getStatus().session.pctUsed).toBeNull();
+  });
+
+  it('seedFiredThresholdsFromSessionTotal below every threshold marks nothing as fired', () => {
+    const events: unknown[] = [];
+    const t = new BudgetTracker({
+      sessionBudgetUsd: 10,
+      dailyBudgetUsd: null,
+      weeklyBudgetUsd: null,
+      onThreshold: (e) => events.push(e),
+    });
+    t.seedFiredThresholdsFromSessionTotal(1); // 10% — below the 50% floor
+    t.updateCost(5.1, 0, 0); // now crosses 50% for the first time
+    expect(events).toHaveLength(1);
+    expect((events[0] as { thresholdPct: number }).thresholdPct).toBe(50);
+  });
 });

--- a/src/metrics/budget-tracker.ts
+++ b/src/metrics/budget-tracker.ts
@@ -148,6 +148,45 @@ export class BudgetTracker {
     }
   }
 
+  /**
+   * Marks every session-period threshold already implied by a just-restored
+   * CostTracker total as already-fired, so `checkPeriod()` doesn't treat
+   * spend that already existed *before* this process started as a brand-new
+   * crossing. Called from inside `rehydrateTrackersIfResumed()` in
+   * index.ts, using CostTracker's own (by then already restored via its own
+   * restart-recovery seeding) session total. That helper is guarded per
+   * session id, not fired-once — it can run again later in the same process
+   * as different session-id-resolution paths (the synchronous guess,
+   * `adoptRealSessionId`, or a PPID correction) confirm the real id, so this
+   * method can be invoked more than once across a session's lifetime, with
+   * a different (and possibly stale or updated) total each time.
+   *
+   * Repeated invocation is safe: this method only ever marks *additional*
+   * thresholds as fired based on the total it's given — it never un-marks
+   * one already in `firedThresholds`, so calling it again is idempotent-safe
+   * regardless of how the total has moved between calls.
+   *
+   * Scoped to the `session` period only: `dailySpentUsd`/`weeklySpentUsd`
+   * are computed elsewhere from cross-session aggregation, not from a single
+   * restart-recoverable checkpoint, so there's no equivalent restored total
+   * to seed against yet for those two periods.
+   *
+   * Deliberately does not call `onThreshold` or push onto `alerts` — these
+   * thresholds were already alerted on (or silently passed, pre-fix) by the
+   * now-dead prior process; this only suppresses a duplicate, not un-fired
+   * spend the user hasn't been told about yet.
+   */
+  seedFiredThresholdsFromSessionTotal(sessionSpentUsd: number): void {
+    if (this.sessionBudgetUsd === null || this.sessionBudgetUsd <= 0) return;
+    const pctUsed = (sessionSpentUsd / this.sessionBudgetUsd) * 100;
+    const currentPeriod = this.currentPeriodId('session');
+    for (const level of THRESHOLD_LEVELS) {
+      if (pctUsed >= level) {
+        this.firedThresholds.set(`session_${level}`, currentPeriod);
+      }
+    }
+  }
+
   getStatus(): BudgetStatus {
     return {
       session: this.buildPeriodStatus(this.sessionSpentUsd, this.sessionBudgetUsd),

--- a/src/metrics/efficiency-score.test.ts
+++ b/src/metrics/efficiency-score.test.ts
@@ -607,3 +607,75 @@ describe('scores cap (MAX_SCORES = 1000)', () => {
     expect(recorded).toHaveLength(5); // only t2, not t1 again
   });
 });
+
+// ---------------------------------------------------------------------------
+// seedFromPersisted
+// ---------------------------------------------------------------------------
+
+describe('seedFromPersisted', () => {
+  it('blends a weighted seeded average into getSessionAverage()', () => {
+    const scorer = new EfficiencyScorer();
+    // Seed represents 4 pre-restart tasks averaging score=0.8.
+    scorer.seedFromPersisted({
+      score: 0.8,
+      components: { speed: 0.9, correctness: 0.7, autonomy: 1, firstAttemptQuality: 0.6 },
+      sampleCount: 4,
+    });
+    // One fresh task scoring 0 across the board post-restart.
+    scorer.computeScore(
+      makeTask({ linesChanged: 0, testsRun: 0, testsPassed: 0, askedUserQuestions: 10 }),
+    );
+
+    const avg = scorer.getSessionAverage();
+    expect(avg).not.toBeNull();
+    // Weighted: (0.8*4 + freshScore*1) / 5 — assert via the same math the
+    // fresh task's own computeScore() result reports, rather than a second
+    // hardcoded literal, so this test can't drift from computeScore()'s own
+    // formula.
+    const fresh = scorer.getScores()[0]!;
+    expect(avg!.score).toBeCloseTo((0.8 * 4 + fresh.score * 1) / 5, 6);
+    expect(avg!.components.speed).toBeCloseTo((0.9 * 4 + fresh.components.speed * 1) / 5, 6);
+  });
+
+  it('returns the seed unweighted-by-fresh-data average when no fresh tasks have been scored yet', () => {
+    const scorer = new EfficiencyScorer();
+    scorer.seedFromPersisted({
+      score: 0.65,
+      components: { speed: 0.5, correctness: 0.6, autonomy: 0.7, firstAttemptQuality: 0.8 },
+      sampleCount: 2,
+    });
+    const avg = scorer.getSessionAverage();
+    expect(avg!.score).toBeCloseTo(0.65, 6);
+    expect(avg!.components).toEqual({
+      speed: 0.5,
+      correctness: 0.6,
+      autonomy: 0.7,
+      firstAttemptQuality: 0.8,
+    });
+  });
+
+  it('is additive across multiple calls', () => {
+    const scorer = new EfficiencyScorer();
+    scorer.seedFromPersisted({
+      score: 1,
+      components: { speed: 1, correctness: 1, autonomy: 1, firstAttemptQuality: 1 },
+      sampleCount: 1,
+    });
+    scorer.seedFromPersisted({
+      score: 0,
+      components: { speed: 0, correctness: 0, autonomy: 0, firstAttemptQuality: 0 },
+      sampleCount: 1,
+    });
+    expect(scorer.getSessionAverage()!.score).toBeCloseTo(0.5, 6);
+  });
+
+  it('is a no-op for a zero sampleCount', () => {
+    const scorer = new EfficiencyScorer();
+    scorer.seedFromPersisted({
+      score: 1,
+      components: { speed: 1, correctness: 1, autonomy: 1, firstAttemptQuality: 1 },
+      sampleCount: 0,
+    });
+    expect(scorer.getSessionAverage()).toBeNull();
+  });
+});

--- a/src/metrics/efficiency-score.ts
+++ b/src/metrics/efficiency-score.ts
@@ -41,6 +41,19 @@ export interface EfficiencyScoreOptions {
   readonly speedBaselineLinesPerSecond?: number;
 }
 
+/**
+ * Input shape for `EfficiencyScorer.seedFromPersisted()` — a previous
+ * process's last checkpoint of `getSessionAverage()` for this same session,
+ * built directly from `FullSessionSummary.efficiencyScore` +
+ * `.efficiencyScoreComponents` + `.efficiencyScoreSampleCount`
+ * (session-store.ts).
+ */
+export interface EfficiencyScoreSeed {
+  readonly score: number;
+  readonly components: EfficiencyScoreComponents;
+  readonly sampleCount: number;
+}
+
 // ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
@@ -66,6 +79,18 @@ export class EfficiencyScorer implements Resettable {
 
   private readonly scores: EfficiencyScore[] = [];
   private lastEmittedIndex = 0;
+
+  // Weighted seed from a previous process's last checkpoint for this same
+  // session — see seedFromPersisted()'s doc comment. The persisted
+  // checkpoint is already itself an average (not raw per-task scores), so
+  // seeding accumulates a weighted contribution (value * sampleCount) rather
+  // than raw per-task totals like CostTracker.seedFromPersisted() does.
+  private seededScoreSum = 0;
+  private seededSpeedSum = 0;
+  private seededCorrectnessSum = 0;
+  private seededAutonomySum = 0;
+  private seededFirstAttemptSum = 0;
+  private seededSampleCount = 0;
 
   constructor(options?: EfficiencyScoreOptions) {
     this.speedWeight = options?.speedWeight ?? DEFAULT_SPEED_WEIGHT;
@@ -108,16 +133,39 @@ export class EfficiencyScorer implements Resettable {
   }
 
   /**
+   * Seeds a weighted contribution to the session average from a previous
+   * process's last checkpoint for this same session — same restart-recovery
+   * problem as `CostTracker.seedFromPersisted()`/`ModelUsageTracker.seedFromPersisted()`,
+   * but adapted for a tracker whose own persisted checkpoint is already an
+   * average rather than raw per-task data — the per-task score list isn't
+   * reconstructable from a checkpoint, only the average is.
+   *
+   * Adds to current totals rather than overwriting, so callers must invoke
+   * this at most once per (re)adopted session id, before any real activity
+   * for that id has reached this tracker.
+   */
+  seedFromPersisted(seed: EfficiencyScoreSeed): void {
+    if (seed.sampleCount <= 0) return;
+    this.seededScoreSum += seed.score * seed.sampleCount;
+    this.seededSpeedSum += seed.components.speed * seed.sampleCount;
+    this.seededCorrectnessSum += seed.components.correctness * seed.sampleCount;
+    this.seededAutonomySum += seed.components.autonomy * seed.sampleCount;
+    this.seededFirstAttemptSum += seed.components.firstAttemptQuality * seed.sampleCount;
+    this.seededSampleCount += seed.sampleCount;
+  }
+
+  /**
    * Session-wide rolling average across all scored tasks.
    */
   getSessionAverage(): EfficiencyScore | null {
-    if (this.scores.length === 0) return null;
+    const n = this.scores.length + this.seededSampleCount;
+    if (n === 0) return null;
 
-    let totalScore = 0;
-    let totalSpeed = 0;
-    let totalCorrectness = 0;
-    let totalAutonomy = 0;
-    let totalFirstAttempt = 0;
+    let totalScore = this.seededScoreSum;
+    let totalSpeed = this.seededSpeedSum;
+    let totalCorrectness = this.seededCorrectnessSum;
+    let totalAutonomy = this.seededAutonomySum;
+    let totalFirstAttempt = this.seededFirstAttemptSum;
 
     for (const s of this.scores) {
       totalScore += s.score;
@@ -126,8 +174,6 @@ export class EfficiencyScorer implements Resettable {
       totalAutonomy += s.components.autonomy;
       totalFirstAttempt += s.components.firstAttemptQuality;
     }
-
-    const n = this.scores.length;
 
     return {
       score: Math.round((totalScore / n) * 1000) / 1000,
@@ -140,6 +186,17 @@ export class EfficiencyScorer implements Resettable {
       taskId: 'session-average',
       timestamp: Date.now(),
     };
+  }
+
+  /**
+   * Effective sample count behind getSessionAverage() — fresh scores plus
+   * any seeded weight from a previous process's checkpoint. Distinct from
+   * getScores().length, which is fresh-only and would silently drop or
+   * under-weight seeded history if used to persist the sample count that
+   * pairs with getSessionAverage()'s seed-inclusive score.
+   */
+  getSessionSampleCount(): number {
+    return this.scores.length + this.seededSampleCount;
   }
 
   /**
@@ -196,6 +253,12 @@ export class EfficiencyScorer implements Resettable {
   reset(_sessionId: string): void {
     this.scores.length = 0;
     this.lastEmittedIndex = 0;
+    this.seededScoreSum = 0;
+    this.seededSpeedSum = 0;
+    this.seededCorrectnessSum = 0;
+    this.seededAutonomySum = 0;
+    this.seededFirstAttemptSum = 0;
+    this.seededSampleCount = 0;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/metrics/quality-proxy-tracker.test.ts
+++ b/src/metrics/quality-proxy-tracker.test.ts
@@ -197,6 +197,70 @@ describe('QualityProxyTracker', () => {
       expect.anything(),
     );
   });
+
+  it('seedFromPersisted adds persisted raw counts into getRawCounts()', () => {
+    const tracker = new QualityProxyTracker();
+    tracker.recordToolCall(makeRecord({ toolName: 'Edit', filePath: '/a.ts', success: true }));
+
+    tracker.seedFromPersisted({
+      totalSignals: 4,
+      diffApplyCleanCount: 2,
+      diffFailCount: 1,
+      testPassCount: 1,
+      testFailCount: 0,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    });
+
+    const counts = tracker.getRawCounts();
+    expect(counts.totalSignals).toBe(5); // 1 live diff_applied_clean + 4 seeded
+    expect(counts.diffApplyCleanCount).toBe(3); // 1 live + 2 seeded
+    expect(counts.diffFailCount).toBe(1);
+    expect(counts.testPassCount).toBe(1);
+  });
+
+  it('seedFromPersisted is additive across multiple calls (repeated rehydration guard upstream)', () => {
+    const tracker = new QualityProxyTracker();
+    tracker.seedFromPersisted({
+      totalSignals: 1,
+      diffApplyCleanCount: 1,
+      diffFailCount: 0,
+      testPassCount: 0,
+      testFailCount: 0,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    });
+    tracker.seedFromPersisted({
+      totalSignals: 1,
+      diffApplyCleanCount: 1,
+      diffFailCount: 0,
+      testPassCount: 0,
+      testFailCount: 0,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    });
+    expect(tracker.getRawCounts().diffApplyCleanCount).toBe(2);
+  });
+
+  it('seeded counts feed diffApplyRate/testPassRate via getMetrics()', () => {
+    const tracker = new QualityProxyTracker();
+    tracker.seedFromPersisted({
+      totalSignals: 4,
+      diffApplyCleanCount: 3,
+      diffFailCount: 1,
+      testPassCount: 0,
+      testFailCount: 0,
+      backtrackCount: 0,
+      selfCorrectionCount: 0,
+    });
+    expect(tracker.getMetrics().diffApplyRate).toBe(0.75);
+  });
+
+  it('is a no-op when the persisted counts are all zero', () => {
+    const tracker = new QualityProxyTracker();
+    tracker.seedFromPersisted(ZERO_QUALITY_PROXY_COUNTS);
+    expect(tracker.getRawCounts()).toEqual(ZERO_QUALITY_PROXY_COUNTS);
+  });
 });
 
 describe('QualityProxyTracker.getRawCounts', () => {

--- a/src/metrics/quality-proxy-tracker.ts
+++ b/src/metrics/quality-proxy-tracker.ts
@@ -155,6 +155,15 @@ export class QualityProxyTracker {
   private lastEditTurn = 0;
   private lastEditSuccess = false;
 
+  // Additive seed from a previous process's last checkpoint for this same
+  // session — see seedFromPersisted()'s doc comment for why. Kept separate
+  // from `events` rather than pushed in as synthetic entries: `events` feeds
+  // computeTurnBuckets()/detectDegradation(), which need real turn numbers a
+  // persisted aggregate count can't provide (see FullSessionSummary.qualityProxy's
+  // doc comment for the same caveat). Only the aggregate counts/rates below
+  // are recoverable this way.
+  private seededCounts: QualityProxyRawCounts = { ...ZERO_QUALITY_PROXY_COUNTS };
+
   constructor(options?: QualityProxyOptions) {
     this.bucketSize = options?.bucketSize ?? DEFAULT_BUCKET_SIZE;
     this.maxEvents = options?.maxEvents ?? DEFAULT_MAX_EVENTS;
@@ -217,19 +226,47 @@ export class QualityProxyTracker {
     }
   }
 
+  /**
+   * Seeds cumulative raw signal counts from a previous process's last
+   * checkpoint for this same session — mirrors
+   * `ModelUsageTracker.seedFromPersisted()`, which has the identical
+   * in-memory-only, resets-on-restart problem: a process restart mid-session
+   * (sleep, closing a terminal, `claude --resume`, a crash) otherwise
+   * silently discards every diff/test/backtrack/self-correction signal a
+   * now-dead prior process already observed.
+   *
+   * Adds to current counts rather than overwriting, so callers must invoke
+   * this at most once per (re)adopted session id, before any real activity
+   * for that id has reached this tracker.
+   */
+  seedFromPersisted(counts: QualityProxyRawCounts): void {
+    if (counts.totalSignals === 0) return;
+    this.seededCounts = {
+      totalSignals: this.seededCounts.totalSignals + counts.totalSignals,
+      diffApplyCleanCount: this.seededCounts.diffApplyCleanCount + counts.diffApplyCleanCount,
+      diffFailCount: this.seededCounts.diffFailCount + counts.diffFailCount,
+      testPassCount: this.seededCounts.testPassCount + counts.testPassCount,
+      testFailCount: this.seededCounts.testFailCount + counts.testFailCount,
+      backtrackCount: this.seededCounts.backtrackCount + counts.backtrackCount,
+      selfCorrectionCount: this.seededCounts.selfCorrectionCount + counts.selfCorrectionCount,
+    };
+  }
+
   // Raw per-session counts only — no derived rates. This is the shape
   // persisted onto FullSessionSummary.qualityProxy (session-store.ts) so a
   // session file never stores a stale derived rate; rates are always
   // recomputed at read time via getMetrics()/combineQualityProxyRawCounts().
   getRawCounts(): QualityProxyRawCounts {
     return {
-      totalSignals: this.events.length,
-      diffApplyCleanCount: this.countBySignal('diff_applied_clean'),
-      diffFailCount: this.countBySignal('diff_failed'),
-      testPassCount: this.countBySignal('test_pass'),
-      testFailCount: this.countBySignal('test_fail'),
-      backtrackCount: this.countBySignal('backtrack'),
-      selfCorrectionCount: this.countBySignal('self_correction'),
+      totalSignals: this.events.length + this.seededCounts.totalSignals,
+      diffApplyCleanCount:
+        this.countBySignal('diff_applied_clean') + this.seededCounts.diffApplyCleanCount,
+      diffFailCount: this.countBySignal('diff_failed') + this.seededCounts.diffFailCount,
+      testPassCount: this.countBySignal('test_pass') + this.seededCounts.testPassCount,
+      testFailCount: this.countBySignal('test_fail') + this.seededCounts.testFailCount,
+      backtrackCount: this.countBySignal('backtrack') + this.seededCounts.backtrackCount,
+      selfCorrectionCount:
+        this.countBySignal('self_correction') + this.seededCounts.selfCorrectionCount,
     };
   }
 
@@ -276,6 +313,7 @@ export class QualityProxyTracker {
     this.lastEditFile = null;
     this.lastEditTurn = 0;
     this.lastEditSuccess = false;
+    this.seededCounts = { ...ZERO_QUALITY_PROXY_COUNTS };
   }
 
   private addEvent(signal: QualitySignal, turnNumber: number, toolName: string): void {

--- a/src/metrics/task-detector-seed.test.ts
+++ b/src/metrics/task-detector-seed.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildTaskDetectorSeed } from './task-detector-seed.js';
+import type { FullSessionSummary } from '../storage/session-store.js';
+import { ZERO_QUALITY_PROXY_COUNTS } from './quality-proxy-tracker.js';
+
+function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummary {
+  const now = Date.now();
+  return {
+    sessionId: `sess-${now}`,
+    sessionName: null,
+    repoName: null,
+    startTime: now - 60_000,
+    endTime: now,
+    durationMs: 60_000,
+    toolCallCount: 10,
+    developer: 'alice',
+    model: null,
+    toolBreakdown: {},
+    filesRead: ['/src/a.ts', '/src/b.ts'],
+    filesModified: ['/src/a.ts'],
+    linesAdded: 20,
+    linesRemoved: 5,
+    bashCommandCount: 0,
+    testRunCount: 3,
+    testPassCount: 2,
+    buildRunCount: 1,
+    buildPassCount: 1,
+    estimatedCostUsd: 1.5,
+    subagentCostUsd: 0,
+    tokensInput: 0,
+    tokensOutput: 0,
+    tokensThinking: 0,
+    tokensCacheRead: 0,
+    tokensCacheCreation: 0,
+    cacheSavingsUsd: 0,
+    efficiencyScore: null,
+    toolSelectionMetrics: null,
+    modelBreakdown: {},
+    costByWorkflowRunId: {},
+    qualityProxy: { ...ZERO_QUALITY_PROXY_COUNTS },
+    antiPatterns: [],
+    taskCount: 4,
+    taskSuccessRate: null,
+    toolSuccessRate: null,
+    contextCompressions: 0,
+    agentSpawns: 2,
+    userMessages: 0,
+    assistantMessages: 0,
+    userCorrections: 0,
+    outcome: 'completed',
+    ...overrides,
+  };
+}
+
+describe('buildTaskDetectorSeed', () => {
+  it('maps every relevant FullSessionSummary field onto the seed', () => {
+    const seed = buildTaskDetectorSeed(makeSummary());
+    expect(seed.filesRead).toEqual(['/src/a.ts', '/src/b.ts']);
+    expect(seed.filesModified).toEqual(['/src/a.ts']);
+    expect(seed.linesAdded).toBe(20);
+    expect(seed.linesRemoved).toBe(5);
+    expect(seed.testsRun).toBe(3);
+    expect(seed.testsPassed).toBe(2);
+    expect(seed.buildRun).toBe(1);
+    expect(seed.buildPassed).toBe(1);
+    expect(seed.agentSpawns).toBe(2);
+    expect(seed.taskCount).toBe(4);
+  });
+
+  it('produces an all-zero/empty seed for a session with no task activity', () => {
+    const seed = buildTaskDetectorSeed(
+      makeSummary({
+        filesRead: [],
+        filesModified: [],
+        linesAdded: 0,
+        linesRemoved: 0,
+        testRunCount: 0,
+        testPassCount: 0,
+        buildRunCount: 0,
+        buildPassCount: 0,
+        agentSpawns: 0,
+        taskCount: 0,
+      }),
+    );
+    expect(seed.filesRead).toEqual([]);
+    expect(seed.taskCount).toBe(0);
+  });
+});

--- a/src/metrics/task-detector-seed.ts
+++ b/src/metrics/task-detector-seed.ts
@@ -1,0 +1,22 @@
+import type { FullSessionSummary } from '../storage/session-store.js';
+import type { TaskDetectorSeed } from './task-detector.js';
+
+// Builds the seed a freshly-started process's TaskDetector needs to recover
+// a resumed session's pre-restart file/line/test/build/agent-spawn totals —
+// see TaskDetector.seedFromPersisted() for why this exists. Lives in its own
+// file (not task-detector.ts) to avoid a circular import: session-store.ts
+// already imports TaskDetector/TaskMetrics from task-detector.ts.
+export function buildTaskDetectorSeed(persisted: FullSessionSummary): TaskDetectorSeed {
+  return {
+    filesRead: persisted.filesRead,
+    filesModified: persisted.filesModified,
+    linesAdded: persisted.linesAdded,
+    linesRemoved: persisted.linesRemoved,
+    testsRun: persisted.testRunCount,
+    testsPassed: persisted.testPassCount,
+    buildRun: persisted.buildRunCount,
+    buildPassed: persisted.buildPassCount,
+    agentSpawns: persisted.agentSpawns,
+    taskCount: persisted.taskCount,
+  };
+}

--- a/src/metrics/task-detector.test.ts
+++ b/src/metrics/task-detector.test.ts
@@ -815,3 +815,97 @@ describe('markBoundary', () => {
     expect(detector.getCurrentTask()).toBeNull();
   });
 });
+
+describe('seedFromPersisted', () => {
+  it('folds seeded totals into getMetrics().seededAggregate, additive across calls', () => {
+    const detector = new TaskDetector();
+    detector.seedFromPersisted({
+      filesRead: ['/a.ts', '/b.ts'],
+      filesModified: ['/a.ts'],
+      linesAdded: 10,
+      linesRemoved: 2,
+      testsRun: 3,
+      testsPassed: 3,
+      buildRun: 1,
+      buildPassed: 1,
+      agentSpawns: 1,
+      taskCount: 2,
+    });
+    detector.seedFromPersisted({
+      filesRead: ['/b.ts', '/c.ts'],
+      filesModified: ['/c.ts'],
+      linesAdded: 5,
+      linesRemoved: 1,
+      testsRun: 1,
+      testsPassed: 0,
+      buildRun: 0,
+      buildPassed: 0,
+      agentSpawns: 0,
+      taskCount: 1,
+    });
+
+    const metrics = detector.getMetrics();
+    expect(metrics.totalTasksCompleted).toBe(3); // 2 + 1, no real tasks completed yet
+    expect(metrics.seededAggregate).not.toBeNull();
+    expect(metrics.seededAggregate!.filesRead.sort()).toEqual(['/a.ts', '/b.ts', '/c.ts']); // deduped
+    expect(metrics.seededAggregate!.filesModified.sort()).toEqual(['/a.ts', '/c.ts']);
+    expect(metrics.seededAggregate!.linesAdded).toBe(15);
+    expect(metrics.seededAggregate!.linesRemoved).toBe(3);
+    expect(metrics.seededAggregate!.testsRun).toBe(4);
+    expect(metrics.seededAggregate!.testsPassed).toBe(3);
+    expect(metrics.seededAggregate!.buildRun).toBe(1);
+    expect(metrics.seededAggregate!.buildPassed).toBe(1);
+    expect(metrics.seededAggregate!.agentSpawns).toBe(1);
+
+    detector.dispose();
+  });
+
+  it('is a no-op when every seed field is zero/empty', () => {
+    const detector = new TaskDetector();
+    detector.seedFromPersisted({
+      filesRead: [],
+      filesModified: [],
+      linesAdded: 0,
+      linesRemoved: 0,
+      testsRun: 0,
+      testsPassed: 0,
+      buildRun: 0,
+      buildPassed: 0,
+      agentSpawns: 0,
+      taskCount: 0,
+    });
+    expect(detector.getMetrics().seededAggregate).toBeNull();
+    expect(detector.getMetrics().totalTasksCompleted).toBe(0);
+    detector.dispose();
+  });
+
+  it('does not affect averageTaskDurationMs/averageToolCallsPerTask, which stay derived from real completed tasks only', () => {
+    jest.useFakeTimers();
+    const detector = new TaskDetector();
+    detector.seedFromPersisted({
+      filesRead: ['/a.ts'],
+      filesModified: [],
+      linesAdded: 100,
+      linesRemoved: 0,
+      testsRun: 0,
+      testsPassed: 0,
+      buildRun: 0,
+      buildPassed: 0,
+      agentSpawns: 0,
+      taskCount: 5,
+    });
+
+    for (let i = 0; i < 3; i++) {
+      jest.advanceTimersByTime(2000);
+      detector.recordToolCall(makeRecord({ toolName: `Tool${i}` }));
+    }
+    jest.advanceTimersByTime(45_000);
+
+    const metrics = detector.getMetrics();
+    expect(metrics.completedTasks).toHaveLength(1); // only the 1 real task, no synthetic entry
+    expect(metrics.averageToolCallsPerTask).toBe(3); // unskewed by the 5 seeded tasks
+
+    detector.dispose();
+    jest.useRealTimers();
+  });
+});

--- a/src/metrics/task-detector.ts
+++ b/src/metrics/task-detector.ts
@@ -55,6 +55,52 @@ export interface TaskMetrics {
   readonly averageTaskDurationMs: number | null;
   readonly averageToolCallsPerTask: number | null;
   readonly completedTasks: AiCodingTask[];
+  /**
+   * Pre-restart file/line/test/build/agent-spawn totals recovered by
+   * `seedFromPersisted()`, folded in by `buildSessionSummary()` alongside
+   * the totals it derives from `completedTasks` (session-store.ts). null
+   * when nothing has been seeded. Deliberately NOT represented as a
+   * synthetic entry inside `completedTasks` itself — that would skew
+   * `averageTaskDurationMs`/`averageToolCallsPerTask` above (both derived
+   * from `completedTasks.length`) and has no real `toolCalls` list to
+   * attach — the per-task tool-call list isn't reconstructable from a
+   * scalar checkpoint.
+   */
+  readonly seededAggregate: TaskSeedAggregate | null;
+}
+
+/** See `TaskMetrics.seededAggregate`'s doc comment. */
+export interface TaskSeedAggregate {
+  readonly filesRead: string[];
+  readonly filesModified: string[];
+  readonly linesAdded: number;
+  readonly linesRemoved: number;
+  readonly testsRun: number;
+  readonly testsPassed: number;
+  readonly buildRun: number;
+  readonly buildPassed: number;
+  readonly agentSpawns: number;
+}
+
+/**
+ * Input shape for `TaskDetector.seedFromPersisted()` — built from a
+ * previous process's last `FullSessionSummary` checkpoint for this same
+ * session by `buildTaskDetectorSeed()` (task-detector-seed.ts). Kept as a
+ * separate type/file rather than importing `FullSessionSummary` directly
+ * into this file, which would create a circular import (session-store.ts
+ * already imports from this file).
+ */
+export interface TaskDetectorSeed {
+  readonly filesRead: readonly string[];
+  readonly filesModified: readonly string[];
+  readonly linesAdded: number;
+  readonly linesRemoved: number;
+  readonly testsRun: number;
+  readonly testsPassed: number;
+  readonly buildRun: number;
+  readonly buildPassed: number;
+  readonly agentSpawns: number;
+  readonly taskCount: number;
 }
 
 export interface TaskDetectorOptions {
@@ -209,6 +255,19 @@ export class TaskDetector implements Resettable {
   private lifetimeCompletedCount = 0;
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Additive seed from a previous process's last checkpoint for this same
+  // session — see seedFromPersisted()'s doc comment for why these are kept
+  // separate from `completedTasks` rather than added as a synthetic entry.
+  private readonly seededFilesRead = new Set<string>();
+  private readonly seededFilesModified = new Set<string>();
+  private seededLinesAdded = 0;
+  private seededLinesRemoved = 0;
+  private seededTestsRun = 0;
+  private seededTestsPassed = 0;
+  private seededBuildRun = 0;
+  private seededBuildPassed = 0;
+  private seededAgentSpawns = 0;
+
   // Cost/token snapshots at task start for computing deltas
   private costAtTaskStart = 0;
   private tokensAtTaskStart = 0;
@@ -283,6 +342,41 @@ export class TaskDetector implements Resettable {
     return this.closeCurrentTask(timestamp);
   }
 
+  /**
+   * Seeds cumulative file/line/test/build/agent-spawn totals (plus the
+   * lifetime completed-task count) from a previous process's last
+   * checkpoint for this same session — same restart-recovery problem as
+   * `CostTracker.seedFromPersisted()`. See `TaskMetrics.seededAggregate`'s
+   * doc comment for why this doesn't touch `completedTasks` directly.
+   *
+   * Adds to current totals rather than overwriting, so callers must invoke
+   * this at most once per (re)adopted session id, before any real activity
+   * for that id has reached this tracker.
+   */
+  seedFromPersisted(seed: TaskDetectorSeed): void {
+    const hasAnything =
+      seed.filesRead.length > 0 ||
+      seed.filesModified.length > 0 ||
+      seed.linesAdded !== 0 ||
+      seed.linesRemoved !== 0 ||
+      seed.testsRun !== 0 ||
+      seed.buildRun !== 0 ||
+      seed.agentSpawns !== 0 ||
+      seed.taskCount !== 0;
+    if (!hasAnything) return;
+
+    for (const f of seed.filesRead) this.seededFilesRead.add(f);
+    for (const f of seed.filesModified) this.seededFilesModified.add(f);
+    this.seededLinesAdded += seed.linesAdded;
+    this.seededLinesRemoved += seed.linesRemoved;
+    this.seededTestsRun += seed.testsRun;
+    this.seededTestsPassed += seed.testsPassed;
+    this.seededBuildRun += seed.buildRun;
+    this.seededBuildPassed += seed.buildPassed;
+    this.seededAgentSpawns += seed.agentSpawns;
+    this.lifetimeCompletedCount += seed.taskCount;
+  }
+
   getMetrics(): TaskMetrics {
     const completed = this.completedTasks;
 
@@ -300,6 +394,15 @@ export class TaskDetector implements Resettable {
       avgToolCalls = Math.round((totalToolCalls / completed.length) * 100) / 100;
     }
 
+    const hasSeededAggregate =
+      this.seededFilesRead.size > 0 ||
+      this.seededFilesModified.size > 0 ||
+      this.seededLinesAdded !== 0 ||
+      this.seededLinesRemoved !== 0 ||
+      this.seededTestsRun !== 0 ||
+      this.seededBuildRun !== 0 ||
+      this.seededAgentSpawns !== 0;
+
     return {
       totalTasksCompleted: this.lifetimeCompletedCount,
       currentTaskActive: this.activeTask !== null,
@@ -307,6 +410,19 @@ export class TaskDetector implements Resettable {
       averageTaskDurationMs: avgDuration,
       averageToolCallsPerTask: avgToolCalls,
       completedTasks: [...completed],
+      seededAggregate: hasSeededAggregate
+        ? {
+            filesRead: [...this.seededFilesRead],
+            filesModified: [...this.seededFilesModified],
+            linesAdded: this.seededLinesAdded,
+            linesRemoved: this.seededLinesRemoved,
+            testsRun: this.seededTestsRun,
+            testsPassed: this.seededTestsPassed,
+            buildRun: this.seededBuildRun,
+            buildPassed: this.seededBuildPassed,
+            agentSpawns: this.seededAgentSpawns,
+          }
+        : null,
     };
   }
 
@@ -331,6 +447,15 @@ export class TaskDetector implements Resettable {
     this.costAtTaskStart = 0;
     this.tokensAtTaskStart = 0;
     this.lifetimeCompletedCount = 0;
+    this.seededFilesRead.clear();
+    this.seededFilesModified.clear();
+    this.seededLinesAdded = 0;
+    this.seededLinesRemoved = 0;
+    this.seededTestsRun = 0;
+    this.seededTestsPassed = 0;
+    this.seededBuildRun = 0;
+    this.seededBuildPassed = 0;
+    this.seededAgentSpawns = 0;
   }
 
   dispose(): void {

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -785,6 +785,8 @@ describe('buildSessionSummary', () => {
         taskId: 'session-average',
         timestamp: Date.now(),
       }),
+      getScores: () => [{}, {}],
+      getSessionSampleCount: () => 2,
     };
 
     const summary = buildSessionSummary({
@@ -814,10 +816,108 @@ describe('buildSessionSummary', () => {
     expect(summary.tokensOutput).toBe(5_000);
     expect(summary.tokensThinking).toBe(2_000);
     expect(summary.efficiencyScore).toBe(0.82);
+    expect(summary.efficiencyScoreSampleCount).toBe(2);
+    expect(summary.efficiencyScoreComponents).toEqual({
+      speed: 0.7,
+      correctness: 0.9,
+      autonomy: 1,
+      firstAttemptQuality: 0.7,
+    });
     expect(summary.taskCount).toBe(2);
     expect(summary.agentSpawns).toBe(1);
     expect(summary.toolSuccessRate).toBe(0.9);
     expect(summary.outcome).toBe('completed');
+  });
+
+  it('folds TaskMetrics.seededAggregate into filesRead/linesAdded/testRunCount/etc alongside completedTasks', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 0,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: 1,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+
+    const mockTaskDetector = {
+      getCurrentTask: () => null,
+      getMetrics: () => ({
+        totalTasksCompleted: 3,
+        currentTaskActive: false,
+        currentTaskToolCalls: 0,
+        averageTaskDurationMs: null,
+        averageToolCallsPerTask: null,
+        completedTasks: [
+          {
+            taskId: 't1',
+            startTime: 1700000000000,
+            endTime: 1700000060000,
+            durationMs: 60_000,
+            toolCallCount: 2,
+            toolCallsByType: {},
+            filesRead: ['/live.ts'],
+            filesModified: [],
+            linesChanged: 4,
+            linesAdded: 4,
+            linesRemoved: 0,
+            bashCommandsRun: 0,
+            testsRun: 1,
+            testsPassed: 1,
+            buildRun: 0,
+            buildPassed: 0,
+            estimatedCostUsd: null,
+            tokensUsed: 0,
+            askedUserQuestions: 0,
+            subAgentsSpawned: 0,
+            toolCalls: [],
+          },
+        ],
+        seededAggregate: {
+          filesRead: ['/seeded-a.ts', '/live.ts'],
+          filesModified: ['/seeded-a.ts'],
+          linesAdded: 20,
+          linesRemoved: 5,
+          testsRun: 3,
+          testsPassed: 2,
+          buildRun: 1,
+          buildPassed: 1,
+          agentSpawns: 2,
+        },
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as Parameters<
+        typeof buildSessionSummary
+      >[0]['sessionTracker'],
+      taskDetector: mockTaskDetector as unknown as Parameters<
+        typeof buildSessionSummary
+      >[0]['taskDetector'],
+      developer: 'alice',
+    });
+
+    expect(summary.filesRead.sort()).toEqual(['/live.ts', '/seeded-a.ts'].sort()); // deduped union
+    expect(summary.filesModified).toEqual(['/seeded-a.ts']);
+    expect(summary.linesAdded).toBe(24); // 4 live + 20 seeded
+    expect(summary.linesRemoved).toBe(5);
+    expect(summary.testRunCount).toBe(4); // 1 live + 3 seeded
+    expect(summary.testPassCount).toBe(3);
+    expect(summary.buildRunCount).toBe(1);
+    expect(summary.buildPassCount).toBe(1);
+    expect(summary.agentSpawns).toBe(2);
+    expect(summary.taskCount).toBe(3); // from totalTasksCompleted, unaffected by this fold
   });
 
   it('reads userMessages/assistantMessages/userCorrections from transcriptMessageTracker', () => {
@@ -1564,6 +1664,142 @@ describe('buildSessionSummary', () => {
       >[0],
     );
     expect(roundTripped.toolSelectionMetrics).toBeNull();
+  });
+
+  it('captures efficiencyScoreSampleCount and efficiencyScoreComponents from EfficiencyScorer', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 0,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: 1,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+    const mockEfficiencyScorer = {
+      getSessionAverage: () => ({
+        score: 0.77,
+        components: { speed: 0.8, correctness: 0.7, autonomy: 0.9, firstAttemptQuality: 0.6 },
+        taskId: 'session-average',
+        timestamp: Date.now(),
+      }),
+      getScores: () => [{}, {}, {}],
+      getSessionSampleCount: () => 3, // what buildSessionSummary actually reads
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as Parameters<
+        typeof buildSessionSummary
+      >[0]['sessionTracker'],
+      efficiencyScorer: mockEfficiencyScorer as unknown as Parameters<
+        typeof buildSessionSummary
+      >[0]['efficiencyScorer'],
+      developer: 'alice',
+    });
+
+    expect(summary.efficiencyScore).toBe(0.77);
+    expect(summary.efficiencyScoreSampleCount).toBe(3);
+    expect(summary.efficiencyScoreComponents).toEqual({
+      speed: 0.8,
+      correctness: 0.7,
+      autonomy: 0.9,
+      firstAttemptQuality: 0.6,
+    });
+  });
+
+  it('defaults efficiencyScoreSampleCount to 0 and efficiencyScoreComponents to null with no efficiencyScorer', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 0,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: 1,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as Parameters<
+        typeof buildSessionSummary
+      >[0]['sessionTracker'],
+      developer: 'alice',
+    });
+    expect(summary.efficiencyScoreSampleCount).toBe(0);
+    expect(summary.efficiencyScoreComponents).toBeNull();
+  });
+
+  it('persists efficiencyScoreSampleCount from getSessionSampleCount(), not the fresh-only getScores().length, so seeded weight from an earlier restart survives a second checkpoint', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'test-session',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 0,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: 1,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+    // Simulates a session on its second restart: only 1 fresh task has been
+    // scored since the last restart, but getSessionAverage() (and therefore
+    // this checkpoint's efficiencyScore) is already weighted by 4 seeded
+    // samples carried over from the prior process's own checkpoint. If
+    // buildSessionSummary persisted getScores().length here instead of
+    // getSessionSampleCount(), it would record sampleCount=1 alongside a
+    // score that actually reflects 5 samples' worth of history.
+    const mockEfficiencyScorer = {
+      getSessionAverage: () => ({
+        score: 0.81,
+        components: { speed: 0.75, correctness: 0.85, autonomy: 0.9, firstAttemptQuality: 0.75 },
+        taskId: 'session-average',
+        timestamp: Date.now(),
+      }),
+      getScores: () => [{}], // 1 fresh score this process
+      getSessionSampleCount: () => 5, // 1 fresh + 4 seeded from a prior restart
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as Parameters<
+        typeof buildSessionSummary
+      >[0]['sessionTracker'],
+      efficiencyScorer: mockEfficiencyScorer as unknown as Parameters<
+        typeof buildSessionSummary
+      >[0]['efficiencyScorer'],
+      developer: 'alice',
+    });
+
+    expect(summary.efficiencyScoreSampleCount).toBe(5);
+    expect(summary.efficiencyScoreSampleCount).not.toBe(mockEfficiencyScorer.getScores().length);
   });
 });
 

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -22,7 +22,7 @@ import type { SessionTracker } from '../metrics/session-tracker.js';
 import type { CostTracker } from '../metrics/cost-tracker.js';
 import type { TaskDetector } from '../metrics/task-detector.js';
 import type { AntiPatternDetector } from '../metrics/anti-patterns.js';
-import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
+import type { EfficiencyScorer, EfficiencyScoreComponents } from '../metrics/efficiency-score.js';
 import type { TranscriptMessageTracker } from '../metrics/transcript-message-tracker.js';
 import type { SessionOutcomeRecord } from '../metrics/instruction-drift-tracker.js';
 import type { AntiPattern } from '../metrics/anti-patterns.js';
@@ -106,6 +106,28 @@ export interface FullSessionSummary extends SessionSummary {
   readonly tokensCacheCreation: number;
   readonly cacheSavingsUsd: number;
   readonly efficiencyScore: number | null;
+  /**
+   * Number of individual task scores that fed `efficiencyScore` at save
+   * time — captured from `EfficiencyScorer.getSessionSampleCount()`, which
+   * includes any weight seeded from an earlier restart's checkpoint (not
+   * just fresh-this-process scores). Lets a resumed session re-seed a
+   * weighted average via `EfficiencyScorer.seedFromPersisted()` instead of
+   * losing every pre-restart task's contribution to it. Optional (unlike
+   * most fields on this interface) so the many existing test factories
+   * building `FullSessionSummary` literals don't all need updating for an
+   * additive field — read with `?? 0` at the point of use. 0/absent for
+   * pre-fix session files and for sessions with no scored tasks.
+   */
+  readonly efficiencyScoreSampleCount?: number;
+  /**
+   * Component breakdown backing `efficiencyScore` at save time, captured
+   * from `EfficiencyScorer.getSessionAverage()?.components`. Persisted
+   * alongside `efficiencyScoreSampleCount` so a re-seeded average's
+   * component breakdown is exact, not just its top-level score. Optional
+   * for the same reason as `efficiencyScoreSampleCount` above. null/absent
+   * for pre-fix session files and for sessions with no scored tasks.
+   */
+  readonly efficiencyScoreComponents?: EfficiencyScoreComponents | null;
   readonly antiPatterns: PersistedAntiPattern[];
   readonly taskCount: number;
   readonly taskSuccessRate: number | null;
@@ -428,6 +450,21 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
       totalAgentSpawns += task.subAgentsSpawned;
       allToolCalls.push(...task.toolCalls);
     }
+
+    // Fold in pre-restart totals recovered by TaskDetector.seedFromPersisted()
+    // — see TaskMetrics.seededAggregate's doc comment for why these can't be
+    // represented as a synthetic entry in completedTasks above.
+    if (taskMetrics.seededAggregate) {
+      for (const f of taskMetrics.seededAggregate.filesRead) allFilesRead.add(f);
+      for (const f of taskMetrics.seededAggregate.filesModified) allFilesModified.add(f);
+      totalLinesAdded += taskMetrics.seededAggregate.linesAdded;
+      totalLinesRemoved += taskMetrics.seededAggregate.linesRemoved;
+      totalTestsRun += taskMetrics.seededAggregate.testsRun;
+      totalTestsPassed += taskMetrics.seededAggregate.testsPassed;
+      totalBuildsRun += taskMetrics.seededAggregate.buildRun;
+      totalBuildsPassed += taskMetrics.seededAggregate.buildPassed;
+      totalAgentSpawns += taskMetrics.seededAggregate.agentSpawns;
+    }
   }
 
   // Anti-pattern analysis
@@ -503,6 +540,8 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     tokensCacheCreation: costMetrics?.totalCacheCreationTokens ?? 0,
     cacheSavingsUsd: costMetrics?.totalCacheSavingsUsd ?? 0,
     efficiencyScore: efficiencyAvg?.score ?? null,
+    efficiencyScoreSampleCount: efficiencyScorer?.getSessionSampleCount() ?? 0,
+    efficiencyScoreComponents: efficiencyAvg?.components ?? null,
     antiPatterns,
     taskCount: (taskMetrics?.totalTasksCompleted ?? 0) + (taskMetrics?.currentTaskActive ? 1 : 0),
     taskSuccessRate,
@@ -595,6 +634,8 @@ interface SerializedFullSessionSummary {
   readonly tokensCacheCreation?: unknown;
   readonly cacheSavingsUsd?: unknown;
   readonly efficiencyScore?: unknown;
+  readonly efficiencyScoreSampleCount?: unknown;
+  readonly efficiencyScoreComponents?: Record<string, unknown>;
   readonly antiPatterns?: Array<Record<string, unknown>>;
   readonly taskCount?: unknown;
   readonly taskSuccessRate?: unknown;
@@ -753,6 +794,26 @@ export function deserializeFullSessionSummary(
     };
   })();
 
+  const efficiencyScoreComponents: EfficiencyScoreComponents | null = (() => {
+    const c = obj.efficiencyScoreComponents;
+    if (typeof c !== 'object' || c === null) return null;
+    const r = c as Record<string, unknown>;
+    if (
+      typeof r.speed !== 'number' ||
+      typeof r.correctness !== 'number' ||
+      typeof r.autonomy !== 'number' ||
+      typeof r.firstAttemptQuality !== 'number'
+    ) {
+      return null;
+    }
+    return {
+      speed: r.speed,
+      correctness: r.correctness,
+      autonomy: r.autonomy,
+      firstAttemptQuality: r.firstAttemptQuality,
+    };
+  })();
+
   return {
     sessionId:
       typeof obj.sessionId === 'string' && obj.sessionId.length > 0 ? obj.sessionId : 'unknown',
@@ -787,6 +848,9 @@ export function deserializeFullSessionSummary(
     tokensCacheCreation: typeof obj.tokensCacheCreation === 'number' ? obj.tokensCacheCreation : 0,
     cacheSavingsUsd: typeof obj.cacheSavingsUsd === 'number' ? obj.cacheSavingsUsd : 0,
     efficiencyScore: typeof obj.efficiencyScore === 'number' ? obj.efficiencyScore : null,
+    efficiencyScoreSampleCount:
+      typeof obj.efficiencyScoreSampleCount === 'number' ? obj.efficiencyScoreSampleCount : 0,
+    efficiencyScoreComponents,
     antiPatterns,
     taskCount: typeof obj.taskCount === 'number' ? obj.taskCount : 0,
     taskSuccessRate: typeof obj.taskSuccessRate === 'number' ? obj.taskSuccessRate : null,


### PR DESCRIPTION
Fixes #452
Fixes #453
Fixes #454
Fixes #455

## Summary
- Extends the restart-recovery pattern from the v1.15.4 fix (session cost/token totals surviving an MCP process restart) to the four remaining stateful trackers found in that same audit:
  - **#453** QualityProxyTracker — diff/test/backtrack/self-correction signal counts now survive a process restart
  - **#455** BudgetTracker — session-budget threshold alerts (50%/80%/100%) no longer re-fire after a restart, including for sessions whose real id resolves asynchronously (cwd-fallback / PPID-correction paths)
  - **#452** TaskDetector — file/line/test/build/agent-spawn totals and task count now survive a restart, without skewing average-duration/average-tool-calls metrics
  - **#454** EfficiencyScorer — session average now survives a restart via a weighted re-blend, including correctly across repeated restarts of the same session
- Bumps version to 1.15.5 and updates CHANGELOG.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 5584 passed, 3 skipped (pre-existing, unrelated), 0 failed
- [x] `npm run lint` — 0 errors/0 warnings
- [x] `npm run format:check` — clean