### PR TITLE
Fix: correct context-composition token math and retry-detector false positives (v1.15.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.6] - 2026-08-18
+
+### Fixed
+
+- **`nr_observe_get_context_composition` no longer reports dominance percentages in the millions of percent with `fillPercent` near zero.** Under prompt caching, the turn's total context size was computed from the uncached input delta alone instead of including cache-read and cache-creation tokens, producing a denominator many orders of magnitude too small. The tool also now resolves the model's real context window instead of staying hard-coded at a 200k default.
+- **`nr_observe_get_retry_alerts` no longer flags ordinary, non-repeated tool calls as thrashing for tools without dedicated metadata extraction** (e.g. the native Windows PowerShell tool). Every call to such a tool previously serialized identically for similarity comparison regardless of how different the underlying input actually was. The dedupe key and wasted-token estimate were also corrected so the same offending calls aren't re-counted repeatedly and only genuinely redundant repeats are charged as waste.
+
 ## [1.15.5] - 2026-08-17
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.15.5",
+  "version": "1.15.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.15.5",
+      "version": "1.15.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.15.5",
+  "version": "1.15.6",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -224,6 +224,40 @@ describe('collector-script', () => {
     });
   });
 
+  describe('processHook() — PowerShell (native Windows tool, no Git Bash)', () => {
+    // PowerShell is a real, first-party Claude Code tool (see
+    // code.claude.com/docs/en/tools-reference) — extractInputMeta() had no
+    // case for it, so toolInput stayed undefined and every PowerShell call
+    // serialized identically downstream.
+    it('stores command/description/timeout/run_in_background metadata, same as Bash', () => {
+      const input = {
+        command: 'Get-Process',
+        description: 'List processes',
+        timeout: 30000,
+        run_in_background: false,
+      };
+      processHook(makePreToolUse({ tool_name: 'PowerShell', tool_input: input }));
+
+      const event = readBufferEvents()[0]!;
+      expect(event.toolInput).toEqual({
+        command: 'Get-Process',
+        description: 'List processes',
+        timeout: 30000,
+        run_in_background: false,
+      });
+    });
+
+    it('redacts sensitive content in the command, same as Bash', () => {
+      const input = { command: '$env:API_KEY = "sk-1234567890abcdef"' };
+      processHook(makePreToolUse({ tool_name: 'PowerShell', tool_input: input }));
+
+      const event = readBufferEvents()[0]!;
+      const toolInput = event.toolInput as Record<string, unknown>;
+      expect(toolInput.command).not.toContain('sk-1234567890abcdef');
+      expect(toolInput.command).toContain('[REDACTED]');
+    });
+  });
+
   describe('processHook() — PostToolUse (toolOutput)', () => {
     it('stores output metadata fields when available', () => {
       const response = { exitCode: 0, stdout: 'lots of output here' };

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -396,7 +396,12 @@ function extractInputMeta(toolName: string, input: unknown): Record<string, unkn
       }
       if (typeof obj.replace_all === 'boolean') meta.replace_all = obj.replace_all;
       break;
+    // PowerShell is a real, first-party Claude Code tool on native Windows,
+    // auto-enabled without Git Bash (code.claude.com/docs/en/tools-reference,
+    // /setup, /env-vars) — same command/description/timeout/run_in_background
+    // input shape as Bash.
     case 'Bash':
+    case 'PowerShell':
       if (typeof obj.command === 'string') meta.command = redact(obj.command);
       if (typeof obj.description === 'string') meta.description = redact(obj.description);
       if (typeof obj.timeout === 'number') meta.timeout = obj.timeout;

--- a/src/hooks/tool-parsers.test.ts
+++ b/src/hooks/tool-parsers.test.ts
@@ -222,6 +222,35 @@ describe('parseToolSpecificFields', () => {
     });
   });
 
+  describe('PowerShell parser', () => {
+    // PowerShell is a real, first-party Claude Code tool on native Windows —
+    // auto-enabled without Git Bash, opt-in via CLAUDE_CODE_USE_POWERSHELL_TOOL
+    // elsewhere (code.claude.com/docs/en/tools-reference, /setup, /env-vars).
+    // It carries the same command/description/timeout/run_in_background input
+    // shape as Bash, so it should get the same parsing.
+    it('extracts command and description, same as Bash', () => {
+      const input = { command: 'Get-Process', description: 'List processes' };
+      const fields = parseToolSpecificFields('PowerShell', input, undefined);
+
+      expect(fields.command).toBe('Get-Process');
+      expect(fields.commandDescription).toBe('List processes');
+    });
+
+    it('extracts timeout and run_in_background', () => {
+      const input = { command: 'npm start', timeout: 30000, run_in_background: true };
+      const fields = parseToolSpecificFields('PowerShell', input, undefined);
+
+      expect(fields.commandTimeout).toBe(30000);
+      expect(fields.runInBackground).toBe(true);
+    });
+
+    it('attaches bashCategory / bashLeading from the same classifier as Bash', () => {
+      const fields = parseToolSpecificFields('PowerShell', { command: 'git status' }, undefined);
+      expect(fields.bashCategory).toBe('git');
+      expect(fields.bashLeading).toBe('git');
+    });
+  });
+
   describe('Grep parser', () => {
     it('extracts pattern, grepPath, and outputMode', () => {
       const input = { pattern: 'TODO', path: '/src', output_mode: 'content' };

--- a/src/hooks/tool-parsers.ts
+++ b/src/hooks/tool-parsers.ts
@@ -169,6 +169,10 @@ const INPUT_PARSERS: Record<string, (input: Record<string, unknown>) => ToolFiel
   Write: parseWrite,
   Edit: parseEdit,
   Bash: parseBash,
+  // PowerShell is a real, first-party Claude Code tool on native Windows,
+  // auto-enabled without Git Bash — same command/description/timeout/
+  // run_in_background input shape as Bash (code.claude.com/docs/en/tools-reference).
+  PowerShell: parseBash,
   Grep: parseGrep,
   Glob: parseGlob,
   Agent: parseAgent,

--- a/src/metrics/context-composition-tracker.test.ts
+++ b/src/metrics/context-composition-tracker.test.ts
@@ -4,6 +4,20 @@ import type {
   ContextThresholdAlert,
   CategoryDominanceAlert,
 } from './context-composition-tracker.js';
+import type { TokenEvent } from '../storage/types.js';
+
+function makeTokenEvent(overrides: Partial<TokenEvent> = {}): TokenEvent {
+  return {
+    mode: 'token',
+    timestamp: Date.now(),
+    inputTokens: 2,
+    outputTokens: 100,
+    cacheReadTokens: 33_862,
+    cacheCreationTokens: 18_238,
+    model: 'claude-opus-5',
+    ...overrides,
+  };
+}
 
 const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 afterEach(() => stderrSpy.mockClear());
@@ -243,6 +257,70 @@ describe('ContextCompositionTracker', () => {
     expect(aggregator.record).toHaveBeenCalledWith('ai.context.total_tokens', 4000);
     expect(aggregator.record).toHaveBeenCalledWith('ai.context.category_tokens', 1000, {
       category: 'system_prompt',
+    });
+  });
+
+  describe('recordTokenEvent', () => {
+    it('includes cache tokens in totalTokens, matching the sibling ContextTracker', () => {
+      const tracker = new ContextCompositionTracker({ modelContextWindow: 1_000_000 });
+      // Under prompt caching, inputTokens is only the uncached delta, so the
+      // true turn size is
+      // inputTokens + cacheReadTokens + cacheCreationTokens = 2 + 33862 + 18238 = 52102.
+      tracker.recordTokenEvent(makeTokenEvent());
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.currentFillPercent).toBeCloseTo(5.21, 2);
+    });
+
+    it('does not report dominance percentages above 100', () => {
+      const alerts: CategoryDominanceAlert[] = [];
+      const tracker = new ContextCompositionTracker({
+        modelContextWindow: 1_000_000,
+        onDominanceAlert: (a) => alerts.push(a),
+      });
+
+      tracker.recordTokenEvent(makeTokenEvent());
+
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0].percent).toBeLessThanOrEqual(100);
+      expect(alerts[0].percent).toBeCloseTo(99.996, 2);
+    });
+
+    it('reproduces the reported turn-1/28/29 sequence without the totalTokens desync', () => {
+      const tracker = new ContextCompositionTracker({ modelContextWindow: 1_000_000 });
+
+      tracker.recordTokenEvent(makeTokenEvent({ cacheReadTokens: 0, cacheCreationTokens: 52_100 }));
+      tracker.recordTokenEvent(
+        makeTokenEvent({ cacheReadTokens: 103_637, cacheCreationTokens: 0 }),
+      );
+      tracker.recordTokenEvent(
+        makeTokenEvent({ inputTokens: 1, cacheReadTokens: 105_627, cacheCreationTokens: 0 }),
+      );
+
+      const metrics = tracker.getMetrics();
+      const [turn1, turn28, turn29] = metrics.history;
+      expect(turn1.totalTokens).toBe(52_102);
+      expect(turn28.totalTokens).toBe(103_639);
+      expect(turn29.totalTokens).toBe(105_628);
+    });
+
+    it('resolves the model context window from the event model, like ContextTracker does', () => {
+      const tracker = new ContextCompositionTracker(); // default 200_000 window
+      tracker.recordTokenEvent(makeTokenEvent({ model: 'claude-opus-5' })); // 1,000,000-token model
+
+      const metrics = tracker.getMetrics();
+      // With a resolved 1,000,000 window, fillPercent should be ~5.21, not the
+      // ~26% a stale 200,000 default would produce.
+      expect(metrics.currentFillPercent).toBeCloseTo(5.21, 2);
+    });
+
+    it('ignores a zero-token event', () => {
+      const tracker = new ContextCompositionTracker({ modelContextWindow: 1_000_000 });
+      tracker.recordTokenEvent(
+        makeTokenEvent({ inputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 }),
+      );
+
+      expect(tracker.getMetrics().turnCount).toBe(0);
     });
   });
 

--- a/src/metrics/context-composition-tracker.ts
+++ b/src/metrics/context-composition-tracker.ts
@@ -1,5 +1,5 @@
 import type { MetricAggregator } from '../shared/index.js';
-import { createLogger } from '../shared/index.js';
+import { createLogger, resolveModelPricing } from '../shared/index.js';
 import type { TokenEvent } from '../storage/types.js';
 
 const logger = createLogger('context-composition');
@@ -81,7 +81,7 @@ const CONTEXT_COMPOSITION_NOTE =
 // ---------------------------------------------------------------------------
 
 export class ContextCompositionTracker {
-  private readonly modelContextWindow: number;
+  private modelContextWindow: number;
   private readonly fillThresholds: readonly number[];
   private readonly dominanceThreshold: number;
   private readonly maxHistorySize: number;
@@ -152,13 +152,25 @@ export class ContextCompositionTracker {
     // Approximate composition from token counts:
     // - cacheReadTokens = previously cached context (system prompt + conversation history)
     // - cacheCreationTokens = first-time context being cached this turn
-    // - remainder of inputTokens = new content (tool results + user input)
+    // - inputTokens = new content this turn (tool results + user input) — under
+    //   prompt caching this is only the uncached delta, NOT the turn's total size,
+    //   so it must never be used alone as the fillPercent/dominance denominator.
+    //   The true total is the sum of all three, matching the sibling
+    //   ContextTracker's totalContext.
     const cachedContext = event.cacheReadTokens;
     const cacheCreation = event.cacheCreationTokens;
-    const newContent = Math.max(0, event.inputTokens - cachedContext - cacheCreation);
-    const totalInput = event.inputTokens;
+    const newContent = Math.max(0, event.inputTokens);
+    const totalInput = event.inputTokens + cachedContext + cacheCreation;
 
     if (totalInput === 0) return;
+
+    // Self-update from the resolved model's pricing entry, mirroring
+    // ContextTracker.recordTurn — never shrinks, so a mid-session model switch
+    // to a smaller-window model doesn't understate an already-larger window.
+    const pricing = resolveModelPricing(event.model);
+    if (pricing && pricing.contextWindow > this.modelContextWindow) {
+      this.modelContextWindow = pricing.contextWindow;
+    }
 
     // cacheCreationTokens are newly-cached conversation context (not just the system prompt),
     // so bucket them under conversation_history for a less misleading breakdown.

--- a/src/metrics/retry-detector.test.ts
+++ b/src/metrics/retry-detector.test.ts
@@ -109,7 +109,7 @@ describe('RetryDetector', () => {
     expect(detector.getMetrics().totalAlertsEmitted).toBe(0);
   });
 
-  it('estimates tokens wasted from input/output sizes', () => {
+  it('estimates tokens wasted from only the repeats, not the whole group', () => {
     const detector = new RetryDetector();
 
     detector.recordToolCall(
@@ -123,23 +123,74 @@ describe('RetryDetector', () => {
     );
 
     expect(alert).not.toBeNull();
-    // 3 calls × (400 + 600) bytes / 4 bytes per token = 750
-    expect(alert!.tokensWastedEstimate).toBe(750);
+    // The first call is necessary work, not waste — only the 2 repeats are
+    // charged: 2 calls × (400 + 600) bytes / 4 bytes per token = 500.
+    expect(alert!.tokensWastedEstimate).toBe(500);
   });
 
-  it('does not fire duplicate alerts for the same window position', () => {
+  it('does not re-fire for the exact same offending call group when an unrelated call arrives', () => {
     const detector = new RetryDetector();
 
     detector.recordToolCall(makeRecord({ toolName: 'Bash', success: false }));
     detector.recordToolCall(makeRecord({ toolName: 'Bash', success: false }));
     detector.recordToolCall(makeRecord({ toolName: 'Bash', success: false }));
+    expect(detector.getMetrics().totalAlertsEmitted).toBe(1);
 
-    // 4th call in same streak — should not re-fire for same dedup key
-    const result = detector.recordToolCall(makeRecord({ toolName: 'Bash', success: false }));
-    // A new window position may trigger a new alert (4 calls in last 5)
-    // but total should be limited
-    expect(detector.getMetrics().totalAlertsEmitted).toBeLessThanOrEqual(2);
-    void result;
+    // A call to a different tool shifts the window but leaves the same 3
+    // Bash calls as the offending group — this must not re-count them.
+    detector.recordToolCall(makeRecord({ toolName: 'Read', success: true }));
+    expect(detector.getMetrics().totalAlertsEmitted).toBe(1);
+  });
+
+  it('fires again once a genuinely new occurrence joins the offending group', () => {
+    const detector = new RetryDetector();
+
+    detector.recordToolCall(makeRecord({ toolName: 'Bash', success: false }));
+    detector.recordToolCall(makeRecord({ toolName: 'Bash', success: false }));
+    detector.recordToolCall(makeRecord({ toolName: 'Bash', success: false }));
+    expect(detector.getMetrics().totalAlertsEmitted).toBe(1);
+
+    // A 4th failing Bash call is genuinely new information, worth its own alert.
+    detector.recordToolCall(makeRecord({ toolName: 'Bash', success: false }));
+    expect(detector.getMetrics().totalAlertsEmitted).toBe(2);
+  });
+
+  it('does not flag genuinely different calls of a tool with no metadata extractor', () => {
+    // A tool outside extractInputMeta()'s switch (e.g. PowerShell, WebFetch,
+    // a third-party MCP tool) carries no tool-specific fields, so every call
+    // used to serialize identically regardless of how different the real
+    // inputs were.
+    const detector = new RetryDetector();
+
+    detector.recordToolCall(
+      makeRecord({ toolName: 'WebFetch', success: true, inputHash: 'aaaa1111bbbb2222' }),
+    );
+    detector.recordToolCall(
+      makeRecord({ toolName: 'WebFetch', success: true, inputHash: 'cccc3333dddd4444' }),
+    );
+    const result = detector.recordToolCall(
+      makeRecord({ toolName: 'WebFetch', success: true, inputHash: 'eeee5555ffff6666' }),
+    );
+
+    expect(result).toBeNull();
+    expect(detector.getMetrics().totalAlertsEmitted).toBe(0);
+  });
+
+  it('still detects genuine identical retries of a tool with no metadata extractor', () => {
+    const detector = new RetryDetector();
+
+    detector.recordToolCall(
+      makeRecord({ toolName: 'WebFetch', success: true, inputHash: 'aaaa1111bbbb2222' }),
+    );
+    detector.recordToolCall(
+      makeRecord({ toolName: 'WebFetch', success: true, inputHash: 'aaaa1111bbbb2222' }),
+    );
+    const result = detector.recordToolCall(
+      makeRecord({ toolName: 'WebFetch', success: true, inputHash: 'aaaa1111bbbb2222' }),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.similarity).toBe(1);
   });
 
   it('reset clears all state', () => {

--- a/src/metrics/retry-detector.ts
+++ b/src/metrics/retry-detector.ts
@@ -111,7 +111,6 @@ export class RetryDetector implements Resettable {
   private totalTokensWasted = 0;
   // Track which tool+window combos already fired to avoid spamming
   private readonly firedKeys = new Set<string>();
-  private callCounter = 0;
 
   constructor(options?: RetryDetectorOptions) {
     this.minOccurrences = options?.minOccurrences ?? DEFAULT_MIN_OCCURRENCES;
@@ -122,7 +121,6 @@ export class RetryDetector implements Resettable {
 
   recordToolCall(record: ToolCallRecord): ThrashingAlert | null {
     this.recentCalls.push(record);
-    this.callCounter++;
 
     // Only keep the window we need
     if (this.recentCalls.length > this.windowSize * 2) {
@@ -152,7 +150,6 @@ export class RetryDetector implements Resettable {
     this.alerts.length = 0;
     this.totalTokensWasted = 0;
     this.firedKeys.clear();
-    this.callCounter = 0;
   }
 
   private checkWindow(): ThrashingAlert | null {
@@ -177,8 +174,16 @@ export class RetryDetector implements Resettable {
 
       if (!allFailed && !isSimilar) continue;
 
-      // Dedupe: use the call counter so alerts can fire again after new calls arrive
-      const dedupeKey = `${toolName}:${this.callCounter}`;
+      // Dedupe on the offending group's actual call IDs — not a monotonic
+      // counter, which never repeats and so never dedupes: it re-fired for
+      // the same unchanged group on every subsequent call, however unrelated.
+      // A key built from the group's own call IDs repeats exactly when the
+      // group itself hasn't changed, and changes the moment a call ages out
+      // of the window or a genuinely new occurrence joins it.
+      const dedupeKey = `${toolName}:${calls
+        .map((c) => c.id)
+        .sort()
+        .join(',')}`;
       if (this.firedKeys.has(dedupeKey)) continue;
       this.firedKeys.add(dedupeKey);
 
@@ -233,6 +238,16 @@ export class RetryDetector implements Resettable {
   // input/arguments are identical (timestamps, ids, sizes, error details) —
   // without stripping these, every call would serialize as "different" and
   // similarity would never detect a genuine repeated-input retry.
+  //
+  // inputHash is kept, deliberately not stripped: it's a hash of the FULL raw
+  // tool input, computed for every call regardless of tool name, unlike the
+  // narrowed per-tool fields extractInputMeta()/parseToolSpecificFields() only
+  // populate for a known subset of tools. Without it, a call to any tool
+  // outside that subset (PowerShell, WebFetch, a third-party MCP tool, ...)
+  // serializes to just `{toolName}` — identical for every call regardless of
+  // how different the real inputs were, so it always scored similarity 1.0.
+  // A genuine repeat still hashes identically, so real-retry detection is
+  // unaffected.
   private serializeInput(record: ToolCallRecord): string {
     const {
       id: _id,
@@ -244,7 +259,6 @@ export class RetryDetector implements Resettable {
       error: _er,
       inputSizeBytes: _is,
       outputSizeBytes: _os,
-      inputHash: _ih,
       toolUseId: _tu,
       ...rest
     } = record;
@@ -255,9 +269,11 @@ export class RetryDetector implements Resettable {
     }
   }
 
+  // The first call in the group is necessary work, not waste — only the
+  // repeats after it represent redundant, wasted effort.
   private estimateTokensWasted(calls: ToolCallRecord[]): number {
     let totalBytes = 0;
-    for (const call of calls) {
+    for (const call of calls.slice(1)) {
       totalBytes += (call.inputSizeBytes ?? 0) + (call.outputSizeBytes ?? 0);
     }
     return Math.ceil(totalBytes / BYTES_PER_TOKEN_ESTIMATE);


### PR DESCRIPTION
## Summary

**Context composition (`nr_observe_get_context_composition`)**

- Dominance percentages could read in the millions of percent, with `fillPercent` reading near zero. The turn's total context size was computed from the uncached input delta alone instead of including cache-read and cache-creation tokens, producing a denominator many orders of magnitude too small.
- The tool now also resolves the model's real context window instead of staying hard-coded at a 200k default regardless of the actual model in use.

**Retry/thrashing detection (`nr_observe_get_retry_alerts`)**

- Ordinary, non-repeated tool calls were flagged as thrashing for any tool without dedicated metadata extraction (e.g. the native Windows PowerShell tool) — every call to such a tool serialized identically for similarity comparison regardless of how different the underlying input actually was.
- Added PowerShell to the set of tools with dedicated metadata extraction, matching Bash.
- Fixed the dedupe key so the same offending group of calls isn't re-counted every time an unrelated tool call shifts the sliding window.
- The wasted-token estimate now charges only the redundant repeats, not the first (necessary) call in a group.

Fixes #459
Fixes #460

## Test plan

- [x] `npm run build && npm test` — 5594/5597 passing (3 pre-existing skips, unrelated)
- [x] `npm run lint` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>