### PR TITLE
Fix: correct cost attribution — day-bucket Spend Today, stop duplicate-session double-count (v1.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.1] - 2026-08-20
+
+### Fixed
+
+- **"Spend Today" no longer inflates to wildly untrustworthy totals for a resumed multi-day session.** A session's cost is now summed from its actual per-day spend instead of pro-rating its full lifetime cost by a tool-call timeline — which previously attributed a resumed session's entire multi-week cumulative cost to a single day whenever it had no timeline to pro-rate against.
+- **Token and cost totals are no longer double-counted for a session that continues after its underlying project folder is renamed or moved.** The transcript watchers now read only the newest copy of a session's transcript when more than one exists on disk, instead of applying one copy's read position to the other's unrelated content.
+
 ## [1.16.0] - 2026-08-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/alerts/alert-snapshot-collector.ts
+++ b/src/alerts/alert-snapshot-collector.ts
@@ -63,9 +63,8 @@ export interface AlertSnapshotCollectorDeps {
    * snapshot's `cost.todayUsd` and `cost.weekUsd` reflect prior-session +
    * current-session today/weekly totals (the same numbers fed to
    * BudgetTracker.updateCost), enabling cost.window rules with `today`/
-   * `week` periods to fire. Without this, today/week fall back to 0 — the
-   * pre-fix behavior — so cost.window rules with non-session periods
-   * effectively become no-ops.
+   * `week` periods to fire. Without this, today/week fall back to 0, so
+   * cost.window rules with non-session periods effectively become no-ops.
    */
   readonly budgetTracker?: {
     getStatus(): {
@@ -284,7 +283,7 @@ export class AlertSnapshotCollector {
       // spent — same numbers that feed budget alerts, computed in index.ts
       // from costTracker.getCostForDay() + cross-midnight-aware prior session
       // baseline. Falls back to 0 when no budgetTracker is wired (older
-      // configs / tests), matching the pre-fix placeholder behavior.
+      // configs / tests).
       const status = this.deps.budgetTracker?.getStatus();
       return {
         sessionUsd: sessionUsd ?? 0,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -2380,6 +2380,150 @@ describe('api-handler GET /api/sessions/today/aggregate', () => {
     expect(parsed.totalCostUsd).toBe(0);
   });
 
+  // Regression: a resumed multi-day session persists a LIFETIME estimatedCostUsd
+  // (e.g. a month of cache-read tokens ≈ $250) but only spent a little today.
+  // "Spend Today" must sum the session's real today-bucket (costByDayUsd), not
+  // the lifetime total. Before the fix, a timeline-less session pro-rated to
+  // ratio 1.0 and dumped its whole lifetime onto today (the $248/$863 phantoms).
+  it('sums a persisted session today-bucket, not its lifetime estimatedCostUsd', async () => {
+    const now = Date.now();
+    const startMs = localStartOfDay();
+    const todayKey = localDateKey(now);
+    const yesterdayKey = localDateKey(startMs - 1);
+
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [
+          {
+            sessionId: 'resumed-1',
+            startTime: startMs + 10_000,
+            endTime: startMs + 70_000,
+            // Lifetime cumulative — most of it spent on prior days.
+            estimatedCostUsd: 250.0,
+            subagentCostUsd: 0,
+            costByDayUsd: { [yesterdayKey]: 245.0, [todayKey]: 5.0 },
+            subagentCostByDayUsd: {},
+            // No tool-call activity recorded today (the phantom shape).
+            timeline: [],
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { totalCostUsd: number };
+    // Today's bucket only — NOT the $250 lifetime, NOT 0.
+    expect(parsed.totalCostUsd).toBeCloseTo(5.0, 6);
+  });
+
+  // Phantom guard: a session file without day buckets (no costByDayUsd) with
+  // cost but ZERO attributable activity — no tool calls, no timeline, no
+  // subagent spend — is an unverifiable re-read artifact. Its estimatedCostUsd
+  // is a lifetime total, and todayPortionRatio returns 1.0 for its
+  // entirely-today window, dumping the whole lifetime onto today (the observed
+  // $248/$863 phantoms, which had toolCallCount 0 and subagentCostUsd 0). It
+  // must contribute 0; the real figure is recovered once the session
+  // re-persists with day buckets.
+  it('excludes a zero-activity session cost from today when it has no day buckets (unverifiable re-read artifact)', async () => {
+    const startMs = localStartOfDay();
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [
+          {
+            sessionId: 'phantom-1',
+            startTime: startMs + 10_000,
+            endTime: startMs + 70_000,
+            estimatedCostUsd: 248.83,
+            // No day buckets (no costByDayUsd), with zero activity signals of any kind.
+            toolCallCount: 0,
+            subagentCostUsd: 0,
+            timeline: [],
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { totalCostUsd: number };
+    expect(parsed.totalCostUsd).toBe(0);
+  });
+
+  // A legitimate cross-session subagent-only session has an EMPTY parent
+  // timeline (subagent tool calls are not in it) yet real subagentCostUsd — it
+  // must NOT be treated as a phantom. The guard keys on subagent spend, so this
+  // session's cost pro-rates normally on both the total and subagent lines.
+  it('still counts a subagent-only session without day buckets (empty timeline, real subagent cost)', async () => {
+    const startMs = localStartOfDay();
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [
+          {
+            sessionId: 'subagent-only',
+            startTime: startMs + 10_000,
+            endTime: startMs + 70_000,
+            estimatedCostUsd: 3.0,
+            subagentCostUsd: 3.0,
+            toolCallCount: 0,
+            timeline: [],
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { totalCostUsd: number; subagentUsd: number };
+    // Entirely-today window → ratio 1.0 → full 3.0 on both lines.
+    expect(parsed.totalCostUsd).toBeCloseTo(3.0, 6);
+    expect(parsed.subagentUsd).toBeCloseTo(3.0, 6);
+  });
+
+  // Guard: a session without day buckets that DID record tool-call activity
+  // today still pro-rates its cost as before.
+  it('still pro-rates a session cost when it has no day buckets but has timeline activity', async () => {
+    const startMs = localStartOfDay();
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [
+          {
+            sessionId: 'legit-prefix-1',
+            startTime: startMs + 10_000,
+            endTime: startMs + 70_000,
+            estimatedCostUsd: 0.5,
+            timeline: [
+              { timestamp: startMs + 20_000, durationMs: 50, toolName: 'Read', success: true },
+              { timestamp: startMs + 40_000, durationMs: 60, toolName: 'Edit', success: true },
+            ],
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { totalCostUsd: number };
+    // Both timeline entries are today → ratio 1.0 → full 0.5.
+    expect(parsed.totalCostUsd).toBeCloseTo(0.5, 6);
+  });
+
   it('reports today-scoped subagent spend without double-counting the total', async () => {
     const handler = createApiHandler({
       localStore: { peekAllBuffers: () => [] },
@@ -2412,6 +2556,40 @@ describe('api-handler GET /api/sessions/today/aggregate', () => {
     expect(parsed.totalCostUsd).toBeCloseTo(9, 3);
     // Subagent KPI is the today-scoped portion (6), not the cumulative 99.
     expect(parsed.subagentUsd).toBeCloseTo(6, 3);
+  });
+
+  // A NEW-format session with day buckets contributes exactly its today-bucket
+  // for both total and subagent, even with an empty timeline.
+  it('uses day buckets for subagent spend regardless of timeline presence', async () => {
+    const startMs = localStartOfDay();
+    const todayKey = localDateKey(Date.now());
+    const yesterdayKey = localDateKey(startMs - 1);
+    const handler = createApiHandler({
+      localStore: { peekAllBuffers: () => [] },
+      sessionStore: {
+        loadTodaySessions: () => [
+          {
+            sessionId: 'bucketed-sub',
+            startTime: startMs + 10_000,
+            endTime: startMs + 70_000,
+            estimatedCostUsd: 250.0,
+            subagentCostUsd: 200.0,
+            costByDayUsd: { [yesterdayKey]: 245.0, [todayKey]: 5.0 },
+            subagentCostByDayUsd: { [yesterdayKey]: 196.0, [todayKey]: 4.0 },
+            timeline: [],
+          },
+        ],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/today/aggregate' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { totalCostUsd: number; subagentUsd: number };
+    expect(parsed.totalCostUsd).toBeCloseTo(5.0, 6);
+    expect(parsed.subagentUsd).toBeCloseTo(4.0, 6);
   });
 
   it('does not add its own live today-portion when the live session id is an unscoped aggregator (--local/proxy)', async () => {
@@ -2601,7 +2779,6 @@ describe('api-handler GET /api/sessions/today/aggregate', () => {
     expect(status()).toBe(200);
     const parsed = JSON.parse(body()) as { toolCallCount: number };
     // 200 persisted timeline entries + 5 buffer post events = 205.
-    // Pre-fix this returned 5.
     expect(parsed.toolCallCount).toBe(205);
   });
 

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -1396,6 +1396,11 @@ export function createApiHandler(
     // the cache-hit assertions in api-handler.test.ts.
     const overlappingTodaySessions =
       deps.sessionStore?.loadSessionsOverlappingToday?.() ?? todaySessions;
+    // Local-day key for "today", shared by the persisted-session loop below and
+    // the live top-up further down. Sessions persisted with per-day cost buckets
+    // (costByDayUsd) let us sum a session's REAL today-spend instead of
+    // pro-rating its lifetime estimatedCostUsd by a timeline.
+    const todayKey = localDateKey(now);
     for (const raw of overlappingTodaySessions) {
       const s = raw as {
         sessionId?: string;
@@ -1403,6 +1408,9 @@ export function createApiHandler(
         endTime: number;
         estimatedCostUsd: number | null;
         subagentCostUsd?: number;
+        costByDayUsd?: Record<string, number>;
+        subagentCostByDayUsd?: Record<string, number>;
+        toolCallCount?: number;
         tokensInput?: number;
         tokensCacheRead?: number;
         tokensCacheCreation?: number;
@@ -1429,14 +1437,48 @@ export function createApiHandler(
           }
         }
       }
-      totalCostUsd += todayPortionOfSessionCost(s, now);
-      // (2b) subagent-only portion of the same session, same pro-rating.
-      // This is what makes the "subagent spend" KPI cross-session: each
-      // `--stdio` process persists its own subagentCostUsd, so summing it
-      // here (rather than reading only THIS process's live CostTracker)
-      // picks up subagent activity that happened in any concurrent session.
+      // Cost attributed to TODAY. Prefer the session's persisted per-day
+      // bucket — authoritative, since each token event was bucketed by its real
+      // transcript timestamp. For older session files without buckets, fall back to
+      // pro-rating the lifetime estimatedCostUsd by the timeline — EXCEPT a
+      // session with cost but ZERO attributable activity (no tool calls AND no
+      // subagent spend) is an unverifiable re-read artifact: its
+      // estimatedCostUsd is a cumulative lifetime total that may include a
+      // resumed transcript's month of cache-read tokens re-read in one pass, and
+      // todayPortionRatio returns 1.0 for its entirely-today window, dumping the
+      // whole total onto today (the observed $248/$863 phantoms, which had
+      // toolCallCount 0 and subagentCostUsd 0). Bias toward trust and contribute
+      // 0; the real per-day figure is recovered once the session re-persists
+      // WITH day buckets. Note: an EMPTY timeline alone is NOT the signal — a
+      // legitimate subagent-only session has an empty PARENT timeline (subagent
+      // tool calls are not in it) yet real subagentCostUsd, so the guard keys on
+      // subagent spend too, never zeroing genuine cross-session subagent work.
+      const hasNoAttributableActivity =
+        (s.toolCallCount ?? 0) === 0 &&
+        (s.subagentCostUsd ?? 0) === 0 &&
+        !(Array.isArray(s.timeline) && s.timeline.length > 0);
       const ratio = todayPortionRatio(s, now);
-      subagentUsd += (s.subagentCostUsd ?? 0) * ratio;
+      totalCostUsd +=
+        s.costByDayUsd !== undefined
+          ? (s.costByDayUsd[todayKey] ?? 0)
+          : hasNoAttributableActivity
+            ? 0
+            : todayPortionOfSessionCost(s, now);
+      // (2b) subagent-only portion of the same session. Day-bucket-first, else
+      // pro-rate — applying the same phantom guard explicitly rather than
+      // relying on hasNoAttributableActivity's subagentCostUsd===0 term to
+      // zero this out implicitly (that held today, but shouldn't be a silent
+      // invariant across two separate expressions). This is what makes the
+      // KPI cross-session: each `--stdio` process persists its own subagent
+      // cost, so summing it here (rather than reading only THIS process's
+      // live CostTracker) picks up subagent activity from any concurrent
+      // session.
+      subagentUsd +=
+        s.subagentCostByDayUsd !== undefined
+          ? (s.subagentCostByDayUsd[todayKey] ?? 0)
+          : hasNoAttributableActivity
+            ? 0
+            : (s.subagentCostUsd ?? 0) * ratio;
       // Cache token/dollar sums below carry the same unguarded overlap
       // characteristic subagentUsd/totalCostUsd already have on this line:
       // a session that's concurrently live in ANOTHER process (so
@@ -1482,7 +1524,9 @@ export function createApiHandler(
     const liveIsUnscopedAggregator = isUnscopedAggregatorSessionId(liveSid);
 
     if (!liveAlreadyPersisted && !liveIsUnscopedAggregator) {
-      const todayKey = localDateKey(now);
+      // Reuses `todayKey` from the enclosing scope (declared above the
+      // persisted-session loop) so the persisted-loop and this live top-up can
+      // never split onto two independently-derived day keys.
       const liveTodayUsd = deps.costTracker?.getCostForDay?.(todayKey) ?? null;
       if (typeof liveTodayUsd === 'number') {
         totalCostUsd += liveTodayUsd;

--- a/src/hooks/parent-transcript-watcher.test.ts
+++ b/src/hooks/parent-transcript-watcher.test.ts
@@ -7,6 +7,7 @@ import {
   writeFileSync,
   existsSync,
   appendFileSync,
+  utimesSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -140,6 +141,71 @@ describe('ParentTranscriptWatcher', () => {
     const events = readTokenEvents();
     expect(events).toHaveLength(2);
     expect(events[1]!.messageId).toBe('msg_2');
+  });
+
+  it('REGRESSION: dedupes one sessionId across two project dirs, reading only the newest copy', () => {
+    // Repo-rename scenario: Claude Code creates a new project-slug dir when a
+    // repo moves, leaving the old dir's <sessionId>.jsonl behind with divergent
+    // content. The byte cursor is keyed by sessionId alone, so reading BOTH
+    // copies applies one file's offset to the other's unrelated bytes and
+    // double-counts token/cost totals. Unfiltered (--local) discovery must keep
+    // only the newest-mtime (active) copy.
+    const dirOld = join(projectsDir, 'project-old-slug');
+    const dirNew = join(projectsDir, 'project-new-slug');
+    mkdirSync(dirOld, { recursive: true });
+    mkdirSync(dirNew, { recursive: true });
+    const fileOld = join(dirOld, `${SESSION_ID}.jsonl`);
+    const fileNew = join(dirNew, `${SESSION_ID}.jsonl`);
+    writeFileSync(fileOld, makeAssistantLine({ messageId: 'msg_STALE', inputTokens: 9 }) + '\n');
+    writeFileSync(fileNew, makeAssistantLine({ messageId: 'msg_ACTIVE', inputTokens: 111 }) + '\n');
+    // Force the "new" slug's copy to be strictly newer than the stale one.
+    const older = new Date(Date.now() - 60_000);
+    const newer = new Date();
+    utimesSync(fileOld, older, older);
+    utimesSync(fileNew, newer, newer);
+
+    // Unfiltered mode (no parentSessionId) — the --local dashboard path.
+    const watcher = new ParentTranscriptWatcher({ storagePath, projectsDir });
+    watcher.poll();
+    const events = readTokenEvents();
+    // Exactly one turn, from the active copy — the stale copy is never read.
+    expect(events).toHaveLength(1);
+    expect(events[0]!.messageId).toBe('msg_ACTIVE');
+    expect(events[0]!.inputTokens).toBe(111);
+  });
+
+  it('REGRESSION: resets the sessionId-keyed cursor when the canonical copy switches project dirs mid-stream', () => {
+    // Poll 1 tails a LARGE transcript under the old slug (cursor advances to a
+    // large bytePos, path=old). A repo rename then makes a SMALLER transcript
+    // under a new slug the newest copy. Without a path-aware cursor reset, the
+    // stale large bytePos is >= the new file's size, so processFile early-returns
+    // (`startCursor.bytePos >= size`) and silently drops ALL post-rename turns.
+    const dirOld = join(projectsDir, 'project-old-slug');
+    const dirNew = join(projectsDir, 'project-new-slug');
+    mkdirSync(dirOld, { recursive: true });
+    mkdirSync(dirNew, { recursive: true });
+    const fileOld = join(dirOld, `${SESSION_ID}.jsonl`);
+    const fileNew = join(dirNew, `${SESSION_ID}.jsonl`);
+
+    // Old copy is large (padded) so its cursor bytePos exceeds the new copy's size.
+    writeFileSync(fileOld, makeAssistantLine({ messageId: 'msg_OLD', padBytes: 4096 }) + '\n');
+    const t0 = new Date(Date.now() - 60_000);
+    utimesSync(fileOld, t0, t0);
+
+    const watcher = new ParentTranscriptWatcher({ storagePath, projectsDir });
+    watcher.poll();
+    expect(readTokenEvents().map((e) => e.messageId)).toEqual(['msg_OLD']);
+
+    // Rename: new slug's copy is small and strictly newer.
+    writeFileSync(fileNew, makeAssistantLine({ messageId: 'msg_AFTER_RENAME' }) + '\n');
+    const t1 = new Date();
+    utimesSync(fileNew, t1, t1);
+
+    watcher.poll();
+    const ids = readTokenEvents().map((e) => e.messageId);
+    // The post-rename turn is captured (cursor reset to 0 for the new file),
+    // not dropped by a stale large offset.
+    expect(ids).toContain('msg_AFTER_RENAME');
   });
 
   it('REGRESSION: captures every turn in a tool-call / text-only / tool-call sequence, not just the last', () => {

--- a/src/hooks/parent-transcript-watcher.ts
+++ b/src/hooks/parent-transcript-watcher.ts
@@ -96,6 +96,16 @@ interface ParsedParentTurn {
 interface CursorState {
   readonly bytePos: number;
   readonly partialLine: string;
+  /**
+   * The resolved transcript path this byte offset belongs to. The cursor file
+   * is keyed by sessionId alone, but the canonical file for a sessionId can
+   * switch (repo rename → newest-mtime copy under a different project dir). A
+   * byte offset from the previous file is meaningless against the new one, so
+   * `processFile` resets to a fresh cursor when this differs from the file it
+   * is about to read. Undefined for a cursor file written before this field
+   * existed (no reset — it keeps its existing offset, exactly as before).
+   */
+  readonly path?: string;
 }
 
 export interface ParentTranscriptWatcherHealth {
@@ -220,7 +230,17 @@ export class ParentTranscriptWatcher {
    * derived from cwd, since a cwd-derived dashed dir name breaks under git
    * worktrees (the same reason collector-script.ts's retired getTranscriptPath()
    * preferred the hook's transcript_path field, which this watcher has no
-   * access to). Cached after first success.
+   * access to).
+   *
+   * When the sessionId exists under more than one project dir (a repo rename
+   * leaves the old dir's copy behind), pick the newest-mtime copy — the same
+   * canonical-selection rule discoverUnfiltered() uses — rather than the first
+   * arbitrary readdir match, which was nondeterministic and could freeze onto
+   * the stale copy. Cached after first success for poll-loop efficiency; a
+   * rename that occurs AFTER this cache is warmed is followed on the next
+   * process restart (the path-aware cursor then resets cleanly onto the new
+   * file). Mid-session re-resolution is intentionally not attempted here to
+   * avoid flip-flopping between two concurrently-touched copies.
    */
   private resolveScopedPath(): string | null {
     if (this.cachedScopedPath && existsSync(this.cachedScopedPath)) {
@@ -235,18 +255,26 @@ export class ParentTranscriptWatcher {
       this.recordError(err);
       return null;
     }
+    let best: { path: string; mtimeMs: number } | null = null;
     for (const project of entries) {
       const candidate = join(this.projectsDir, project, `${sessionId}.jsonl`);
       try {
-        if (statSync(candidate).isFile()) {
-          this.cachedScopedPath = candidate;
-          return candidate;
+        const st = statSync(candidate);
+        if (!st.isFile()) continue;
+        if (
+          best === null ||
+          st.mtimeMs > best.mtimeMs ||
+          (st.mtimeMs === best.mtimeMs && candidate < best.path)
+        ) {
+          best = { path: candidate, mtimeMs: st.mtimeMs };
         }
       } catch {
         /* not in this project dir */
       }
     }
-    return null; // not created yet — Claude Code creates it lazily on first message
+    if (best === null) return null; // not created yet — Claude Code creates it lazily
+    this.cachedScopedPath = best.path;
+    return best.path;
   }
 
   /**
@@ -257,8 +285,7 @@ export class ParentTranscriptWatcher {
    * cursor file.
    */
   private discoverUnfiltered(): Array<{ path: string; sessionId: string }> {
-    const out: Array<{ path: string; sessionId: string }> = [];
-    if (!existsSync(this.projectsDir)) return out;
+    if (!existsSync(this.projectsDir)) return [];
     const cutoffMs = Date.now() - this.discoveryHours * 60 * 60 * 1000;
     const liveOwnedSessionIds = this.localStore?.getActiveSessionIdsFromHeartbeats() ?? null;
 
@@ -267,8 +294,18 @@ export class ParentTranscriptWatcher {
       projectEntries = readdirSync(this.projectsDir);
     } catch (err) {
       this.recordError(err);
-      return out;
+      return [];
     }
+    // The same sessionId can exist under MORE THAN ONE project dir — Claude Code
+    // creates a new project-slug directory when a repo is renamed/moved, and the
+    // old dir's `<sessionId>.jsonl` lingers with divergent content. Since the
+    // byte cursor is keyed by sessionId alone (cursorPath), reading two files
+    // for one sessionId would apply one file's byte offset to the other's
+    // unrelated bytes — re-parsing mismatched turns and inflating token/cost
+    // totals (observed: a resumed session double-counted across two project
+    // dirs). Keep only the newest-mtime copy per sessionId: after a rename the
+    // stale dir stops being written, so newest === the active, canonical file.
+    const canonicalBySession = new Map<string, { path: string; mtimeMs: number }>();
     for (const project of projectEntries) {
       const projectPath = join(this.projectsDir, project);
       let entries: string[];
@@ -290,8 +327,23 @@ export class ParentTranscriptWatcher {
           continue;
         }
         if (!st.isFile() || st.mtimeMs < cutoffMs) continue;
-        out.push({ path, sessionId });
+        const existing = canonicalBySession.get(sessionId);
+        // Newest mtime wins; on an exact mtime tie (mtime-preserving
+        // copy/restore, coarse-resolution FS, same-second writes) break
+        // deterministically by lexicographically-smallest path so the choice
+        // is stable across platforms/runs rather than following readdir order.
+        if (
+          existing === undefined ||
+          st.mtimeMs > existing.mtimeMs ||
+          (st.mtimeMs === existing.mtimeMs && path < existing.path)
+        ) {
+          canonicalBySession.set(sessionId, { path, mtimeMs: st.mtimeMs });
+        }
       }
+    }
+    const out: Array<{ path: string; sessionId: string }> = [];
+    for (const [sessionId, { path }] of canonicalBySession) {
+      out.push({ path, sessionId });
     }
     return out;
   }
@@ -310,7 +362,19 @@ export class ParentTranscriptWatcher {
     }
 
     const cursorPath = this.cursorPath(sessionId);
-    const startCursor = this.readCursor(cursorPath);
+    const persisted = this.readCursor(cursorPath);
+    // If the canonical copy for this sessionId switched project dirs since the
+    // last poll (repo rename → newest-mtime copy now wins in discovery), the
+    // persisted byte offset belongs to the OLD file and is meaningless against
+    // this one. Start fresh so the new file is read from the top; the
+    // event-processor dedupes any shared-history turns by (sessionId,
+    // messageId), and day-bucketing attributes each re-read turn to its real
+    // transcript-timestamp day, so "spend today" is unaffected.
+    const switchedFile = persisted.path !== undefined && persisted.path !== path;
+    const startCursor: CursorState = switchedFile
+      ? { bytePos: 0, partialLine: '', path }
+      : persisted;
+    if (switchedFile) this.partialByPath.delete(path);
     if (startCursor.bytePos >= size) return;
 
     const remaining = size - startCursor.bytePos;
@@ -394,7 +458,7 @@ export class ParentTranscriptWatcher {
       this.appendToParentBuffer(sessionId, event);
     }
 
-    this.writeCursor(cursorPath, nextBytePos, newPartial);
+    this.writeCursor(cursorPath, nextBytePos, newPartial, path);
     if (newPartial.length > 0) {
       this.partialByPath.set(path, newPartial);
     } else {
@@ -480,20 +544,28 @@ export class ParentTranscriptWatcher {
       const bytePos =
         typeof parsed.bytePos === 'number' && parsed.bytePos >= 0 ? parsed.bytePos : 0;
       const partialLine = typeof parsed.partialLine === 'string' ? parsed.partialLine : '';
-      return { bytePos, partialLine };
+      const path = typeof parsed.path === 'string' ? parsed.path : undefined;
+      return { bytePos, partialLine, path };
     } catch {
       return { bytePos: 0, partialLine: '' };
     }
   }
 
-  private writeCursor(cursorPath: string, bytePos: number, partialLine: string): void {
+  private writeCursor(
+    cursorPath: string,
+    bytePos: number,
+    partialLine: string,
+    sourcePath: string,
+  ): void {
     try {
       if (!existsSync(this.storagePath)) {
         mkdirSync(this.storagePath, { recursive: true, mode: 0o700 });
       }
       const dir = dirname(cursorPath);
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
-      writeFileSync(cursorPath, JSON.stringify({ bytePos, partialLine }), { mode: 0o600 });
+      writeFileSync(cursorPath, JSON.stringify({ bytePos, partialLine, path: sourcePath }), {
+        mode: 0o600,
+      });
     } catch (err) {
       this.recordError(err);
     }

--- a/src/hooks/subagent-watcher.test.ts
+++ b/src/hooks/subagent-watcher.test.ts
@@ -228,6 +228,83 @@ describe('SubagentWatcher', () => {
       expect(tokenLines).toHaveLength(1);
     });
 
+    it('REGRESSION: dedupes one (sessionId, agentId) across two project dirs, reading only the newest copy', () => {
+      // Repo-rename scenario, subagent side: the same session's subagent
+      // transcript exists under two project-slug dirs. The per-agent cursor is
+      // keyed by (parentSessionId, agentId) alone, so reading both copies
+      // cross-contaminates the cursor and double-counts subagent spend. Only
+      // the newest-mtime copy must be read.
+      const staleAgent = agentJsonl; // under project-slug (from beforeEach)
+      const newDir = join(projectsDir, 'project-new-slug', PARENT_SESSION, 'subagents');
+      mkdirSync(newDir, { recursive: true });
+      const activeAgent = join(newDir, `agent-${AGENT_ID}.jsonl`);
+      writeFileSync(
+        staleAgent,
+        makeAssistantLine({ messageId: 'msg_STALE', inputTokens: 9 }) + '\n',
+      );
+      writeFileSync(
+        activeAgent,
+        makeAssistantLine({ messageId: 'msg_ACTIVE', inputTokens: 111 }) + '\n',
+      );
+      const older = Date.now() / 1000 - 60;
+      const newer = Date.now() / 1000;
+      utimesSync(staleAgent, older, older);
+      utimesSync(activeAgent, newer, newer);
+
+      const watcher = new SubagentWatcher({ storagePath, projectsDir });
+      watcher.poll();
+      const buf = readFileSync(join(storagePath, `buffer-${PARENT_SESSION}.jsonl`), 'utf-8');
+      const tokenLines = buf
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l))
+        .filter((l) => l.mode === 'subagent_token');
+      expect(tokenLines).toHaveLength(1);
+      expect(tokenLines[0].messageId).toBe('msg_ACTIVE');
+      expect(tokenLines[0].inputTokens).toBe(111);
+    });
+
+    it('REGRESSION: resets the (sessionId,agentId) cursor when the canonical copy switches project dirs mid-stream', () => {
+      // Poll 1 tails a LARGE agent transcript under the old slug (cursor advances
+      // to a large bytePos, path=old). A repo rename then makes a SMALLER copy
+      // under a new slug the newest. Without a path-aware cursor reset the stale
+      // bytePos >= the new file's size, so processFile early-returns and drops
+      // every post-rename subagent turn.
+      const staleAgent = agentJsonl; // project-slug (from beforeEach)
+      const newDir = join(projectsDir, 'project-new-slug', PARENT_SESSION, 'subagents');
+      mkdirSync(newDir, { recursive: true });
+      const activeAgent = join(newDir, `agent-${AGENT_ID}.jsonl`);
+
+      writeFileSync(staleAgent, makeAssistantLine({ messageId: 'msg_OLD', padBytes: 4096 }) + '\n');
+      const t0 = Date.now() / 1000 - 60;
+      utimesSync(staleAgent, t0, t0);
+
+      const watcher = new SubagentWatcher({ storagePath, projectsDir });
+      watcher.poll();
+      const bufPath = join(storagePath, `buffer-${PARENT_SESSION}.jsonl`);
+      const idsAfter1 = readFileSync(bufPath, 'utf-8')
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l))
+        .filter((l) => l.mode === 'subagent_token')
+        .map((l) => l.messageId);
+      expect(idsAfter1).toEqual(['msg_OLD']);
+
+      // Rename: new slug's copy is small and strictly newer.
+      writeFileSync(activeAgent, makeAssistantLine({ messageId: 'msg_AFTER_RENAME' }) + '\n');
+      const t1 = Date.now() / 1000;
+      utimesSync(activeAgent, t1, t1);
+
+      watcher.poll();
+      const idsAfter2 = readFileSync(bufPath, 'utf-8')
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l))
+        .filter((l) => l.mode === 'subagent_token')
+        .map((l) => l.messageId);
+      expect(idsAfter2).toContain('msg_AFTER_RENAME');
+    });
+
     it("skips a session whose --stdio owner is alive, so it doesn't race that session's own scoped watcher over the same cursor file", () => {
       writeFileSync(agentJsonl, makeAssistantLine({ messageId: 'msg_1' }) + '\n');
       // A live heartbeat means a --stdio process already owns and tails this
@@ -605,10 +682,9 @@ describe('SubagentWatcher', () => {
 
   it('emits a line larger than MAX_BYTES_PER_POLL exactly once and bounds memory under sustained polling', () => {
     // A single assistant turn whose serialized JSONL exceeds 64 KiB (here ~200
-    // KiB via padding). Under the pre-fix code this never emitted and leaked
-    // ~64 KiB per poll. Under the fix the cursor advances each poll, the line
-    // emits once its terminating newline is reached, and further polls are
-    // no-ops.
+    // KiB via padding). The cursor advances each poll regardless of whether a
+    // full line was read, so the line emits once its terminating newline is
+    // reached, and further polls are no-ops.
     const bigLine = makeAssistantLine({ messageId: 'msg_big', padBytes: 200 * 1024 });
     expect(Buffer.byteLength(bigLine)).toBeGreaterThan(64 * 1024);
     writeFileSync(agentJsonl, bigLine + '\n');
@@ -639,11 +715,11 @@ describe('SubagentWatcher', () => {
   });
 
   it('keeps the persisted partial bounded for a never-terminated giant blob across many polls', () => {
-    // A file that is one enormous un-terminated token (no '\n' ever). This is
-    // the pathological case: the pre-fix code grew the partial without bound.
-    // The fix caps the retained partial at MAX_PARTIAL_LINE_BYTES (1 MiB) and
-    // drops the line, so the persisted partial can never exceed the cap (plus
-    // one chunk), no matter how long we poll.
+    // A file that is one enormous un-terminated token (no '\n' ever) — the
+    // pathological case for an unbounded partial-line buffer. The retained
+    // partial is capped at MAX_PARTIAL_LINE_BYTES (1 MiB) and the line is
+    // dropped once it exceeds that, so the persisted partial can never exceed
+    // the cap (plus one chunk), no matter how long we poll.
     const blob = 'x'.repeat(5 * 1024 * 1024); // 5 MiB, no newline
     writeFileSync(agentJsonl, blob);
 

--- a/src/hooks/subagent-watcher.ts
+++ b/src/hooks/subagent-watcher.ts
@@ -193,6 +193,16 @@ interface DiscoveredFile {
 interface CursorState {
   readonly bytePos: number;
   readonly partialLine: string;
+  /**
+   * The resolved agent-transcript path this byte offset belongs to. The cursor
+   * file is keyed by (parentSessionId, agentId) alone, but the canonical file
+   * for that pair can switch project dirs (repo rename → newest-mtime copy).
+   * `processFile` resets to a fresh cursor when this differs from the file it
+   * is about to read, so a stale offset is never applied to a different file.
+   * Undefined for a cursor file written before this field existed (no reset —
+   * existing offset preserved).
+   */
+  readonly path?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -471,7 +481,40 @@ export class SubagentWatcher {
         }
       }
     }
-    return out;
+    return this.dedupeByCursorKey(out);
+  }
+
+  /**
+   * Collapse discovered files that would share one cursor to a single
+   * newest-mtime copy. The per-agent byte cursor is keyed by
+   * (parentSessionId, agentId) alone (see cursorPath), but the same
+   * (parentSessionId, agentId) pair can appear under more than one project dir:
+   * Claude Code creates a fresh project-slug directory when a repo is
+   * renamed/moved, and the old dir's `subagents/.../agent-*.jsonl` lingers with
+   * divergent content. Reading both would apply one file's byte offset to the
+   * other's unrelated bytes, re-parsing mismatched turns and inflating subagent
+   * token/cost totals. After a rename the stale dir stops being written, so the
+   * newest-mtime copy is the active, canonical one. Mirrors the identical
+   * dedupe in ParentTranscriptWatcher.discoverUnfiltered().
+   */
+  private dedupeByCursorKey(files: DiscoveredFile[]): DiscoveredFile[] {
+    const canonical = new Map<string, DiscoveredFile>();
+    for (const f of files) {
+      const key = `${f.parentSessionId}|${f.agentId}`;
+      const existing = canonical.get(key);
+      // Newest mtime wins; on an exact mtime tie, break deterministically by
+      // lexicographically-smallest path (see ParentTranscriptWatcher's
+      // identical tie-break) so the choice is stable rather than following
+      // readdir order.
+      if (
+        existing === undefined ||
+        f.stat.mtimeMs > existing.stat.mtimeMs ||
+        (f.stat.mtimeMs === existing.stat.mtimeMs && f.path < existing.path)
+      ) {
+        canonical.set(key, f);
+      }
+    }
+    return [...canonical.values()];
   }
 
   /** Returns the file's Stats when it passes the mtime cutoff, else null — callers reuse the Stats instead of re-statting the same path. */
@@ -531,7 +574,17 @@ export class SubagentWatcher {
   private processFile(file: DiscoveredFile): void {
     const st = file.stat;
     const cursorPath = this.cursorPath(file.parentSessionId, file.agentId);
-    const startCursor = this.readCursor(cursorPath);
+    const persisted = this.readCursor(cursorPath);
+    // If the canonical copy for this (parentSessionId, agentId) switched project
+    // dirs since the last poll (repo rename → newest-mtime copy now wins in
+    // dedupeByCursorKey), the persisted byte offset belongs to the OLD file and
+    // is meaningless here. Start fresh; the event-processor dedupes shared turns
+    // by (agentId, messageId) and day-bucketing keeps "spend today" correct.
+    const switchedFile = persisted.path !== undefined && persisted.path !== file.path;
+    const startCursor: CursorState = switchedFile
+      ? { bytePos: 0, partialLine: '', path: file.path }
+      : persisted;
+    if (switchedFile) this.partialByPath.delete(file.path);
 
     if (startCursor.bytePos >= st.size) return;
 
@@ -647,7 +700,7 @@ export class SubagentWatcher {
     // restart resumes exactly where we left off. Keep the in-memory mirror in
     // sync; when the partial is empty, drop the key entirely so a fully-consumed
     // file leaves no residual entry in the map.
-    this.writeCursor(cursorPath, nextBytePos, newPartial);
+    this.writeCursor(cursorPath, nextBytePos, newPartial, file.path);
     if (newPartial.length > 0) {
       this.partialByPath.set(file.path, newPartial);
     } else {
@@ -767,20 +820,28 @@ export class SubagentWatcher {
       const bytePos =
         typeof parsed.bytePos === 'number' && parsed.bytePos >= 0 ? parsed.bytePos : 0;
       const partialLine = typeof parsed.partialLine === 'string' ? parsed.partialLine : '';
-      return { bytePos, partialLine };
+      const path = typeof parsed.path === 'string' ? parsed.path : undefined;
+      return { bytePos, partialLine, path };
     } catch {
       return { bytePos: 0, partialLine: '' };
     }
   }
 
-  private writeCursor(cursorPath: string, bytePos: number, partialLine: string): void {
+  private writeCursor(
+    cursorPath: string,
+    bytePos: number,
+    partialLine: string,
+    sourcePath: string,
+  ): void {
     try {
       if (!existsSync(this.storagePath)) {
         mkdirSync(this.storagePath, { recursive: true, mode: 0o700 });
       }
       const dir = dirname(cursorPath);
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
-      writeFileSync(cursorPath, JSON.stringify({ bytePos, partialLine }), { mode: 0o600 });
+      writeFileSync(cursorPath, JSON.stringify({ bytePos, partialLine, path: sourcePath }), {
+        mode: 0o600,
+      });
     } catch (err) {
       this.recordError(err);
     }

--- a/src/metrics/budget-tracker.ts
+++ b/src/metrics/budget-tracker.ts
@@ -172,9 +172,10 @@ export class BudgetTracker {
    * to seed against yet for those two periods.
    *
    * Deliberately does not call `onThreshold` or push onto `alerts` — these
-   * thresholds were already alerted on (or silently passed, pre-fix) by the
-   * now-dead prior process; this only suppresses a duplicate, not un-fired
-   * spend the user hasn't been told about yet.
+   * thresholds were already alerted on (or silently passed, on an older
+   * build that didn't alert on them) by the now-dead prior process; this
+   * only suppresses a duplicate, not un-fired spend the user hasn't been
+   * told about yet.
    */
   seedFiredThresholdsFromSessionTotal(sessionSpentUsd: number): void {
     if (this.sessionBudgetUsd === null || this.sessionBudgetUsd <= 0) return;

--- a/src/metrics/cost-tracker.test.ts
+++ b/src/metrics/cost-tracker.test.ts
@@ -290,6 +290,58 @@ describe('CostTracker', () => {
     });
   });
 
+  describe('getMetrics() per-day cost buckets', () => {
+    // These maps are persisted onto the session summary so the dashboard's
+    // "Spend Today" can sum a session's real today-bucket instead of pro-rating
+    // its lifetime total. They must reflect the same day-attribution the live
+    // getCostForDay()/getSubagentCostForDay() accessors use.
+    it('exposes costByDayUsd / subagentCostByDayUsd bucketed by transcript timestamp', () => {
+      const tracker = new CostTracker();
+      const now = Date.now();
+      const todayKey = localDateKey(now);
+      // A day well within the 48h late-arrival window so it is NOT dropped.
+      const earlierMs = now - 12 * 60 * 60 * 1000;
+      const earlierKey = localDateKey(earlierMs);
+
+      // Parent spend today.
+      tracker.recordTokenUsage(
+        makeUsage({ inputTokens: 100_000, totalTokens: 100_000 }),
+        'claude-sonnet-4',
+        { timestampMs: now } satisfies TokenRecordContext,
+      );
+      // Subagent spend today.
+      tracker.recordTokenUsage(
+        makeUsage({ inputTokens: 50_000, outputTokens: 50_000, totalTokens: 100_000 }),
+        'claude-sonnet-4',
+        { agentId: 'agent-1', timestampMs: now } satisfies TokenRecordContext,
+      );
+      // Parent spend earlier (distinct day when run near midnight; otherwise
+      // same key — either way the accessor and the map must agree).
+      tracker.recordTokenUsage(
+        makeUsage({ inputTokens: 30_000, totalTokens: 30_000 }),
+        'claude-sonnet-4',
+        { timestampMs: earlierMs } satisfies TokenRecordContext,
+      );
+
+      const m = tracker.getMetrics();
+      // The serialized map must agree with the live per-day accessors.
+      expect(m.costByDayUsd[todayKey]).toBeCloseTo(tracker.getCostForDay(todayKey), 6);
+      expect(m.costByDayUsd[earlierKey]).toBeCloseTo(tracker.getCostForDay(earlierKey), 6);
+      expect(m.subagentCostByDayUsd[todayKey]).toBeCloseTo(
+        tracker.getSubagentCostForDay(todayKey),
+        6,
+      );
+      // Subagent bucket is strictly less than the all-in bucket for the same day.
+      expect(m.subagentCostByDayUsd[todayKey]).toBeLessThan(m.costByDayUsd[todayKey]!);
+    });
+
+    it('returns empty day maps for a tracker with no activity', () => {
+      const m = new CostTracker().getMetrics();
+      expect(m.costByDayUsd).toEqual({});
+      expect(m.subagentCostByDayUsd).toEqual({});
+    });
+  });
+
   describe('costPerFileModified', () => {
     it('computes $0.50/file for $2.00 cost and 4 files', () => {
       const sessionTracker = new SessionTracker('test-session');
@@ -1127,7 +1179,7 @@ function makeSeed(overrides?: Partial<CostTrackerSeed>): CostTrackerSeed {
 }
 
 describe('seedFromPersisted()', () => {
-  it('adds seeded totals into a fresh tracker — reproduces the pre-fix bug directly', () => {
+  it('restores a fresh tracker from a persisted checkpoint at realistic multi-day scale', () => {
     const tracker = new CostTracker();
 
     tracker.seedFromPersisted(

--- a/src/metrics/cost-tracker.ts
+++ b/src/metrics/cost-tracker.ts
@@ -82,6 +82,20 @@ export interface CostMetrics {
    * Shape: `{ [runId]: { [dayKey]: usd } }`
    */
   readonly costByWorkflowRunId: Record<string, Record<string, number>>;
+  /**
+   * Total cost bucketed by local-day key (`YYYY-MM-DD`). Each token event is
+   * attributed to the day it was actually recorded in (by transcript
+   * timestamp, not read time), so this is the authoritative "how much did this
+   * session spend on day X" source. Persisted onto the session summary so the
+   * dashboard's "Spend Today" can sum a session's real today-bucket instead of
+   * pro-rating its lifetime `sessionTotalCostUsd` by a tool-call timeline —
+   * which mis-attributes a resumed multi-day session's whole cumulative cost to
+   * a single day when it has no timeline to pro-rate against.
+   */
+  readonly costByDayUsd: Record<string, number>;
+  /** Subagent-attributed cost bucketed by local-day key; today-scoped
+   * counterpart to `subagentCostUsd`. Same rationale as `costByDayUsd`. */
+  readonly subagentCostByDayUsd: Record<string, number>;
 }
 
 /**
@@ -532,6 +546,8 @@ export class CostTracker implements Resettable {
       subagentCostUsd: this.subagentCostUsd,
       parentCostUsd: this.parentCostUsd,
       costByWorkflowRunId,
+      costByDayUsd: Object.fromEntries(this.costByDayUsd),
+      subagentCostByDayUsd: Object.fromEntries(this.subagentCostByDayUsd),
     };
   }
 

--- a/src/metrics/instruction-drift-tracker.ts
+++ b/src/metrics/instruction-drift-tracker.ts
@@ -112,8 +112,7 @@ export class InstructionDriftTracker {
     } catch (err) {
       // File gone/unreadable by the time we process this event — no signal,
       // but log at debug level since this can also mean permission-denied
-      // or an EISDIR (unlike the pre-fix code, which never touched the
-      // filesystem here at all).
+      // or an EISDIR, not just a missing file.
       logger.debug('Could not hash instruction file', { filePath, error: String(err) });
       return;
     }

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -139,7 +139,7 @@ describe('instructionPromptHash field', () => {
     expect(roundTripped.instructionPromptHash).toBe('hash-xyz');
   });
 
-  it('deserializeFullSessionSummary defaults instructionPromptHash to null when field is missing (pre-fix session files)', () => {
+  it('deserializeFullSessionSummary defaults instructionPromptHash to null when the field is missing', () => {
     const summary = makeSummary();
     const raw = JSON.parse(JSON.stringify(summary)) as Record<string, unknown>;
     delete raw.instructionPromptHash;
@@ -1275,6 +1275,8 @@ describe('buildSessionSummary', () => {
       subagentCostUsd: 0.021,
       parentCostUsd: 0.029,
       costByWorkflowRunId: {},
+      costByDayUsd: {},
+      subagentCostByDayUsd: {},
     } satisfies CostMetrics);
     const summary = buildSessionSummary({
       sessionTracker,
@@ -1311,6 +1313,8 @@ describe('buildSessionSummary', () => {
       subagentCostUsd: 0.021,
       parentCostUsd: 0.029,
       costByWorkflowRunId: { wf_test_run: { '2026-08-14': 0.05 } },
+      costByDayUsd: { '2026-08-14': 0.05 },
+      subagentCostByDayUsd: {},
     } satisfies CostMetrics);
     const summary = buildSessionSummary({
       sessionTracker,
@@ -1428,7 +1432,7 @@ describe('buildSessionSummary', () => {
     expect(result.subagentCostUsd).toBe(0.0345);
   });
 
-  it('deserializeFullSessionSummary defaults subagentCostUsd to 0 for pre-fix session files', () => {
+  it('deserializeFullSessionSummary defaults subagentCostUsd to 0 when the field is missing', () => {
     const raw = {
       sessionId: 'sess-old',
       startTime: 1_700_000_000_000,
@@ -1457,7 +1461,7 @@ describe('buildSessionSummary', () => {
     });
   });
 
-  it('deserializeFullSessionSummary defaults costByWorkflowRunId to {} for pre-fix session files', () => {
+  it('deserializeFullSessionSummary defaults costByWorkflowRunId to {} when the field is missing', () => {
     const raw = {
       sessionId: 'sess-old',
       startTime: 1_700_000_000_000,
@@ -1468,6 +1472,69 @@ describe('buildSessionSummary', () => {
     };
     const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
     expect(result.costByWorkflowRunId).toEqual({});
+  });
+
+  it('deserializeFullSessionSummary round-trips costByDayUsd / subagentCostByDayUsd', () => {
+    const raw = {
+      sessionId: 'sess-day-buckets',
+      startTime: 1_700_000_000_000,
+      endTime: 1_700_003_600_000,
+      durationMs: 3_600_000,
+      toolCallCount: 5,
+      developer: 'dev',
+      costByDayUsd: { '2026-08-17': 245.0, '2026-08-18': 5.0 },
+      subagentCostByDayUsd: { '2026-08-18': 1.5 },
+    };
+    const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
+    expect(result.costByDayUsd).toEqual({ '2026-08-17': 245.0, '2026-08-18': 5.0 });
+    expect(result.subagentCostByDayUsd).toEqual({ '2026-08-18': 1.5 });
+  });
+
+  it('deserializeFullSessionSummary leaves day-bucket maps undefined when the fields are missing', () => {
+    // Undefined (not {}) so the aggregate route can distinguish "old file, fall
+    // back to timeline pro-rate" from "new file that genuinely spent $0 today".
+    const raw = {
+      sessionId: 'sess-old',
+      startTime: 1_700_000_000_000,
+      endTime: 1_700_003_600_000,
+      durationMs: 3_600_000,
+      toolCallCount: 5,
+      developer: 'dev',
+    };
+    const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
+    expect(result.costByDayUsd).toBeUndefined();
+    expect(result.subagentCostByDayUsd).toBeUndefined();
+  });
+
+  it('deserializeFullSessionSummary drops non-numeric values inside the day-bucket maps', () => {
+    const raw = {
+      sessionId: 'sess-malformed-day',
+      startTime: 1_700_000_000_000,
+      endTime: 1_700_003_600_000,
+      durationMs: 3_600_000,
+      toolCallCount: 5,
+      developer: 'dev',
+      costByDayUsd: { '2026-08-18': 5.0, '2026-08-17': 'nope', bad: null },
+    };
+    const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
+    expect(result.costByDayUsd).toEqual({ '2026-08-18': 5.0 });
+  });
+
+  it('deserializeFullSessionSummary treats an array costByDayUsd as absent (undefined), not a {0:..} map', () => {
+    // typeof [] === 'object'; without an Array guard a corrupt array would
+    // become { '0': 5 } (defined) and wrongly take the day-bucket branch in the
+    // aggregate route (reading $0 today) instead of falling back to pro-rating.
+    const raw = {
+      sessionId: 'sess-array-day',
+      startTime: 1_700_000_000_000,
+      endTime: 1_700_003_600_000,
+      durationMs: 3_600_000,
+      toolCallCount: 5,
+      developer: 'dev',
+      costByDayUsd: [5.0, 6.0],
+    };
+    const result = deserializeFullSessionSummary(raw as unknown as Record<string, unknown>);
+    expect(result.costByDayUsd).toBeUndefined();
   });
 
   it('deserializeFullSessionSummary drops non-numeric values inside costByWorkflowRunId rather than throwing', () => {

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -102,10 +102,26 @@ export interface FullSessionSummary extends SessionSummary {
   readonly estimatedCostUsd: number | null;
   /**
    * Portion of estimatedCostUsd attributed to subagent (ctx.agentId) calls —
-   * see CostMetrics.subagentCostUsd. 0 for pre-fix session files (subagent
-   * cost was never tracked) and for sessions with no subagent activity.
+   * see CostMetrics.subagentCostUsd. 0 for an older session summary written
+   * before subagent cost was tracked, and for sessions with no subagent
+   * activity.
    */
   readonly subagentCostUsd: number;
+  /**
+   * Total cost bucketed by local-day key (`YYYY-MM-DD`), mirrored from
+   * `CostMetrics.costByDayUsd`. The dashboard's "Spend Today" aggregate sums
+   * `costByDayUsd[todayKey]` across sessions — the authoritative today-figure —
+   * instead of pro-rating `estimatedCostUsd` (a lifetime cumulative total) by a
+   * tool-call timeline, which over-attributes a resumed multi-day session's
+   * whole cost to one day. Optional: absent on a session summary written
+   * before this field existed, which falls back to the timeline pro-rate
+   * path in the aggregate route.
+   */
+  readonly costByDayUsd?: Record<string, number>;
+  /** Subagent-attributed cost by local-day key; today-scoped counterpart to
+   * `subagentCostUsd`. Optional for the same backward-compat reason as
+   * `costByDayUsd`. */
+  readonly subagentCostByDayUsd?: Record<string, number>;
   readonly tokensInput: number;
   readonly tokensOutput: number;
   readonly tokensThinking: number;
@@ -122,8 +138,9 @@ export interface FullSessionSummary extends SessionSummary {
    * losing every pre-restart task's contribution to it. Optional (unlike
    * most fields on this interface) so the many existing test factories
    * building `FullSessionSummary` literals don't all need updating for an
-   * additive field — read with `?? 0` at the point of use. 0/absent for
-   * pre-fix session files and for sessions with no scored tasks.
+   * additive field — read with `?? 0` at the point of use. 0/absent for an
+   * older session summary written before this field existed, and for
+   * sessions with no scored tasks.
    */
   readonly efficiencyScoreSampleCount?: number;
   /**
@@ -132,7 +149,8 @@ export interface FullSessionSummary extends SessionSummary {
    * alongside `efficiencyScoreSampleCount` so a re-seeded average's
    * component breakdown is exact, not just its top-level score. Optional
    * for the same reason as `efficiencyScoreSampleCount` above. null/absent
-   * for pre-fix session files and for sessions with no scored tasks.
+   * for an older session summary written before this field existed, and
+   * for sessions with no scored tasks.
    */
   readonly efficiencyScoreComponents?: EfficiencyScoreComponents | null;
   readonly antiPatterns: PersistedAntiPattern[];
@@ -153,7 +171,8 @@ export interface FullSessionSummary extends SessionSummary {
    * time from the full in-memory ToolCallRecord[] — the only point where
    * outputSizeBytes (needed for unused-output detection) is still available;
    * it is never persisted anywhere else, including `timeline` above. null
-   * for pre-fix session files and for sessions with no tool calls.
+   * for an older session summary written before this field existed, and
+   * for sessions with no tool calls.
    */
   readonly toolSelectionMetrics: ToolSelectionSummary | null;
   /**
@@ -161,7 +180,8 @@ export interface FullSessionSummary extends SessionSummary {
    * Captured once at save time from ModelUsageTracker.getRawBreakdown(). Raw
    * counters only, no derived ratios — see ModelUsageTracker.combineBreakdowns
    * for why ratios are always recomputed at read time instead of persisted.
-   * `{}` for pre-fix session files and for sessions with no token events.
+   * `{}` for an older session summary written before this field existed,
+   * and for sessions with no token events.
    */
   readonly modelBreakdown: Readonly<Record<string, ModelBreakdownEntry>>;
   /**
@@ -169,7 +189,8 @@ export interface FullSessionSummary extends SessionSummary {
    * day key — the exact shape `CostMetrics.costByWorkflowRunId` already
    * produces. Captured once at save time so a resumed session's per-run
    * spend survives a process restart (see CostTracker.seedFromPersisted()).
-   * `{}` for pre-fix session files and for sessions with no workflow runs.
+   * `{}` for an older session summary written before this field existed,
+   * and for sessions with no workflow runs.
    */
   readonly costByWorkflowRunId: Record<string, Record<string, number>>;
   /**
@@ -177,8 +198,9 @@ export interface FullSessionSummary extends SessionSummary {
    * time from QualityProxyTracker.getRawCounts(). Raw counts only, no derived
    * rates — see combineQualityProxyRawCounts for why rates are always
    * recomputed at read time instead of persisted. All-zero
-   * (ZERO_QUALITY_PROXY_COUNTS) for pre-fix session files and for sessions
-   * with no quality signals. Nested (not top-level) specifically to avoid
+   * (ZERO_QUALITY_PROXY_COUNTS) for an older session summary written before
+   * this field existed, and for sessions with no quality signals. Nested
+   * (not top-level) specifically to avoid
    * colliding with the unrelated top-level testPassCount/testRunCount fields
    * above (total task test runs, not quality-proxy test signals).
    */
@@ -767,6 +789,8 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
     buildPassCount: totalBuildsPassed,
     estimatedCostUsd: costMetrics?.sessionTotalCostUsd ?? null,
     subagentCostUsd: costMetrics?.subagentCostUsd ?? 0,
+    costByDayUsd: costMetrics?.costByDayUsd ?? {},
+    subagentCostByDayUsd: costMetrics?.subagentCostByDayUsd ?? {},
     tokensInput: costMetrics?.totalInputTokens ?? 0,
     tokensOutput: costMetrics?.totalOutputTokens ?? 0,
     tokensThinking: costMetrics?.totalThinkingTokens ?? 0,
@@ -861,6 +885,8 @@ interface SerializedFullSessionSummary {
   readonly buildPassCount?: unknown;
   readonly estimatedCostUsd?: unknown;
   readonly subagentCostUsd?: unknown;
+  readonly costByDayUsd?: unknown;
+  readonly subagentCostByDayUsd?: unknown;
   readonly tokensInput?: unknown;
   readonly tokensOutput?: unknown;
   readonly tokensThinking?: unknown;
@@ -887,6 +913,26 @@ interface SerializedFullSessionSummary {
   readonly modelBreakdown?: Record<string, unknown>;
   readonly costByWorkflowRunId?: Record<string, unknown>;
   readonly qualityProxy?: Record<string, unknown>;
+}
+
+/**
+ * Parse an untrusted value into a `Record<string, number>`, dropping any
+ * non-finite or non-numeric entries. Used to hydrate the per-day cost maps
+ * (`costByDayUsd` / `subagentCostByDayUsd`) from disk. Returns undefined when
+ * the value is absent or not an object, so a session summary that predates
+ * these keys leaves the field undefined and falls through to the aggregate
+ * route's timeline pro-rate fallback.
+ */
+function parseNumberRecord(value: unknown): Record<string, number> | undefined {
+  // Reject arrays too (typeof [] === 'object'): a corrupt `costByDayUsd: [5]`
+  // must yield undefined so the aggregate route falls through to the timeline
+  // pro-rate path, not a bogus `{ '0': 5 }` map that silently reads as $0 today.
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  const out: Record<string, number> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === 'number' && Number.isFinite(v)) out[k] = v;
+  }
+  return out;
 }
 
 /**
@@ -1075,6 +1121,8 @@ export function deserializeFullSessionSummary(
     buildPassCount: typeof obj.buildPassCount === 'number' ? obj.buildPassCount : 0,
     estimatedCostUsd: typeof obj.estimatedCostUsd === 'number' ? obj.estimatedCostUsd : null,
     subagentCostUsd: typeof obj.subagentCostUsd === 'number' ? obj.subagentCostUsd : 0,
+    costByDayUsd: parseNumberRecord(obj.costByDayUsd),
+    subagentCostByDayUsd: parseNumberRecord(obj.subagentCostByDayUsd),
     tokensInput: typeof obj.tokensInput === 'number' ? obj.tokensInput : 0,
     tokensOutput: typeof obj.tokensOutput === 'number' ? obj.tokensOutput : 0,
     tokensThinking: typeof obj.tokensThinking === 'number' ? obj.tokensThinking : 0,

--- a/src/tools/cost-tools.test.ts
+++ b/src/tools/cost-tools.test.ts
@@ -258,6 +258,8 @@ describe('handleGetPromptCacheHealth()', () => {
       subagentCostUsd: 0,
       parentCostUsd: 0,
       costByWorkflowRunId: {},
+      costByDayUsd: {},
+      subagentCostByDayUsd: {},
       ...overrides,
     } satisfies CostMetrics);
     return tracker;

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -1087,7 +1087,7 @@ export interface ObservabilityHealthResponse {
   readonly filesWatched?: number;
   readonly parseErrors?: number;
   // Absent on older server builds — treat as equivalent to 'env_var' (the
-  // banner's original, pre-fix behavior) rather than hiding the message.
+  // banner's original behavior) rather than hiding the message.
   readonly watcherDisabledReason?: 'env_var' | 'mode_mismatch' | null;
 }
 


### PR DESCRIPTION
Fixes #469

## Summary

- **"Spend Today" no longer inflates to wildly untrustworthy totals for a resumed multi-day session.** A session's cost is now summed from its actual per-day spend instead of pro-rating its full lifetime cost by a tool-call timeline — which previously attributed a resumed session's entire multi-week cumulative cost to a single day whenever it had no timeline to pro-rate against.
- **Token and cost totals are no longer double-counted for a session that continues after its underlying project folder is renamed or moved.** The transcript watchers now read only the newest copy of a session's transcript when more than one exists on disk, instead of applying one copy's read position to the other's unrelated content.
- Bumps version to 1.16.1 and updates CHANGELOG.

Related: a residual edge case in the rename-handling fix above (a global dedup-ring cap that could double-count a very long-lived session's shared history on the rare rename+huge-history combination) is tracked separately in #465 — not fixed by this PR.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 5797 passed, 3 skipped (pre-existing, unrelated), 0 failed
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run format:check` — clean