### PR TITLE
Fix #464-#467: session-seeding, ppid-breadcrumb, platform-precedence, dedup-ring fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.2] - 2026-08-20
+
+### Fixed
+
+- **A resumed session's tool-call and Bash-command counts no longer under-report after the MCP server process restarts mid-session.** These two counters previously stayed in-memory only and reset to zero on restart, same class of bug as the cost/token restart-recovery fixes in earlier releases.
+- **An MCP process on native Windows can no longer resolve to a completely unrelated session from days or weeks earlier.** The session-id breadcrumb keyed on a shared parent process ID could be silently reused once the OS recycled that PID for an unrelated process; a breadcrumb older than the resolving process's own start time is now rejected instead of trusted.
+- **Platform detection no longer misattributes a session to the wrong AI coding assistant when more than one is installed.** An explicit platform configuration (e.g. registering the MCP server for GitHub Copilot) is now always honored over an inherited ambient signal from an unrelated installed tool, regardless of adapter registration order.
+- **Very long-lived or heavily-resumed sessions can no longer have older token-usage turns double-counted after certain project-rename recovery scenarios.** The in-memory dedup mechanism that guards against redelivered lines was previously shared globally across every active session; it's now scoped per session so one session's activity can no longer evict another's dedup history.
+
 ## [1.16.1] - 2026-08-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import {
@@ -1392,6 +1392,27 @@ describe('collector-script', () => {
       // The mtime may or may not change depending on filesystem — the key
       // assertion is correctness; the perf claim is documented separately.
       expect(typeof firstStat).toBe('number');
+    });
+
+    it('refreshes mtime on the short-circuit path so an active session never goes stale', () => {
+      writePpidBreadcrumb('sess-active');
+      const ppid = process.ppid;
+      const breadcrumbPath = resolve(tmpDir, 'session-by-ppid', `${ppid}.txt`);
+
+      // Simulate this breadcrumb having gone quiet for a while (e.g. no hook
+      // fired since before an MCP server restart) by backdating its mtime.
+      const oldMs = Date.now() - 60_000;
+      utimesSync(breadcrumbPath, oldMs / 1000, oldMs / 1000);
+      expect(statSync(breadcrumbPath).mtimeMs).toBeLessThan(Date.now() - 30_000);
+
+      // A subsequent hook call with the SAME session_id (content unchanged,
+      // short-circuit path) must still bump mtime — otherwise
+      // resolveFromBreadcrumb()'s staleness check (session-resolver.ts)
+      // would reject this breadcrumb forever after any MCP restart that
+      // keeps the same ppid and session_id.
+      writePpidBreadcrumb('sess-active');
+      expect(readFileSync(breadcrumbPath, 'utf-8')).toBe('sess-active');
+      expect(statSync(breadcrumbPath).mtimeMs).toBeGreaterThan(Date.now() - 5_000);
     });
 
     it('processHook() drops the breadcrumb on every fire (idempotent overwrite)', () => {

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -19,6 +19,7 @@ import {
   closeSync,
   mkdirSync,
   existsSync,
+  utimesSync,
   constants as fsConstants,
 } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -242,10 +243,25 @@ function writePpidBreadcrumb(sessionId: string): void {
     let wroteAny = false;
     for (const pid of pids) {
       const breadcrumbPath = resolve(breadcrumbDir, `${pid}.txt`);
-      // Short-circuit: no write needed if content already matches.
+      // Short-circuit: no content rewrite needed if it already matches, but
+      // still touch mtime — resolveFromBreadcrumb() (session-resolver.ts)
+      // rejects a breadcrumb older than the reading process's own start
+      // time, so an actively-hooked session's breadcrumb must keep looking
+      // fresh across an MCP server restart (same ppid, same session_id,
+      // content genuinely unchanged) or that restart would permanently lose
+      // ppid-based resolution for the rest of the session. A breadcrumb from
+      // a session that's actually over stops getting touched here (nothing
+      // calls this with its old ppid+session_id again), so it still goes
+      // stale and gets rejected exactly as intended.
       if (existsSync(breadcrumbPath)) {
         try {
           if (readFileSync(breadcrumbPath, 'utf-8').trim() === sessionId) {
+            const now = new Date();
+            try {
+              utimesSync(breadcrumbPath, now, now);
+            } catch {
+              // Best-effort — an unwritable mtime doesn't block the session.
+            }
             wroteAny = true;
             continue;
           }

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { LocalStore } from '../storage/local-store.js';
-import { HookEventProcessor } from './event-processor.js';
+import { HookEventProcessor, DedupRingRegistry } from './event-processor.js';
 import { AntigravityAdapter } from '../platforms/antigravity-adapter.js';
 import type { HookEvent, PreHookEvent, PostHookEvent, ToolCallRecord } from '../storage/types.js';
 
@@ -797,6 +797,82 @@ describe('HookEventProcessor', () => {
       processor.processEvents([tokenEvent, { ...tokenEvent }]);
 
       expect(tokenEvents).toHaveLength(2);
+    });
+
+    it("does not let one session evict another session's dedup entries", () => {
+      const tokenEvents: unknown[] = [];
+      const processor = new HookEventProcessor({
+        store,
+        onRecord,
+        onTokenEvent: (event) => {
+          tokenEvents.push(event);
+        },
+      });
+
+      const makeTokenEvent = (sessionId: string, messageId: string): HookEvent => ({
+        mode: 'token',
+        tool: '',
+        timestamp: 5000,
+        inputTokens: 100,
+        outputTokens: 20,
+        model: 'claude-opus-4-6',
+        sessionId,
+        messageId,
+      });
+
+      // Session A delivers a handful of token events, including 'a-0'.
+      for (let i = 0; i < 10; i++) {
+        processor.processEvents([makeTokenEvent('session-a', `a-${i}`)]);
+      }
+
+      // Session B alone delivers more unique messageIds than the OLD global
+      // ring's total 4096-entry cap. Under the old single shared ring, this
+      // would have evicted session A's 'a-0' long before B finished, purely
+      // because A and B shared one FIFO order array.
+      for (let i = 0; i < 4100; i++) {
+        processor.processEvents([makeTokenEvent('session-b', `b-${i}`)]);
+      }
+
+      // Re-delivering session A's first messageId (a re-read after a crash
+      // mid-write, the scenario this ring exists for) must still be
+      // recognized as a duplicate and dropped, not accepted as new — proving
+      // session B's growth never touched session A's own ring.
+      tokenEvents.length = 0;
+      processor.processEvents([makeTokenEvent('session-a', 'a-0')]);
+      expect(tokenEvents).toHaveLength(0);
+    });
+  });
+
+  describe('DedupRingRegistry', () => {
+    it('evicts the least-recently-used scope once maxScopes is exceeded', () => {
+      const registry = new DedupRingRegistry(2, 10);
+
+      expect(registry.hasAndAdd('a', 'k1')).toBe(false); // creates scope 'a'
+      expect(registry.hasAndAdd('b', 'k1')).toBe(false); // creates scope 'b'
+      expect(registry.scopeCount).toBe(2);
+
+      // A third distinct scope exceeds maxScopes (2) — the least-recently-used
+      // scope ('a', the oldest, untouched since its first insert) gets evicted.
+      expect(registry.hasAndAdd('c', 'k1')).toBe(false);
+      expect(registry.scopeCount).toBe(2);
+
+      // 'b' survived the eviction (it's newer than 'a') and still remembers
+      // its own key — checking an EXISTING scope never itself triggers
+      // eviction, so this assertion doesn't disturb the registry further.
+      expect(registry.hasAndAdd('b', 'k1')).toBe(true);
+    });
+
+    it('touching an existing scope refreshes its LRU position', () => {
+      const registry = new DedupRingRegistry(2, 10);
+      registry.hasAndAdd('a', 'k1');
+      registry.hasAndAdd('b', 'k1');
+      // Touch 'a' again so 'b' becomes the least-recently-used scope instead.
+      registry.hasAndAdd('a', 'k2');
+
+      registry.hasAndAdd('c', 'k1'); // exceeds maxScopes — evicts 'b', not 'a'
+
+      expect(registry.hasAndAdd('a', 'k1')).toBe(true); // 'a' survived, key still known
+      expect(registry.hasAndAdd('b', 'k1')).toBe(false); // 'b' was evicted, key forgotten
     });
   });
 

--- a/src/hooks/event-processor.ts
+++ b/src/hooks/event-processor.ts
@@ -133,6 +133,75 @@ const DEFAULT_POLL_INTERVAL_MS = 100;
 const DEFAULT_ORPHAN_TIMEOUT_MS = 60_000;
 const DEFAULT_MAX_PENDING = 2_000;
 
+/**
+ * Fixed-capacity FIFO dedup set for one session/agent's own event stream.
+ * Extracted out of a single global ring (see DedupRingRegistry) so one
+ * scope's dedup keys can never evict another's.
+ */
+class DedupRing {
+  private readonly seen = new Set<string>();
+  private readonly order: string[] = [];
+
+  constructor(private readonly capacity: number) {}
+
+  /** Returns true if `key` was already seen (and does nothing further); otherwise records it and returns false. */
+  hasAndAdd(key: string): boolean {
+    if (this.seen.has(key)) return true;
+    this.seen.add(key);
+    this.order.push(key);
+    if (this.order.length > this.capacity) {
+      const evicted = this.order.shift();
+      if (evicted !== undefined) this.seen.delete(evicted);
+    }
+    return false;
+  }
+}
+
+/**
+ * LRU-bounded registry of per-scope DedupRings, keyed by session/agent id —
+ * mirrors ContextTrackerRegistry's eviction pattern (src/metrics/context-tracker.ts).
+ * A scope that goes quiet for a while eventually gets evicted entirely, so a
+ * burst of short-lived scopes can't grow this registry without bound while a
+ * long-lived scope's own ring keeps its full per-scope capacity regardless of
+ * how many OTHER scopes are active.
+ *
+ * Exported (unlike DedupRing) so tests can exercise the maxScopes eviction
+ * path directly with a small value — mirroring how ContextTrackerRegistry's
+ * own `{ maxSessions }` option is tested — rather than only through
+ * HookEventProcessor's fixed production values.
+ */
+export class DedupRingRegistry {
+  private readonly rings = new Map<string, DedupRing>();
+
+  constructor(
+    private readonly maxScopes: number,
+    private readonly perScopeCapacity: number,
+  ) {}
+
+  /** Returns true if `dedupKey` was already seen within `scopeKey`'s own ring. */
+  hasAndAdd(scopeKey: string, dedupKey: string): boolean {
+    let ring = this.rings.get(scopeKey);
+    if (ring) {
+      // Move to end for LRU ordering.
+      this.rings.delete(scopeKey);
+      this.rings.set(scopeKey, ring);
+    } else {
+      if (this.rings.size >= this.maxScopes) {
+        const oldest = this.rings.keys().next().value;
+        if (oldest !== undefined) this.rings.delete(oldest);
+      }
+      ring = new DedupRing(this.perScopeCapacity);
+      this.rings.set(scopeKey, ring);
+    }
+    return ring.hasAndAdd(dedupKey);
+  }
+
+  /** Number of scopes currently tracked — test seam for eviction assertions. */
+  get scopeCount(): number {
+    return this.rings.size;
+  }
+}
+
 export class HookEventProcessor {
   private store: LocalStore;
   private readonly pollIntervalMs: number;
@@ -147,12 +216,13 @@ export class HookEventProcessor {
   private readonly onWorkflowRun: ((event: WorkflowRunEvent) => void) | null;
   private readonly platformAdapter: PlatformAdapter;
   /**
-   * Dedup ring of `(agentId, messageId)` for recent subagent turns. Cursor
-   * recovery may re-read a line after a crash mid-write; double-counting would
-   * be silent, so we drop on the seen-set (capped at 4096 to bound memory).
+   * Per-agent dedup rings for recent subagent turns (scoped by agentId, one
+   * DedupRing per agent, LRU-bounded across agents). Cursor recovery may
+   * re-read a line after a crash mid-write; double-counting would be silent,
+   * so we drop on the seen-set. Was previously one global ring shared across
+   * every agent — see DedupRingRegistry's doc comment for why that's wrong.
    */
-  private readonly subagentDedup = new Set<string>();
-  private readonly subagentDedupOrder: string[] = [];
+  private readonly subagentDedupRegistry = new DedupRingRegistry(50, 4096);
   /**
    * Dedup ring of `(workflowRunId, timestamp)` for recent workflow_run
    * events, mirroring subagentDedup above. This path only matters for
@@ -167,15 +237,15 @@ export class HookEventProcessor {
   private readonly workflowRunDedup = new Set<string>();
   private readonly workflowRunDedupOrder: string[] = [];
   /**
-   * Dedup ring of `sessionId|messageId` for recent parent-transcript token
-   * events, mirroring subagentDedup above. `ParentTranscriptWatcher` tails the
-   * main transcript via a durable byte cursor and can re-deliver a line after
-   * a crash mid-emit; without this, that redelivery double-counts cost. Only
-   * applied when messageId is present — events without one (defensive; any
-   * other/future producer) pass through unchanged, unaffected by this ring.
+   * Per-session dedup rings for recent parent-transcript token events (scoped
+   * by sessionId), mirroring subagentDedupRegistry above. ParentTranscriptWatcher
+   * tails the main transcript via a durable byte cursor and can re-deliver a
+   * line after a crash mid-emit, or after a rename-triggered cursor reset;
+   * without this, that redelivery double-counts cost. Only applied when
+   * messageId is present — events without one (defensive; any other/future
+   * producer) pass through unchanged, unaffected by this ring.
    */
-  private readonly tokenDedup = new Set<string>();
-  private readonly tokenDedupOrder: string[] = [];
+  private readonly tokenDedupRegistry = new DedupRingRegistry(50, 4096);
 
   private readonly pending: Map<string, PreHookEvent> = new Map();
   private readonly maxPendingEvents: number;
@@ -451,14 +521,8 @@ export class HookEventProcessor {
     if (!this.onTokenEvent) return;
 
     if (typeof event.messageId === 'string' && event.messageId.length > 0) {
-      const dedupKey = `${event.sessionId ?? ''}|${event.messageId}`;
-      if (this.tokenDedup.has(dedupKey)) return;
-      this.tokenDedup.add(dedupKey);
-      this.tokenDedupOrder.push(dedupKey);
-      if (this.tokenDedupOrder.length > 4096) {
-        const evicted = this.tokenDedupOrder.shift();
-        if (evicted) this.tokenDedup.delete(evicted);
-      }
+      const scopeKey = event.sessionId ?? '';
+      if (this.tokenDedupRegistry.hasAndAdd(scopeKey, event.messageId)) return;
     }
 
     const tokenEvent: TokenEvent = {
@@ -576,14 +640,7 @@ export class HookEventProcessor {
     const agentId = event.agentId ?? '';
     const messageId = event.messageId ?? '';
     if (!agentId || !messageId) return;
-    const dedupKey = `${agentId}|${messageId}`;
-    if (this.subagentDedup.has(dedupKey)) return;
-    this.subagentDedup.add(dedupKey);
-    this.subagentDedupOrder.push(dedupKey);
-    if (this.subagentDedupOrder.length > 4096) {
-      const evicted = this.subagentDedupOrder.shift();
-      if (evicted) this.subagentDedup.delete(evicted);
-    }
+    if (this.subagentDedupRegistry.hasAndAdd(agentId, messageId)) return;
 
     const turn: SubagentTurnEvent = {
       timestampMs:

--- a/src/hooks/session-resolver.test.ts
+++ b/src/hooks/session-resolver.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -105,6 +105,33 @@ describe('session-resolver', () => {
       mkdirSync(resolve(tmpDir, 'session-by-ppid'), { recursive: true });
       writeFileSync(resolve(tmpDir, 'session-by-ppid', `${ppid}.txt`), 'has spaces');
       expect(resolveFromBreadcrumb(tmpDir, ppid)).toBeNull();
+    });
+
+    it('rejects a breadcrumb whose mtime predates the given process start time', () => {
+      const ppid = 4242;
+      const breadcrumbDir = resolve(tmpDir, 'session-by-ppid');
+      mkdirSync(breadcrumbDir, { recursive: true });
+      const breadcrumbPath = resolve(breadcrumbDir, `${ppid}.txt`);
+      writeFileSync(breadcrumbPath, 'sess-stale-leftover');
+
+      // Simulate the breadcrumb having been written well before "now" by
+      // backdating its mtime, then asking for a process that started later.
+      const oldMs = Date.now() - 60_000;
+      utimesSync(breadcrumbPath, oldMs / 1000, oldMs / 1000);
+
+      const processStartMs = Date.now(); // this "process" started after the breadcrumb was written
+      expect(resolveFromBreadcrumb(tmpDir, ppid, processStartMs)).toBeNull();
+    });
+
+    it('accepts a breadcrumb whose mtime is at or after the given process start time', () => {
+      const ppid = 4243;
+      const breadcrumbDir = resolve(tmpDir, 'session-by-ppid');
+      mkdirSync(breadcrumbDir, { recursive: true });
+      const breadcrumbPath = resolve(breadcrumbDir, `${ppid}.txt`);
+      writeFileSync(breadcrumbPath, 'sess-fresh');
+
+      const processStartMs = Date.now() - 60_000; // this "process" started well before the write
+      expect(resolveFromBreadcrumb(tmpDir, ppid, processStartMs)).toBe('sess-fresh');
     });
   });
 

--- a/src/hooks/session-resolver.ts
+++ b/src/hooks/session-resolver.ts
@@ -6,8 +6,11 @@
  *      session UUID from the `linkScanPath` field's filename. Instant; used
  *      by background-job MCPs.
  *   2. PPID breadcrumb at `<storage>/session-by-ppid/<process.ppid>.txt` —
- *      written by the hook collector on every tool call. Precise: no
- *      cross-session collision risk when it resolves.
+ *      written by the hook collector on every tool call. Precise as long as
+ *      the OS hasn't recycled the PPID to an unrelated process since the
+ *      breadcrumb was written — resolveFromBreadcrumb() guards against that
+ *      by rejecting a breadcrumb older than the resolving process's own
+ *      start time (see its doc comment).
  *   3. cwd breadcrumb at `<storage>/session-by-cwd/<sanitized-cwd>.txt` —
  *      also written by the hook collector on every tool call, keyed by the
  *      project directory instead of a PID. Fallback for platforms where the
@@ -24,7 +27,7 @@
  * one up.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { resolve, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { createLogger } from '../shared/index.js';
@@ -105,14 +108,39 @@ export function resolveFromJobDir(claudeJobDir: string | null | undefined): stri
 /**
  * Try to resolve the session_id synchronously from the PPID breadcrumb file.
  * Returns the validated session_id or null.
+ *
+ * Rejects a breadcrumb whose mtime predates `processStartMs` (defaults to
+ * this process's own wall-clock start time). Without this, a breadcrumb keyed
+ * on a PID the OS has since recycled — the PPID this process shares with an
+ * unrelated PRIOR process — silently resolves to that prior process's
+ * session_id, weeks after it ended. gcStaleBreadcrumbs() can't catch this: it
+ * only checks whether the PID is alive, and a recycled PID always is.
  */
 export function resolveFromBreadcrumb(
   storagePath: string,
   ppid: number | undefined,
+  processStartMs: number = Date.now() - process.uptime() * 1000,
 ): string | null {
   if (typeof ppid !== 'number' || ppid <= 0) return null;
   const breadcrumbPath = resolve(storagePath, 'session-by-ppid', `${ppid}.txt`);
   if (!existsSync(breadcrumbPath)) return null;
+
+  let mtimeMs: number;
+  try {
+    mtimeMs = statSync(breadcrumbPath).mtimeMs;
+  } catch (err) {
+    logger.debug('Breadcrumb file unstatable', { error: String(err) });
+    return null;
+  }
+  if (mtimeMs < processStartMs) {
+    logger.debug('Rejecting stale ppid breadcrumb (predates process start)', {
+      ppid,
+      mtimeMs,
+      processStartMs,
+    });
+    return null;
+  }
+
   let raw: string;
   try {
     raw = readFileSync(breadcrumbPath, 'utf-8');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1109,6 +1109,10 @@ async function main(): Promise<void> {
         const persisted = sessionStore!.loadSession(sessionId);
         if (!persisted) return;
         costTracker.seedFromPersisted(buildCostTrackerSeed(persisted));
+        sessionTracker!.seedFromPersisted({
+          toolCallCount: persisted.toolCallCount,
+          bashCommandCount: persisted.bashCommandCount,
+        });
         budgetTracker.seedFiredThresholdsFromSessionTotal(
           costTracker.getMetrics().sessionTotalCostUsd ?? 0,
         );

--- a/src/metrics/session-tracker.test.ts
+++ b/src/metrics/session-tracker.test.ts
@@ -501,6 +501,37 @@ describe('SessionTracker', () => {
       expect(v.max).toBe(200);
     });
   });
+
+  describe('seedFromPersisted()', () => {
+    it('adds persisted toolCallCount and bashCommandCount to live counters', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.recordToolCall(makeRecord({ toolName: 'Read' }));
+      tracker.recordToolCall(makeRecord({ toolName: 'Bash' }));
+
+      tracker.seedFromPersisted({ toolCallCount: 6, bashCommandCount: 3 });
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.toolCallCount).toBe(8); // 2 live + 6 seeded
+      expect(metrics.bashCommandsRun).toBe(4); // 1 live + 3 seeded
+    });
+
+    it('is a no-op for an all-zero seed', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.recordToolCall(makeRecord({ toolName: 'Read' }));
+
+      tracker.seedFromPersisted({ toolCallCount: 0, bashCommandCount: 0 });
+
+      expect(tracker.getMetrics().toolCallCount).toBe(1);
+    });
+
+    it('seeds correctly even with no prior live activity', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.seedFromPersisted({ toolCallCount: 5, bashCommandCount: 2 });
+      const metrics = tracker.getMetrics();
+      expect(metrics.toolCallCount).toBe(5);
+      expect(metrics.bashCommandsRun).toBe(2);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/metrics/session-tracker.ts
+++ b/src/metrics/session-tracker.ts
@@ -104,6 +104,24 @@ export function computeDurationStats(durations: number[]): DurationStats {
   };
 }
 
+/**
+ * Pre-restart totals to fold into a freshly-started process's SessionTracker
+ * for a resumed session — mirrors CostTracker.seedFromPersisted()'s pattern
+ * (see that file's doc comment for why this exists: SessionStore.mergeSummaries()
+ * merges scalar counters via Math.max(), which under-reports when pre- and
+ * post-restart activity are disjoint rather than overlapping).
+ *
+ * Only toolCallCount and bashCommandCount are seeded here — SessionTracker's
+ * other counters that end up on FullSessionSummary (linesAdded, linesRemoved,
+ * testRunCount/testPassCount, buildRunCount/buildPassCount) are sourced from
+ * TaskDetector's seededAggregate instead (see buildSessionSummary() in
+ * session-store.ts) and are already seeded there.
+ */
+export interface SessionTrackerSeed {
+  readonly toolCallCount: number;
+  readonly bashCommandCount: number;
+}
+
 // ---------------------------------------------------------------------------
 // SessionTracker
 // ---------------------------------------------------------------------------
@@ -322,6 +340,17 @@ export class SessionTracker implements Resettable {
       throw new Error('SessionTracker.adoptSessionId() requires a non-empty sessionId');
     }
     this.sessionId = sessionId;
+  }
+
+  /**
+   * Fold a resumed session's pre-restart toolCallCount/bashCommandCount into
+   * this (freshly-started) process's live counters. See SessionTrackerSeed's
+   * doc comment for why this exists.
+   */
+  seedFromPersisted(seed: SessionTrackerSeed): void {
+    if (seed.toolCallCount === 0 && seed.bashCommandCount === 0) return;
+    this.toolCallCount += seed.toolCallCount;
+    this.bashCommandsRun += seed.bashCommandCount;
   }
 
   reset(sessionId: string): void {

--- a/src/platforms/platform-registry.test.ts
+++ b/src/platforms/platform-registry.test.ts
@@ -225,6 +225,25 @@ describe('PlatformRegistry', () => {
       expect(detected!.platformName).toBe('claude-code');
     });
 
+    it('prefers an explicit MCP_CLIENT match over an earlier-registered adapter matched by ambient signal', () => {
+      process.env.CLAUDE_CODE_VERSION = '1.2.3'; // ambient — ClaudeCodeAdapter registers first
+      process.env.MCP_CLIENT = 'copilot'; // explicit — CopilotAdapter registers later
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('copilot');
+    });
+
+    it('falls back to ambient-signal registration order when no explicit MCP_CLIENT/NEW_RELIC_AI_PLATFORM is set', () => {
+      process.env.CLAUDE_CODE_VERSION = '1.2.3';
+      const registry = createDefaultRegistry();
+
+      const detected = registry.detect();
+      expect(detected).not.toBeNull();
+      expect(detected!.platformName).toBe('claude-code');
+    });
+
     it('selects Copilot adapter when Copilot platform env is set', () => {
       process.env.NEW_RELIC_AI_PLATFORM = 'copilot';
       const registry = createDefaultRegistry();

--- a/src/platforms/platform-registry.ts
+++ b/src/platforms/platform-registry.ts
@@ -30,7 +30,29 @@ export class PlatformRegistry {
     logger.debug('Registered platform adapter', { platform: adapter.platformName });
   }
 
+  /**
+   * Explicit configuration (MCP_CLIENT / NEW_RELIC_AI_PLATFORM naming an
+   * adapter's own platformName) always wins over an ambient signal, even one
+   * matched by an earlier-registered adapter. Every adapter's isSupported()
+   * checks process.env.MCP_CLIENT === '<its own platformName>' (and usually
+   * NEW_RELIC_AI_PLATFORM too) alongside its ambient checks, with equal
+   * weight — so without this, an ambient signal inherited from a launching
+   * process (e.g. CLAUDE_CODE_VERSION) can outrank an explicit config for a
+   * different platform purely because that adapter registers first.
+   */
   detect(): PlatformAdapter | null {
+    const explicitPlatform = process.env.MCP_CLIENT ?? process.env.NEW_RELIC_AI_PLATFORM;
+    if (explicitPlatform) {
+      const explicitMatch = this.adapters.find((a) => a.platformName === explicitPlatform);
+      if (explicitMatch?.isSupported()) {
+        this.active = explicitMatch;
+        logger.info('Detected platform (explicit config)', {
+          platform: explicitMatch.platformName,
+        });
+        return explicitMatch;
+      }
+    }
+
     for (const adapter of this.adapters) {
       if (adapter.isSupported()) {
         this.active = adapter;


### PR DESCRIPTION
## Summary
- Fixes #464: seed SessionTracker's toolCallCount/bashCommandCount on resume
- Fixes #465: scope tokenDedup/subagentDedup rings per-session/per-agent instead of one shared global ring
- Fixes #466: reject PPID breadcrumbs older than the resolving process's own start time (and refresh the breadcrumb's mtime on content-unchanged writes, so an actively-hooked session never falsely goes stale after a restart)
- Fixes #467: explicit MCP_CLIENT/NEW_RELIC_AI_PLATFORM now wins over an ambient signal in platform detection

Bumps version to 1.16.2 with a matching CHANGELOG entry.

## Test plan
- [x] `npm run build && npm test && npm run lint` all pass in this repo
- [x] New unit tests added per fix (session-tracker, session-resolver, platform-registry, event-processor, collector-script)