### PR TITLE
Fix #462, #470, #473: Copilot SDK health signal, MCP PR tracking, retry false positives (v1.16.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.3] - 2026-08-21
+
+### Added
+
+- **A GitHub Copilot SDK usage-capture extension that was never installed at its documented path is now reported via the observability-health API** instead of failing silently to a log file no one normally checks. Mirrors the existing signal for the VS Code Copilot Chat integration's equivalent gap.
+
+### Fixed
+
+- **`nr_observe_get_git_efficiency`'s PR metrics no longer undercount pull requests created or edited through the GitHub MCP server's tools** (`create_pull_request`, `update_pull_request`) rather than the `gh` CLI. These tool calls were already captured by Preflight but were previously ignored by the PR metric entirely.
+- **`nr_observe_get_retry_alerts` no longer flags genuinely distinct, successful tool calls as thrashing when they share the same working directory, transcript, and permission mode.** Session-constant metadata fields were previously compared for similarity alongside the actual command content, pulling unrelated calls into a false-positive band just above the detection threshold.
+
 ## [1.16.2] - 2026-08-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.16.2",
+      "version": "1.16.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -318,6 +318,15 @@ export interface ObservabilityHealthSnapshot {
    * Optional/absent for non-Copilot deployments and older snapshot producers.
    */
   readonly copilotDebugLoggingDisabled?: boolean;
+  /**
+   * True when the active platform is the GitHub Copilot SDK/CLI runtime and
+   * its optional token-exact-cost extension isn't at its documented install
+   * path (~/.copilot/extensions/preflight/extension.mjs) — the extension was
+   * likely never copied. Doesn't catch every failure cause (see
+   * copilot-sdk-extension-health.ts's doc comment). Optional/absent for
+   * non-copilot-sdk deployments and older snapshot producers.
+   */
+  readonly copilotSdkExtensionMissing?: boolean;
 }
 
 export interface ApiHandlerDeps {

--- a/src/hooks/copilot-sdk-extension-health.test.ts
+++ b/src/hooks/copilot-sdk-extension-health.test.ts
@@ -1,0 +1,46 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  copilotSdkExtensionInstallPath,
+  isCopilotSdkExtensionMissing,
+} from './copilot-sdk-extension-health.js';
+
+jest.mock('node:fs', () => {
+  const real = jest.requireActual<typeof import('node:fs')>('node:fs');
+  return { ...real, existsSync: jest.fn() };
+});
+
+const mockExistsSync = existsSync as jest.Mock;
+
+afterEach(() => mockExistsSync.mockReset());
+
+describe('isCopilotSdkExtensionMissing()', () => {
+  it('is false for a non-copilot-sdk platform regardless of file presence', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(isCopilotSdkExtensionMissing('claude-code')).toBe(false);
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+
+  it('is true for copilot-sdk when the extension file is absent', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(isCopilotSdkExtensionMissing('copilot-sdk')).toBe(true);
+  });
+
+  it('is false for copilot-sdk when the extension file is present', () => {
+    mockExistsSync.mockReturnValue(true);
+    expect(isCopilotSdkExtensionMissing('copilot-sdk')).toBe(false);
+  });
+
+  it('checks the documented install path', () => {
+    mockExistsSync.mockReturnValue(true);
+    isCopilotSdkExtensionMissing('copilot-sdk');
+    expect(mockExistsSync).toHaveBeenCalledWith(copilotSdkExtensionInstallPath());
+  });
+});
+
+describe('copilotSdkExtensionInstallPath()', () => {
+  it('resolves to the documented .copilot/extensions/preflight/extension.mjs path', () => {
+    const path = copilotSdkExtensionInstallPath();
+    expect(path.endsWith(join('.copilot', 'extensions', 'preflight', 'extension.mjs'))).toBe(true);
+  });
+});

--- a/src/hooks/copilot-sdk-extension-health.ts
+++ b/src/hooks/copilot-sdk-extension-health.ts
@@ -1,0 +1,30 @@
+/**
+ * Health check for the bundled GitHub Copilot SDK usage-capture extension
+ * (`copilot-sdk-extension/extension.mjs`) — detects the one failure cause
+ * that's checkable from the MCP server process without a live-session
+ * signal: the extension was never copied to its documented install path (see
+ * `getHookInstallInstructions()` in `../platforms/copilot-sdk-adapter.js`).
+ * Deliberately does NOT catch the issue's other named causes (`--experimental`
+ * not set, a version-incompatible `joinSession()`, an unwritable storage
+ * dir) — none of those are filesystem-observable from this process. Same
+ * partial-coverage tradeoff already accepted by `CopilotUsageWatcher`'s
+ * `debugLoggingLikelyDisabled` (see that type's doc comment).
+ */
+
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export function copilotSdkExtensionInstallPath(): string {
+  return join(homedir(), '.copilot', 'extensions', 'preflight', 'extension.mjs');
+}
+
+/**
+ * True only when `platformName` is `'copilot-sdk'` and the extension isn't
+ * at its documented install path. Always false for every other platform —
+ * the extension is copilot-sdk-only, so its absence there is meaningless.
+ */
+export function isCopilotSdkExtensionMissing(platformName: string): boolean {
+  if (platformName !== 'copilot-sdk') return false;
+  return !existsSync(copilotSdkExtensionInstallPath());
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { LiveEventBus } from './dashboard/index.js';
 import type { ObservabilityHealthSnapshot } from './dashboard/routes/api-handler.js';
 import { SubagentTimelineStore } from './dashboard/subagent-timeline-store.js';
 import { WorkflowStore } from './dashboard/workflow-store.js';
+import { isCopilotSdkExtensionMissing } from './hooks/copilot-sdk-extension-health.js';
 import { CopilotUsageWatcher } from './hooks/copilot-usage-watcher.js';
 import { HookEventProcessor } from './hooks/index.js';
 import { ParentTranscriptWatcher } from './hooks/parent-transcript-watcher.js';
@@ -1476,6 +1477,13 @@ async function main(): Promise<void> {
         alertEvaluationInterval.unref?.();
       }
 
+      // Platform is env-derived and fixed for this process's lifetime —
+      // resolve it once here rather than inside observabilityHealth's
+      // getSnapshot() closure below, which fires on every dashboard poll
+      // (10-30s) and would otherwise re-run full platform detection (and
+      // its info-level log line) on every single request.
+      const activePlatformName = createDefaultRegistry().getActive().platformName;
+
       dashboardServer = new DashboardServer({
         port: config.dashboard.port,
         host: config.dashboard.host,
@@ -1596,6 +1604,7 @@ async function main(): Promise<void> {
                 watcherDisabledReason,
                 copilotDebugLoggingDisabled:
                   activeCopilotUsageWatcher?.getHealth().debugLoggingLikelyDisabled ?? false,
+                copilotSdkExtensionMissing: isCopilotSdkExtensionMissing(activePlatformName),
               };
             },
           },

--- a/src/metrics/git-efficiency-tracker.test.ts
+++ b/src/metrics/git-efficiency-tracker.test.ts
@@ -1273,6 +1273,29 @@ describe('GitEfficiencyTracker', () => {
       // commit the tracker ever saw.
       expect(metrics.prMetrics.avgTimeToCreateMs).toBe(7_500);
     });
+
+    it('counts a create_pull_request MCP tool call even with no command field', () => {
+      tracker.recordToolCall(makeRecord({ toolName: 'create_pull_request', command: undefined }));
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.prMetrics.created).toBe(1);
+    });
+
+    it('counts an update_pull_request MCP tool call as prsUpdated', () => {
+      tracker.recordToolCall(makeRecord({ toolName: 'update_pull_request', command: undefined }));
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.prMetrics.prsUpdated).toBe(1);
+    });
+
+    it('does not double-count a gh pr create Bash call as also being an MCP PR event', () => {
+      tracker.recordToolCall(
+        makeRecord({ toolName: 'Bash', command: 'gh pr create --title "Add feature"' }),
+      );
+
+      const metrics = tracker.getMetrics();
+      expect(metrics.prMetrics.created).toBe(1);
+    });
   });
 
   describe('hydration entry points', () => {

--- a/src/metrics/git-efficiency-tracker.ts
+++ b/src/metrics/git-efficiency-tracker.ts
@@ -82,6 +82,21 @@ const GH_COMMAND_RE = /\bgh\s+/;
 // Extract PR number from gh commands
 const GH_PR_NUMBER_RE = /\bgh\s+pr\s+\w+\s+(\d+)/;
 
+/**
+ * GitHub MCP server tool names confirmed via live-account NRQL evidence
+ * to reach Preflight as first-class AiToolCall events with these exact
+ * `tool` values,
+ * but never counted by the PR metric because recordToolCall() only inspects
+ * `record.command` — which MCP tool calls never carry. Deliberately limited
+ * to the two names the issue's own evidence covers; other GitHub-MCP PR
+ * tools (merge_pull_request, etc.) are unconfirmed and out of scope pending
+ * their own evidence.
+ */
+const MCP_PR_TOOL_ACTION: Record<string, PrEvent['action']> = {
+  create_pull_request: 'create',
+  update_pull_request: 'edit',
+};
+
 // hydrateGitLog()'s dedup window, used only against a hook-observed commit
 // event (one with no hash in its command text): `git log`'s %ct has 1-second
 // resolution and a hook-observed commit event's timestamp is recorded when
@@ -392,6 +407,16 @@ export class GitEfficiencyTracker {
     // Track build/test commands for "verify before push" metric
     if (record.isTestCommand || record.isBuildCommand) {
       this.lastBuildOrTestTimestamp = record.timestamp;
+    }
+
+    // MCP tool calls (e.g. the GitHub MCP server's create_pull_request /
+    // update_pull_request) carry no `command` field, so they'd otherwise be
+    // silently dropped by the guard below. See MCP_PR_TOOL_ACTION's doc
+    // comment. No confirmed PR-number field exists for these — prNumber is
+    // null, unlike the gh-CLI path below which extracts it from command text.
+    const mcpPrAction = MCP_PR_TOOL_ACTION[record.toolName];
+    if (mcpPrAction) {
+      this.prEvents.push({ timestamp: record.timestamp, action: mcpPrAction, prNumber: null });
     }
 
     const rawCommand = record.command as string | undefined;

--- a/src/metrics/retry-detector.test.ts
+++ b/src/metrics/retry-detector.test.ts
@@ -176,6 +176,94 @@ describe('RetryDetector', () => {
     expect(detector.getMetrics().totalAlertsEmitted).toBe(0);
   });
 
+  it('does not flag distinct PowerShell calls whose shared session metadata dominates the serialized envelope', () => {
+    // Reproduces a real false positive: every field below except
+    // command/bashLeading/commandDescription/inputHash is identical across
+    // all 4 calls, same as a real session's PowerShell calls sharing one
+    // cwd/transcriptPath/permissionMode and near-constant classifier fields
+    // from extractInputMeta().
+    const detector = new RetryDetector();
+    const constant = {
+      toolName: 'PowerShell',
+      success: true,
+      cwd: 'C:\\Users\\dev\\preflight_test',
+      transcriptPath:
+        'C:\\Users\\dev\\.claude\\projects\\C--Users-dev-preflight-test\\d5be26f9-abcd.jsonl',
+      permissionMode: 'auto',
+      isTestCommand: false,
+      isBuildCommand: false,
+      isLintCommand: false,
+      bashCategory: 'shell-other',
+      bashDestructive: false,
+      bashNetwork: false,
+      commandTimeout: 600000,
+    };
+    const calls = [
+      {
+        command: 'Get-Date -Format o',
+        bashLeading: 'Get-Date',
+        commandDescription: 'Get current date/time',
+        inputHash: 'a1b2c3d4e5f60718',
+      },
+      {
+        command: '$PSVersionTable.PSVersion.ToString()',
+        bashLeading: '$PSVersionTable.PSVersion.ToString',
+        commandDescription: 'Get PowerShell version',
+        inputHash: 'b2c3d4e5f6071829',
+      },
+      {
+        command: '(Get-ChildItem -Path $PWD -File | Measure-Object).Count',
+        bashLeading: 'Get-ChildItem',
+        commandDescription: 'Count files in cwd',
+        inputHash: 'c3d4e5f60718293a',
+      },
+      {
+        command: '[System.Environment]::OSVersion.VersionString',
+        bashLeading: '[System.Environment]::OSVersion.VersionString',
+        commandDescription: 'Get OS version',
+        inputHash: 'd4e5f60718293a4b',
+      },
+    ];
+
+    let result = null;
+    for (const call of calls) {
+      result = detector.recordToolCall(makeRecord({ ...constant, ...call }));
+    }
+
+    expect(result).toBeNull();
+    expect(detector.getMetrics().totalAlertsEmitted).toBe(0);
+  });
+
+  it('does not conflate two different sessions running the same command once cwd/transcriptPath are stripped', () => {
+    const detector = new RetryDetector();
+    const sessionA = {
+      sessionId: 'session-a',
+      cwd: '/Users/dev/repo-a',
+      transcriptPath: '/tmp/a.jsonl',
+    };
+    const sessionB = {
+      sessionId: 'session-b',
+      cwd: '/Users/dev/repo-b',
+      transcriptPath: '/tmp/b.jsonl',
+    };
+
+    detector.recordToolCall(
+      makeRecord({ ...sessionA, toolName: 'Bash', command: 'npm test', success: true }),
+    );
+    detector.recordToolCall(
+      makeRecord({ ...sessionB, toolName: 'Bash', command: 'npm test', success: true }),
+    );
+    const result = detector.recordToolCall(
+      makeRecord({ ...sessionA, toolName: 'Bash', command: 'npm test', success: true }),
+    );
+
+    // Only 2 of these 3 calls belong to session-a — below minOccurrences (3)
+    // once correctly scoped per session, even though all 3 share toolName
+    // and identical command text with cwd/transcriptPath now stripped.
+    expect(result).toBeNull();
+    expect(detector.getMetrics().totalAlertsEmitted).toBe(0);
+  });
+
   it('still detects genuine identical retries of a tool with no metadata extractor', () => {
     const detector = new RetryDetector();
 

--- a/src/metrics/retry-detector.ts
+++ b/src/metrics/retry-detector.ts
@@ -156,16 +156,24 @@ export class RetryDetector implements Resettable {
     const window = this.recentCalls.slice(-this.windowSize);
     if (window.length < this.minOccurrences) return null;
 
-    // Group calls by tool name within the window
-    const byTool = new Map<string, ToolCallRecord[]>();
+    // Group calls by tool name AND session — a shared RetryDetector instance
+    // in --local mode processes every concurrently-live session's calls
+    // (HookEventProcessor's drainAllSessions), so grouping by tool name
+    // alone let two different sessions running the same ordinary command
+    // (e.g. both running `npm test`) collapse into one group and risk a
+    // false thrashing alert now that serializeInput() no longer includes
+    // cwd/transcriptPath to distinguish them.
+    const byToolAndSession = new Map<string, ToolCallRecord[]>();
     for (const call of window) {
-      const arr = byTool.get(call.toolName) ?? [];
+      const key = `${call.toolName}|${call.sessionId ?? ''}`;
+      const arr = byToolAndSession.get(key) ?? [];
       arr.push(call);
-      byTool.set(call.toolName, arr);
+      byToolAndSession.set(key, arr);
     }
 
-    for (const [toolName, calls] of byTool) {
+    for (const calls of byToolAndSession.values()) {
       if (calls.length < this.minOccurrences) continue;
+      const toolName = calls[0]!.toolName;
 
       // Check: either all failed, or inputs are highly similar
       const allFailed = calls.every((c) => !c.success);
@@ -237,17 +245,28 @@ export class RetryDetector implements Resettable {
   // Excludes per-call metadata that varies even when the actual tool
   // input/arguments are identical (timestamps, ids, sizes, error details) —
   // without stripping these, every call would serialize as "different" and
-  // similarity would never detect a genuine repeated-input retry.
+  // similarity would never detect a genuine repeated-input retry. Also
+  // excludes fields that are constant or near-constant *within a session*
+  // regardless of how different two calls' real inputs are: cwd and
+  // transcriptPath never change within a session, permissionMode rarely
+  // does, and extractInputMeta()'s boolean/enum classifier fields
+  // (isTestCommand/isBuildCommand/isLintCommand/bashCategory/
+  // bashDestructive/bashNetwork) are identical for any two "ordinary" shell
+  // commands. Left in place, these dominate the serialized string and pull
+  // genuinely distinct calls' similarity up into a false-positive band just
+  // above the default 0.8 threshold.
   //
   // inputHash is kept, deliberately not stripped: it's a hash of the FULL raw
   // tool input, computed for every call regardless of tool name, unlike the
   // narrowed per-tool fields extractInputMeta()/parseToolSpecificFields() only
   // populate for a known subset of tools. Without it, a call to any tool
-  // outside that subset (PowerShell, WebFetch, a third-party MCP tool, ...)
-  // serializes to just `{toolName}` — identical for every call regardless of
-  // how different the real inputs were, so it always scored similarity 1.0.
-  // A genuine repeat still hashes identically, so real-retry detection is
-  // unaffected.
+  // outside that subset (WebFetch, a third-party MCP tool, ...) serializes to just
+  // `{toolName}` — identical for every call regardless of how different the
+  // real inputs were, so it always scored similarity 1.0. A genuine repeat
+  // still hashes identically, so real-retry detection is unaffected. Removing
+  // it would reopen the earlier no-metadata-extractor regression this project
+  // already fixed once; stripping the near-constant fields above is
+  // sufficient on its own without touching inputHash.
   private serializeInput(record: ToolCallRecord): string {
     const {
       id: _id,
@@ -260,6 +279,15 @@ export class RetryDetector implements Resettable {
       inputSizeBytes: _is,
       outputSizeBytes: _os,
       toolUseId: _tu,
+      cwd: _cwd,
+      transcriptPath: _tp,
+      permissionMode: _pm,
+      isTestCommand: _itc,
+      isBuildCommand: _ibc,
+      isLintCommand: _ilc,
+      bashCategory: _bc,
+      bashDestructive: _bdes,
+      bashNetwork: _bnet,
       ...rest
     } = record;
     try {


### PR DESCRIPTION
## Summary
- Adds a `copilotSdkExtensionMissing` observability-health signal for a GitHub Copilot SDK usage-capture extension that was never installed at its documented path — mirrors the existing signal for the VS Code Copilot Chat integration's equivalent gap.
- Counts pull requests created or edited through the GitHub MCP server's tools (`create_pull_request`, `update_pull_request`), not just the `gh` CLI, in `nr_observe_get_git_efficiency`'s PR metrics.
- Fixes `nr_observe_get_retry_alerts` flagging genuinely distinct, successful tool calls as thrashing by excluding near-constant session metadata (working directory, transcript path, permission mode, and classifier fields) from the similarity comparison, and scoping the detection window by session as well as tool name.

Fixes #462, fixes #470, fixes #473.

## Test plan
- [x] `npm run build && npm test && npm run lint` all pass
- [x] New unit tests added per fix