### PR TITLE
Fix #475: RetryDetector inputHash equality instead of Levenshtein

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.4] - 2026-08-24
+
+### Fixed
+
+- **`nr_observe_get_retry_alerts` no longer flags genuinely distinct, successful calls to a third-party MCP tool (or any tool with no built-in input parser) as thrashing.** The similarity check previously Levenshtein-compared each call's full input hash directly; two unrelated hashes still share enough characters by chance to land above the detection threshold once a handful of calls accumulate. The hash is now compared by exact-match equality instead, which still catches genuine identical-input retries without the false-positive floor.
+
 ## [1.16.3] - 2026-08-21
 
 ### Added

--- a/docs/COMMANDS_TABLE.md
+++ b/docs/COMMANDS_TABLE.md
@@ -1423,7 +1423,7 @@ Thrashing and retry detection alerts within a sliding window.
 
 **Data source:** `RetryDetector`
 
-**How it works:** Tracks repeated tool calls with identical or highly similar inputs (Levenshtein similarity ≥ 0.8) within a rolling window (default: 5 calls). Fires an alert when the same input appears 3+ times consecutively. `totalTokensWasted` estimates tokens consumed on redundant calls (`inputSize / 4`).
+**How it works:** Tracks repeated tool calls with identical or highly similar inputs (similarity ≥ 0.8, via Levenshtein distance or exact input-hash match) within a rolling window (default: 5 calls). Fires an alert when the same input appears 3+ times consecutively. `totalTokensWasted` estimates tokens consumed on redundant calls (`inputSize / 4`).
 
 **Requires:** `RetryDetector`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.16.3",
+      "version": "1.16.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/metrics/retry-detector.test.ts
+++ b/src/metrics/retry-detector.test.ts
@@ -234,6 +234,64 @@ describe('RetryDetector', () => {
     expect(detector.getMetrics().totalAlertsEmitted).toBe(0);
   });
 
+  it('does not flag genuinely different calls to a parser-less tool whose random hashes coincidentally overlap under Levenshtein comparison', () => {
+    // A tool outside extractInputMeta()'s switch (a third-party MCP tool
+    // here) serializes to just `{toolName, inputHash}`. With a realistic
+    // (long) tool name, unrelated 16-hex-char hashes still share enough
+    // characters by chance for Levenshtein similarity to land above the 0.8
+    // threshold if inputHash is Levenshtein-compared directly instead of by
+    // equality — verified at 0.8561 against that direct-comparison approach.
+    const detector = new RetryDetector();
+    const toolName = 'mcp__plugin_context7_context7__resolve-library-id';
+    const hashes = ['a1b2c3d4e5f60718', 'f00dfeed12345678', '13579bdf2468ace0', '0badc0de55aa11ff'];
+
+    let result = null;
+    for (const inputHash of hashes) {
+      result = detector.recordToolCall(makeRecord({ toolName, success: true, inputHash }));
+    }
+
+    expect(result).toBeNull();
+    expect(detector.getMetrics().totalAlertsEmitted).toBe(0);
+  });
+
+  it('still detects near-identical (not byte-identical) retries of a tool with real parser fields, even when every call has a distinct inputHash', () => {
+    // A parser-rich tool's genuine near-identical retries (varying only the
+    // test filter, e.g. re-running the same suite with different -t flags)
+    // must not be capped by inputHash — inputHash differs on every call
+    // here (it always does for non-identical real input), same as
+    // production traffic. Verified numerically: 0.9091 group similarity
+    // under the gated formula, comfortably above the 0.8 default threshold.
+    const detector = new RetryDetector();
+
+    detector.recordToolCall(
+      makeRecord({
+        toolName: 'Bash',
+        success: true,
+        command: 'npm test -- src/retry-detector.test.ts',
+        inputHash: 'bbbb2222cccc0001',
+      }),
+    );
+    detector.recordToolCall(
+      makeRecord({
+        toolName: 'Bash',
+        success: true,
+        command: 'npm test -- src/retry-detector.test.ts -t foo',
+        inputHash: 'bbbb2222cccc0002',
+      }),
+    );
+    const result = detector.recordToolCall(
+      makeRecord({
+        toolName: 'Bash',
+        success: true,
+        command: 'npm test -- src/retry-detector.test.ts -t bar',
+        inputHash: 'bbbb2222cccc0003',
+      }),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.similarity).toBeGreaterThanOrEqual(0.8);
+  });
+
   it('does not conflate two different sessions running the same command once cwd/transcriptPath are stripped', () => {
     const detector = new RetryDetector();
     const sessionA = {

--- a/src/metrics/retry-detector.ts
+++ b/src/metrics/retry-detector.ts
@@ -3,7 +3,9 @@
  * where the same tool is either failing repeatedly or being called with
  * near-identical input, both signs of retrying the same broken approach
  * instead of changing strategy. Similarity between calls is measured with
- * Levenshtein distance over each call's serialized (non-metadata) fields.
+ * Levenshtein distance over each call's serialized (non-metadata) fields,
+ * falling back to exact-match equality on a raw input hash only when those
+ * fields carry no signal of their own (see computeGroupSimilarity()).
  */
 
 import type { MetricAggregator } from '../shared/index.js';
@@ -232,10 +234,30 @@ export class RetryDetector implements Resettable {
     let totalSimilarity = 0;
     let comparisons = 0;
 
-    // Compare each pair against the first (reference) input
+    // Compare each pair against the first (reference) input. When the
+    // non-hash fields already carry a discriminating signal (Levenshtein
+    // similarity < 1 — real parser-populated content differs, e.g. Edit's
+    // command text or Bash's command string), trust that signal alone;
+    // inputHash contributes nothing here, so a tool with rich parser
+    // fields keeps its pre-existing near-identical (not just
+    // byte-identical) retry detection.
+    //
+    // Only when the non-hash fields carry NO signal at all (similarity
+    // exactly 1 — every remaining field is identical, which for a
+    // parser-less tool means the serialized string reduced to just
+    // `{toolName}`) does inputHash's binary equality take over: 1 when
+    // both calls' hashes match (a genuine retry), 0 when they don't.
+    // Levenshtein-comparing the hash itself creates a false-positive floor
+    // there, because unrelated random hex strings still share characters
+    // by chance. See serializeInput()'s doc comment.
     const reference = inputs[0];
+    const referenceHash = calls[0].inputHash;
     for (let i = 1; i < inputs.length; i++) {
-      totalSimilarity += normalizedLevenshteinSimilarity(reference, inputs[i]);
+      const levenshteinSimilarity = normalizedLevenshteinSimilarity(reference, inputs[i]);
+      const hashSimilarity = referenceHash === calls[i].inputHash ? 1 : 0;
+      const combinedSimilarity =
+        levenshteinSimilarity === 1 ? hashSimilarity : levenshteinSimilarity;
+      totalSimilarity += combinedSimilarity;
       comparisons++;
     }
 
@@ -256,17 +278,27 @@ export class RetryDetector implements Resettable {
   // genuinely distinct calls' similarity up into a false-positive band just
   // above the default 0.8 threshold.
   //
-  // inputHash is kept, deliberately not stripped: it's a hash of the FULL raw
-  // tool input, computed for every call regardless of tool name, unlike the
-  // narrowed per-tool fields extractInputMeta()/parseToolSpecificFields() only
-  // populate for a known subset of tools. Without it, a call to any tool
-  // outside that subset (WebFetch, a third-party MCP tool, ...) serializes to just
-  // `{toolName}` — identical for every call regardless of how different the
-  // real inputs were, so it always scored similarity 1.0. A genuine repeat
-  // still hashes identically, so real-retry detection is unaffected. Removing
-  // it would reopen the earlier no-metadata-extractor regression this project
-  // already fixed once; stripping the near-constant fields above is
-  // sufficient on its own without touching inputHash.
+  // inputHash is also excluded here, but NOT dropped from similarity scoring
+  // entirely — computeGroupSimilarity() falls back to comparing it by
+  // equality, but ONLY when the fields above give it nothing else to work
+  // with (see that method's comment for the exact condition). inputHash is
+  // a hash of the FULL raw tool input, computed for every call regardless
+  // of tool name, unlike the narrowed per-tool fields
+  // extractInputMeta()/parseToolSpecificFields() only populate for a known
+  // subset of tools; for a tool outside that subset (a third-party MCP
+  // tool, ...) the remaining serialized string is just `{toolName}` —
+  // identical for every call. Levenshtein-comparing inputHash directly used
+  // to compensate for that, but two *unrelated* 16-hex-char hashes still
+  // share enough characters by chance for Levenshtein similarity to land
+  // above the 0.8 threshold once the boilerplate JSON/toolName padding
+  // dilutes the comparison. Equality doesn't have that floor: two unrelated
+  // hashes essentially never match (contributes 0), while a genuine repeat
+  // still hashes identically (contributes 1) — real-retry detection for
+  // parser-less tools is unaffected. Gating this on the fields above having
+  // no signal of their own also means a tool WITH rich parser fields (Edit,
+  // Bash, ...) never has its near-identical-but-not-byte-identical retry
+  // detection capped by an unrelated hash comparison — only a parser-less
+  // tool's calls ever reach the gate condition in practice.
   private serializeInput(record: ToolCallRecord): string {
     const {
       id: _id,
@@ -288,6 +320,7 @@ export class RetryDetector implements Resettable {
       bashCategory: _bc,
       bashDestructive: _bdes,
       bashNetwork: _bnet,
+      inputHash: _ih,
       ...rest
     } = record;
     try {


### PR DESCRIPTION
Fixes #475

## Summary
- `RetryDetector`'s similarity check previously Levenshtein-compared each call's full input hash directly. Two unrelated hashes still share enough characters by chance to land above the detection threshold once a handful of calls accumulate, flagging genuinely distinct calls to a third-party MCP tool (or any tool with no built-in input parser) as thrashing.
- The hash is now compared by exact-match equality, falling back to it only when a call's other fields carry no distinguishing signal of their own — tools with real parser fields (Edit, Bash, ...) keep their existing near-identical retry detection unaffected.
- Includes the v1.16.4 version bump and CHANGELOG entry.

## Test plan
- [x] `npm run build && npm test && npm run lint` all pass
- [x] New regression tests cover the false-positive fix and confirm near-identical (non-identical) retry detection is preserved for tools with real parser fields