### PR TITLE
v1.18.0: per-session naming from Claude Code job/transcript titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.0] - 2026-08-28
+
+### Added
+
+- **Sessions are now named from Claude Code's own per-session titles** — a human-given name or Claude's auto-generated title — instead of just the project directory, so sessions in the same repo no longer all show up under one identical, uninformative name. Falls back to the directory name when no title is available yet, and a name only ever gets replaced by an equally or more trustworthy one.
+- **When content recording is enabled, each session's originating prompt is now available** as `session_intent` through the MCP tools, redacted the same way as all other captured content. Off by default, and never exposed on the local dashboard.
+
 ## [1.17.1] - 2026-08-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.17.1",
+      "version": "1.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/scripts/backfill-sessions.ts
+++ b/scripts/backfill-sessions.ts
@@ -334,6 +334,8 @@ async function main(): Promise<void> {
     const summary: FullSessionSummary = {
       sessionId,
       sessionName: null, // not recoverable from NR event data
+      sessionNameSource: null, // not recoverable from NR event data
+      sessionIntent: null, // not recoverable from NR event data
       repoName: null, // not recoverable from NR event data
       startTime: base.startTime,
       endTime: base.endTime,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -6762,3 +6762,90 @@ describe('computeCrossProcessLiveSessionIds', () => {
     expect(ids).toEqual([]);
   });
 });
+
+describe('api-handler — session_intent is never exposed on the HTTP surface', () => {
+  // session_intent (the first user prompt) is SENSITIVE content: captured only
+  // under recordContent, redacted, and persisted for the MCP tools + 0o600 disk
+  // summary — but the dashboard HTTP surface is broader, so every route that
+  // returns a session must drop it. These guard against a regression that would
+  // silently leak intent while every other assertion stays green.
+  const INTENT = 'redacted first prompt text';
+
+  const summaryWithIntent = {
+    sessionId: 'sess-intent-1',
+    startTime: Date.now() - 5000,
+    toolCallCount: 10,
+    developer: 'alice',
+    sessionName: 'my session',
+    sessionNameSource: 'ai-title',
+    sessionIntent: INTENT,
+  };
+
+  it('GET /api/session/current strips sessionIntent from live metrics', async () => {
+    const handler = createApiHandler({
+      sessionTracker: {
+        getMetrics: () => ({ sessionId: 'sess-intent-1', toolCallCount: 3, sessionIntent: INTENT }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionTracker'],
+    });
+    const req = { method: 'GET', url: '/api/session/current' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body());
+    expect('sessionIntent' in parsed).toBe(false);
+  });
+
+  it('GET /api/session/today strips sessionIntent from each summary', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [summaryWithIntent],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/session/today' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as Array<Record<string, unknown>>;
+    expect(parsed.length).toBe(1);
+    expect('sessionIntent' in parsed[0]!).toBe(false);
+    // the non-sensitive fields still come through
+    expect(parsed[0]!.sessionName).toBe('my session');
+  });
+
+  it('GET /api/sessions strips sessionIntent from the slimmed list', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadAllSessions: () => [summaryWithIntent],
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as Array<Record<string, unknown>>;
+    expect(parsed.length).toBe(1);
+    expect('sessionIntent' in parsed[0]!).toBe(false);
+  });
+
+  it('GET /api/sessions/:id strips sessionIntent from the detail response', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: (id: string) => (id === 'sess-intent-1' ? summaryWithIntent : null),
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-intent-1' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as Record<string, unknown>;
+    expect('sessionIntent' in parsed).toBe(false);
+    expect(parsed.sessionName).toBe('my session');
+  });
+});

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -5,6 +5,7 @@ import { normalizeDeveloperName, redactSensitive } from '../../config.js';
 import {
   isSyntheticSessionId,
   isUnscopedAggregatorSessionId,
+  type SessionNameSource,
 } from '../../hooks/session-resolver.js';
 import {
   localDateKey,
@@ -275,9 +276,34 @@ function toLiveWorkflowDetail(live: LiveWorkflowRunDetail): {
   return { run, agents, topology: live.topology ?? null };
 }
 
+/**
+ * Persisted-summary fields that must never reach the dashboard HTTP surface.
+ * `sessionIntent` (the first user prompt) is SENSITIVE content — it is captured
+ * only under recordContent, redacted, and persisted for the MCP tools + the
+ * 0o600 on-disk summary, but the HTTP surface is strictly broader than that
+ * file, so every route that returns a persisted summary must drop it. Keep this
+ * the single place the exclusion is declared.
+ */
+const DASHBOARD_OMITTED_SUMMARY_FIELDS: ReadonlySet<string> = new Set(['sessionIntent']);
+
+/**
+ * Shallow-copy a persisted session summary for an HTTP response, dropping every
+ * field in `DASHBOARD_OMITTED_SUMMARY_FIELDS`. Route all summary-returning
+ * dashboard endpoints through this so a content field can never leak by being
+ * spread verbatim.
+ */
+function toDashboardSummary(summary: FullSessionSummary): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(summary)) {
+    if (!DASHBOARD_OMITTED_SUMMARY_FIELDS.has(k)) out[k] = v;
+  }
+  return out;
+}
+
 interface LiveSessionMetrics {
   readonly sessionId: string;
   readonly sessionName: string | null;
+  readonly sessionNameSource: SessionNameSource | null;
   readonly sessionStartTime: number;
   readonly sessionDurationMs: number;
   readonly toolCallCount: number;
@@ -523,6 +549,10 @@ export interface ApiHandlerDeps {
     // default to the most-recently-active session. Older fakes / mocks that
     // don't implement it still work — `?.` falls back to undefined.
     getLastActivity?: (sessionId: string) => number | null;
+    // Optional for the same reason: lets the session-list/detail surfaces
+    // report which source produced the name (see SessionNameSource). Callers
+    // use `getSessionNameSource?.(id) ?? null` so partial mocks fall back safely.
+    getSessionNameSource?: (sessionId: string) => SessionNameSource | null;
   };
   readonly concurrencyTracker?: {
     getConcurrentCount: () => number;
@@ -1058,12 +1088,21 @@ export function createApiHandler(
     // no tasks have been scored yet (or when the scorer wasn't wired in).
     const efficiencyScore = deps.efficiencyScorer?.getSessionAverage()?.score ?? null;
     const liveSessions = computeCrossProcessLiveSessionIds(deps);
-    jsonOk(res, { ...deps.sessionTracker.getMetrics(), efficiencyScore, liveSessions });
+    // getMetrics() returns the full SessionMetrics at runtime (LiveSessionMetrics
+    // is a curated subset type). session_intent (the first prompt) is SENSITIVE
+    // content and is deliberately NOT exposed on the dashboard HTTP surface — it
+    // lives only on the MCP tool responses and persisted summaries (both
+    // redacted). Strip it from the shallow copy before spreading it into the
+    // response rather than emitting the whole metrics object verbatim.
+    const { sessionIntent, ...metricsForResponse } =
+      deps.sessionTracker.getMetrics() as LiveSessionMetrics & { sessionIntent?: unknown };
+    void sessionIntent;
+    jsonOk(res, { ...metricsForResponse, efficiencyScore, liveSessions });
   });
 
   routes.set('GET /api/session/today', (_req, res) => {
     if (!deps.sessionStore) return unavailable(res, 'sessionStore');
-    jsonOk(res, deps.sessionStore.loadTodaySessions());
+    jsonOk(res, deps.sessionStore.loadTodaySessions().map(toDashboardSummary));
   });
 
   routes.set('GET /api/sessions', (req, res) => {
@@ -1107,6 +1146,7 @@ export function createApiHandler(
         sliced.push({
           sessionId: live.sessionId,
           sessionName: live.sessionName ?? null,
+          sessionNameSource: live.sessionNameSource ?? null,
           startTime: live.sessionStartTime,
           durationMs: live.sessionDurationMs,
           toolCallCount: live.toolCallCount,
@@ -1153,6 +1193,7 @@ export function createApiHandler(
           sliced.push({
             sessionId: id,
             sessionName: deps.liveSessionRegistry.getSessionName(id),
+            sessionNameSource: deps.liveSessionRegistry.getSessionNameSource?.(id) ?? null,
             startTime: sessionStart,
             durationMs: lastActivityTs != null ? Math.max(0, lastActivityTs - sessionStart) : 0,
             toolCallCount: stats?.count ?? 0,
@@ -1171,7 +1212,9 @@ export function createApiHandler(
       const o = s as Record<string, unknown>;
       const out: Record<string, unknown> = {};
       for (const k of Object.keys(o)) {
-        if (!HEAVY_FIELDS.has(k)) out[k] = o[k];
+        // Drop heavy fields the list view never renders AND sensitive content
+        // fields (session_intent) that must not reach the HTTP surface.
+        if (!HEAVY_FIELDS.has(k) && !DASHBOARD_OMITTED_SUMMARY_FIELDS.has(k)) out[k] = o[k];
       }
       return out;
     });
@@ -1219,6 +1262,7 @@ export function createApiHandler(
       return {
         sessionId: id,
         sessionName: deps.liveSessionRegistry?.getSessionName(id) ?? null,
+        sessionNameSource: deps.liveSessionRegistry?.getSessionNameSource?.(id) ?? null,
         startTime: stats?.firstTs ?? lastActivity,
         lastActivity,
       };
@@ -2871,7 +2915,10 @@ export function createApiHandler(
           const quality = combineQualityProxyRawCounts([
             session.qualityProxy ?? ZERO_QUALITY_PROXY_COUNTS,
           ]);
-          const responseBody: Record<string, unknown> = { ...session };
+          // toDashboardSummary drops sensitive content fields (session_intent)
+          // that must not reach the HTTP surface; the detail view augments the
+          // remaining fields below.
+          const responseBody: Record<string, unknown> = toDashboardSummary(session);
           if (quality.totalSignals > 0) responseBody.qualityProxy = quality;
           // The persisted shape's key is `toolSelectionMetrics`, but
           // Sessions.tsx's SessionTimeline reads `toolSelectionScore` —
@@ -2907,6 +2954,7 @@ export function createApiHandler(
             jsonOk(res, {
               sessionId: live.sessionId,
               sessionName: live.sessionName ?? null,
+              sessionNameSource: live.sessionNameSource ?? null,
               startTime: live.sessionStartTime,
               durationMs: live.sessionDurationMs,
               toolCallCount: live.toolCallCount,
@@ -2984,6 +3032,7 @@ export function createApiHandler(
           jsonOk(res, {
             sessionId,
             sessionName: deps.liveSessionRegistry?.getSessionName(sessionId) ?? null,
+            sessionNameSource: deps.liveSessionRegistry?.getSessionNameSource?.(sessionId) ?? null,
             startTime,
             durationMs: lastTs - startTime,
             toolCallCount: records.length,

--- a/src/hooks/session-resolver.test.ts
+++ b/src/hooks/session-resolver.test.ts
@@ -11,7 +11,15 @@ import {
   isSyntheticSessionId,
   isUnscopedAggregatorSessionId,
   watchPpidBreadcrumb,
+  readJobState,
+  readTranscriptTitle,
+  findLastAiTitleInText,
+  resolveSessionName,
+  sessionNameSourceRank,
+  shouldReplaceSessionName,
+  sanitizeCwdForFilename,
 } from './session-resolver.js';
+import { redactSensitive } from '../config.js';
 
 let stderrSpy: ReturnType<typeof jest.spyOn>;
 let tmpDir: string;
@@ -497,5 +505,334 @@ describe('isUnscopedAggregatorSessionId', () => {
 
   it('returns false for undefined', () => {
     expect(isUnscopedAggregatorSessionId(undefined)).toBe(false);
+  });
+});
+
+describe('sanitizeCwdForFilename', () => {
+  it('replaces backslash, forward slash, and colon with "-"', () => {
+    expect(sanitizeCwdForFilename('/Users/dev/projects/app')).toBe('-Users-dev-projects-app');
+    expect(sanitizeCwdForFilename('C:\\Users\\dev\\app')).toBe('C--Users-dev-app');
+  });
+});
+
+describe('readJobState', () => {
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let jobDir: string;
+
+  beforeEach(() => {
+    stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    jobDir = resolve(tmpdir(), `nr-jobstate-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(jobDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    if (existsSync(jobDir)) rmSync(jobDir, { recursive: true, force: true });
+  });
+
+  it('returns null when the dir is null/undefined/empty or state.json is missing', () => {
+    expect(readJobState(null)).toBeNull();
+    expect(readJobState(undefined)).toBeNull();
+    expect(readJobState('')).toBeNull();
+    expect(readJobState(jobDir)).toBeNull();
+  });
+
+  it('returns null when state.json is invalid JSON', () => {
+    writeFileSync(resolve(jobDir, 'state.json'), 'not json');
+    expect(readJobState(jobDir)).toBeNull();
+  });
+
+  it('reads name, nameSource, and an explicit sessionId, gating intent behind recordContent', () => {
+    writeFileSync(
+      resolve(jobDir, 'state.json'),
+      JSON.stringify({
+        sessionId: 'abc-123-def',
+        name: 'refactor auth flow',
+        nameSource: 'user',
+        intent: 'please refactor the auth flow',
+        linkScanPath: '/somewhere/other-uuid.jsonl',
+      }),
+    );
+    // Default (no recordContent) and recordContent:false both keep the
+    // sensitive intent null; only recordContent:true surfaces it.
+    expect(readJobState(jobDir)).toEqual({
+      sessionId: 'abc-123-def',
+      name: 'refactor auth flow',
+      nameSource: 'user',
+      intent: null,
+    });
+    expect(readJobState(jobDir, { recordContent: false })).toEqual({
+      sessionId: 'abc-123-def',
+      name: 'refactor auth flow',
+      nameSource: 'user',
+      intent: null,
+    });
+    expect(readJobState(jobDir, { recordContent: true })).toEqual({
+      sessionId: 'abc-123-def',
+      name: 'refactor auth flow',
+      nameSource: 'user',
+      intent: 'please refactor the auth flow',
+    });
+  });
+
+  it('falls back to the linkScanPath UUID when no explicit sessionId field', () => {
+    writeFileSync(
+      resolve(jobDir, 'state.json'),
+      JSON.stringify({ name: 'x', nameSource: 'auto', linkScanPath: '/dir/link-uuid.jsonl' }),
+    );
+    expect(readJobState(jobDir)?.sessionId).toBe('link-uuid');
+  });
+
+  it('normalizes an invalid nameSource, empty name, and empty intent to null', () => {
+    writeFileSync(
+      resolve(jobDir, 'state.json'),
+      JSON.stringify({ sessionId: 'sess-1', name: '', nameSource: 'bogus', intent: '' }),
+    );
+    // recordContent:true so the empty-string intent is normalized to null by
+    // the length check, not merely suppressed by the recordContent gate.
+    expect(readJobState(jobDir, { recordContent: true })).toEqual({
+      sessionId: 'sess-1',
+      name: null,
+      nameSource: null,
+      intent: null,
+    });
+  });
+});
+
+describe('findLastAiTitleInText', () => {
+  it('returns the LAST ai-title when several are present', () => {
+    const text = [
+      '{"type":"user","text":"hi"}',
+      '{"type":"ai-title","aiTitle":"first guess"}',
+      '{"type":"assistant","text":"work"}',
+      '{"type":"ai-title","aiTitle":"refined title"}',
+      '',
+    ].join('\n');
+    expect(findLastAiTitleInText(text, true)).toBe('refined title');
+  });
+
+  it('ignores non-ai-title records (e.g. agent-name)', () => {
+    const text = [
+      '{"type":"ai-title","aiTitle":"the title"}',
+      '{"type":"agent-name","agentName":"explorer"}',
+      '',
+    ].join('\n');
+    expect(findLastAiTitleInText(text, true)).toBe('the title');
+  });
+
+  it('skips malformed JSON lines', () => {
+    const text = ['{"type":"ai-title","aiTitle":"good"}', 'this is not json', ''].join('\n');
+    expect(findLastAiTitleInText(text, true)).toBe('good');
+  });
+
+  it('skips the partial leading fragment when firstFragmentComplete is false', () => {
+    // The leading fragment is a truncated ai-title whose start is unread; it
+    // must be ignored, yielding null (no complete ai-title follows it).
+    const text = 'e":"ai-title","aiTitle":"truncated"}\n{"type":"user","text":"hi"}\n';
+    expect(findLastAiTitleInText(text, false)).toBeNull();
+  });
+
+  it('returns null when no ai-title is present', () => {
+    expect(findLastAiTitleInText('{"type":"user","text":"hi"}\n', true)).toBeNull();
+  });
+});
+
+describe('readTranscriptTitle', () => {
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let projectsDir: string;
+  // Deliberately contains a dot (a worktree/hidden dir) so the slug below
+  // exercises the dot-replacement that the OLD cwd-derived path missed.
+  const cwd = '/Users/dev/projects/.worktrees/preflight';
+  const sessionId = 'sess-transcript-1';
+
+  // Build the fixture under a Claude-Code-style slug that REPLACES dots (which
+  // our breadcrumb sanitizer does not) — the transcript is located by matching
+  // <sessionId>.jsonl across slugs, so the exact slug must not matter.
+  const slug = cwd.replace(/[\\/:.]/g, '-');
+  const writeTranscript = (content: string): void => {
+    const dir = resolve(projectsDir, slug);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, `${sessionId}.jsonl`), content);
+  };
+
+  beforeEach(() => {
+    stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    projectsDir = resolve(
+      tmpdir(),
+      `nr-transcript-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(projectsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    if (existsSync(projectsDir)) rmSync(projectsDir, { recursive: true, force: true });
+  });
+
+  it('returns null when the transcript file is missing', () => {
+    expect(readTranscriptTitle({ projectsDir, sessionId })).toBeNull();
+  });
+
+  it('returns null for an invalid sessionId (never builds a path)', () => {
+    expect(readTranscriptTitle({ projectsDir, sessionId: 'has spaces' })).toBeNull();
+  });
+
+  it('returns the last ai-title, locating the transcript by sessionId under a dot-replacing slug', () => {
+    writeTranscript(
+      [
+        '{"type":"ai-title","aiTitle":"first title","sessionId":"sess-transcript-1"}',
+        '{"type":"assistant","message":{"content":[]}}',
+        '{"type":"ai-title","aiTitle":"session naming logic","sessionId":"sess-transcript-1"}',
+        '{"type":"agent-name","agentName":"explorer","sessionId":"sess-transcript-1"}',
+        '',
+      ].join('\n'),
+    );
+    expect(readTranscriptTitle({ projectsDir, sessionId })).toBe('session naming logic');
+  });
+
+  it('finds the last ai-title even when it sits many chunks back from EOF', () => {
+    // Put the ai-title near the top, then >200KB of filler after it so the
+    // reverse chunk scan (64KB chunks) must cross several boundaries to reach
+    // it — exercises the partial-line carry between chunks.
+    const filler = `${'{"type":"assistant","message":{"content":[]}}'}\n`.repeat(5000);
+    writeTranscript(`{"type":"ai-title","aiTitle":"deep title"}\n${filler}`);
+    expect(readTranscriptTitle({ projectsDir, sessionId })).toBe('deep title');
+  });
+
+  it('returns null when the only ai-title is beyond the bounded scan window', () => {
+    // ai-title at the very start, followed by >1MB of filler (past
+    // TRANSCRIPT_TITLE_MAX_SCAN_BYTES) — the bounded scan stops before reaching it.
+    const filler = `${'{"type":"assistant","message":{"content":[]}}'}\n`.repeat(30_000);
+    writeTranscript(`{"type":"ai-title","aiTitle":"too far back"}\n${filler}`);
+    expect(readTranscriptTitle({ projectsDir, sessionId })).toBeNull();
+  });
+
+  it('redacts the returned title', () => {
+    const raw = 'debugging AKIAIOSFODNN7EXAMPLE key';
+    writeTranscript(`{"type":"ai-title","aiTitle":${JSON.stringify(raw)}}\n`);
+    // The reader must apply redactSensitive on the way out — assert against it
+    // directly so the test tracks whatever DEFAULT_REDACTION_PATTERNS match.
+    expect(readTranscriptTitle({ projectsDir, sessionId })).toBe(redactSensitive(raw));
+  });
+});
+
+describe('resolveSessionName', () => {
+  it('returns null when nothing is usable', () => {
+    expect(resolveSessionName({})).toBeNull();
+    expect(resolveSessionName({ jobState: null, transcriptTitle: null, cwd: null })).toBeNull();
+  });
+
+  it('1: a user-authored job-state name wins over everything', () => {
+    expect(
+      resolveSessionName({
+        jobState: { sessionId: 's', name: 'human name', nameSource: 'user', intent: null },
+        transcriptTitle: 'ai title',
+        cwd: '/Users/dev/projects/app',
+      }),
+    ).toEqual({ name: 'human name', source: 'user' });
+  });
+
+  it('2: the transcript ai-title wins over an auto job-state name and cwd', () => {
+    expect(
+      resolveSessionName({
+        jobState: { sessionId: 's', name: 'auto name', nameSource: 'auto', intent: null },
+        transcriptTitle: 'ai title',
+        cwd: '/Users/dev/projects/app',
+      }),
+    ).toEqual({ name: 'ai title', source: 'ai-title' });
+  });
+
+  it('3: an auto job-state name wins over cwd when there is no user name or ai-title', () => {
+    expect(
+      resolveSessionName({
+        jobState: { sessionId: 's', name: 'auto name', nameSource: 'auto', intent: null },
+        transcriptTitle: null,
+        cwd: '/Users/dev/projects/app',
+      }),
+    ).toEqual({ name: 'auto name', source: 'auto' });
+  });
+
+  it('4: falls back to the cwd basename', () => {
+    expect(resolveSessionName({ cwd: '/Users/dev/projects/my-app' })).toEqual({
+      name: 'my-app',
+      source: 'cwd',
+    });
+  });
+
+  it('4: a degenerate cwd basename falls through to null (streaming fallback can do better)', () => {
+    expect(resolveSessionName({ cwd: '/tmp' })).toBeNull();
+    expect(resolveSessionName({ cwd: '/var' })).toBeNull();
+  });
+
+  it('4: the degenerate-cwd guard is case-insensitive', () => {
+    // Exercises the DEGENERATE_NAMES.has(base.toLowerCase()) lowering branch.
+    expect(resolveSessionName({ cwd: '/TMP' })).toBeNull();
+    expect(resolveSessionName({ cwd: '/Users/dev/VAR' })).toBeNull();
+  });
+
+  it('1: a user nameSource with an empty name falls through to the next tier', () => {
+    // nameSource is 'user' but name is empty → tier 1 must not fire; the
+    // transcript ai-title should win instead.
+    expect(
+      resolveSessionName({
+        jobState: { sessionId: 's', name: '', nameSource: 'user', intent: null },
+        transcriptTitle: 'ai title',
+        cwd: '/Users/dev/projects/app',
+      }),
+    ).toEqual({ name: 'ai title', source: 'ai-title' });
+  });
+
+  it('does not use a job-state name whose nameSource is null', () => {
+    // name present but nameSource unknown/null → skip to next tier (cwd here).
+    expect(
+      resolveSessionName({
+        jobState: { sessionId: 's', name: 'unlabeled', nameSource: null, intent: null },
+        cwd: '/Users/dev/projects/app',
+      }),
+    ).toEqual({ name: 'app', source: 'cwd' });
+  });
+});
+
+describe('sessionNameSourceRank', () => {
+  it('ranks sources most-trusted-first, mirroring resolveSessionName precedence', () => {
+    expect(sessionNameSourceRank('user')).toBe(0);
+    expect(sessionNameSourceRank('ai-title')).toBe(1);
+    expect(sessionNameSourceRank('auto')).toBe(2);
+    expect(sessionNameSourceRank('cwd')).toBe(3);
+    // Strictly ordered: user < ai-title < auto < cwd.
+    expect(sessionNameSourceRank('user')).toBeLessThan(sessionNameSourceRank('ai-title'));
+    expect(sessionNameSourceRank('ai-title')).toBeLessThan(sessionNameSourceRank('auto'));
+    expect(sessionNameSourceRank('auto')).toBeLessThan(sessionNameSourceRank('cwd'));
+  });
+});
+
+describe('shouldReplaceSessionName', () => {
+  it('always accepts when the session is not yet named (current === null)', () => {
+    expect(shouldReplaceSessionName(null, 'cwd')).toBe(true);
+    expect(shouldReplaceSessionName(null, 'user')).toBe(true);
+  });
+
+  it('accepts an upgrade to a more-trusted source', () => {
+    expect(shouldReplaceSessionName('cwd', 'auto')).toBe(true);
+    expect(shouldReplaceSessionName('auto', 'ai-title')).toBe(true);
+    expect(shouldReplaceSessionName('ai-title', 'user')).toBe(true);
+    // And the full jump end-to-end.
+    expect(shouldReplaceSessionName('cwd', 'user')).toBe(true);
+  });
+
+  it('accepts a refresh at the same source (equal rank)', () => {
+    expect(shouldReplaceSessionName('ai-title', 'ai-title')).toBe(true);
+    expect(shouldReplaceSessionName('user', 'user')).toBe(true);
+    expect(shouldReplaceSessionName('cwd', 'cwd')).toBe(true);
+  });
+
+  it('refuses a downgrade to a less-trusted source', () => {
+    // The load-bearing invariant: a user name is never demoted.
+    expect(shouldReplaceSessionName('user', 'ai-title')).toBe(false);
+    expect(shouldReplaceSessionName('user', 'auto')).toBe(false);
+    expect(shouldReplaceSessionName('user', 'cwd')).toBe(false);
+    expect(shouldReplaceSessionName('ai-title', 'auto')).toBe(false);
+    expect(shouldReplaceSessionName('ai-title', 'cwd')).toBe(false);
+    expect(shouldReplaceSessionName('auto', 'cwd')).toBe(false);
   });
 });

--- a/src/hooks/session-resolver.ts
+++ b/src/hooks/session-resolver.ts
@@ -27,10 +27,21 @@
  * one up.
  */
 
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  openSync,
+  readSync,
+  closeSync,
+  constants as fsConstants,
+} from 'node:fs';
 import { resolve, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { createLogger } from '../shared/index.js';
+
+import { redactSensitive } from '../config.js';
 
 const logger = createLogger('session-resolver');
 
@@ -64,16 +75,28 @@ export interface SessionResolverOptions {
   readonly onResolutionSource?: (info: { source: SessionIdSource; sessionId: string }) => void;
 }
 
-/** The one field `resolveFromJobDir` reads out of `CLAUDE_JOB_DIR/state.json`. */
+/**
+ * The fields Preflight reads out of `CLAUDE_JOB_DIR/state.json` (Claude Code
+ * writes this for background jobs). Every field is optional and `unknown` — a
+ * given build of Claude Code may omit any of them, and the readers below
+ * validate each before use. `name`/`nameSource`/`intent` are consumed by
+ * `readJobState`; `resolveFromJobDir` reads only `linkScanPath`.
+ */
 interface ClaudeJobDirState {
   readonly linkScanPath?: unknown;
+  readonly sessionId?: unknown;
+  readonly name?: unknown;
+  readonly nameSource?: unknown;
+  readonly intent?: unknown;
 }
 
 /**
- * Try to resolve the session_id synchronously from `CLAUDE_JOB_DIR/state.json`.
- * Returns the validated session_id or null.
+ * Read and JSON-parse `<claudeJobDir>/state.json`, returning the parsed object
+ * or null on any failure (missing dir, unreadable, invalid JSON, non-object).
+ * Shared by `resolveFromJobDir` and `readJobState` so both derive from one
+ * read; neither's public contract changes.
  */
-export function resolveFromJobDir(claudeJobDir: string | null | undefined): string | null {
+function readAndParseJobState(claudeJobDir: string | null | undefined): ClaudeJobDirState | null {
   if (!claudeJobDir || typeof claudeJobDir !== 'string') return null;
   const statePath = resolve(claudeJobDir, 'state.json');
   if (!existsSync(statePath)) return null;
@@ -92,17 +115,30 @@ export function resolveFromJobDir(claudeJobDir: string | null | undefined): stri
     return null;
   }
   if (parsed === null || typeof parsed !== 'object') return null;
-  const linkScanPath = (parsed as ClaudeJobDirState).linkScanPath;
-  if (typeof linkScanPath !== 'string' || linkScanPath.length === 0) return null;
+  return parsed as ClaudeJobDirState;
+}
 
-  // The session UUID is the basename minus its extension. Validate against
-  // the same character class used everywhere else so we never accept a
-  // path-traversing value.
+/**
+ * Extract the session UUID from a `linkScanPath` value: the basename minus its
+ * extension, validated against `SESSION_ID_RE` so a path-traversing value is
+ * never accepted. Returns null when absent or invalid.
+ */
+function sessionIdFromLinkScanPath(linkScanPath: unknown): string | null {
+  if (typeof linkScanPath !== 'string' || linkScanPath.length === 0) return null;
   const file = basename(linkScanPath);
   const dot = file.lastIndexOf('.');
   const sid = dot > 0 ? file.slice(0, dot) : file;
-  if (!SESSION_ID_RE.test(sid)) return null;
-  return sid;
+  return SESSION_ID_RE.test(sid) ? sid : null;
+}
+
+/**
+ * Try to resolve the session_id synchronously from `CLAUDE_JOB_DIR/state.json`.
+ * Returns the validated session_id or null.
+ */
+export function resolveFromJobDir(claudeJobDir: string | null | undefined): string | null {
+  const parsed = readAndParseJobState(claudeJobDir);
+  if (!parsed) return null;
+  return sessionIdFromLinkScanPath(parsed.linkScanPath);
 }
 
 /**
@@ -154,18 +190,27 @@ export function resolveFromBreadcrumb(
 }
 
 /**
+ * Sanitize a cwd into the single filename segment used both by the collector's
+ * `writeCwdBreadcrumb()` (session-by-cwd breadcrumb) and by Claude Code's own
+ * transcript-directory naming under `~/.claude/projects/`: backslash, forward
+ * slash, and colon each become `-`. Must stay identical to
+ * `collector-script.ts` so both sides derive the same filename independently.
+ * Colons are stripped so a Windows drive letter (e.g. `C:`) never survives into
+ * a filename where `path.resolve()` on win32 would reinterpret it as a
+ * drive-relative component and read/write outside the intended directory.
+ */
+export function sanitizeCwdForFilename(cwd: string): string {
+  return cwd.replace(/[\\/:]/g, '-');
+}
+
+/**
  * Try to resolve the session_id synchronously from the cwd breadcrumb file.
  * Fallback for platforms where the PPID breadcrumb never matches (see the
  * module doc comment above). Returns the validated session_id or null.
  */
 export function resolveFromCwd(storagePath: string, cwd: string | undefined): string | null {
   if (typeof cwd !== 'string' || cwd.length === 0) return null;
-  // Same sanitization scheme as the collector's writeCwdBreadcrumb() /
-  // getTranscriptPath() — must stay identical so both sides derive the same
-  // filename independently. Colons are stripped too (unlike
-  // getTranscriptPath) so a Windows drive letter never survives into the
-  // filename — see the matching comment in writeCwdBreadcrumb().
-  const sanitizedCwd = cwd.replace(/[\\/:]/g, '-');
+  const sanitizedCwd = sanitizeCwdForFilename(cwd);
   const breadcrumbPath = resolve(storagePath, 'session-by-cwd', `${sanitizedCwd}.txt`);
   if (!existsSync(breadcrumbPath)) return null;
   let raw: string;
@@ -395,4 +440,325 @@ export function isSyntheticSessionId(id: string | null | undefined): boolean {
 export function isUnscopedAggregatorSessionId(id: string | null | undefined): boolean {
   if (!id) return false;
   return id.startsWith('local-') || id.startsWith('proxy-');
+}
+
+// ---------------------------------------------------------------------------
+// Session naming
+//
+// Replaces cwd-basename naming (which labels every session in a repo
+// identically) with Claude Code's own per-session human-readable titles. Two
+// name sources, both authored by Claude Code:
+//   1. The background-job state file (CLAUDE_JOB_DIR/state.json) — present only
+//      for background jobs; carries a possibly human-authored `name`.
+//   2. The transcript JSONL (universal) — carries `ai-title` records that
+//      Claude Code refines over the session.
+// `resolveSessionName` combines them into a single precedence decision.
+// ---------------------------------------------------------------------------
+
+/** Where a resolved session name came from, most trusted first. */
+export type SessionNameSource = 'user' | 'ai-title' | 'auto' | 'cwd';
+
+/**
+ * The naming-relevant fields read out of `CLAUDE_JOB_DIR/state.json`.
+ * `sessionId`/`name`/`nameSource` are labels; `intent` is CONTENT.
+ */
+export interface JobState {
+  /** Full session UUID, from the explicit `sessionId` field or `linkScanPath`. */
+  readonly sessionId: string | null;
+  /** Human-readable title Claude Code wrote for the job. */
+  readonly name: string | null;
+  /** Whether a human named it (`user`) or Claude auto-generated it (`auto`). */
+  readonly nameSource: 'user' | 'auto' | null;
+  /**
+   * SENSITIVE (CONTENT): the job's first user prompt. Populated ONLY when
+   * `readJobState` is called with `{ recordContent: true }`; otherwise null,
+   * so the sensitive field is off by construction rather than by convention.
+   * Because `recordContent` is force-disabled under highSecurity upstream
+   * (never bypass), passing `config.recordContent` keeps intent null in high
+   * security mode automatically. Even when populated it is returned verbatim,
+   * so any consumer MUST still pass it through `redactSensitive()` before it
+   * reaches a log, NR event, tool response, or persisted file. Phase-1 wiring
+   * reads `name`/`nameSource` only and never requests or forwards `intent`.
+   */
+  readonly intent: string | null;
+}
+
+/**
+ * Read the naming fields from `CLAUDE_JOB_DIR/state.json`. Sibling to
+ * `resolveFromJobDir` (whose `string | null` contract is unchanged) — returns
+ * null when there is no readable state file. `sessionId` prefers an explicit
+ * `sessionId` field, falling back to the UUID embedded in `linkScanPath`.
+ *
+ * The sensitive `intent` (first-prompt CONTENT) is populated ONLY when
+ * `options.recordContent === true`; it is null otherwise. This gates the
+ * content field by construction (mirroring `DecisionTracker`'s `recordContent`
+ * gate) so a future consumer that copies the `name`/`nameSource` wiring cannot
+ * leak prompt content by simply reading `.intent`. Pass `config.recordContent`
+ * (already force-disabled under highSecurity) to stay compliant; the `name`/
+ * `nameSource` display labels are never gated.
+ */
+export function readJobState(
+  claudeJobDir: string | null | undefined,
+  options?: { readonly recordContent?: boolean },
+): JobState | null {
+  const parsed = readAndParseJobState(claudeJobDir);
+  if (!parsed) return null;
+
+  const sessionId =
+    typeof parsed.sessionId === 'string' && SESSION_ID_RE.test(parsed.sessionId)
+      ? parsed.sessionId
+      : sessionIdFromLinkScanPath(parsed.linkScanPath);
+  const name = typeof parsed.name === 'string' && parsed.name.length > 0 ? parsed.name : null;
+  const nameSource =
+    parsed.nameSource === 'user' || parsed.nameSource === 'auto' ? parsed.nameSource : null;
+  const intent =
+    options?.recordContent === true && typeof parsed.intent === 'string' && parsed.intent.length > 0
+      ? parsed.intent
+      : null;
+
+  return { sessionId, name, nameSource, intent };
+}
+
+// Bounded transcript reads: scan at most this many bytes back from EOF, one
+// chunk at a time, to find the last `ai-title`. A degenerate huge transcript
+// with no title in its tail costs at most MAX_SCAN_BYTES of IO, never the
+// whole file.
+const TRANSCRIPT_TITLE_CHUNK_BYTES = 64 * 1024;
+const TRANSCRIPT_TITLE_MAX_SCAN_BYTES = 1024 * 1024;
+
+/** The one transcript record shape we care about here. */
+interface TranscriptTitleLine {
+  readonly type?: unknown;
+  readonly aiTitle?: unknown;
+}
+
+/**
+ * Scan `text` (a suffix of a transcript JSONL file) for the LAST `ai-title`
+ * record and return its `aiTitle` (raw, unredacted — the caller redacts).
+ * `firstFragmentComplete` must be true only when `text` begins exactly at a
+ * file/line boundary; otherwise the substring before the first newline is a
+ * partial line whose start lies in an earlier, unread region and is skipped.
+ * Scanning newest-first means the first match is the file's last `ai-title`.
+ */
+export function findLastAiTitleInText(text: string, firstFragmentComplete: boolean): string | null {
+  const parts = text.split('\n');
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (i === 0 && !firstFragmentComplete) break; // partial leading line — its start is unread
+    const line = parts[i]!;
+    if (line.length === 0) continue;
+    // Cheap pre-filter: `ai-title` records are rare, so skip JSON.parse unless
+    // the marker is present at all.
+    if (!line.includes('"ai-title"')) continue;
+    let parsed: TranscriptTitleLine;
+    try {
+      parsed = JSON.parse(line) as TranscriptTitleLine;
+    } catch {
+      continue;
+    }
+    if (
+      parsed.type === 'ai-title' &&
+      typeof parsed.aiTitle === 'string' &&
+      parsed.aiTitle.length > 0
+    ) {
+      return parsed.aiTitle;
+    }
+  }
+  return null;
+}
+
+/**
+ * Locate a session's transcript file under `<projectsDir>/<slug>/<sessionId>.jsonl`.
+ *
+ * Claude Code names each project subdirectory with a slug derived from the cwd,
+ * but that scheme is NOT the same as our breadcrumb `sanitizeCwdForFilename`
+ * (Claude Code also replaces `.` — so `/repo/.claude/wt` becomes
+ * `-repo--claude-wt`). Rather than mirror an undocumented slug scheme that can
+ * drift, we exploit the fact that a session id is a UUID — globally unique
+ * across every project slug — and find the one subdirectory that contains
+ * `<sessionId>.jsonl`. Returns the first match, or null.
+ */
+function findTranscriptPath(projectsDir: string, sessionId: string): string | null {
+  const fileName = `${sessionId}.jsonl`;
+  let entries: string[];
+  try {
+    entries = readdirSync(projectsDir);
+  } catch (err) {
+    logger.debug('projects dir unreadable', { error: String(err) });
+    return null;
+  }
+  for (const entry of entries) {
+    const candidate = resolve(projectsDir, entry, fileName);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Read the last `ai-title` from a session's transcript JSONL, redacted.
+ * Locates the transcript by matching `<sessionId>.jsonl` under any project slug
+ * (see `findTranscriptPath` — robust to Claude Code's cwd-slug scheme). Reads
+ * BOUNDED — reverse-scans the file's tail one chunk at a time up to
+ * `TRANSCRIPT_TITLE_MAX_SCAN_BYTES`, never slurping the whole file. Returns null
+ * on any miss (no file, no title, bad sessionId) and never throws.
+ *
+ * @param projectsDir Override for `~/.claude/projects` (test seam).
+ */
+export function readTranscriptTitle(input: {
+  readonly projectsDir?: string;
+  readonly sessionId: string;
+}): string | null {
+  const { sessionId } = input;
+  if (!SESSION_ID_RE.test(sessionId)) return null;
+
+  const projectsDir = input.projectsDir ?? resolve(homedir(), '.claude', 'projects');
+  const transcriptPath = findTranscriptPath(projectsDir, sessionId);
+  if (transcriptPath === null) return null;
+
+  let fd: number;
+  let size: number;
+  try {
+    size = statSync(transcriptPath).size;
+    if (size === 0) return null;
+    fd = openSync(transcriptPath, fsConstants.O_RDONLY);
+  } catch (err) {
+    logger.debug('transcript unreadable', { error: String(err) });
+    return null;
+  }
+
+  try {
+    let pos = size;
+    // Accumulate raw chunks and decode the contiguous tail as ONE buffer each
+    // iteration, so a multi-byte UTF-8 sequence straddling a 64KB chunk
+    // boundary is decoded intact — decoding each chunk in isolation would
+    // corrupt a straddling character to U+FFFD on both sides.
+    const chunks: Buffer[] = [];
+    while (pos > 0 && size - pos < TRANSCRIPT_TITLE_MAX_SCAN_BYTES) {
+      const chunkSize = Math.min(TRANSCRIPT_TITLE_CHUNK_BYTES, pos);
+      pos -= chunkSize;
+      const buffer = Buffer.alloc(chunkSize);
+      const bytesRead = readSync(fd, buffer, 0, chunkSize, pos);
+      chunks.unshift(bytesRead === chunkSize ? buffer : buffer.subarray(0, bytesRead));
+      const acc = Buffer.concat(chunks).toString('utf-8');
+      // `pos === 0` means `acc` now starts at the file head, so its first line
+      // is complete; otherwise the leading fragment is partial and skipped.
+      const title = findLastAiTitleInText(acc, pos === 0);
+      if (title !== null) return redactSensitive(title);
+    }
+    return null;
+  } catch (err) {
+    logger.debug('transcript read failed', { error: String(err) });
+    return null;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Directory basenames too generic to serve as a session label. Single source
+ * of truth for the guard `SessionTracker`'s streaming cwd fallback also uses. A
+ * degenerate startup cwd yields no authoritative `cwd` name (step 4 falls
+ * through to null), leaving the tracker's streaming fallback free to upgrade to
+ * a better name from a later tool call's cwd.
+ */
+export const DEGENERATE_NAMES: ReadonlySet<string> = new Set([
+  'tmp',
+  'temp',
+  'var',
+  'usr',
+  'opt',
+  'home',
+  '.',
+  '..',
+  '',
+]);
+
+/** Inputs to the pure `resolveSessionName` precedence decision. */
+export interface ResolveSessionNameInputs {
+  /** Parsed background-job state, from `readJobState` (null if none). */
+  readonly jobState?: JobState | null;
+  /** Last transcript `ai-title`, from `readTranscriptTitle` (null if none). */
+  readonly transcriptTitle?: string | null;
+  /** Working directory, for the basename fallback. */
+  readonly cwd?: string | null;
+}
+
+/** A resolved session name plus which source produced it. */
+export interface SessionNameResult {
+  readonly name: string;
+  readonly source: SessionNameSource;
+}
+
+/**
+ * Pure precedence decision for a session's display name (first hit wins):
+ *   1. state.json `name` where `nameSource === 'user'`  → `user`
+ *   2. transcript last `ai-title`                        → `ai-title`
+ *   3. state.json `name` where `nameSource === 'auto'`   → `auto`
+ *   4. basename(cwd), unless degenerate                  → `cwd`
+ *   5. null
+ * Does no IO and gates on nothing: callers pass already-read values and redact
+ * the returned name at each sink.
+ */
+export function resolveSessionName(inputs: ResolveSessionNameInputs): SessionNameResult | null {
+  const jobState = inputs.jobState ?? null;
+
+  if (jobState && jobState.nameSource === 'user' && jobState.name) {
+    return { name: jobState.name, source: 'user' };
+  }
+  if (inputs.transcriptTitle && inputs.transcriptTitle.length > 0) {
+    return { name: inputs.transcriptTitle, source: 'ai-title' };
+  }
+  if (jobState && jobState.nameSource === 'auto' && jobState.name) {
+    return { name: jobState.name, source: 'auto' };
+  }
+  const cwd = inputs.cwd;
+  if (typeof cwd === 'string' && cwd.length > 0) {
+    const base = basename(cwd);
+    if (base.length > 0 && !DEGENERATE_NAMES.has(base.toLowerCase())) {
+      return { name: base, source: 'cwd' };
+    }
+  }
+  return null;
+}
+
+/**
+ * Trust rank of a session-name source; LOWER is more trusted. Mirrors
+ * `resolveSessionName`'s precedence exactly: `user`(0) > `ai-title`(1) >
+ * `auto`(2) > `cwd`(3). Used to decide whether a freshly re-resolved name may
+ * replace the one already in place (see `shouldReplaceSessionName`).
+ */
+export function sessionNameSourceRank(source: SessionNameSource): number {
+  switch (source) {
+    case 'user':
+      return 0;
+    case 'ai-title':
+      return 1;
+    case 'auto':
+      return 2;
+    case 'cwd':
+      return 3;
+  }
+}
+
+/**
+ * Whether a re-resolved name from `next` should replace a name currently
+ * sourced from `current`. Freshness re-resolution (Phase 2) re-reads Claude
+ * Code's name sources at persist/shutdown time so a refined `ai-title` — or a
+ * name a human later assigns — supersedes the first-prompt guess.
+ *
+ * Replaces only when `next` is at least as trusted as `current`
+ * (`rank(next) <= rank(current)`): an equal-or-better source wins (which also
+ * picks up refined text for the SAME source, e.g. an updated `ai-title`),
+ * while a strictly-less-trusted source is refused. That refusal is the
+ * load-bearing invariant: a `user`-sourced name is NEVER downgraded to
+ * `auto`/`cwd`, even if the job-state file that supplied it later disappears
+ * and re-resolution would otherwise fall through to the transcript title or
+ * the cwd basename. A `null` current source (session not yet named) always
+ * accepts.
+ */
+export function shouldReplaceSessionName(
+  current: SessionNameSource | null,
+  next: SessionNameSource,
+): boolean {
+  if (current === null) return true;
+  return sessionNameSourceRank(next) <= sessionNameSourceRank(current);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { LocalAlertEngine } from './alerts/local-alert-engine.js';
 import { parseLocalAlertRules } from './alerts/local-alert-rule.js';
 import { OsNotifier } from './alerts/os-notifier.js';
 import type { McpServerConfig } from './config.js';
-import { DEFAULT_STORAGE_PATH, loadMcpConfig } from './config.js';
+import { DEFAULT_STORAGE_PATH, loadMcpConfig, redactSensitive } from './config.js';
 import { DashboardServer } from './dashboard/dashboard-server.js';
 import { LiveEventBus } from './dashboard/index.js';
 import type { ObservabilityHealthSnapshot } from './dashboard/routes/api-handler.js';
@@ -22,10 +22,13 @@ import { HookEventProcessor } from './hooks/index.js';
 import { ParentTranscriptWatcher } from './hooks/parent-transcript-watcher.js';
 import {
   isSyntheticSessionId,
+  readJobState,
+  readTranscriptTitle,
   resolveFromBreadcrumb,
   resolveFromCwd,
   resolveFromJobDir,
   resolveSessionId,
+  resolveSessionName,
   watchPpidBreadcrumb,
 } from './hooks/session-resolver.js';
 import { SubagentWatcher } from './hooks/subagent-watcher.js';
@@ -1031,6 +1034,76 @@ async function main(): Promise<void> {
     // Unconditional in every mode — decoupled from whether the `--local`
     // dashboard wins its port bind (see startMaintenanceGc()'s doc comment).
     maintenanceGcInterval = startMaintenanceGc({ localStore, liveSessionRegistry });
+
+    // Resolve the authoritative, human-readable session name for a real session
+    // id and push it into both trackers, so their streaming cwd-basename
+    // fallback only fills in when no better name exists (authoritative wins).
+    // Reads Claude Code's own name sources — the background-job state file and
+    // the transcript's last ai-title (see resolveSessionName's precedence).
+    // Best-effort and cheap; any failure just leaves the streaming fallback in
+    // place. A no-op for synthetic ids (local-/proxy-/pending-*), which own no
+    // single transcript. Called both here (eager synchronous resolution) and
+    // from adoptRealSessionId (pending -> real transition and PPID correction),
+    // so the name is refreshed against whichever id ends up being authoritative.
+    const applyAuthoritativeSessionName = (sessionId: string): void => {
+      if (isSyntheticSessionId(sessionId)) return;
+      try {
+        const cwd = process.cwd();
+        // `intent` (the first user prompt) from the job state is SENSITIVE
+        // content, so readJobState only populates it when recordContent is
+        // enabled (config.recordContent is already force-disabled under
+        // highSecurity upstream — never bypass). resolveSessionName still uses
+        // only name/nameSource, which are display labels; the intent is
+        // surfaced separately as session_intent below.
+        const jobState = readJobState(process.env.CLAUDE_JOB_DIR ?? null, {
+          recordContent: config?.recordContent ?? false,
+        });
+        const transcriptTitle = readTranscriptTitle({ sessionId });
+        const resolved = resolveSessionName({ jobState, transcriptTitle, cwd });
+        if (!resolved) return;
+        // Redact ONCE, before the name reaches either tracker, so it stays
+        // redacted in in-memory tracker state and every downstream sink is
+        // covered: the MCP tool responses, the persisted summaries, AND the
+        // dashboard HTTP reads (which read the tracker/registry name directly
+        // and do NOT redact on their own). The `ai-title` source is already
+        // redacted at readTranscriptTitle; the `user`/`auto` job-state names
+        // and the cwd basename are raw until here — redacting all of them
+        // makes the existing tool/persist redaction idempotent and harmless.
+        const safeName = redactSensitive(resolved.name);
+        // Both trackers enforce the no-downgrade invariant internally
+        // (shouldReplaceSessionName), so re-resolving on the persist/shutdown
+        // path can only upgrade or refresh the name — never demote a better
+        // one. `changed` reflects whether SessionTracker actually (re)named,
+        // so the periodic re-resolve stays quiet unless something moved.
+        const changed = sessionTracker?.setAuthoritativeName(safeName, resolved.source) ?? false;
+        liveSessionRegistry?.setAuthoritativeName(sessionId, safeName, resolved.source);
+        // Phase 3: surface the originating intent (first prompt) as
+        // session_intent. jobState.intent is already null unless recordContent
+        // is enabled (gated in readJobState); redact before it reaches the
+        // tracker so every downstream sink (tool response, persisted summary)
+        // stays redacted. When content recording is off, this is a no-op and
+        // session_intent stays null everywhere.
+        if (jobState?.intent) {
+          sessionTracker?.setSessionIntent(redactSensitive(jobState.intent));
+        }
+        if (changed) {
+          logger.info('Resolved authoritative session name', {
+            source: resolved.source,
+            name: safeName,
+          });
+        }
+      } catch (err) {
+        logger.debug('Authoritative session name resolution failed (continuing)', {
+          error: String(err),
+        });
+      }
+    };
+
+    // Eager synchronous stdio path: when the id was resolved up front (job dir
+    // / ppid / cwd breadcrumb), name it now. Provisional (pending-*) and
+    // --local ids are synthetic, so this is a no-op for them — the provisional
+    // window is named later via adoptRealSessionId once its real id resolves.
+    if (options.stdio) applyAuthoritativeSessionName(sessionTraceId);
     const turnCostAttributor = new TurnCostAttributor();
     const turnTracker = new TurnTracker();
     const gitEfficiencyTracker = new GitEfficiencyTracker();
@@ -2165,6 +2238,15 @@ async function main(): Promise<void> {
       if (!sessionStore || !sessionTracker || !taskDetector || !config) return;
       try {
         transcriptMessageTracker.refresh();
+        // Phase 2 freshness: re-read Claude Code's own name sources (job-state
+        // title + transcript ai-title) right before building the summary, so a
+        // title refined after the first exchange — or a name a human assigns
+        // mid-session — wins over the first-prompt guess in the persisted/
+        // shutdown snapshot. Runs on both the periodic checkpoint and the
+        // terminal save (both flow through here). setAuthoritativeName enforces
+        // the no-downgrade invariant, so this can only upgrade or refresh —
+        // never demote a user name to auto/cwd. A no-op for synthetic ids.
+        applyAuthoritativeSessionName(sessionTraceId);
         const summary = buildSessionSummary({
           sessionTracker,
           costTracker,
@@ -2451,6 +2533,11 @@ async function main(): Promise<void> {
       }
       sessionTraceId = realId;
       sessionTracker!.adoptSessionId(realId);
+      // Now that the real id (and thus its transcript path) is known, resolve
+      // and apply the authoritative name. On a correction this re-resolves
+      // against the corrected id's own transcript, replacing any name derived
+      // for the previously-adopted (wrong) id.
+      applyAuthoritativeSessionName(realId);
       // viaCwdOnly means this id came from the collision-prone cwd fallback
       // and hasn't been confirmed by the PPID breadcrumb yet — mirrors the
       // resolvedViaCwdOnly gate on the synchronous resolution path's own

--- a/src/metrics/claudemd-tracker.test.ts
+++ b/src/metrics/claudemd-tracker.test.ts
@@ -35,6 +35,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   return {
     sessionId: `sess-${now}-${Math.random().toString(36).slice(2)}`,
     sessionName: null,
+    sessionNameSource: null,
+    sessionIntent: null,
     repoName: null,
     startTime: now - 60_000,
     endTime: now,

--- a/src/metrics/collaboration-profile.test.ts
+++ b/src/metrics/collaboration-profile.test.ts
@@ -32,6 +32,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   return {
     sessionId: `sess-${now}-${Math.random().toString(36).slice(2)}`,
     sessionName: null,
+    sessionNameSource: null,
+    sessionIntent: null,
     repoName: null,
     startTime: now - 60_000,
     endTime: now,

--- a/src/metrics/cost-tracker-seed.test.ts
+++ b/src/metrics/cost-tracker-seed.test.ts
@@ -9,6 +9,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   return {
     sessionId: `sess-${now}`,
     sessionName: 'my-project',
+    sessionNameSource: null,
+    sessionIntent: null,
     repoName: null,
     startTime: now - 60_000,
     endTime: now,

--- a/src/metrics/live-session-registry.test.ts
+++ b/src/metrics/live-session-registry.test.ts
@@ -165,4 +165,115 @@ describe('LiveSessionRegistry', () => {
       reg.stopSampling();
     });
   });
+
+  describe('setAuthoritativeName', () => {
+    it('sets the display name for a session', () => {
+      const reg = new LiveSessionRegistry();
+      reg.setAuthoritativeName('sess-a', 'refactor auth flow', 'ai-title');
+      expect(reg.getSessionName('sess-a')).toBe('refactor auth flow');
+    });
+
+    it('overrides a cwd basename already stored by touch()', () => {
+      const reg = new LiveSessionRegistry();
+      reg.touch('sess-a', '/Users/dev/projects/preflight');
+      expect(reg.getSessionName('sess-a')).toBe('preflight');
+      reg.setAuthoritativeName('sess-a', 'session naming logic', 'ai-title');
+      expect(reg.getSessionName('sess-a')).toBe('session naming logic');
+    });
+
+    it('is not overwritten by a later touch() with a cwd', () => {
+      const reg = new LiveSessionRegistry();
+      reg.setAuthoritativeName('sess-a', 'session naming logic', 'ai-title');
+      reg.touch('sess-a', '/Users/dev/projects/preflight');
+      expect(reg.getSessionName('sess-a')).toBe('session naming logic');
+    });
+
+    it('ignores an empty name', () => {
+      const reg = new LiveSessionRegistry();
+      reg.touch('sess-a', '/Users/dev/projects/preflight');
+      reg.setAuthoritativeName('sess-a', '', 'ai-title');
+      expect(reg.getSessionName('sess-a')).toBe('preflight');
+    });
+
+    it('is cleared on reset()', () => {
+      const reg = new LiveSessionRegistry();
+      reg.setAuthoritativeName('sess-a', 'session naming logic', 'ai-title');
+      reg.reset();
+      expect(reg.getSessionName('sess-a')).toBeNull();
+    });
+
+    // --- Phase 2 freshness: re-resolution may upgrade, never downgrade ---
+
+    it('upgrades the name as a better source arrives (cwd -> auto -> ai-title -> user)', () => {
+      const reg = new LiveSessionRegistry();
+      // cwd basename first (from touch), then progressively better re-resolves.
+      reg.touch('sess-a', '/Users/dev/projects/preflight');
+      expect(reg.getSessionName('sess-a')).toBe('preflight');
+      reg.setAuthoritativeName('sess-a', 'auto guess', 'auto');
+      expect(reg.getSessionName('sess-a')).toBe('auto guess');
+      reg.setAuthoritativeName('sess-a', 'refined title', 'ai-title');
+      expect(reg.getSessionName('sess-a')).toBe('refined title');
+      reg.setAuthoritativeName('sess-a', 'human named it', 'user');
+      expect(reg.getSessionName('sess-a')).toBe('human named it');
+    });
+
+    it('refreshes text for the same source (ai-title -> refined ai-title)', () => {
+      const reg = new LiveSessionRegistry();
+      reg.setAuthoritativeName('sess-a', 'first guess', 'ai-title');
+      reg.setAuthoritativeName('sess-a', 'refined title', 'ai-title');
+      expect(reg.getSessionName('sess-a')).toBe('refined title');
+    });
+
+    it('never downgrades a user name to auto or cwd', () => {
+      const reg = new LiveSessionRegistry();
+      reg.setAuthoritativeName('sess-a', 'human named it', 'user');
+      // A later re-resolve that fell back to auto/cwd (e.g. the job-state file
+      // disappeared) must not demote the user name.
+      reg.setAuthoritativeName('sess-a', 'auto guess', 'auto');
+      expect(reg.getSessionName('sess-a')).toBe('human named it');
+      reg.setAuthoritativeName('sess-a', 'cwd basename', 'cwd');
+      expect(reg.getSessionName('sess-a')).toBe('human named it');
+      // And a later touch() with a cwd still can't clobber it either.
+      reg.touch('sess-a', '/Users/dev/projects/preflight');
+      expect(reg.getSessionName('sess-a')).toBe('human named it');
+    });
+
+    it('does not downgrade an ai-title to auto', () => {
+      const reg = new LiveSessionRegistry();
+      reg.setAuthoritativeName('sess-a', 'refined title', 'ai-title');
+      reg.setAuthoritativeName('sess-a', 'auto guess', 'auto');
+      expect(reg.getSessionName('sess-a')).toBe('refined title');
+    });
+  });
+
+  describe('getSessionNameSource', () => {
+    it('returns null for an unknown/unnamed session', () => {
+      const reg = new LiveSessionRegistry();
+      expect(reg.getSessionNameSource('sess-a')).toBeNull();
+    });
+
+    it("reports 'cwd' for a name set by the touch() streaming fallback", () => {
+      const reg = new LiveSessionRegistry();
+      reg.touch('sess-a', '/Users/dev/projects/preflight');
+      expect(reg.getSessionName('sess-a')).toBe('preflight');
+      expect(reg.getSessionNameSource('sess-a')).toBe('cwd');
+    });
+
+    it('reports the authoritative source and tracks upgrades', () => {
+      const reg = new LiveSessionRegistry();
+      reg.touch('sess-a', '/Users/dev/projects/preflight');
+      expect(reg.getSessionNameSource('sess-a')).toBe('cwd');
+      reg.setAuthoritativeName('sess-a', 'refined title', 'ai-title');
+      expect(reg.getSessionNameSource('sess-a')).toBe('ai-title');
+      reg.setAuthoritativeName('sess-a', 'human named it', 'user');
+      expect(reg.getSessionNameSource('sess-a')).toBe('user');
+    });
+
+    it('is cleared on reset()', () => {
+      const reg = new LiveSessionRegistry();
+      reg.setAuthoritativeName('sess-a', 'human named it', 'user');
+      reg.reset();
+      expect(reg.getSessionNameSource('sess-a')).toBeNull();
+    });
+  });
 });

--- a/src/metrics/live-session-registry.ts
+++ b/src/metrics/live-session-registry.ts
@@ -4,7 +4,11 @@
  */
 
 import { basename } from 'node:path';
-import { isSyntheticSessionId } from '../hooks/session-resolver.js';
+import {
+  isSyntheticSessionId,
+  shouldReplaceSessionName,
+  type SessionNameSource,
+} from '../hooks/session-resolver.js';
 
 export const DEFAULT_STALE_THRESHOLD_MS = 180_000; // 3 minutes
 const MAX_CONCURRENCY_SAMPLES = 2880; // 24h at 30s intervals
@@ -18,6 +22,14 @@ export interface ConcurrencySample {
 export class LiveSessionRegistry {
   private readonly lastActivity = new Map<string, number>();
   private readonly sessionNames = new Map<string, string>();
+  // Sessions whose name was set authoritatively (job-state title / transcript
+  // ai-title). `touch()` must never overwrite these with a cwd basename.
+  private readonly authoritativeNames = new Set<string>();
+  // The source that produced each authoritative name, so a Phase-2 freshness
+  // re-resolve can be refused when it would DOWNGRADE the name (e.g. a `cwd`
+  // re-resolve arriving after a `user` name was set). Keyed identically to
+  // `authoritativeNames`; cleared alongside it on eviction/reset.
+  private readonly authoritativeSources = new Map<string, SessionNameSource>();
   private readonly staleThresholdMs: number;
   private peakConcurrent = 0;
   private readonly concurrencyTimeSeries: ConcurrencySample[] = [];
@@ -29,10 +41,19 @@ export class LiveSessionRegistry {
 
   touch(sessionId: string, cwd?: string): void {
     this.lastActivity.set(sessionId, Date.now());
-    if (cwd && !this.sessionNames.has(sessionId)) {
+    // Streaming FALLBACK naming: skip when an authoritative name is set, and
+    // (as before) only fill the first time we see a cwd for this session.
+    if (cwd && !this.authoritativeNames.has(sessionId) && !this.sessionNames.has(sessionId)) {
       const name = basename(cwd);
       if (name.length > 0 && name !== '.' && name !== '..') {
         this.sessionNames.set(sessionId, name);
+        // Tag the fallback source so getSessionNameSource() reports 'cwd' for a
+        // basename-named session (matching SessionTracker's streaming fallback,
+        // which also tags 'cwd'). NOT added to `authoritativeNames`: this stays
+        // a low-trust fallback that setAuthoritativeName may freely upgrade —
+        // 'cwd' is the lowest rank, so shouldReplaceSessionName lets any real
+        // source override it.
+        this.authoritativeSources.set(sessionId, 'cwd');
       }
     }
     const liveCount = this.getLiveSessions({ includeSynthetic: true }).length;
@@ -41,8 +62,41 @@ export class LiveSessionRegistry {
     }
   }
 
+  /**
+   * Set the authoritative display name for a session (from the job-state title
+   * or transcript ai-title, per `resolveSessionName`'s precedence). Overrides
+   * any cwd basename `touch()` may have already stored and pins it against
+   * future `touch()` calls. Ignores empty names. Mirrors
+   * `SessionTracker.setAuthoritativeName`, including the Phase-2 freshness
+   * guard: when re-resolved on the persist/shutdown path, a strictly-less-
+   * trusted `source` (e.g. `cwd` after a `user` name) is refused via
+   * `shouldReplaceSessionName`, so a better name is never downgraded here.
+   */
+  setAuthoritativeName(sessionId: string, name: string, source: SessionNameSource): void {
+    if (typeof name !== 'string' || name.length === 0) return;
+    if (!shouldReplaceSessionName(this.authoritativeSources.get(sessionId) ?? null, source)) {
+      return;
+    }
+    this.authoritativeNames.add(sessionId);
+    this.authoritativeSources.set(sessionId, source);
+    this.sessionNames.set(sessionId, name);
+  }
+
   getSessionName(sessionId: string): string | null {
     return this.sessionNames.get(sessionId) ?? null;
+  }
+
+  /**
+   * Which source produced the name `getSessionName` returns for this session
+   * (see `SessionNameSource`), or null when the session is untracked or was
+   * only ever named by the streaming cwd fallback in `touch()` (which records
+   * a name but no source). Lets dashboard surfaces distinguish an
+   * authoritative `user`/`ai-title`/`auto` name from a cwd-basename fallback,
+   * matching the `session_name_source` the MCP tool and persisted summaries
+   * already expose.
+   */
+  getSessionNameSource(sessionId: string): SessionNameSource | null {
+    return this.authoritativeSources.get(sessionId) ?? null;
   }
 
   // The dashboard's `/api/sessions/live` endpoint surfaces last-activity per
@@ -67,6 +121,8 @@ export class LiveSessionRegistry {
     for (const id of stale) {
       this.lastActivity.delete(id);
       this.sessionNames.delete(id);
+      this.authoritativeNames.delete(id);
+      this.authoritativeSources.delete(id);
     }
     // Synthetic session IDs (`local-*`, `proxy-*`, `pending-*`) are
     // MCP-internal bookkeeping from --local / proxy modes, not real Claude
@@ -79,6 +135,8 @@ export class LiveSessionRegistry {
   reset(): void {
     this.lastActivity.clear();
     this.sessionNames.clear();
+    this.authoritativeNames.clear();
+    this.authoritativeSources.clear();
   }
 
   isLive(sessionId: string): boolean {
@@ -87,6 +145,8 @@ export class LiveSessionRegistry {
     if (Date.now() - ts > this.staleThresholdMs) {
       this.lastActivity.delete(sessionId);
       this.sessionNames.delete(sessionId);
+      this.authoritativeNames.delete(sessionId);
+      this.authoritativeSources.delete(sessionId);
       return false;
     }
     return true;

--- a/src/metrics/prompt-feedback.test.ts
+++ b/src/metrics/prompt-feedback.test.ts
@@ -37,6 +37,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   return {
     sessionId: `sess-${now}-${Math.random().toString(36).slice(2)}`,
     sessionName: null,
+    sessionNameSource: null,
+    sessionIntent: null,
     repoName: null,
     startTime: now - 60_000,
     endTime: now,

--- a/src/metrics/recommendation-engine.test.ts
+++ b/src/metrics/recommendation-engine.test.ts
@@ -38,6 +38,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   return {
     sessionId: `sess-${now}-${Math.random().toString(36).slice(2)}`,
     sessionName: null,
+    sessionNameSource: null,
+    sessionIntent: null,
     repoName: null,
     startTime: now - 60_000,
     endTime: now,

--- a/src/metrics/session-tracker.test.ts
+++ b/src/metrics/session-tracker.test.ts
@@ -377,6 +377,166 @@ describe('SessionTracker', () => {
       tracker.reset('new-session');
       expect(tracker.getMetrics().sessionName).toBeNull();
     });
+
+    it("reports the cwd fallback via sessionNameSource === 'cwd'", () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.recordToolCall(makeRecord({ cwd: '/Users/dev/projects/my-app' }));
+      const metrics = tracker.getMetrics();
+      expect(metrics.sessionName).toBe('my-app');
+      expect(metrics.sessionNameSource).toBe('cwd');
+    });
+
+    it('has a null source when no name has been derived', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.recordToolCall(makeRecord());
+      expect(tracker.getMetrics().sessionNameSource).toBeNull();
+    });
+  });
+
+  describe('setAuthoritativeName()', () => {
+    it('sets the name and its source', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.setAuthoritativeName('session naming logic', 'ai-title');
+      const metrics = tracker.getMetrics();
+      expect(metrics.sessionName).toBe('session naming logic');
+      expect(metrics.sessionNameSource).toBe('ai-title');
+    });
+
+    it('wins over the streaming cwd fallback regardless of call order', () => {
+      const tracker = new SessionTracker('test-session');
+      // cwd first, then authoritative
+      tracker.recordToolCall(makeRecord({ cwd: '/Users/dev/projects/preflight' }));
+      tracker.setAuthoritativeName('user title', 'user');
+      // subsequent tool calls with a cwd must NOT override the authoritative name
+      tracker.recordToolCall(makeRecord({ cwd: '/Users/dev/projects/other-repo' }));
+      const metrics = tracker.getMetrics();
+      expect(metrics.sessionName).toBe('user title');
+      expect(metrics.sessionNameSource).toBe('user');
+    });
+
+    it('suppresses the cwd fallback when set before any tool call', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.setAuthoritativeName('auto name', 'auto');
+      tracker.recordToolCall(makeRecord({ cwd: '/Users/dev/projects/preflight' }));
+      const metrics = tracker.getMetrics();
+      expect(metrics.sessionName).toBe('auto name');
+      expect(metrics.sessionNameSource).toBe('auto');
+    });
+
+    it('ignores an empty name', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.recordToolCall(makeRecord({ cwd: '/Users/dev/projects/preflight' }));
+      tracker.setAuthoritativeName('', 'ai-title');
+      // unchanged: still the cwd-derived name, and the fallback stays active
+      expect(tracker.getMetrics().sessionName).toBe('preflight');
+      expect(tracker.getMetrics().sessionNameSource).toBe('cwd');
+    });
+
+    it('is cleared on reset()', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.setAuthoritativeName('user title', 'user');
+      tracker.reset('new-session');
+      const metrics = tracker.getMetrics();
+      expect(metrics.sessionName).toBeNull();
+      expect(metrics.sessionNameSource).toBeNull();
+      // After reset the streaming fallback is active again.
+      tracker.recordToolCall(makeRecord({ cwd: '/Users/dev/projects/preflight' }));
+      expect(tracker.getMetrics().sessionName).toBe('preflight');
+      expect(tracker.getMetrics().sessionNameSource).toBe('cwd');
+    });
+
+    it('returns true when it (re)names and false on a no-op', () => {
+      const tracker = new SessionTracker('test-session');
+      // First set: null -> ai-title is a real change.
+      expect(tracker.setAuthoritativeName('a title', 'ai-title')).toBe(true);
+      // Same name + source again: nothing moved.
+      expect(tracker.setAuthoritativeName('a title', 'ai-title')).toBe(false);
+      // Refined text at the same source: a real change.
+      expect(tracker.setAuthoritativeName('refined title', 'ai-title')).toBe(true);
+      // Empty name is always ignored (no change).
+      expect(tracker.setAuthoritativeName('', 'user')).toBe(false);
+    });
+
+    // --- Phase 2 freshness: re-resolution may upgrade, never downgrade ---
+
+    it('upgrades the name as a better source arrives (cwd -> auto -> ai-title -> user)', () => {
+      const tracker = new SessionTracker('test-session');
+      // Streaming cwd fallback first.
+      tracker.recordToolCall(makeRecord({ cwd: '/Users/dev/projects/preflight' }));
+      expect(tracker.getMetrics().sessionName).toBe('preflight');
+      expect(tracker.getMetrics().sessionNameSource).toBe('cwd');
+      // Each better source replaces the previous.
+      expect(tracker.setAuthoritativeName('auto guess', 'auto')).toBe(true);
+      expect(tracker.getMetrics().sessionNameSource).toBe('auto');
+      expect(tracker.setAuthoritativeName('refined title', 'ai-title')).toBe(true);
+      expect(tracker.getMetrics().sessionNameSource).toBe('ai-title');
+      expect(tracker.setAuthoritativeName('human named it', 'user')).toBe(true);
+      const metrics = tracker.getMetrics();
+      expect(metrics.sessionName).toBe('human named it');
+      expect(metrics.sessionNameSource).toBe('user');
+    });
+
+    it('never downgrades a user name to auto or cwd', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.setAuthoritativeName('human named it', 'user');
+      // A later re-resolve that fell back to auto/cwd (e.g. the job-state file
+      // disappeared) must be refused rather than demote the user name.
+      expect(tracker.setAuthoritativeName('auto guess', 'auto')).toBe(false);
+      expect(tracker.setAuthoritativeName('cwd basename', 'cwd')).toBe(false);
+      const metrics = tracker.getMetrics();
+      expect(metrics.sessionName).toBe('human named it');
+      expect(metrics.sessionNameSource).toBe('user');
+      // The streaming fallback stays suppressed too.
+      tracker.recordToolCall(makeRecord({ cwd: '/Users/dev/projects/other-repo' }));
+      expect(tracker.getMetrics().sessionName).toBe('human named it');
+    });
+
+    it('does not downgrade an ai-title to auto', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.setAuthoritativeName('refined title', 'ai-title');
+      expect(tracker.setAuthoritativeName('auto guess', 'auto')).toBe(false);
+      expect(tracker.getMetrics().sessionName).toBe('refined title');
+      expect(tracker.getMetrics().sessionNameSource).toBe('ai-title');
+    });
+  });
+
+  // --- Phase 3: session intent (first prompt), captured gated + redacted ---
+  describe('setSessionIntent()', () => {
+    it('defaults to null (no intent captured)', () => {
+      const tracker = new SessionTracker('test-session');
+      expect(tracker.getMetrics().sessionIntent).toBeNull();
+    });
+
+    it('stores the intent surfaced via getMetrics()', () => {
+      const tracker = new SessionTracker('test-session');
+      // The caller (index.ts) owns the recordContent gate + redaction; the
+      // tracker stores the already-safe string it is handed.
+      tracker.setSessionIntent('how are we naming sessions now?');
+      expect(tracker.getMetrics().sessionIntent).toBe('how are we naming sessions now?');
+    });
+
+    it('treats null or empty as cleared', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.setSessionIntent('some intent');
+      tracker.setSessionIntent('');
+      expect(tracker.getMetrics().sessionIntent).toBeNull();
+      tracker.setSessionIntent('some intent');
+      tracker.setSessionIntent(null);
+      expect(tracker.getMetrics().sessionIntent).toBeNull();
+    });
+
+    it('is independent of the session name (a name never implies an intent)', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.setAuthoritativeName('session naming logic', 'ai-title');
+      expect(tracker.getMetrics().sessionIntent).toBeNull();
+    });
+
+    it('is cleared on reset()', () => {
+      const tracker = new SessionTracker('test-session');
+      tracker.setSessionIntent('how are we naming sessions now?');
+      tracker.reset('new-session');
+      expect(tracker.getMetrics().sessionIntent).toBeNull();
+    });
   });
 
   describe('adoptSessionId()', () => {

--- a/src/metrics/session-tracker.ts
+++ b/src/metrics/session-tracker.ts
@@ -9,6 +9,11 @@
 import { basename } from 'node:path';
 import type { MetricAggregator } from '../shared/index.js';
 import type { ToolCallRecord } from '../storage/types.js';
+import {
+  DEGENERATE_NAMES,
+  shouldReplaceSessionName,
+  type SessionNameSource,
+} from '../hooks/session-resolver.js';
 import { computePercentile } from './percentile.js';
 import type { Resettable } from './tracker-contracts.js';
 
@@ -34,6 +39,16 @@ export interface TimelineEntry {
 export interface SessionMetrics {
   sessionId: string;
   sessionName: string | null;
+  /** Which source produced `sessionName` (see SessionNameSource), or null when unnamed. */
+  sessionNameSource: SessionNameSource | null;
+  /**
+   * The session's originating intent (the first user prompt), or null. This is
+   * SENSITIVE content: it is populated ONLY when `recordContent` is enabled
+   * (force-disabled under highSecurity upstream) and is always redacted before
+   * being stored. Null whenever content recording is off. See
+   * `setSessionIntent`.
+   */
+  sessionIntent: string | null;
   sessionStartTime: number;
   sessionDurationMs: number;
   toolCallCount: number;
@@ -129,6 +144,15 @@ export interface SessionTrackerSeed {
 export class SessionTracker implements Resettable {
   private sessionId: string;
   private sessionName: string | null = null;
+  private sessionNameSource: SessionNameSource | null = null;
+  private sessionIntent: string | null = null;
+  /**
+   * True once an authoritative name (resolved at startup from the job state
+   * file or transcript title) has been set via `setAuthoritativeName`. While
+   * true, the streaming cwd-basename derivation in `recordToolCall` is
+   * suppressed — the authoritative name always wins.
+   */
+  private authoritativeName = false;
   private sessionStartTime: number;
 
   private toolCallCount = 0;
@@ -161,14 +185,17 @@ export class SessionTracker implements Resettable {
   recordToolCall(record: ToolCallRecord): void {
     this.toolCallCount++;
 
-    // Derive session name from cwd; prefer a later, more meaningful name if the
-    // current one is a degenerate system directory (tmp, var, usr, etc.).
-    const DEGENERATE_NAMES = new Set(['tmp', 'temp', 'var', 'usr', 'opt', 'home', '.', '..', '']);
-    if (typeof record.cwd === 'string' && record.cwd.length > 0) {
+    // FALLBACK naming only: an authoritative name (job-state title or
+    // transcript ai-title, resolved once at startup) always wins, so skip the
+    // cwd derivation entirely once one is set. Otherwise derive from cwd,
+    // preferring a later, more meaningful name if the current one is a
+    // degenerate system directory (tmp, var, usr, etc.).
+    if (!this.authoritativeName && typeof record.cwd === 'string' && record.cwd.length > 0) {
       const name = basename(record.cwd);
       if (name.length > 0 && name !== '.' && name !== '..') {
         if (this.sessionName === null || DEGENERATE_NAMES.has(this.sessionName.toLowerCase())) {
           this.sessionName = name;
+          this.sessionNameSource = 'cwd';
         }
       }
     }
@@ -284,6 +311,8 @@ export class SessionTracker implements Resettable {
     return {
       sessionId: this.sessionId,
       sessionName: this.sessionName,
+      sessionNameSource: this.sessionNameSource,
+      sessionIntent: this.sessionIntent,
       sessionStartTime: this.sessionStartTime,
       sessionDurationMs: Date.now() - this.sessionStartTime,
       toolCallCount: this.toolCallCount,
@@ -334,6 +363,47 @@ export class SessionTracker implements Resettable {
     aggregator.record('ai.session.unique_files_written', this.filesWritten.size);
   }
 
+  /**
+   * Set the authoritative session name (from the job-state title or the
+   * transcript ai-title, per `resolveSessionName`'s precedence). Overrides any
+   * name the streaming cwd fallback may have set, and suppresses that fallback
+   * for the rest of the session. Ignores empty names. The name is a display
+   * LABEL; callers redact it at each sink.
+   *
+   * Called both once at startup AND repeatedly on the persist/shutdown path
+   * (Phase 2 freshness), so a refined `ai-title` — or a name a human later
+   * assigns — replaces the first-prompt guess. `shouldReplaceSessionName`
+   * enforces the no-downgrade invariant: a strictly-less-trusted source (e.g.
+   * a `cwd` re-resolve arriving after a `user` name was set) is refused rather
+   * than allowed to demote the better name.
+   *
+   * Returns true only when the stored name or source actually changed, so the
+   * caller can log a genuine (re)naming without spamming on every no-op
+   * re-resolve.
+   */
+  setAuthoritativeName(name: string, source: SessionNameSource): boolean {
+    if (typeof name !== 'string' || name.length === 0) return false;
+    if (!shouldReplaceSessionName(this.sessionNameSource, source)) return false;
+    const changed = this.sessionName !== name || this.sessionNameSource !== source;
+    this.sessionName = name;
+    this.sessionNameSource = source;
+    this.authoritativeName = true;
+    return changed;
+  }
+
+  /**
+   * Set the session's originating intent (the first user prompt).
+   *
+   * The caller owns the content gate and redaction: this must only be called
+   * with an already-redacted string, and only when `recordContent` is enabled
+   * (force-disabled under highSecurity upstream — never bypass). A null/empty
+   * value clears it. Because the intent is stable across a session (it is the
+   * first prompt), re-calling on the persist/shutdown path is idempotent.
+   */
+  setSessionIntent(intent: string | null): void {
+    this.sessionIntent = intent && intent.length > 0 ? intent : null;
+  }
+
   /** Update the session ID in place without clearing any accumulated metrics. */
   adoptSessionId(sessionId: string): void {
     if (typeof sessionId !== 'string' || sessionId.length === 0) {
@@ -359,6 +429,9 @@ export class SessionTracker implements Resettable {
     }
     this.sessionId = sessionId;
     this.sessionName = null;
+    this.sessionNameSource = null;
+    this.sessionIntent = null;
+    this.authoritativeName = false;
     this.sessionStartTime = Date.now();
     this.toolCallCount = 0;
     this.toolErrorCount = 0;

--- a/src/metrics/task-detector-seed.test.ts
+++ b/src/metrics/task-detector-seed.test.ts
@@ -8,6 +8,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   return {
     sessionId: `sess-${now}`,
     sessionName: null,
+    sessionNameSource: null,
+    sessionIntent: null,
     repoName: null,
     startTime: now - 60_000,
     endTime: now,

--- a/src/metrics/trend-analyzer.test.ts
+++ b/src/metrics/trend-analyzer.test.ts
@@ -37,6 +37,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   return {
     sessionId: `sess-${now}-${Math.random().toString(36).slice(2)}`,
     sessionName: null,
+    sessionNameSource: null,
+    sessionIntent: null,
     repoName: null,
     startTime: now - 60_000,
     endTime: now,

--- a/src/storage/session-store.test.ts
+++ b/src/storage/session-store.test.ts
@@ -6,6 +6,7 @@ import {
   SessionStore,
   buildSessionSummary,
   deserializeFullSessionSummary,
+  mergeSummaries,
   sessionSummaryToDriftRecord,
 } from './session-store.js';
 import type { FullSessionSummary } from './session-store.js';
@@ -46,6 +47,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   return {
     sessionId: `sess-${now}`,
     sessionName: 'my-project',
+    sessionNameSource: null,
+    sessionIntent: null,
     repoName: null,
     startTime: now - 60_000,
     endTime: now,
@@ -1172,6 +1175,126 @@ describe('buildSessionSummary', () => {
 
     expect(summary.sessionName).toBeNull();
     expect(summary.repoName).toBeNull();
+  });
+
+  it('redacts secret-shaped substrings in sessionIntent (Phase 3)', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'redact-test-intent',
+        sessionName: null,
+        sessionNameSource: null,
+        // Sensitive first-prompt content; only ever non-null when recordContent
+        // was on. Persist must redact it (idempotently) before it hits disk.
+        sessionIntent: 'deploy with API_KEY=abc123def456secretvalue please',
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: 1,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      developer: 'alice',
+    });
+
+    expect(summary.sessionIntent).toBe('deploy with [REDACTED] please');
+  });
+
+  it('leaves sessionIntent null when not provided (recordContent off)', () => {
+    const mockSessionTracker = {
+      getMetrics: () => ({
+        sessionId: 'redact-test-intent-null',
+        sessionName: null,
+        sessionNameSource: null,
+        sessionIntent: null,
+        sessionStartTime: 1700000000000,
+        sessionDurationMs: 1000,
+        toolCallCount: 0,
+        toolCallCountByTool: {},
+        toolDurationMsByTool: {},
+        toolSuccessRate: 1,
+        toolSuccessRateByTool: {},
+        toolErrorCount: 0,
+        toolErrorsByType: {},
+        uniqueFilesRead: 0,
+        uniqueFilesWritten: 0,
+        bashCommandsRun: 0,
+        bashExitCodes: {},
+        searchQueries: 0,
+        toolCallTimeline: [],
+      }),
+    };
+
+    const summary = buildSessionSummary({
+      sessionTracker: mockSessionTracker as unknown as SessionTracker,
+      developer: 'alice',
+    });
+
+    expect(summary.sessionIntent).toBeNull();
+  });
+
+  it('deserializeFullSessionSummary round-trips sessionIntent and defaults it to null when missing', () => {
+    const original = makeSummary({ sessionIntent: 'refactor the auth flow' });
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(JSON.stringify(original)) as Parameters<typeof deserializeFullSessionSummary>[0],
+    );
+    expect(roundTripped.sessionIntent).toBe('refactor the auth flow');
+
+    // Pre-Phase-3 session files have no sessionIntent field → null, not undefined.
+    const raw = JSON.parse(JSON.stringify(original)) as Record<string, unknown>;
+    delete raw.sessionIntent;
+    expect(deserializeFullSessionSummary(raw).sessionIntent).toBeNull();
+  });
+
+  it('deserializeFullSessionSummary round-trips a valid sessionNameSource and rejects bogus/missing to null', () => {
+    const original = makeSummary({ sessionName: 'my session', sessionNameSource: 'ai-title' });
+    const roundTripped = deserializeFullSessionSummary(
+      JSON.parse(JSON.stringify(original)) as Parameters<typeof deserializeFullSessionSummary>[0],
+    );
+    expect(roundTripped.sessionNameSource).toBe('ai-title');
+
+    // A value outside the 4-way enum → null (defends against a corrupt/edited file).
+    const bogus = JSON.parse(JSON.stringify(original)) as Record<string, unknown>;
+    bogus.sessionNameSource = 'nonsense';
+    expect(deserializeFullSessionSummary(bogus).sessionNameSource).toBeNull();
+
+    // Pre-feature session files have no field → null.
+    const missing = JSON.parse(JSON.stringify(original)) as Record<string, unknown>;
+    delete missing.sessionNameSource;
+    expect(deserializeFullSessionSummary(missing).sessionNameSource).toBeNull();
+  });
+
+  it('mergeSummaries keeps name and source together and never clobbers a captured intent', () => {
+    const existing = makeSummary({
+      sessionName: 'human named it',
+      sessionNameSource: 'user',
+      sessionIntent: 'the original prompt',
+    });
+    // A later (checkpoint) write that never resolved a name/intent this run:
+    // both are null on `incoming`.
+    const incoming = makeSummary({
+      sessionName: null,
+      sessionNameSource: null,
+      sessionIntent: null,
+    });
+    const merged = mergeSummaries(existing, incoming);
+    // Name kept — and its source must stay tied to it (no user→null desync).
+    expect(merged.sessionName).toBe('human named it');
+    expect(merged.sessionNameSource).toBe('user');
+    // A previously-captured intent is preserved, not overwritten to null.
+    expect(merged.sessionIntent).toBe('the original prompt');
   });
 
   it('includes active task data in the summary', () => {

--- a/src/storage/session-store.ts
+++ b/src/storage/session-store.ts
@@ -23,7 +23,7 @@ import {
 import { join, resolve, sep } from 'node:path';
 import { createLogger } from '../shared/index.js';
 import { redactSensitive } from '../config.js';
-import { isSyntheticSessionId } from '../hooks/session-resolver.js';
+import { isSyntheticSessionId, type SessionNameSource } from '../hooks/session-resolver.js';
 import type { SessionSummary, ReplayTimelineEntry } from './types.js';
 import type { SessionTracker } from '../metrics/session-tracker.js';
 import type { CostTracker } from '../metrics/cost-tracker.js';
@@ -87,6 +87,14 @@ export function toPersistedAntiPatterns(patterns: readonly AntiPattern[]): Persi
 
 export interface FullSessionSummary extends SessionSummary {
   readonly sessionName: string | null;
+  /** Which source produced `sessionName` (see SessionNameSource), or null. */
+  readonly sessionNameSource: SessionNameSource | null;
+  /**
+   * The session's originating intent (first user prompt), redacted, or null.
+   * SENSITIVE content: only ever non-null when recordContent was enabled at
+   * capture time (force-disabled under highSecurity). See SessionMetrics.
+   */
+  readonly sessionIntent: string | null;
   readonly repoName: string | null;
   readonly model: string | null;
   readonly toolBreakdown: Record<string, number>;
@@ -341,6 +349,17 @@ export function mergeSummaries(
     durationMs: Math.max(0, endTime - startTime),
     toolCallCount: maxNum(existing.toolCallCount, incoming.toolCallCount),
     sessionName: incoming.sessionName ?? existing.sessionName,
+    // Tie the source to whichever name won above so a name/source desync can't
+    // arise (incoming spreads a null source alongside a null name). The
+    // in-process tracker already enforces the no-downgrade invariant on
+    // `incoming`, so taking incoming's name+source when present is safe.
+    sessionNameSource: incoming.sessionName
+      ? incoming.sessionNameSource
+      : existing.sessionNameSource,
+    // Never clobber a previously-captured intent with a later intent-less write
+    // (e.g. a checkpoint saved before the name/intent was resolved, or a run
+    // with recordContent off).
+    sessionIntent: incoming.sessionIntent ?? existing.sessionIntent,
     repoName: incoming.repoName ?? existing.repoName,
     model: incoming.model ?? existing.model,
     platform: incoming.platform ?? existing.platform,
@@ -768,6 +787,14 @@ export function buildSessionSummary(sources: BuildSessionSummarySources): FullSe
   return {
     sessionId: sessionMetrics.sessionId,
     sessionName: sessionMetrics.sessionName ? redactSensitive(sessionMetrics.sessionName) : null,
+    // Source is an enum label (not user content) — persisted unredacted.
+    sessionNameSource: sessionMetrics.sessionNameSource ?? null,
+    // Intent is SENSITIVE content; the tracker only holds a value when
+    // recordContent was on, and it is already redacted there. Redact again
+    // (idempotent) so persistence is safe regardless of caller.
+    sessionIntent: sessionMetrics.sessionIntent
+      ? redactSensitive(sessionMetrics.sessionIntent)
+      : null,
     repoName: sources.repoName ? redactSensitive(sources.repoName) : null,
     startTime: sessionMetrics.sessionStartTime,
     endTime: now,
@@ -866,6 +893,8 @@ function formatDate(date: Date): string {
 interface SerializedFullSessionSummary {
   readonly sessionId?: unknown;
   readonly sessionName?: unknown;
+  readonly sessionNameSource?: unknown;
+  readonly sessionIntent?: unknown;
   readonly repoName?: unknown;
   readonly startTime?: unknown;
   readonly endTime?: unknown;
@@ -1098,6 +1127,14 @@ export function deserializeFullSessionSummary(
     sessionId:
       typeof obj.sessionId === 'string' && obj.sessionId.length > 0 ? obj.sessionId : 'unknown',
     sessionName: typeof obj.sessionName === 'string' ? obj.sessionName : null,
+    sessionNameSource:
+      obj.sessionNameSource === 'user' ||
+      obj.sessionNameSource === 'ai-title' ||
+      obj.sessionNameSource === 'auto' ||
+      obj.sessionNameSource === 'cwd'
+        ? obj.sessionNameSource
+        : null,
+    sessionIntent: typeof obj.sessionIntent === 'string' ? obj.sessionIntent : null,
     repoName: typeof obj.repoName === 'string' ? obj.repoName : null,
     startTime: typeof obj.startTime === 'number' ? obj.startTime : 0,
     endTime: typeof obj.endTime === 'number' ? obj.endTime : 0,

--- a/src/storage/weekly-summary.test.ts
+++ b/src/storage/weekly-summary.test.ts
@@ -37,6 +37,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   return {
     sessionId: `sess-${now}-${Math.random().toString(36).slice(2)}`,
     sessionName: null,
+    sessionNameSource: null,
+    sessionIntent: null,
     repoName: null,
     startTime: now - 60_000,
     endTime: now,

--- a/src/tools/cross-session-tools.test.ts
+++ b/src/tools/cross-session-tools.test.ts
@@ -66,6 +66,8 @@ function makeSummary(overrides?: Partial<FullSessionSummary>): FullSessionSummar
   return {
     sessionId: `sess-${now}-${Math.random().toString(36).slice(2)}`,
     sessionName: null,
+    sessionNameSource: null,
+    sessionIntent: null,
     repoName: null,
     startTime: now - 60_000,
     endTime: now,

--- a/src/tools/cross-session-tools.ts
+++ b/src/tools/cross-session-tools.ts
@@ -298,7 +298,11 @@ export function handleGetSessionHistory(
 
   const result = limited.map((s) => ({
     session_id: s.sessionId,
+    // Already redacted at persist time (session-store buildFullSessionSummary).
     session_name: s.sessionName ?? null,
+    session_name_source: s.sessionNameSource ?? null,
+    // Intent already redacted at persist time; null unless recordContent was on.
+    session_intent: s.sessionIntent ?? null,
     developer: s.developer,
     start_time: new Date(s.startTime).toISOString(),
     duration_ms: s.durationMs,

--- a/src/tools/session-stats.test.ts
+++ b/src/tools/session-stats.test.ts
@@ -140,6 +140,29 @@ describe('handleGetSessionStats()', () => {
 
     expect(stats.avg_tool_duration_ms).toBe(0);
   });
+
+  it('surfaces session_name (redacted), session_name_source, and session_intent (redacted)', () => {
+    const tracker = new SessionTracker('name-session');
+    // Names/intent can contain secret-shaped text; the tool boundary must redact
+    // both before they leave the process.
+    tracker.setAuthoritativeName('proj AKIAIOSFODNN7EXAMPLE', 'ai-title');
+    tracker.setSessionIntent('deploy with AKIAIOSFODNN7EXAMPLE now');
+
+    const stats = JSON.parse(handleGetSessionStats(tracker).content[0].text);
+
+    expect(stats.session_name_source).toBe('ai-title');
+    expect(stats.session_name).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(stats.session_name).toContain('[REDACTED]');
+    expect(stats.session_intent).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(stats.session_intent).toContain('[REDACTED]');
+  });
+
+  it('reports null session_name_source and session_intent when unset', () => {
+    const tracker = new SessionTracker('bare-session');
+    const stats = JSON.parse(handleGetSessionStats(tracker).content[0].text);
+    expect(stats.session_name_source).toBeNull();
+    expect(stats.session_intent).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tools/session-stats.ts
+++ b/src/tools/session-stats.ts
@@ -16,6 +16,7 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import { createLogger } from '../shared/index.js';
+import { redactSensitive } from '../config.js';
 import { VERSION } from '../version.js';
 
 const logger = createLogger('session-stats');
@@ -169,7 +170,13 @@ export function handleGetSessionStats(sessionTracker: SessionTracker, sessionTra
   const stats = {
     session_trace_id: sessionTraceId ?? null,
     session_id: metrics.sessionId,
-    session_name: metrics.sessionName ?? null,
+    // The name can be an ai-title or a user-given title (not just a directory
+    // basename), so redact before it leaves the process.
+    session_name: metrics.sessionName ? redactSensitive(metrics.sessionName) : null,
+    session_name_source: metrics.sessionNameSource ?? null,
+    // Intent is SENSITIVE content; non-null only when recordContent was on at
+    // capture. Redact again (idempotent) before it leaves the process.
+    session_intent: metrics.sessionIntent ? redactSensitive(metrics.sessionIntent) : null,
     session_duration_ms: metrics.sessionDurationMs,
     tool_calls: metrics.toolCallCount,
     tool_calls_by_type: metrics.toolCallCountByTool,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -40,6 +40,11 @@ export interface AntiPattern {
   readonly suggestion: string;
 }
 
+// Which source produced a session's display name, mirroring the server's
+// SessionNameSource (src/hooks/session-resolver.ts). Declared locally so the
+// web bundle never imports server code; keep the union in sync with the server.
+export type SessionNameSource = 'user' | 'ai-title' | 'auto' | 'cwd';
+
 // Real server type also has `sessionId`/`sessionName`/`liveSessions`/many more
 // counters (see SessionTracker.getMetrics() + efficiencyScore/liveSessions
 // added by the route). Declared fully so every current and future consumer
@@ -47,6 +52,10 @@ export interface AntiPattern {
 export interface SessionCurrentResponse {
   readonly sessionId: string;
   readonly sessionName: string | null;
+  // Lets the UI distinguish an authoritative user/ai-title/auto name from a
+  // cwd-basename fallback (null when unnamed). Matches session_name_source in
+  // the MCP tool response and the persisted summaries.
+  readonly sessionNameSource: SessionNameSource | null;
   readonly sessionStartTime: number;
   readonly sessionDurationMs: number;
   readonly toolCallCount: number;


### PR DESCRIPTION
Fixes #510

## Summary
- Sessions are now named from Claude Code's own per-session titles — a human-given name or Claude's auto-generated title — instead of just the project directory, so sessions in the same repo no longer all show up under one identical, uninformative name. Falls back to the directory name when no title is available yet, and a name only ever gets replaced by an equally or more trustworthy one.
- When content recording is enabled, each session's originating prompt is now available as `session_intent` through the MCP tools, redacted the same way as all other captured content. Off by default, and never exposed on the local dashboard.
- Includes the `1.18.0` version bump and CHANGELOG entry.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors/warnings)
- [x] `npm test` passes (175/176 suites, 1 pre-existing skip; 5936 tests)