### PR TITLE
v1.18.1: session detail shows every model used, not just the last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.1] - 2026-08-28
+
+### Fixed
+
+- **The session detail view's Model card now shows every model used during a session, not just the last one.** A session that switched models partway through (for example, via `/model`) previously showed only whichever model happened to be active when the view loaded.
+
 ## [1.18.0] - 2026-08-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -487,6 +487,76 @@ describe('api-handler GET /api/sessions/:id', () => {
     expect(parsed.outcome).toBe('in progress');
   });
 
+  it('includes modelBreakdown for the current live session when modelUsageTracker is present', async () => {
+    const tracker = new ModelUsageTracker();
+    tracker.recordUsage('claude-sonnet-5', 1000, 500, 3.2);
+    tracker.recordUsage('claude-opus-5', 200, 100, 1.5);
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () =>
+          ({
+            sessionId: 'sess-live-1',
+            sessionName: null,
+            sessionNameSource: null,
+            sessionStartTime: Date.now() - 1_000,
+            sessionDurationMs: 1_000,
+            toolCallCount: 2,
+            toolCallCountByTool: {},
+            toolCallTimeline: [],
+          }) as unknown as ReturnType<
+            NonNullable<Parameters<typeof createApiHandler>[0]['sessionTracker']>['getMetrics']
+          >,
+      },
+      modelUsageTracker: tracker,
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-live-1' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { modelBreakdown: unknown };
+    expect(parsed.modelBreakdown).toEqual(tracker.getRawBreakdown());
+    expect(Object.keys(parsed.modelBreakdown as object)).toEqual([
+      'claude-sonnet-5',
+      'claude-opus-5',
+    ]);
+  });
+
+  it('omits modelBreakdown for the current live session when modelUsageTracker is absent', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () =>
+          ({
+            sessionId: 'sess-live-2',
+            sessionName: null,
+            sessionNameSource: null,
+            sessionStartTime: Date.now() - 1_000,
+            sessionDurationMs: 1_000,
+            toolCallCount: 0,
+            toolCallCountByTool: {},
+            toolCallTimeline: [],
+          }) as unknown as ReturnType<
+            NonNullable<Parameters<typeof createApiHandler>[0]['sessionTracker']>['getMetrics']
+          >,
+      },
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-live-2' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { modelBreakdown?: unknown };
+    expect(parsed.modelBreakdown).toBeUndefined();
+  });
+
   it('attaches qualityProxy (derived from persisted raw counts) to a persisted session with real signals', async () => {
     const fakeSession = {
       sessionId: 'sess-quality-1',

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -2944,6 +2944,13 @@ export function createApiHandler(
             const costMetrics = deps.costTracker?.getMetrics();
             const costUsd = costMetrics?.sessionTotalCostUsd ?? null;
             const model = costMetrics?.model ?? null;
+            // Per-model breakdown so the UI can show every model used this
+            // session, not just the last one seen (`model` above collapses a
+            // mid-session model switch to whichever model was current at
+            // read time). Persisted sessions already carry this via
+            // FullSessionSummary.modelBreakdown — mirror it here so the live
+            // branch renders the same way.
+            const modelBreakdown = deps.modelUsageTracker?.getRawBreakdown();
             const antiPatterns: PersistedAntiPattern[] = deps.antiPatternDetector
               ? toPersistedAntiPatterns(deps.antiPatternDetector.getCurrentPatterns())
               : [];
@@ -2960,6 +2967,7 @@ export function createApiHandler(
               toolCallCount: live.toolCallCount,
               estimatedCostUsd: costUsd,
               model,
+              modelBreakdown,
               outcome: 'in progress',
               toolBreakdown: live.toolCallCountByTool,
               antiPatterns,

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -262,6 +262,22 @@ export interface SessionDetail {
   readonly durationMs?: number;
   readonly estimatedCostUsd?: number | null;
   readonly model?: string | null;
+  // Per-model request/token/cost counters for this session. Present when the
+  // session used one or more models — when it used more than one (a
+  // mid-session model switch, e.g. via /model), `model` above only reflects
+  // whichever model was current at read time, so the UI should prefer this
+  // for display when it has more than one key.
+  readonly modelBreakdown?: Readonly<
+    Record<
+      string,
+      {
+        readonly requestCount: number;
+        readonly totalInputTokens: number;
+        readonly totalOutputTokens: number;
+        readonly totalCostUsd: number;
+      }
+    >
+  >;
   readonly outcome?: string;
   readonly toolBreakdown?: Record<string, number>;
   readonly filesRead?: string[];

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -234,6 +234,71 @@ describe('Sessions view', () => {
     expect(screen.getByText('completed')).toBeInTheDocument();
   });
 
+  it('renders every model in the Model card when modelBreakdown has more than one entry, most-called first', async () => {
+    const detail = {
+      sessionId: 's1',
+      model: 'claude-opus-5',
+      modelBreakdown: {
+        'claude-opus-5': {
+          requestCount: 2,
+          totalInputTokens: 100,
+          totalOutputTokens: 50,
+          totalCostUsd: 0.5,
+        },
+        'claude-sonnet-5': {
+          requestCount: 8,
+          totalInputTokens: 400,
+          totalOutputTokens: 200,
+          totalCostUsd: 1.5,
+        },
+      },
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+    };
+    const { container } = renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(screen.getAllByText('Read').length).toBeGreaterThanOrEqual(1));
+    expect(screen.getByText('Models (2)')).toBeInTheDocument();
+    expect(screen.getByText('claude-sonnet-5')).toBeInTheDocument();
+    expect(screen.getByText('claude-opus-5')).toBeInTheDocument();
+    // Most-called model (claude-sonnet-5, 8 requests) renders before the
+    // last-seen one (claude-opus-5, `model` above, only 2 requests).
+    const text = container.textContent ?? '';
+    expect(text.indexOf('claude-sonnet-5')).toBeLessThan(text.indexOf('claude-opus-5'));
+  });
+
+  it('renders the single-model layout unchanged when modelBreakdown has exactly one entry', async () => {
+    const detail = {
+      sessionId: 's1',
+      model: 'claude-sonnet-5',
+      modelBreakdown: {
+        'claude-sonnet-5': {
+          requestCount: 5,
+          totalInputTokens: 200,
+          totalOutputTokens: 100,
+          totalCostUsd: 1,
+        },
+      },
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+    };
+    renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(screen.getAllByText('Read').length).toBeGreaterThanOrEqual(1));
+    expect(screen.getByText('Model')).toBeInTheDocument();
+    expect(screen.queryByText(/Models \(/)).toBeNull();
+    expect(screen.getByText('claude-sonnet-5')).toBeInTheDocument();
+  });
+
+  it('falls back to data.model when modelBreakdown is absent or empty', async () => {
+    const detail = {
+      sessionId: 's1',
+      model: 'claude-sonnet-5',
+      modelBreakdown: {},
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+    };
+    renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(screen.getAllByText('Read').length).toBeGreaterThanOrEqual(1));
+    expect(screen.getByText('Model')).toBeInTheDocument();
+    expect(screen.getByText('claude-sonnet-5')).toBeInTheDocument();
+  });
+
   it('renders a Files Read list from data.filesRead, truncated to the last two path segments', async () => {
     const detail = {
       sessionId: 's1',

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -873,6 +873,21 @@ function SessionTimeline({
   const durationLabel = data.durationMs != null ? formatDuration(data.durationMs) : null;
   const entries = data.timeline ?? [];
   const first = entries.length > 0 ? entries[0]!.timestamp : 0;
+  // Models used this session, most-called first. Falls back to the single
+  // `model` field when no breakdown is present (older persisted sessions,
+  // or the cross-process live branch, predate `modelBreakdown`). A session
+  // that switched models mid-run (e.g. via /model) has more than one entry
+  // here even though `model` only reflects whichever was current at read
+  // time.
+  const modelBreakdownEntries = Object.entries(data.modelBreakdown ?? {});
+  const modelsUsed =
+    modelBreakdownEntries.length > 0
+      ? modelBreakdownEntries
+          .sort((a, b) => b[1].requestCount - a[1].requestCount)
+          .map(([model]) => model)
+      : data.model
+        ? [data.model]
+        : [];
 
   if (entries.length === 0 && breakdownEntries.length === 0) {
     return (
@@ -924,10 +939,20 @@ function SessionTimeline({
       </div>
 
       <div className="grid grid-cols-3 gap-2 mb-4 text-xs">
-        {data.model && (
+        {modelsUsed.length > 0 && (
           <div className="bg-surface-3 rounded-lg p-2.5">
-            <Eyebrow>Model</Eyebrow>
-            <div className="font-mono">{data.model}</div>
+            <Eyebrow>{modelsUsed.length > 1 ? `Models (${modelsUsed.length})` : 'Model'}</Eyebrow>
+            {modelsUsed.length > 1 ? (
+              <div className="flex flex-col gap-0.5 mt-0.5">
+                {modelsUsed.map((m) => (
+                  <div key={m} className="font-mono text-[11px] truncate" title={m}>
+                    {m}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="font-mono">{modelsUsed[0]}</div>
+            )}
           </div>
         )}
         {data.estimatedCostUsd != null && (


### PR DESCRIPTION
## Summary
- The session detail view's Model card read a single "model most recently seen" field, so a session that switched models mid-run (e.g. via `/model`) only ever showed one.
- Surfaces the full per-model breakdown — already tracked and already persisted for completed sessions — on the live-session API branch and in the client type, and renders every model used (most-called first) in the Model card when more than one appears. Single-model sessions render exactly as before.
- Includes the `1.18.1` version bump and CHANGELOG entry.

Fixes #517

Original implementation by @adjohn.

## Test plan
- [x] `npx tsc -b .` passes
- [x] `npm run lint` passes (0 errors/warnings)
- [x] `npm run format:check` passes
- [x] `npm test` passes (175/176 suites, 1 pre-existing skip; 5938 tests)
- [x] `npm run test:web` passes (528 tests)