### PR TITLE
v1.18.2: API Failures dashboard panel and MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.2] - 2026-08-28
+
+### Added
+
+- **A new "API Failures" dashboard panel and `nr_observe_get_api_failures` MCP tool report model-API failures observed via Claude Code's `StopFailure` hook** — turns that failed outright after Claude Code's own retries were exhausted, broken down by error type (rate limit, server error, authentication, context length exceeded) with throttle-rate alerts when a model repeatedly rate-limits in a short window. Token loss, recovery time, and retry-count fields remain unavailable, since the `StopFailure` hook does not carry that data.
+
 ## [1.18.1] - 2026-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.1] - 2026-08-28
+
+### Fixed
+
+- **The session detail view's Model card now shows every model used during a session, not just the last one.** A session that switched models partway through (for example, via `/model`) previously showed only whichever model happened to be active when the view loaded.
+
 ## [1.18.0] - 2026-08-28
 
 ### Added

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -37,7 +37,7 @@ Detection order matters: `createDefaultRegistry()` (`src/platforms/platform-regi
 
 ## Claude Code (`claude-code`)
 
-**Mechanism:** Native `PreToolUse`/`PostToolUse`/`PostToolUseFailure` hooks, installed by Preflight itself.
+**Mechanism:** Native `PreToolUse`/`PostToolUse`/`PostToolUseFailure` hooks, installed by Preflight itself, plus a separate `StopFailure` hook (its own top-level settings.json hooks key, not a `PostToolUse` payload variant) that feeds `ApiFailureTracker` with model-API-call failures.
 
 **Detection (`isSupported()`):** `CLAUDE_CODE` env var set, or `CLAUDE_CODE_VERSION` set, or `MCP_CLIENT === 'claude-code'`.
 

--- a/docs/METRICS_TABLE.md
+++ b/docs/METRICS_TABLE.md
@@ -383,6 +383,20 @@ Emitted every 60 seconds alongside session gauges (only when an `EfficiencyScore
 
 Source: `src/metrics/efficiency-score.ts` — `emitMetrics()`
 
+### MCP Server — API Failure Metrics
+
+Emitted every 60 seconds alongside session gauges (only when an `ApiFailureTracker` is wired in). Attributes: `{developer, session_id?, team_id?, project_id?, org_id?}` plus `{error_type}` or `{model}` where noted.
+
+| Metric Name                     | Value      | Attributes     | How Computed                                                                                                                  |
+| ------------------------------- | ---------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `ai.api.failures_total`         | count      | —              | Total recorded `StopFailure` events                                                                                           |
+| `ai.api.tokens_lost`            | count      | —              | Always 0 — `StopFailure` carries no token data (see tracker note)                                                             |
+| `ai.api.failure_by_type`        | count      | `{error_type}` | Per-`ApiErrorType` failure count, emitted only when count > 0                                                                 |
+| `ai.api.model_failure_rate`     | rate (0–1) | `{model}`      | `failureCount / totalRequests` per model — requires `recordRequest()` calls not currently made, so this stays unemitted today |
+| `ai.api.model_mean_recovery_ms` | duration   | `{model}`      | Mean `recoveryMs` per model — always `null`/unemitted since `StopFailure` never reports a recovery time                       |
+
+Source: `src/metrics/api-failure-tracker.ts` — `emitMetrics()`
+
 ### Metric Aggregation
 
 All metrics pass through the `MetricAggregator` before being sent. For each unique (name + attributes) combination, the aggregator emits a single `summary` metric with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1235,6 +1235,43 @@ describe('api-handler GET /api/retry-alerts', () => {
   });
 });
 
+describe('api-handler GET /api/api-failures', () => {
+  it('returns 503 when apiFailureTracker is missing', async () => {
+    const handler = createApiHandler({});
+    const req = { method: 'GET', url: '/api/api-failures' } as IncomingMessage;
+    const { res, status } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns api failure metrics as JSON', async () => {
+    const fakeMetrics = {
+      totalFailures: 2,
+      byErrorType: { rate_limit: 2 },
+      byModel: {},
+      bySessionPhase: { early: 0, middle: 2, late: 0 },
+      totalTokensLost: 0,
+      totalEstimatedCostLostUsd: 0,
+      meanTimeToRecoveryMs: null,
+      throttleAlerts: [],
+      recentFailures: [],
+      dataAvailable: true,
+      note: 'partial data',
+    };
+    const handler = createApiHandler({
+      apiFailureTracker: { getMetrics: () => fakeMetrics } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['apiFailureTracker'],
+    });
+    const req = { method: 'GET', url: '/api/api-failures' } as IncomingMessage;
+    const { res, status, body, headers } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    expect(headers()['content-type']).toMatch(/application\/json/);
+    expect(JSON.parse(body())).toEqual(fakeMetrics);
+  });
+});
+
 describe('api-handler GET /api/instruction-drift', () => {
   it('returns 503 when instructionDriftTracker is missing', async () => {
     const handler = createApiHandler({});

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -487,6 +487,76 @@ describe('api-handler GET /api/sessions/:id', () => {
     expect(parsed.outcome).toBe('in progress');
   });
 
+  it('includes modelBreakdown for the current live session when modelUsageTracker is present', async () => {
+    const tracker = new ModelUsageTracker();
+    tracker.recordUsage('claude-sonnet-5', 1000, 500, 3.2);
+    tracker.recordUsage('claude-opus-5', 200, 100, 1.5);
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () =>
+          ({
+            sessionId: 'sess-live-1',
+            sessionName: null,
+            sessionNameSource: null,
+            sessionStartTime: Date.now() - 1_000,
+            sessionDurationMs: 1_000,
+            toolCallCount: 2,
+            toolCallCountByTool: {},
+            toolCallTimeline: [],
+          }) as unknown as ReturnType<
+            NonNullable<Parameters<typeof createApiHandler>[0]['sessionTracker']>['getMetrics']
+          >,
+      },
+      modelUsageTracker: tracker,
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-live-1' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { modelBreakdown: unknown };
+    expect(parsed.modelBreakdown).toEqual(tracker.getRawBreakdown());
+    expect(Object.keys(parsed.modelBreakdown as object)).toEqual([
+      'claude-sonnet-5',
+      'claude-opus-5',
+    ]);
+  });
+
+  it('omits modelBreakdown for the current live session when modelUsageTracker is absent', async () => {
+    const handler = createApiHandler({
+      sessionStore: {
+        loadTodaySessions: () => [],
+        listSessions: () => [],
+        loadSession: () => null,
+      } as unknown as Parameters<typeof createApiHandler>[0]['sessionStore'],
+      sessionTracker: {
+        getMetrics: () =>
+          ({
+            sessionId: 'sess-live-2',
+            sessionName: null,
+            sessionNameSource: null,
+            sessionStartTime: Date.now() - 1_000,
+            sessionDurationMs: 1_000,
+            toolCallCount: 0,
+            toolCallCountByTool: {},
+            toolCallTimeline: [],
+          }) as unknown as ReturnType<
+            NonNullable<Parameters<typeof createApiHandler>[0]['sessionTracker']>['getMetrics']
+          >,
+      },
+    });
+    const req = { method: 'GET', url: '/api/sessions/sess-live-2' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as { modelBreakdown?: unknown };
+    expect(parsed.modelBreakdown).toBeUndefined();
+  });
+
   it('attaches qualityProxy (derived from persisted raw counts) to a persisted session with real signals', async () => {
     const fakeSession = {
       sessionId: 'sess-quality-1',

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -15,6 +15,7 @@ import {
 } from '../../lib/date.js';
 import type { AntiPattern } from '../../metrics/anti-patterns.js';
 import { AntiPatternDetector } from '../../metrics/anti-patterns.js';
+import type { ApiFailureMetrics } from '../../metrics/api-failure-tracker.js';
 import type { BudgetStatus } from '../../metrics/budget-tracker.js';
 import type { ContextCompositionMetrics } from '../../metrics/context-composition-tracker.js';
 import type { ContextReplayEvent, ContextTrackerMetrics } from '../../metrics/context-tracker.js';
@@ -450,6 +451,7 @@ export interface ApiHandlerDeps {
     getTotalAntiPatternWaste: () => number;
   };
   readonly retryDetector?: { getMetrics: () => RetryDetectorMetrics };
+  readonly apiFailureTracker?: { getMetrics: () => ApiFailureMetrics };
   readonly instructionDriftTracker?: { getMetrics: () => InstructionDriftMetrics };
   readonly decisionTracker?: { getMetrics: (sessionId?: string) => DecisionTreeMetrics };
   readonly turnCostAttributor?: { getMetrics: (sessionId?: string) => CostAttributionMetrics };
@@ -1811,6 +1813,11 @@ export function createApiHandler(
   routes.set('GET /api/retry-alerts', (_req, res) => {
     if (!deps.retryDetector) return unavailable(res, 'retryDetector');
     jsonOk(res, deps.retryDetector.getMetrics());
+  });
+
+  routes.set('GET /api/api-failures', (_req, res) => {
+    if (!deps.apiFailureTracker) return unavailable(res, 'apiFailureTracker');
+    jsonOk(res, deps.apiFailureTracker.getMetrics());
   });
 
   routes.set('GET /api/instruction-drift', (_req, res) => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -2944,6 +2944,13 @@ export function createApiHandler(
             const costMetrics = deps.costTracker?.getMetrics();
             const costUsd = costMetrics?.sessionTotalCostUsd ?? null;
             const model = costMetrics?.model ?? null;
+            // Per-model breakdown so the UI can show every model used this
+            // session, not just the last one seen (`model` above collapses a
+            // mid-session model switch to whichever model was current at
+            // read time). Persisted sessions already carry this via
+            // FullSessionSummary.modelBreakdown — mirror it here so the live
+            // branch renders the same way.
+            const modelBreakdown = deps.modelUsageTracker?.getRawBreakdown();
             const antiPatterns: PersistedAntiPattern[] = deps.antiPatternDetector
               ? toPersistedAntiPatterns(deps.antiPatternDetector.getCurrentPatterns())
               : [];
@@ -2960,6 +2967,7 @@ export function createApiHandler(
               toolCallCount: live.toolCallCount,
               estimatedCostUsd: costUsd,
               model,
+              modelBreakdown,
               outcome: 'in progress',
               toolBreakdown: live.toolCallCountByTool,
               antiPatterns,

--- a/src/hooks/collector-script.test.ts
+++ b/src/hooks/collector-script.test.ts
@@ -87,6 +87,19 @@ function makePostToolUseFailure(overrides?: Record<string, unknown>): string {
   });
 }
 
+function makeStopFailure(overrides?: Record<string, unknown>): string {
+  return JSON.stringify({
+    session_id: 'abc123',
+    transcript_path: '/Users/test/.claude/projects/test/abc123.jsonl',
+    cwd: '/Users/test/project',
+    hook_event_name: 'StopFailure',
+    error: 'rate_limit',
+    error_details: '429 Too Many Requests',
+    last_assistant_message: 'API Error: Rate limit reached',
+    ...overrides,
+  });
+}
+
 function makeGeminiBeforeTool(overrides?: Record<string, unknown>): string {
   return JSON.stringify({
     hook_event_name: 'BeforeTool',
@@ -513,6 +526,71 @@ describe('collector-script', () => {
       const event = readBufferEvents()[0]!;
       expect(event.error).not.toContain('sk-1234567890abcdef');
       expect(event.error).toContain('[REDACTED]');
+    });
+  });
+
+  describe('processHook() — StopFailure', () => {
+    it('writes an api_failure event with the raw errorType', () => {
+      processHook(makeStopFailure());
+
+      const events = readBufferEvents();
+      expect(events).toHaveLength(1);
+
+      const event = events[0]!;
+      expect(event.mode).toBe('api_failure');
+      expect(event.errorType).toBe('rate_limit');
+      expect(event.sessionId).toBe('abc123');
+    });
+
+    it('includes redacted error_details and last_assistant_message when recordContent=true', () => {
+      process.env.NEW_RELIC_AI_MCP_RECORD_CONTENT = 'true';
+
+      processHook(makeStopFailure());
+
+      const event = readBufferEvents()[0]!;
+      expect(event.errorDetails).toBe('429 Too Many Requests');
+      expect(event.lastAssistantMessage).toBe('API Error: Rate limit reached');
+    });
+
+    it('omits error_details and last_assistant_message when recordContent=false', () => {
+      processHook(makeStopFailure());
+
+      const event = readBufferEvents()[0]!;
+      expect(event.errorDetails).toBeUndefined();
+      expect(event.lastAssistantMessage).toBeUndefined();
+    });
+
+    it('redacts sensitive information in error_details and last_assistant_message', () => {
+      process.env.NEW_RELIC_AI_MCP_RECORD_CONTENT = 'true';
+
+      processHook(
+        makeStopFailure({
+          error_details: 'Authorization failed: Bearer eyJhbGciOiJIUzI1NiJ9.token.signature',
+          last_assistant_message: 'Failed: API_KEY = sk-1234567890abcdef',
+        }),
+      );
+
+      const event = readBufferEvents()[0]!;
+      expect(event.errorDetails).toContain('[REDACTED]');
+      expect(event.errorDetails).not.toContain('eyJhbGciOiJIUzI1NiJ9');
+      expect(event.lastAssistantMessage).toContain('[REDACTED]');
+      expect(event.lastAssistantMessage).not.toContain('sk-1234567890abcdef');
+    });
+
+    it('JSON.stringifies a non-string error_details', () => {
+      process.env.NEW_RELIC_AI_MCP_RECORD_CONTENT = 'true';
+
+      processHook(makeStopFailure({ error_details: { code: 429, message: 'Too Many Requests' } }));
+
+      const event = readBufferEvents()[0]!;
+      expect(event.errorDetails).toBe('{"code":429,"message":"Too Many Requests"}');
+    });
+
+    it('defaults errorType to "unknown" when error is missing', () => {
+      processHook(makeStopFailure({ error: undefined }));
+
+      const event = readBufferEvents()[0]!;
+      expect(event.errorType).toBe('unknown');
     });
   });
 

--- a/src/hooks/collector-script.ts
+++ b/src/hooks/collector-script.ts
@@ -343,6 +343,13 @@ interface HookInput {
   transcript_path?: string;
   error?: string;
   is_interrupt?: boolean;
+  // StopFailure (code.claude.com/docs/en/hooks.md) reuses `error` above for its
+  // closed error-type enum and adds these two free-text fields: error_details
+  // ("when available", no strict type — string or an object to JSON.stringify)
+  // and last_assistant_message (the raw API error text shown to the user, NOT
+  // Claude's conversational output as it is for Stop/SubagentStop).
+  error_details?: unknown;
+  last_assistant_message?: string;
   // Cursor (https://cursor.com/docs/agent/hooks) sends a different field
   // vocabulary per hook type instead of the uniform tool_name/tool_input
   // Claude Code and Kiro use. conversation_id is Cursor's closest analog to
@@ -984,6 +991,36 @@ function processHook(raw: string): void {
       toolUseId: String(data.stepIdx),
       ...(typeof data.error === 'string' && data.error !== '' && { error: redact(data.error) }),
     };
+  } else if (eventName === 'stopfailure') {
+    // Fires once per turn when a model-API call ultimately fails after
+    // Claude Code's own internal retries are exhausted
+    // (code.claude.com/docs/en/hooks.md). Pure notification — no decision
+    // control. `data.error` here is the 10-value closed error-type enum
+    // (rate_limit | overloaded | authentication_failed | ... | unknown),
+    // mapped downstream to ApiErrorType by
+    // metrics/api-failure-tracker.ts#mapClaudeCodeErrorType — never mapped
+    // here, since storage/types.ts must not depend on that module.
+    event = {
+      mode: 'api_failure' as const,
+      errorType: data.error ?? 'unknown',
+      timestamp,
+    };
+
+    // error_details/last_assistant_message are free-text "content" — same
+    // sensitivity class as tool input/output content — unlike errorType
+    // (a safe closed enum), so both are gated behind recordContent.
+    if (recordContent) {
+      if (data.error_details !== undefined) {
+        const details =
+          typeof data.error_details === 'string'
+            ? data.error_details
+            : JSON.stringify(data.error_details);
+        event.errorDetails = redact(truncate(details, maxContentLen));
+      }
+      if (typeof data.last_assistant_message === 'string') {
+        event.lastAssistantMessage = redact(truncate(data.last_assistant_message, maxContentLen));
+      }
+    }
   } else {
     // Unknown hook event — ignore silently
     return;

--- a/src/hooks/event-processor.test.ts
+++ b/src/hooks/event-processor.test.ts
@@ -1217,6 +1217,118 @@ describe('HookEventProcessor', () => {
     });
   });
 
+  describe('mode: api_failure', () => {
+    it('routes mode:api_failure entries through onApiFailure with the raw error type unmapped', () => {
+      const frames: import('./event-processor.js').ApiFailureFrame[] = [];
+      const processor = new HookEventProcessor({
+        store,
+        onRecord: () => undefined,
+        onApiFailure: (f) => frames.push(f),
+      });
+
+      processor.processEvents([
+        {
+          mode: 'api_failure',
+          tool: 'api_failure',
+          errorType: 'overloaded',
+          timestamp: 1700000000000,
+          sessionId: 's1',
+        } as HookEvent,
+      ]);
+
+      expect(frames).toHaveLength(1);
+      // rawErrorType must stay the raw Claude Code string — mapping to ApiErrorType
+      // happens downstream, not in event-processor.ts.
+      expect(frames[0].rawErrorType).toBe('overloaded');
+      expect(frames[0].sessionId).toBe('s1');
+      expect(frames[0].timestamp).toBe(1700000000000);
+    });
+
+    it('carries errorDetails and lastAssistantMessage through when present', () => {
+      const frames: import('./event-processor.js').ApiFailureFrame[] = [];
+      const processor = new HookEventProcessor({
+        store,
+        onRecord: () => undefined,
+        onApiFailure: (f) => frames.push(f),
+      });
+
+      processor.processEvents([
+        {
+          mode: 'api_failure',
+          tool: 'api_failure',
+          errorType: 'rate_limit',
+          errorDetails: '429 Too Many Requests',
+          lastAssistantMessage: 'API Error: Rate limit reached',
+          timestamp: 1700000000000,
+          sessionId: 's1',
+        } as HookEvent,
+      ]);
+
+      expect(frames).toHaveLength(1);
+      expect(frames[0].errorDetails).toBe('429 Too Many Requests');
+      expect(frames[0].lastAssistantMessage).toBe('API Error: Rate limit reached');
+    });
+
+    it('defaults sessionId to null when absent', () => {
+      const frames: import('./event-processor.js').ApiFailureFrame[] = [];
+      const processor = new HookEventProcessor({
+        store,
+        onRecord: () => undefined,
+        onApiFailure: (f) => frames.push(f),
+      });
+
+      processor.processEvents([
+        {
+          mode: 'api_failure',
+          tool: 'api_failure',
+          errorType: 'unknown',
+          timestamp: 1700000000000,
+        } as HookEvent,
+      ]);
+
+      expect(frames).toHaveLength(1);
+      expect(frames[0].sessionId).toBeNull();
+    });
+
+    it('swallows errors from a throwing onApiFailure callback', () => {
+      const processor = new HookEventProcessor({
+        store,
+        onRecord: () => undefined,
+        onApiFailure: () => {
+          throw new Error('boom');
+        },
+      });
+
+      expect(() =>
+        processor.processEvents([
+          {
+            mode: 'api_failure',
+            tool: 'api_failure',
+            errorType: 'rate_limit',
+            timestamp: 1700000000000,
+            sessionId: 's1',
+          } as HookEvent,
+        ]),
+      ).not.toThrow();
+    });
+
+    it('is a no-op when onApiFailure is not configured', () => {
+      const processor = new HookEventProcessor({ store, onRecord });
+
+      expect(() =>
+        processor.processEvents([
+          {
+            mode: 'api_failure',
+            tool: 'api_failure',
+            errorType: 'rate_limit',
+            timestamp: 1700000000000,
+          } as HookEvent,
+        ]),
+      ).not.toThrow();
+      expect(records).toHaveLength(0);
+    });
+  });
+
   describe('platform tool-name mapping', () => {
     it('maps a non-canonical tool name using the injected platform adapter', () => {
       const fakeAdapter = {

--- a/src/hooks/event-processor.ts
+++ b/src/hooks/event-processor.ts
@@ -22,6 +22,7 @@ import type {
   TokenHookEvent,
   SubagentTokenHookEvent,
   ObservabilityHealthHookEvent,
+  ApiFailureHookEvent,
   ToolCallRecord,
   TokenEvent,
   SubagentTokenEvent,
@@ -73,6 +74,8 @@ export interface HookEventProcessorOptions {
   onSubagentToken?: (event: SubagentTokenEvent) => void;
   /** Fires for every `mode: 'workflow_run'` line; errors swallowed. */
   onWorkflowRun?: (event: WorkflowRunEvent) => void;
+  /** Fires for every `mode: 'api_failure'` line; errors swallowed. */
+  onApiFailure?: (event: ApiFailureFrame) => void;
   /**
    * Adapter used to map each platform's raw tool names (e.g. Kiro's `fs_read`)
    * to Preflight's canonical vocabulary (`Read`) before pairing/emitting.
@@ -123,6 +126,21 @@ export interface ObservabilityHealthFrame {
   readonly fingerprint?: string;
   readonly workflowRunId?: string;
   readonly costSelfCheckDeltaPct?: number;
+}
+
+/**
+ * Wire-shape data extracted from a `mode: 'api_failure'` entry. `rawErrorType`
+ * is deliberately kept as Claude Code's raw error string (e.g. 'overloaded'),
+ * NOT mapped to `ApiErrorType` — this file must not depend on `metrics/`, so
+ * mapping happens downstream in the callback wiring, mirroring how
+ * `ObservabilityHealthFrame` stays domain-agnostic too.
+ */
+export interface ApiFailureFrame {
+  readonly timestamp: number;
+  readonly sessionId: string | null;
+  readonly rawErrorType: string;
+  readonly errorDetails?: string;
+  readonly lastAssistantMessage?: string;
 }
 
 function numAttr(v: unknown): number {
@@ -214,6 +232,7 @@ export class HookEventProcessor {
   private readonly onObservabilityHealth: ((event: ObservabilityHealthFrame) => void) | null;
   private readonly onSubagentToken: ((event: SubagentTokenEvent) => void) | null;
   private readonly onWorkflowRun: ((event: WorkflowRunEvent) => void) | null;
+  private readonly onApiFailure: ((event: ApiFailureFrame) => void) | null;
   private readonly platformAdapter: PlatformAdapter;
   /**
    * Per-agent dedup rings for recent subagent turns (scoped by agentId, one
@@ -268,6 +287,7 @@ export class HookEventProcessor {
     this.onObservabilityHealth = options.onObservabilityHealth ?? null;
     this.onSubagentToken = options.onSubagentToken ?? null;
     this.onWorkflowRun = options.onWorkflowRun ?? null;
+    this.onApiFailure = options.onApiFailure ?? null;
     this.platformAdapter = options.platformAdapter ?? createDefaultRegistry().getActive();
 
     this.boundBeforeExit = () => {
@@ -376,6 +396,8 @@ export class HookEventProcessor {
           this.handleObservabilityHealthEvent(event);
         } else if (event.mode === 'workflow_run') {
           this.handleWorkflowRunEvent(event);
+        } else if (event.mode === 'api_failure') {
+          this.handleApiFailureEvent(event);
         }
       } catch (err) {
         logger.warn('Error processing hook event', {
@@ -742,6 +764,29 @@ export class HookEventProcessor {
       this.onObservabilityHealth(frame);
     } catch (err) {
       logger.warn('onObservabilityHealth callback failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private handleApiFailureEvent(event: ApiFailureHookEvent): void {
+    if (!this.onApiFailure) return;
+    const frame: ApiFailureFrame = {
+      timestamp:
+        typeof event.timestamp === 'number' && Number.isFinite(event.timestamp)
+          ? event.timestamp
+          : Date.now(),
+      sessionId: event.sessionId ?? null,
+      rawErrorType: event.errorType,
+      ...(typeof event.errorDetails === 'string' ? { errorDetails: event.errorDetails } : {}),
+      ...(typeof event.lastAssistantMessage === 'string'
+        ? { lastAssistantMessage: event.lastAssistantMessage }
+        : {}),
+    };
+    try {
+      this.onApiFailure(frame);
+    } catch (err) {
+      logger.warn('onApiFailure callback failed', {
         error: err instanceof Error ? err.message : String(err),
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ import { migrateStoragePath } from './install/migrate.js';
 import { checkNodeVersion } from './install/node-version-check.js';
 import { localDateKey, todayPortionOfSessionCost } from './lib/date.js';
 import { AntiPatternDetector } from './metrics/anti-patterns.js';
-import { ApiFailureTracker } from './metrics/api-failure-tracker.js';
+import { ApiFailureTracker, mapClaudeCodeErrorType } from './metrics/api-failure-tracker.js';
 import { BudgetTracker } from './metrics/budget-tracker.js';
 import { ClaudeMdTracker } from './metrics/claudemd-tracker.js';
 import { CollaborationProfiler } from './metrics/collaboration-profile.js';
@@ -1023,11 +1023,12 @@ async function main(): Promise<void> {
     });
     const toolSelectionScorer = new ToolSelectionScorer();
     const qualityProxyTracker = new QualityProxyTracker();
-    // ApiFailureTracker is instantiated but never fed: recordRequest()/recordFailure()
-    // require visibility into model-API-level traffic (LLM provider rate limits,
-    // timeouts, auth errors), which is not observable in either stdio mode (hooks
-    // only see Claude Code's own tool calls) or proxy mode (which forwards to MCP
-    // servers, not the model API). Kept dormant for a future LLM-facing proxy.
+    // Fed via Claude Code's StopFailure hook (see the onApiFailure callback on
+    // eventProcessor below) through recordFailure(). recordRequest() still has
+    // no caller — request-level latency/throughput stays unobservable — and
+    // recordFailure()'s tokensInFlight/recoveryMs/retryCount/totalRequests
+    // inputs stay at their "unknown" defaults for the same reason. See
+    // api-failure-tracker.ts's API_FAILURE_PARTIAL_DATA_NOTE for the full story.
     const apiFailureTracker = new ApiFailureTracker();
     liveSessionRegistry = new LiveSessionRegistry();
     liveSessionRegistry.startSampling();
@@ -1582,6 +1583,7 @@ async function main(): Promise<void> {
           },
           antiPatternDetector,
           retryDetector,
+          apiFailureTracker,
           instructionDriftTracker,
           decisionTracker,
           turnCostAttributor,
@@ -1787,6 +1789,7 @@ async function main(): Promise<void> {
         costTracker,
         efficiencyScorer,
         feedbackCollector,
+        apiFailureTracker,
         turnCostAttributor,
         sessionTraceId,
       });
@@ -2232,6 +2235,30 @@ async function main(): Promise<void> {
             : {}),
         });
       },
+      onApiFailure: (frame) => {
+        if (!config) return;
+        const errorType = mapClaudeCodeErrorType(frame.rawErrorType);
+        // Prefer a model already learned from real token events over the
+        // config default, mirroring the estimateModel fallback above.
+        const model = costTracker.getMetrics().model ?? config.model ?? 'unknown';
+        const turnNumber = turnTracker.getCurrentTurnNumber();
+        // totalTurnsInSession is left unspecified: there is no reliable
+        // "total turns for this session" figure available at failure time
+        // (the session may still be ongoing), and recordFailure() already
+        // defaults it sensibly for sessionPhase bucketing.
+        const duringToolExecution = eventProcessor !== undefined && eventProcessor.pendingCount > 0;
+        apiFailureTracker.recordFailure({
+          errorType,
+          model,
+          turnNumber,
+          // Unobservable from StopFailure; see api-failure-tracker.ts's note constant.
+          tokensInFlight: 0,
+          // Known, not a placeholder: StopFailure only fires after Claude
+          // Code's own retries are exhausted with no successful recovery.
+          recoverySucceeded: false,
+          duringToolExecution,
+        });
+      },
     });
 
     persistSession = (opts?: { periodic?: boolean }) => {
@@ -2611,6 +2638,7 @@ async function main(): Promise<void> {
           costTracker,
           efficiencyScorer,
           feedbackCollector,
+          apiFailureTracker,
           turnCostAttributor,
           sessionTraceId: realId,
         });
@@ -2930,6 +2958,14 @@ async function main(): Promise<void> {
       const proxyLocalStore = new LocalStore(config.storagePath);
       proxyLocalStore.initialize();
 
+      // Proxy mode never constructs a HookEventProcessor, so nothing ever
+      // calls recordFailure() on this instance (StopFailure is a Claude
+      // Code-side hook, not something proxied traffic can surface) — passed
+      // in anyway so NrIngestManager's emitMetrics() call is uniform across
+      // modes, legitimately reporting zero failures rather than being asked
+      // to handle a missing tracker.
+      const apiFailureTracker = new ApiFailureTracker();
+
       nrIngest = new NrIngestManager({
         licenseKey: config.licenseKey,
         transportOptions: {
@@ -2945,6 +2981,7 @@ async function main(): Promise<void> {
         localStore: proxyLocalStore,
         eventHarvestIntervalMs: config.harvestIntervalMs.events,
         metricHarvestIntervalMs: config.harvestIntervalMs.metrics,
+        apiFailureTracker,
         sessionTraceId,
         // Proxy mode has no single coherent session — sessionTracker above is
         // never fed per-client activity, so the ai.session.* gauges would

--- a/src/install/install-helper.test.ts
+++ b/src/install/install-helper.test.ts
@@ -16,6 +16,7 @@ import {
   entryHasAnyCommandHook,
   areHooksInstalled,
   readAndCheckHooks,
+  NR_HOOK_RE,
 } from './install-helper.js';
 import { writeJsonFile } from './json-utils.js';
 
@@ -37,6 +38,30 @@ afterEach(() => {
   if (existsSync(tmpDir)) {
     rmSync(tmpDir, { recursive: true, force: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// NR_HOOK_RE
+// ---------------------------------------------------------------------------
+
+describe('NR_HOOK_RE', () => {
+  it('matches the bare stop-failure command form', () => {
+    expect(NR_HOOK_RE.test('preflight-collector stop-failure')).toBe(true);
+  });
+
+  it('matches the absolute-path stop-failure command form (quoted or unquoted)', () => {
+    expect(NR_HOOK_RE.test('/abs/path/preflight-collector stop-failure')).toBe(true);
+    expect(NR_HOOK_RE.test('"/quoted/path/preflight-collector" stop-failure')).toBe(true);
+  });
+
+  it('still matches pre-tool and post-tool command forms', () => {
+    expect(NR_HOOK_RE.test('preflight-collector pre-tool')).toBe(true);
+    expect(NR_HOOK_RE.test('preflight-collector post-tool')).toBe(true);
+  });
+
+  it('does not match unrelated commands', () => {
+    expect(NR_HOOK_RE.test('some-other-tool stop-failure')).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -135,6 +160,33 @@ describe('generateHookEntries', () => {
     const hooks = generateHookEntries(null);
 
     expect(hooks.PreToolUse[0].hooks[0].command).toBe('preflight-collector pre-tool');
+  });
+
+  it('generates a StopFailure entry alongside PreToolUse/PostToolUse', () => {
+    const hooks = generateHookEntries('/usr/local/bin/preflight');
+
+    expect(hooks.StopFailure).toEqual([
+      {
+        matcher: '',
+        hooks: [{ type: 'command', command: '"/usr/local/bin/preflight-collector" stop-failure' }],
+      },
+    ]);
+  });
+
+  it('generates a bare-name StopFailure command when no binPath provided', () => {
+    const hooks = generateHookEntries();
+
+    expect(hooks.StopFailure).toEqual([
+      { matcher: '', hooks: [{ type: 'command', command: 'preflight-collector stop-failure' }] },
+    ]);
+  });
+
+  it('wsl mode: generates a quoted wsl.exe StopFailure command', () => {
+    const hooks = generateHookEntries('/home/user/bin/preflight', { platform: 'wsl-windows-cc' });
+
+    expect(hooks.StopFailure[0].hooks[0].command).toBe(
+      'wsl.exe -e "/home/user/bin/preflight-collector" stop-failure',
+    );
   });
 });
 
@@ -286,14 +338,50 @@ describe('mergeSettings', () => {
     const hooks = result.hooks as Record<string, unknown[]>;
     expect(hooks.PreToolUse).toHaveLength(1);
     expect(hooks.PostToolUse).toHaveLength(1);
+    expect(hooks.StopFailure).toHaveLength(1);
 
     const pre = hooks.PreToolUse[0] as Record<string, unknown>;
     expect(pre.hooks).toEqual([{ type: 'command', command: 'preflight-collector pre-tool' }]);
     const post = hooks.PostToolUse[0] as Record<string, unknown>;
     expect(post.hooks).toEqual([{ type: 'command', command: 'preflight-collector post-tool' }]);
+    const stopFailure = hooks.StopFailure[0] as Record<string, unknown>;
+    expect(stopFailure.hooks).toEqual([
+      { type: 'command', command: 'preflight-collector stop-failure' },
+    ]);
 
     // MCP servers are NOT managed in settings.json
     expect(result.mcpServers).toBeUndefined();
+  });
+
+  it('preserves an existing foreign StopFailure entry and appends ours', () => {
+    const existing = {
+      hooks: {
+        StopFailure: [
+          { matcher: '', hooks: [{ type: 'command', command: 'some-other-tool --stop-failure' }] },
+        ],
+      },
+    };
+
+    const result = mergeSettings(existing);
+
+    const hooks = result.hooks as Record<string, unknown[]>;
+    expect(hooks.StopFailure).toHaveLength(2);
+    const foreignEntry = hooks.StopFailure[0] as Record<string, unknown>;
+    expect((foreignEntry.hooks as Array<Record<string, string>>)[0].command).toBe(
+      'some-other-tool --stop-failure',
+    );
+    const ourEntry = hooks.StopFailure[1] as Record<string, unknown>;
+    expect((ourEntry.hooks as Array<Record<string, string>>)[0].command).toBe(
+      'preflight-collector stop-failure',
+    );
+  });
+
+  it('is idempotent for StopFailure — running twice does not duplicate entries', () => {
+    const once = mergeSettings({});
+    const twice = mergeSettings(once);
+
+    const hooks = twice.hooks as Record<string, unknown[]>;
+    expect(hooks.StopFailure).toHaveLength(1);
   });
 
   it('preserves existing hooks and other settings', () => {
@@ -448,6 +536,34 @@ describe('removeSettings', () => {
     const result = removeSettings(settings);
 
     expect(result).toEqual(settings);
+  });
+
+  it('removes only preflight StopFailure entries, keeps foreign ones', () => {
+    const settings = {
+      hooks: {
+        StopFailure: [
+          { matcher: '', hooks: [{ type: 'command', command: 'some-other-tool --stop-failure' }] },
+          {
+            matcher: '',
+            hooks: [{ type: 'command', command: 'preflight-collector stop-failure' }],
+          },
+        ],
+      },
+    };
+
+    const result = removeSettings(settings);
+
+    const hooks = result.hooks as Record<string, unknown[]>;
+    expect(hooks.StopFailure).toEqual([
+      { matcher: '', hooks: [{ type: 'command', command: 'some-other-tool --stop-failure' }] },
+    ]);
+  });
+
+  it('removes a full install (Pre/Post/StopFailure) down to an empty hooks object', () => {
+    const settings = mergeSettings({}, '/usr/local/bin/preflight');
+    const result = removeSettings(settings);
+
+    expect(result.hooks).toBeUndefined();
   });
 });
 

--- a/src/install/install-helper.ts
+++ b/src/install/install-helper.ts
@@ -25,7 +25,8 @@ const COLLECTOR_COMMAND = 'preflight-collector';
 //   preflight-collector pre-tool
 //   /abs/path/preflight-collector pre-tool
 //   "/quoted/path/preflight-collector" pre-tool
-export const NR_HOOK_RE = /preflight-collector"?\s+(?:pre|post)-tool/;
+//   preflight-collector stop-failure
+export const NR_HOOK_RE = /preflight-collector"?\s+(?:pre-tool|post-tool|stop-failure)/;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -44,6 +45,7 @@ export interface HookEntry {
 export interface HookEntries {
   PreToolUse: HookEntry[];
   PostToolUse: HookEntry[];
+  StopFailure: HookEntry[];
 }
 
 export interface McpServerConfig {
@@ -66,6 +68,7 @@ export function generateHookEntries(
 ): HookEntries {
   let pre: string;
   let post: string;
+  let stopFailure: string;
 
   if (options?.platform === 'wsl-windows-cc') {
     // Windows Claude Code runs hooks via wsl.exe — call the WSL binary through interop.
@@ -74,6 +77,7 @@ export function generateHookEntries(
     const quotedPath = collectorPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     pre = `wsl.exe -e "${quotedPath}" pre-tool`;
     post = `wsl.exe -e "${quotedPath}" post-tool`;
+    stopFailure = `wsl.exe -e "${quotedPath}" stop-failure`;
   } else {
     // Quote the path so shells with sh -c don't split on spaces (e.g. /Users/John Doe/...).
     // Hook commands use preflight-collector (lightweight, <5ms budget).
@@ -82,11 +86,16 @@ export function generateHookEntries(
       : COLLECTOR_COMMAND;
     pre = `${bin} pre-tool`;
     post = `${bin} post-tool`;
+    stopFailure = `${bin} stop-failure`;
   }
 
   return {
     PreToolUse: [{ matcher: HOOK_MATCHER, hooks: [{ type: 'command', command: pre }] }],
     PostToolUse: [{ matcher: HOOK_MATCHER, hooks: [{ type: 'command', command: post }] }],
+    // StopFailure is its own top-level settings.json hooks key, distinct from
+    // "Stop" — see code.claude.com/docs/en/hooks.md ("once per turn:
+    // UserPromptSubmit, Stop, and StopFailure" are three separate hook events).
+    StopFailure: [{ matcher: HOOK_MATCHER, hooks: [{ type: 'command', command: stopFailure }] }],
   };
 }
 
@@ -202,6 +211,10 @@ function filterNrObserveEntries(entries: unknown[]): unknown[] {
  * Returns true when settingsContent contains both a PreToolUse and PostToolUse
  * entry that match the NR hook pattern (NR_HOOK_RE).
  * Pure — no file I/O.
+ *
+ * Deliberately does NOT check StopFailure: broadening what counts as "hooks
+ * installed" would change behavior for existing users, which is a scope cut
+ * for this PR, not an oversight — don't "fix" this without re-reading why.
  */
 export function areHooksInstalled(settingsContent: Record<string, unknown>): boolean {
   const hooks = settingsContent.hooks;
@@ -237,6 +250,7 @@ const HooksFieldSchema = z
   .object({
     PreToolUse: z.array(z.unknown()).optional(),
     PostToolUse: z.array(z.unknown()).optional(),
+    StopFailure: z.array(z.unknown()).optional(),
   })
   .passthrough();
 const SettingsSchema = z.object({ hooks: HooksFieldSchema.optional() }).passthrough();
@@ -275,7 +289,7 @@ export function mergeSettings(
       ? { ...(result.hooks as Record<string, unknown>) }
       : {};
 
-  for (const hookType of ['PreToolUse', 'PostToolUse'] as const) {
+  for (const hookType of ['PreToolUse', 'PostToolUse', 'StopFailure'] as const) {
     const existingArr = Array.isArray(hooks[hookType]) ? [...(hooks[hookType] as unknown[])] : [];
 
     if (binPath !== null && binPath !== undefined) {
@@ -358,7 +372,7 @@ export function removeSettings(existing: Record<string, unknown>): Record<string
   if (typeof result.hooks === 'object' && result.hooks !== null) {
     const hooks = { ...(result.hooks as Record<string, unknown>) };
 
-    for (const hookType of ['PreToolUse', 'PostToolUse'] as const) {
+    for (const hookType of ['PreToolUse', 'PostToolUse', 'StopFailure'] as const) {
       if (Array.isArray(hooks[hookType])) {
         const filtered = filterNrObserveEntries(hooks[hookType] as unknown[]);
         if (filtered.length > 0) {

--- a/src/metrics/api-failure-tracker.test.ts
+++ b/src/metrics/api-failure-tracker.test.ts
@@ -1,4 +1,4 @@
-import { ApiFailureTracker } from './api-failure-tracker.js';
+import { ApiFailureTracker, mapClaudeCodeErrorType } from './api-failure-tracker.js';
 import type { ThrottleAlert } from './api-failure-tracker.js';
 
 const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -255,16 +255,17 @@ describe('ApiFailureTracker', () => {
     expect(metrics.totalTokensLost).toBe(0);
   });
 
-  it('always reports dataAvailable false with an explanatory note', () => {
+  it('reports dataAvailable true with a partial-data note explaining what remains unavailable', () => {
     const tracker = new ApiFailureTracker();
     const metrics = tracker.getMetrics();
-    expect(metrics.dataAvailable).toBe(false);
+    expect(metrics.dataAvailable).toBe(true);
     expect(metrics.note).toBe(
-      "Model-API-level failure data (rate limits, timeouts, auth errors from the LLM provider itself) is not observable in Preflight's current architecture. Neither Claude Code hook events nor proxy mode see raw model-API traffic — proxy mode forwards requests to MCP servers, not to the model API. All-zero fields below reflect this limitation, not an absence of real failures.",
+      "Failures are captured via Claude Code's StopFailure hook, which fires only once per turn, on a fully-failed turn, after Claude Code's own retries are exhausted — so recoverySucceeded is always false for every recorded event, and recoveryMs/retryCount are always null/0 rather than measured. tokensInFlight is always 0 (this hook carries no token data), so totalTokensLost and totalEstimatedCostLostUsd are not meaningful. Fields derived from totalRequests (failureRate, throttleFrequency, p95LatencyMs) require recordRequest() calls that nothing in this codebase currently makes — model-API request-level latency/throughput has no observable source in stdio or proxy mode — so they stay null/0; real visibility into those would require a future LLM-facing proxy.",
     );
 
-    // Recording real events must not change either field — the limitation is
-    // architectural, not a function of whether any failure was ever recorded.
+    // Recording real events must not change either field — dataAvailable and
+    // the note describe the tracker's fixed capabilities, not a function of
+    // whether any failure has been recorded yet.
     tracker.recordFailure({
       errorType: 'rate_limit',
       model: 'claude-opus-4',
@@ -272,7 +273,46 @@ describe('ApiFailureTracker', () => {
       tokensInFlight: 100,
     });
     const metricsAfter = tracker.getMetrics();
-    expect(metricsAfter.dataAvailable).toBe(false);
+    expect(metricsAfter.dataAvailable).toBe(true);
     expect(metricsAfter.note).toBe(metrics.note);
+  });
+});
+
+describe('mapClaudeCodeErrorType', () => {
+  it.each([
+    ['rate_limit', 'rate_limit'],
+    ['overloaded', 'server_error'],
+    ['authentication_failed', 'authentication'],
+    ['oauth_org_not_allowed', 'authentication'],
+    ['billing_error', 'authentication'],
+    ['invalid_request', 'unknown'],
+    ['model_not_found', 'unknown'],
+    ['server_error', 'server_error'],
+    ['max_output_tokens', 'context_length_exceeded'],
+    ['unknown', 'unknown'],
+    ['something_unrecognized', 'unknown'],
+  ] as const)('maps raw error %s to %s', (raw, expected) => {
+    expect(mapClaudeCodeErrorType(raw)).toBe(expected);
+  });
+
+  it('never produces timeout or connection_error', () => {
+    const rawValues = [
+      'rate_limit',
+      'overloaded',
+      'authentication_failed',
+      'oauth_org_not_allowed',
+      'billing_error',
+      'invalid_request',
+      'model_not_found',
+      'server_error',
+      'max_output_tokens',
+      'unknown',
+      'anything_else',
+    ];
+    for (const raw of rawValues) {
+      const mapped = mapClaudeCodeErrorType(raw);
+      expect(mapped).not.toBe('timeout');
+      expect(mapped).not.toBe('connection_error');
+    }
   });
 });

--- a/src/metrics/api-failure-tracker.ts
+++ b/src/metrics/api-failure-tracker.ts
@@ -17,6 +17,56 @@ export type ApiErrorType =
   | 'authentication'
   | 'unknown';
 
+/**
+ * Maps the raw `error` string from Claude Code's StopFailure hook onto this
+ * tracker's `ApiErrorType` buckets. StopFailure's `error` field is documented
+ * as exactly these 10 values: rate_limit | overloaded | authentication_failed
+ * | oauth_org_not_allowed | billing_error | invalid_request | model_not_found
+ * | server_error | max_output_tokens | unknown.
+ * See https://code.claude.com/docs/en/hooks.md
+ *
+ * Mapping choices:
+ * - `overloaded` -> 'server_error': Anthropic's overloaded_error is a
+ *   transient 5xx-class condition, not distinct from a generic server error.
+ * - `authentication_failed`, `oauth_org_not_allowed`, `billing_error` ->
+ *   'authentication': billing_error has no dedicated bucket in this enum
+ *   (adding one is out of scope); 'authentication' is the closest existing
+ *   access/billing-denied bucket.
+ * - `invalid_request`, `model_not_found` -> 'unknown': both are client-side
+ *   config/request bugs, not transient operational-reliability signals.
+ * - `max_output_tokens` -> 'context_length_exceeded': the closest existing
+ *   "hit a token limit" bucket, even though this is specifically an
+ *   output-token cap being hit, not the model's input context window
+ *   overflowing.
+ * - Any other string, or a value that isn't one of the 10 above -> 'unknown'.
+ *
+ * `timeout` and `connection_error` are never produced by this mapping —
+ * StopFailure only fires after Claude Code's own retry logic has already
+ * exhausted transport-level failures, so its raw `error` enum has no value
+ * corresponding to either bucket. That's expected, not a gap to fill.
+ */
+export function mapClaudeCodeErrorType(raw: string): ApiErrorType {
+  switch (raw) {
+    case 'rate_limit':
+      return 'rate_limit';
+    case 'overloaded':
+    case 'server_error':
+      return 'server_error';
+    case 'authentication_failed':
+    case 'oauth_org_not_allowed':
+    case 'billing_error':
+      return 'authentication';
+    case 'max_output_tokens':
+      return 'context_length_exceeded';
+    case 'invalid_request':
+    case 'model_not_found':
+    case 'unknown':
+      return 'unknown';
+    default:
+      return 'unknown';
+  }
+}
+
 export type SessionPhase = 'early' | 'middle' | 'late';
 
 export interface ApiFailureEvent {
@@ -83,8 +133,8 @@ const DEFAULT_THROTTLE_WINDOW_MINUTES = 10;
 const DEFAULT_MAX_EVENTS = 500;
 const DEFAULT_COST_PER_TOKEN_USD = 0.000003;
 
-const API_FAILURE_DATA_UNAVAILABLE_NOTE =
-  "Model-API-level failure data (rate limits, timeouts, auth errors from the LLM provider itself) is not observable in Preflight's current architecture. Neither Claude Code hook events nor proxy mode see raw model-API traffic — proxy mode forwards requests to MCP servers, not to the model API. All-zero fields below reflect this limitation, not an absence of real failures.";
+const API_FAILURE_PARTIAL_DATA_NOTE =
+  "Failures are captured via Claude Code's StopFailure hook, which fires only once per turn, on a fully-failed turn, after Claude Code's own retries are exhausted — so recoverySucceeded is always false for every recorded event, and recoveryMs/retryCount are always null/0 rather than measured. tokensInFlight is always 0 (this hook carries no token data), so totalTokensLost and totalEstimatedCostLostUsd are not meaningful. Fields derived from totalRequests (failureRate, throttleFrequency, p95LatencyMs) require recordRequest() calls that nothing in this codebase currently makes — model-API request-level latency/throughput has no observable source in stdio or proxy mode — so they stay null/0; real visibility into those would require a future LLM-facing proxy.";
 
 // ---------------------------------------------------------------------------
 // ApiFailureTracker
@@ -200,8 +250,12 @@ export class ApiFailureTracker {
       meanTimeToRecoveryMs: meanRecovery,
       throttleAlerts: this.throttleAlerts,
       recentFailures: this.events.slice(-20),
-      dataAvailable: false,
-      note: API_FAILURE_DATA_UNAVAILABLE_NOTE,
+      // Once StopFailure is wired up to call recordFailure() (a later stage),
+      // totalFailures/byErrorType/bySessionPhase are real observed data —
+      // zero failures then means "no failures happened," not "we can't see
+      // them." See API_FAILURE_PARTIAL_DATA_NOTE for what's still unavailable.
+      dataAvailable: true,
+      note: API_FAILURE_PARTIAL_DATA_NOTE,
     };
   }
 

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -84,9 +84,26 @@ export interface ObservabilityHealthHookEvent extends HookEventBase {
 }
 
 /**
+ * Emitted by Claude Code's StopFailure hook when a turn ends because the
+ * model-API call ultimately failed after Claude Code's own internal retries
+ * are exhausted (code.claude.com/docs/en/hooks.md). `errorType` is the raw
+ * Claude Code error string (e.g. 'rate_limit') — not yet mapped to
+ * `ApiErrorType`; that mapping happens downstream in
+ * `metrics/api-failure-tracker.ts`, which this file must not depend on.
+ */
+export interface ApiFailureHookEvent extends HookEventBase {
+  readonly mode: 'api_failure';
+  readonly sessionId?: string;
+  readonly errorType: string;
+  readonly errorDetails?: string;
+  readonly lastAssistantMessage?: string;
+}
+
+/**
  * Buffer line discriminated union. `pre`/`post`/`token` are the original
  * collector modes. `subagent_token`, `workflow_run`, and
  * `observability_health` are emitted by the SubagentWatcher / WorkflowWatcher.
+ * `api_failure` is emitted by the collector for Claude Code's StopFailure hook.
  */
 export type HookEvent =
   | PreHookEvent
@@ -94,7 +111,8 @@ export type HookEvent =
   | TokenHookEvent
   | SubagentTokenHookEvent
   | WorkflowRunEvent
-  | ObservabilityHealthHookEvent;
+  | ObservabilityHealthHookEvent
+  | ApiFailureHookEvent;
 
 export interface TokenEvent {
   readonly mode: 'token';

--- a/src/tools/extended-analytics-tools.ts
+++ b/src/tools/extended-analytics-tools.ts
@@ -103,7 +103,7 @@ export const QUALITY_PROXY_TOOL = {
 export const API_FAILURES_TOOL = {
   name: 'nr_observe_get_api_failures',
   description:
-    "Get API failure tracking: per-model reliability scorecards, tokens lost, cost impact, throttle alerts, and mean time to recovery. LIMITATION: model-API-level failure data is not observable in Preflight's current architecture (see the note field in the response) — this tool currently always returns empty/zero metrics.",
+    "Get API failure tracking: per-model reliability scorecards, tokens lost, cost impact, throttle alerts, and mean time to recovery. Failures are captured via Claude Code's StopFailure hook, so totalFailures/byErrorType/bySessionPhase reflect real observed failures. LIMITATION: token loss, recovery time, retry count, and totalRequests-derived fields (failureRate, throttleFrequency, p95LatencyMs) remain unavailable or always zero -- StopFailure carries no token/retry data, and nothing currently calls recordRequest() (see the note field in the response).",
   inputSchema: { type: 'object' as const, properties: {} },
   annotations: { readOnlyHint: true },
 };

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -26,6 +26,7 @@ import type { AntiPattern } from '../metrics/anti-patterns.js';
 import type { ContextTurnSnapshot, ToolContextContribution } from '../metrics/context-tracker.js';
 import { SessionTracker } from '../metrics/session-tracker.js';
 import { FeedbackCollector } from '../tools/workflow-tools.js';
+import { ApiFailureTracker } from '../metrics/api-failure-tracker.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -777,6 +778,30 @@ describe('NrIngestManager', () => {
       >;
       const feedbackMetrics = sentMetrics.filter((m) => m.name === 'ai.feedback.count');
       expect(feedbackMetrics).toHaveLength(1);
+    });
+
+    it('emits ai.api.failures_total on stop when an apiFailureTracker is provided', async () => {
+      const sessionTracker = new SessionTracker('api-failure-session');
+      const apiFailureTracker = new ApiFailureTracker();
+      apiFailureTracker.recordFailure({
+        errorType: 'rate_limit',
+        model: 'claude-sonnet-5',
+        turnNumber: 1,
+        tokensInFlight: 0,
+        recoverySucceeded: false,
+      });
+
+      const manager = new NrIngestManager(makeIngestOptions({ sessionTracker, apiFailureTracker }));
+
+      manager.start();
+      await manager.stop();
+
+      expect(mockSendMetrics).toHaveBeenCalled();
+      const sentMetrics = (mockSendMetrics.mock.calls[0] as unknown[])[0] as Array<
+        Record<string, unknown>
+      >;
+      const failureMetrics = sentMetrics.filter((m) => m.name === 'ai.api.failures_total');
+      expect(failureMetrics).toHaveLength(1);
     });
 
     it('emitSessionGauges is a no-op after stop()', async () => {

--- a/src/transport/nr-ingest.ts
+++ b/src/transport/nr-ingest.ts
@@ -31,6 +31,7 @@ import type { AntiPattern } from '../metrics/anti-patterns.js';
 import type { SessionTracker } from '../metrics/session-tracker.js';
 import type { CostTracker } from '../metrics/cost-tracker.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
+import type { ApiFailureTracker } from '../metrics/api-failure-tracker.js';
 import type { FeedbackCollector } from '../tools/workflow-tools.js';
 import type { BudgetThresholdEvent } from '../metrics/budget-tracker.js';
 import type { ContextTurnSnapshot, ToolContextContribution } from '../metrics/context-tracker.js';
@@ -101,6 +102,8 @@ export interface NrIngestOptions {
   efficiencyScorer?: EfficiencyScorer;
   /** Feedback collector for emitting ai.feedback.count metrics. */
   feedbackCollector?: FeedbackCollector;
+  /** API failure tracker for emitting ai.api.* metrics. */
+  apiFailureTracker?: ApiFailureTracker;
   teamId?: string | null;
   projectId?: string | null;
   orgId?: string | null;
@@ -803,6 +806,7 @@ export class NrIngestManager {
   private readonly costTracker?: CostTracker;
   private readonly efficiencyScorer?: EfficiencyScorer;
   private readonly feedbackCollector?: FeedbackCollector;
+  private readonly apiFailureTracker?: ApiFailureTracker;
   readonly auditTrail: AuditTrailManager;
   private readonly developer: string;
   private readonly appName: string;
@@ -833,6 +837,7 @@ export class NrIngestManager {
     this.costTracker = options.costTracker;
     this.efficiencyScorer = options.efficiencyScorer;
     this.feedbackCollector = options.feedbackCollector;
+    this.apiFailureTracker = options.apiFailureTracker;
     this.turnCostAttributor = options.turnCostAttributor;
     this.auditTrail =
       options.auditTrail ??
@@ -1286,7 +1291,12 @@ export class NrIngestManager {
 
     // Emit cost and efficiency metrics with developer dimension so Team View
     // FACET developer queries return per-developer breakdowns.
-    if (this.costTracker || this.efficiencyScorer || this.feedbackCollector) {
+    if (
+      this.costTracker ||
+      this.efficiencyScorer ||
+      this.feedbackCollector ||
+      this.apiFailureTracker
+    ) {
       const developer = this.developer;
       const scheduler = this.scheduler;
       const devAggregator = new DeveloperAttributedMetricAggregator((name, value, attrs) => {
@@ -1301,6 +1311,7 @@ export class NrIngestManager {
       this.costTracker?.emitMetrics(devAggregator);
       this.efficiencyScorer?.emitMetrics(devAggregator);
       this.feedbackCollector?.emitMetrics(devAggregator);
+      this.apiFailureTracker?.emitMetrics(devAggregator);
     }
 
     // Emit aggregated proxy metrics

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -262,6 +262,22 @@ export interface SessionDetail {
   readonly durationMs?: number;
   readonly estimatedCostUsd?: number | null;
   readonly model?: string | null;
+  // Per-model request/token/cost counters for this session. Present when the
+  // session used one or more models — when it used more than one (a
+  // mid-session model switch, e.g. via /model), `model` above only reflects
+  // whichever model was current at read time, so the UI should prefer this
+  // for display when it has more than one key.
+  readonly modelBreakdown?: Readonly<
+    Record<
+      string,
+      {
+        readonly requestCount: number;
+        readonly totalInputTokens: number;
+        readonly totalOutputTokens: number;
+        readonly totalCostUsd: number;
+      }
+    >
+  >;
   readonly outcome?: string;
   readonly toolBreakdown?: Record<string, number>;
   readonly filesRead?: string[];

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -1227,6 +1227,71 @@ export interface InstructionDriftResponse {
 export const fetchInstructionDrift = (): Promise<InstructionDriftResponse> =>
   getJson<InstructionDriftResponse>('/api/instruction-drift');
 
+// Mirrors ApiFailureTracker's own shapes (src/metrics/api-failure-tracker.ts)
+// verbatim — this file has no import wired to server-side tracker types, so
+// every response shape here is re-declared rather than imported, same as
+// QualityProxyMetrics above.
+export type ApiErrorType =
+  | 'rate_limit'
+  | 'timeout'
+  | 'connection_error'
+  | 'server_error'
+  | 'context_length_exceeded'
+  | 'authentication'
+  | 'unknown';
+
+export type SessionPhase = 'early' | 'middle' | 'late';
+
+export interface ApiFailureEvent {
+  readonly errorType: ApiErrorType;
+  readonly model: string;
+  readonly timestamp: number;
+  readonly turnNumber: number;
+  readonly tokensInFlight: number;
+  readonly recoveryMs: number | null;
+  readonly retryCount: number;
+  readonly recoverySucceeded: boolean | null;
+  readonly sessionPhase: SessionPhase;
+  readonly duringToolExecution: boolean;
+}
+
+export interface ModelReliabilityScorecard {
+  readonly model: string;
+  readonly totalRequests: number;
+  readonly failureCount: number;
+  readonly failureRate: number | null;
+  readonly throttleCount: number;
+  readonly throttleFrequency: number | null;
+  readonly meanRecoveryMs: number | null;
+  readonly p95LatencyMs: number | null;
+  readonly tokensLost: number;
+  readonly estimatedCostLostUsd: number;
+}
+
+export interface ThrottleAlert {
+  readonly model: string;
+  readonly count: number;
+  readonly windowMinutes: number;
+  readonly timestamp: number;
+}
+
+export interface ApiFailureMetrics {
+  readonly totalFailures: number;
+  readonly byErrorType: Readonly<Record<ApiErrorType, number>>;
+  readonly byModel: Readonly<Record<string, ModelReliabilityScorecard>>;
+  readonly bySessionPhase: Readonly<Record<SessionPhase, number>>;
+  readonly totalTokensLost: number;
+  readonly totalEstimatedCostLostUsd: number;
+  readonly meanTimeToRecoveryMs: number | null;
+  readonly throttleAlerts: readonly ThrottleAlert[];
+  readonly recentFailures: readonly ApiFailureEvent[];
+  readonly dataAvailable: boolean;
+  readonly note: string;
+}
+
+export const fetchApiFailures = (): Promise<ApiFailureMetrics> =>
+  getJson<ApiFailureMetrics>('/api/api-failures');
+
 export const qk = {
   sessionCurrent: ['session', 'current'] as const,
   sessionsList: (limit: number) => ['sessions', 'list', limit] as const,
@@ -1240,6 +1305,7 @@ export const qk = {
   costPerOutcome: (days: number) => ['cost-per-outcome', days] as const,
   personalCoach: ['personal-coach'] as const,
   instructionDrift: ['instruction-drift'] as const,
+  apiFailures: ['api-failures'] as const,
   recommendations: ['recommendations'] as const,
   claudeMdImpact: ['claudemd-impact'] as const,
   collaborationProfile: ['collaboration-profile'] as const,

--- a/src/web/views/Sessions.test.tsx
+++ b/src/web/views/Sessions.test.tsx
@@ -234,6 +234,71 @@ describe('Sessions view', () => {
     expect(screen.getByText('completed')).toBeInTheDocument();
   });
 
+  it('renders every model in the Model card when modelBreakdown has more than one entry, most-called first', async () => {
+    const detail = {
+      sessionId: 's1',
+      model: 'claude-opus-5',
+      modelBreakdown: {
+        'claude-opus-5': {
+          requestCount: 2,
+          totalInputTokens: 100,
+          totalOutputTokens: 50,
+          totalCostUsd: 0.5,
+        },
+        'claude-sonnet-5': {
+          requestCount: 8,
+          totalInputTokens: 400,
+          totalOutputTokens: 200,
+          totalCostUsd: 1.5,
+        },
+      },
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+    };
+    const { container } = renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(screen.getAllByText('Read').length).toBeGreaterThanOrEqual(1));
+    expect(screen.getByText('Models (2)')).toBeInTheDocument();
+    expect(screen.getByText('claude-sonnet-5')).toBeInTheDocument();
+    expect(screen.getByText('claude-opus-5')).toBeInTheDocument();
+    // Most-called model (claude-sonnet-5, 8 requests) renders before the
+    // last-seen one (claude-opus-5, `model` above, only 2 requests).
+    const text = container.textContent ?? '';
+    expect(text.indexOf('claude-sonnet-5')).toBeLessThan(text.indexOf('claude-opus-5'));
+  });
+
+  it('renders the single-model layout unchanged when modelBreakdown has exactly one entry', async () => {
+    const detail = {
+      sessionId: 's1',
+      model: 'claude-sonnet-5',
+      modelBreakdown: {
+        'claude-sonnet-5': {
+          requestCount: 5,
+          totalInputTokens: 200,
+          totalOutputTokens: 100,
+          totalCostUsd: 1,
+        },
+      },
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+    };
+    renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(screen.getAllByText('Read').length).toBeGreaterThanOrEqual(1));
+    expect(screen.getByText('Model')).toBeInTheDocument();
+    expect(screen.queryByText(/Models \(/)).toBeNull();
+    expect(screen.getByText('claude-sonnet-5')).toBeInTheDocument();
+  });
+
+  it('falls back to data.model when modelBreakdown is absent or empty', async () => {
+    const detail = {
+      sessionId: 's1',
+      model: 'claude-sonnet-5',
+      modelBreakdown: {},
+      timeline: [{ timestamp: 1_000, toolName: 'Read', durationMs: 120, success: true }],
+    };
+    renderSessions(SAMPLE_LIST, { s1: detail });
+    await waitFor(() => expect(screen.getAllByText('Read').length).toBeGreaterThanOrEqual(1));
+    expect(screen.getByText('Model')).toBeInTheDocument();
+    expect(screen.getByText('claude-sonnet-5')).toBeInTheDocument();
+  });
+
   it('renders a Files Read list from data.filesRead, truncated to the last two path segments', async () => {
     const detail = {
       sessionId: 's1',

--- a/src/web/views/Sessions.tsx
+++ b/src/web/views/Sessions.tsx
@@ -873,6 +873,21 @@ function SessionTimeline({
   const durationLabel = data.durationMs != null ? formatDuration(data.durationMs) : null;
   const entries = data.timeline ?? [];
   const first = entries.length > 0 ? entries[0]!.timestamp : 0;
+  // Models used this session, most-called first. Falls back to the single
+  // `model` field when no breakdown is present (older persisted sessions,
+  // or the cross-process live branch, predate `modelBreakdown`). A session
+  // that switched models mid-run (e.g. via /model) has more than one entry
+  // here even though `model` only reflects whichever was current at read
+  // time.
+  const modelBreakdownEntries = Object.entries(data.modelBreakdown ?? {});
+  const modelsUsed =
+    modelBreakdownEntries.length > 0
+      ? modelBreakdownEntries
+          .sort((a, b) => b[1].requestCount - a[1].requestCount)
+          .map(([model]) => model)
+      : data.model
+        ? [data.model]
+        : [];
 
   if (entries.length === 0 && breakdownEntries.length === 0) {
     return (
@@ -924,10 +939,20 @@ function SessionTimeline({
       </div>
 
       <div className="grid grid-cols-3 gap-2 mb-4 text-xs">
-        {data.model && (
+        {modelsUsed.length > 0 && (
           <div className="bg-surface-3 rounded-lg p-2.5">
-            <Eyebrow>Model</Eyebrow>
-            <div className="font-mono">{data.model}</div>
+            <Eyebrow>{modelsUsed.length > 1 ? `Models (${modelsUsed.length})` : 'Model'}</Eyebrow>
+            {modelsUsed.length > 1 ? (
+              <div className="flex flex-col gap-0.5 mt-0.5">
+                {modelsUsed.map((m) => (
+                  <div key={m} className="font-mono text-[11px] truncate" title={m}>
+                    {m}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="font-mono">{modelsUsed[0]}</div>
+            )}
           </div>
         )}
         {data.estimatedCostUsd != null && (

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -2241,3 +2241,129 @@ describe('Today view — Cost by Tool panel', () => {
     expect(screen.getByText('Based on 30% of session cost')).toBeInTheDocument();
   });
 });
+
+describe('Today view — API Failures panel', () => {
+  beforeEach(() => {
+    // todayTotalUsd must be nonzero, or Today's `noActivityToday` short-circuit
+    // (see Today.tsx) replaces the whole KPI/panel grid — including this
+    // panel — with the top-level "No activity yet today" empty state,
+    // regardless of what /api/api-failures returns.
+    useLiveStore.setState({
+      connected: true,
+      recentToolCalls: [],
+      cost: { sessionTotalUsd: 1, todayTotalUsd: 1, forecastEodUsd: null },
+      antiPatterns: [],
+      firingAlerts: new Map(),
+      dismissedAlerts: new Set(),
+    });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const zeroByErrorType = {
+    rate_limit: 0,
+    timeout: 0,
+    connection_error: 0,
+    server_error: 0,
+    context_length_exceeded: 0,
+    authentication: 0,
+    unknown: 0,
+  };
+
+  it('shows the empty state when there are no failures', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/api-failures')) {
+        return new Response(
+          JSON.stringify({
+            totalFailures: 0,
+            byErrorType: zeroByErrorType,
+            byModel: {},
+            bySessionPhase: { early: 0, middle: 0, late: 0 },
+            totalTokensLost: 0,
+            totalEstimatedCostLostUsd: 0,
+            meanTimeToRecoveryMs: null,
+            throttleAlerts: [],
+            recentFailures: [],
+            dataAvailable: true,
+            note: '',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+    expect(await screen.findByText('No API failures')).toBeInTheDocument();
+  });
+
+  it('shows failure count and error-type breakdown when failures exist', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/api-failures')) {
+        return new Response(
+          JSON.stringify({
+            totalFailures: 3,
+            byErrorType: { ...zeroByErrorType, rate_limit: 2, server_error: 1 },
+            byModel: {},
+            bySessionPhase: { early: 1, middle: 1, late: 1 },
+            totalTokensLost: 0,
+            totalEstimatedCostLostUsd: 0,
+            meanTimeToRecoveryMs: null,
+            throttleAlerts: [],
+            recentFailures: [],
+            dataAvailable: true,
+            note: '',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+    expect(await screen.findByText('rate_limit: 2, server_error: 1')).toBeInTheDocument();
+    expect(screen.getByText('API Failures')).toBeInTheDocument();
+  });
+
+  it('shows a throttle-alert warning line when throttleAlerts is non-empty', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/api-failures')) {
+        return new Response(
+          JSON.stringify({
+            totalFailures: 4,
+            byErrorType: { ...zeroByErrorType, rate_limit: 4 },
+            byModel: {},
+            bySessionPhase: { early: 0, middle: 0, late: 4 },
+            totalTokensLost: 0,
+            totalEstimatedCostLostUsd: 0,
+            meanTimeToRecoveryMs: null,
+            throttleAlerts: [
+              { model: 'claude-sonnet-5', count: 3, windowMinutes: 10, timestamp: Date.now() },
+            ],
+            recentFailures: [],
+            dataAvailable: true,
+            note: '',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+    expect(await screen.findByText(/Rate-limit throttling detected/)).toBeInTheDocument();
+  });
+});

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -49,6 +49,8 @@ import {
   type ContextEfficiencyResponse,
   fetchComputeWaste,
   fetchQualityProxy,
+  fetchApiFailures,
+  type ApiFailureMetrics,
   fetchToolSelectionScore,
   fetchConcurrency,
   fetchActivityHeatmap,
@@ -580,6 +582,7 @@ export function Today(): JSX.Element {
 
           <AnimatedCard index={3} className="grid grid-cols-3 gap-3 mb-3">
             <QualityProxyPanel />
+            <ApiFailurePanel />
             <ToolSelectionPanel />
             <LatencyPanel aggregate={aggregate} />
             <ComputeWastePanel />
@@ -768,6 +771,60 @@ function QualityProxyPanel(): JSX.Element {
           </div>
           {data.degradationDetected && (
             <div className="text-accent-amber text-xs mt-2">&#9888; Quality degrading</div>
+          )}
+        </>
+      )}
+    </Card>
+  );
+}
+
+function ApiFailurePanel(): JSX.Element {
+  const { data } = useQuery<ApiFailureMetrics>({
+    queryKey: qk.apiFailures,
+    queryFn: fetchApiFailures,
+    refetchInterval: QUALITY_REFETCH_MS,
+  });
+
+  const errorTypeEntries = data?.byErrorType
+    ? Object.entries(data.byErrorType).filter(([, count]) => count > 0)
+    : [];
+  const throttleAlerts = data?.throttleAlerts ?? [];
+
+  return (
+    <Card padding="sm" className="h-full">
+      <div className="flex items-center gap-1.5 mb-2">
+        <Eyebrow>API Failures</Eyebrow>
+        <InfoTooltip text="Turns that failed outright after Claude Code's own retries were exhausted, captured via its StopFailure hook." />
+      </div>
+      {!data || data.totalFailures === 0 ? (
+        <EmptyState
+          icon="radar"
+          title="No API failures"
+          subtitle="Reflects Claude Code's own StopFailure hook, not proxy-mode traffic."
+        />
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <div>
+              <span className="text-ink-muted">Total </span>
+              <span className="text-accent-amber">{data.totalFailures}</span>
+            </div>
+            <div>
+              <span className="text-ink-muted">Throttle alerts </span>
+              <span className={throttleAlerts.length > 0 ? 'text-accent-amber' : ''}>
+                {throttleAlerts.length}
+              </span>
+            </div>
+          </div>
+          {errorTypeEntries.length > 0 && (
+            <div className="text-[10px] text-ink-subtle mt-1">
+              {errorTypeEntries.map(([type, count]) => `${type}: ${count}`).join(', ')}
+            </div>
+          )}
+          {throttleAlerts.length > 0 && (
+            <div className="text-accent-amber text-xs mt-2">
+              &#9888; Rate-limit throttling detected
+            </div>
           )}
         </>
       )}


### PR DESCRIPTION
## Summary

Wires Claude Code's `StopFailure` hook (fires once per turn when a model-API call ultimately fails after Claude Code's own retries are exhausted) into the previously-dormant `ApiFailureTracker`:

- Hook install: a new top-level `StopFailure` `settings.json` entry alongside `PreToolUse`/`PostToolUse`
- Collector → event-processor plumbing feeding `ApiFailureTracker.recordFailure()`
- A new "API Failures" dashboard panel: total failures, throttle alerts, and a per-error-type breakdown
- The `nr_observe_get_api_failures` MCP tool now returns real observed data instead of always-empty metrics
- `ai.api.*` metrics emission through the existing metric pipeline

Token loss, recovery time, and retry-count fields remain unavailable — the `StopFailure` hook payload doesn't carry that data.

Includes the 1.18.2 version bump and CHANGELOG entry.

Fixes #518

Original implementation by @adjohn.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 5975/5978 passed, 3 pre-existing skips, 0 failed
- [x] `npm run lint` — 0 errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)