### PR TITLE
Fix: attribute retry-thrashing compute waste to its originating session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Preflight is now installable via Homebrew on macOS** (`brew tap newrelic-experimental/preflight && brew install preflight`), alongside the existing npm install path. The formula tracks the npm package; a `scripts/update-homebrew.sh` helper regenerates it for each new release, documented in `docs/maintaining-homebrew-tap.md`.
 
+## [1.18.4] - 2026-08-28
+
+### Added
+
+- **The Compute Waste card now shows the most recent retry-thrashing alert live**, ahead of the next `/api/compute-waste` poll — matching the live treatment anti-pattern alerts already had.
+
+### Fixed
+
+- **Retry-thrashing compute waste is now attributed to the session that caused it.** The Compute Waste card's underlying `RetryDetector` drains every session's buffer in `--local` mode, so a large wasted-token number previously had no way to tell which session was responsible — two unrelated sessions retrying the same tool could also blend into one false alert. `/api/compute-waste` and `/api/retry-alerts` now include a per-session breakdown, and the Compute Waste card shows the top contributing session.
+- **`RetryDetector`'s internal buffers are now bounded** for a long-running `--local` process — the alert list, per-session breakdown, and dedupe tracking all previously grew without limit.
+
 ## [1.18.3] - 2026-08-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.18.3",
+      "version": "1.18.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/dashboard/live-event-bus.ts
+++ b/src/dashboard/live-event-bus.ts
@@ -29,6 +29,16 @@ export interface AntiPatternEvent {
   readonly count: number;
 }
 
+export interface RetryAlertEvent {
+  // Optional — a ThrashingAlert's own sessionId can be null when the
+  // underlying ToolCallRecords carried no session id.
+  readonly sessionId?: string;
+  readonly toolName: string;
+  readonly occurrences: number;
+  readonly tokensWasted: number;
+  readonly ts: number;
+}
+
 export interface HeartbeatEvent {
   readonly ts: number;
 }
@@ -109,21 +119,22 @@ export type LiveEventMap = {
   'tool-call': ToolCallEvent;
   'cost-update': CostUpdateEvent;
   'anti-pattern': AntiPatternEvent;
+  'retry-alert': RetryAlertEvent;
   'context-update': ContextUpdateEvent;
   heartbeat: HeartbeatEvent;
   alert: AlertEvent;
   // Forward-declared, not yet wired: nothing calls bus.emit() for these three
   // event names today, and src/dashboard/routes/sse-handler.ts only
   // subscribes ('on'/'onWithSeq') 'tool-call', 'cost-update', 'anti-pattern',
-  // 'context-update', and 'alert' — 'heartbeat' isn't a bus subscription at
-  // all; sse-handler generates it locally via its own setInterval. Reconnecting
-  // clients would still see buffered instances via replayFrom() (which streams
-  // every buffered type regardless of subscription), but a live client
-  // connected when one of these first fires would silently miss it. Before
-  // wiring an emitter for any of these three, also add the matching
-  // bus.on(...)/bus.onWithSeq(...) subscription (and SSE frame forwarding) in
-  // sse-handler.ts — see its 'tool-call'/'cost-update'/etc. wiring for the
-  // pattern to follow.
+  // 'retry-alert', 'context-update', and 'alert' — 'heartbeat' isn't a bus
+  // subscription at all; sse-handler generates it locally via its own
+  // setInterval. Reconnecting clients would still see buffered instances via
+  // replayFrom() (which streams every buffered type regardless of
+  // subscription), but a live client connected when one of these first fires
+  // would silently miss it. Before wiring an emitter for any of these three,
+  // also add the matching bus.on(...)/bus.onWithSeq(...) subscription (and
+  // SSE frame forwarding) in sse-handler.ts — see its 'tool-call'/
+  // 'cost-update'/etc. wiring for the pattern to follow.
   'subagent-turn': SubagentTurnEvent;
   'workflow-run': WorkflowRunLiveEvent;
   'observability-health': ObservabilityHealthEvent;
@@ -166,11 +177,12 @@ export class LiveEventBus {
 
   constructor(opts: LiveEventBusOptions = {}) {
     this.bufferSize = opts.replayBufferSize ?? DEFAULT_BUFFER_SIZE;
-    // Each SSE connection adds 5 listeners (tool-call, cost-update,
-    // anti-pattern, context-update, alert), each registered under its own
-    // event name. setMaxListeners() caps the count per event name, not in
-    // aggregate, so the real headroom is 200 concurrent connections —
-    // comfortable margin for parallel test runs and bursty client reconnects.
+    // Each SSE connection adds 6 listeners (tool-call, cost-update,
+    // anti-pattern, retry-alert, context-update, alert), each registered
+    // under its own event name. setMaxListeners() caps the count per event
+    // name, not in aggregate, so the real headroom is 200 concurrent
+    // connections — comfortable margin for parallel test runs and bursty
+    // client reconnects.
     this.emitter.setMaxListeners(200);
   }
 

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1206,7 +1206,7 @@ describe('api-handler GET /api/retry-alerts', () => {
     expect(status()).toBe(503);
   });
 
-  it('returns retry detector metrics as JSON', async () => {
+  it('returns retry detector metrics as JSON, plus a by_session breakdown', async () => {
     const fakeMetrics = {
       alerts: [
         {
@@ -1216,10 +1216,12 @@ describe('api-handler GET /api/retry-alerts', () => {
           similarity: 0.9,
           tokensWastedEstimate: 750,
           timestamp: 1700000000000,
+          sessionId: 'sess-a',
         },
       ],
       totalTokensWasted: 750,
       totalAlertsEmitted: 1,
+      bySession: { 'sess-a': { tokensWasted: 750, alertCount: 1 } },
     };
     const handler = createApiHandler({
       retryDetector: { getMetrics: () => fakeMetrics } as unknown as Parameters<
@@ -1231,7 +1233,47 @@ describe('api-handler GET /api/retry-alerts', () => {
     await handler(req, res);
     expect(status()).toBe(200);
     expect(headers()['content-type']).toMatch(/application\/json/);
-    expect(JSON.parse(body())).toEqual(fakeMetrics);
+    const parsed = JSON.parse(body()) as Record<string, unknown>;
+    // The raw camelCase bySession map must not leak into the response
+    // alongside its formatted by_session replacement — same data, two shapes.
+    expect(parsed.bySession).toBeUndefined();
+    const { bySession: _bySession, ...expectedMetrics } = fakeMetrics;
+    expect(parsed).toEqual({
+      ...expectedMetrics,
+      by_session: [{ session_id: 'sess-a', tokens_wasted: 750, alert_count: 1 }],
+    });
+  });
+
+  it('groups by_session across multiple sessions, sorted by tokens wasted', async () => {
+    const fakeMetrics = {
+      alerts: [
+        { toolName: 'Bash', tokensWastedEstimate: 100, sessionId: 'sess-a' },
+        { toolName: 'Bash', tokensWastedEstimate: 900, sessionId: 'sess-b' },
+        { toolName: 'Read', tokensWastedEstimate: 50, sessionId: 'sess-a' },
+        { toolName: 'Read', tokensWastedEstimate: 10, sessionId: null },
+      ],
+      totalTokensWasted: 1060,
+      totalAlertsEmitted: 4,
+      bySession: {
+        'sess-a': { tokensWasted: 150, alertCount: 2 },
+        'sess-b': { tokensWasted: 900, alertCount: 1 },
+        unknown: { tokensWasted: 10, alertCount: 1 },
+      },
+    };
+    const handler = createApiHandler({
+      retryDetector: { getMetrics: () => fakeMetrics } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['retryDetector'],
+    });
+    const req = { method: 'GET', url: '/api/retry-alerts' } as IncomingMessage;
+    const { res, body } = fakeRes();
+    await handler(req, res);
+    const json = JSON.parse(body()) as { by_session: Array<Record<string, unknown>> };
+    expect(json.by_session).toEqual([
+      { session_id: 'sess-b', tokens_wasted: 900, alert_count: 1 },
+      { session_id: 'sess-a', tokens_wasted: 150, alert_count: 2 },
+      { session_id: 'unknown', tokens_wasted: 10, alert_count: 1 },
+    ]);
   });
 });
 
@@ -1451,6 +1493,27 @@ describe('api-handler GET /api/compute-waste', () => {
     expect(json.anti_pattern_tokens_wasted).toBe(200);
     expect(json.status).toBe('clean');
     expect((json.breakdown as unknown[]).length).toBe(1);
+  });
+
+  it('includes a by_session breakdown sourced from the retry detector alerts', async () => {
+    const handler = createApiHandler({
+      retryDetector: {
+        getMetrics: () => ({
+          totalTokensWasted: 300,
+          alerts: [{ toolName: 'Bash', tokensWastedEstimate: 300, sessionId: 'sess-a' }],
+          bySession: { 'sess-a': { tokensWasted: 300, alertCount: 1 } },
+        }),
+      } as unknown as Parameters<typeof createApiHandler>[0]['retryDetector'],
+      antiPatternDetector: {
+        getCurrentPatterns: () => [],
+        getTotalAntiPatternWaste: () => 0,
+      } as unknown as Parameters<typeof createApiHandler>[0]['antiPatternDetector'],
+    });
+    const req = { method: 'GET', url: '/api/compute-waste' } as IncomingMessage;
+    const { res, body } = fakeRes();
+    await handler(req, res);
+    const json = JSON.parse(body()) as { by_session: Array<Record<string, unknown>> };
+    expect(json.by_session).toEqual([{ session_id: 'sess-a', tokens_wasted: 300, alert_count: 1 }]);
   });
 
   it('returns needs_attention when totalTokensWasted >= 2000', async () => {

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -45,7 +45,7 @@ import {
   ZERO_QUALITY_PROXY_COUNTS,
 } from '../../metrics/quality-proxy-tracker.js';
 import type { Recommendation } from '../../metrics/recommendation-engine.js';
-import type { RetryDetectorMetrics } from '../../metrics/retry-detector.js';
+import type { RetryDetectorMetrics, RetrySessionBreakdown } from '../../metrics/retry-detector.js';
 import type {
   ToolSelectionMetrics,
   ToolSelectionSummary,
@@ -595,6 +595,24 @@ function unavailable(res: ServerResponse, what: string): void {
     'content-length': String(Buffer.byteLength(payload)),
   });
   res.end(payload);
+}
+
+// Formats RetryDetector's pre-aggregated by-session breakdown (a --local
+// dashboard process's single RetryDetector drains every session's buffer,
+// see ThrashingAlert's sessionId doc in retry-detector.ts) for the JSON API
+// shape this route has always returned. RetryDetector itself owns grouping
+// and the 'unknown' sentinel for sessionless alerts now — this is a thin
+// shape adapter, not a groupBy.
+function retryAlertsBySession(
+  bySession: Readonly<Record<string, RetrySessionBreakdown>> | undefined,
+): Array<{ session_id: string; tokens_wasted: number; alert_count: number }> {
+  return Object.entries(bySession ?? {})
+    .map(([session_id, v]) => ({
+      session_id,
+      tokens_wasted: v.tokensWasted,
+      alert_count: v.alertCount,
+    }))
+    .sort((a, b) => b.tokens_wasted - a.tokens_wasted);
 }
 
 const MAX_BODY_BYTES = 64 * 1024; // 64 KB — generous for any settings payload
@@ -1812,7 +1830,11 @@ export function createApiHandler(
 
   routes.set('GET /api/retry-alerts', (_req, res) => {
     if (!deps.retryDetector) return unavailable(res, 'retryDetector');
-    jsonOk(res, deps.retryDetector.getMetrics());
+    // Destructure out the raw bySession map — by_session below is its
+    // formatted replacement, so leaving both in the response would just
+    // duplicate the same data under two different shapes/cases.
+    const { bySession, ...metrics } = deps.retryDetector.getMetrics();
+    jsonOk(res, { ...metrics, by_session: retryAlertsBySession(bySession) });
   });
 
   routes.set('GET /api/api-failures', (_req, res) => {
@@ -1880,6 +1902,10 @@ export function createApiHandler(
       retry_tokens_wasted: retryTokensWasted,
       anti_pattern_tokens_wasted: antiPatternTokensWasted,
       breakdown,
+      // Anti-pattern waste has no per-session breakdown yet — AntiPattern
+      // objects don't carry a sessionId (see ThrashingAlert for the retry
+      // side, which now does). This only ever attributes the retry portion.
+      by_session: retryAlertsBySession(deps.retryDetector.getMetrics().bySession),
       status,
     });
   });

--- a/src/dashboard/routes/sse-handler.test.ts
+++ b/src/dashboard/routes/sse-handler.test.ts
@@ -77,11 +77,20 @@ describe('sse-handler', () => {
         todayTotalUsd: 2,
         forecastEodUsd: null,
       });
-      const chunks = await readSseChunks(res, 2);
+      bus.emit('retry-alert', {
+        sessionId: 's1',
+        toolName: 'Bash',
+        occurrences: 3,
+        tokensWasted: 42,
+        ts: 1,
+      });
+      const chunks = await readSseChunks(res, 3);
       const merged = chunks.join('');
       expect(merged).toContain('event: tool-call');
       expect(merged).toContain('"tool":"Read"');
       expect(merged).toContain('event: cost-update');
+      expect(merged).toContain('event: retry-alert');
+      expect(merged).toContain('"toolName":"Bash"');
     } finally {
       await server.close();
     }
@@ -367,7 +376,7 @@ describe('sse-handler', () => {
     (res as unknown as { write: jest.Mock }).write = jest.fn();
 
     createSseHandler(bus)(req, res);
-    // Sanity: bus.onWithSeq attached one listener per channel (5 total).
+    // Sanity: bus.onWithSeq attached one listener per channel (6 total).
     expect(offSpy).not.toHaveBeenCalled();
 
     // Both close events fire — cleanup runs twice but the guard makes the
@@ -382,9 +391,10 @@ describe('sse-handler', () => {
     expect(callsByEvent['tool-call']).toBe(1);
     expect(callsByEvent['cost-update']).toBe(1);
     expect(callsByEvent['anti-pattern']).toBe(1);
+    expect(callsByEvent['retry-alert']).toBe(1);
     expect(callsByEvent['context-update']).toBe(1);
     expect(callsByEvent['alert']).toBe(1);
-    expect(offSpy).toHaveBeenCalledTimes(5);
+    expect(offSpy).toHaveBeenCalledTimes(6);
   });
 
   // Server-side sessionId filtering for the per-session
@@ -547,7 +557,7 @@ describe('sse-handler', () => {
 
     res.emit('error', new Error('EPIPE'));
 
-    expect(offSpy).toHaveBeenCalledTimes(5);
+    expect(offSpy).toHaveBeenCalledTimes(6);
   });
 
   it('res.destroyed short-circuits onAny — no write attempted for live frames', () => {

--- a/src/dashboard/routes/sse-handler.ts
+++ b/src/dashboard/routes/sse-handler.ts
@@ -10,8 +10,9 @@ const HEARTBEAT_MS = 30_000;
 const SESSION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
 
 // Narrow a payload to its sessionId field if present. ToolCall, AntiPattern,
-// CostUpdate, and ContextUpdate all expose `sessionId: string`; AlertEvent has
-// it as `sessionId?: string`. HeartbeatEvent has none (and is unfiltered).
+// CostUpdate, and ContextUpdate all expose `sessionId: string`; AlertEvent
+// and RetryAlertEvent have it as `sessionId?: string`. HeartbeatEvent has
+// none (and is unfiltered).
 function extractSessionId(payload: LiveEventMap[LiveEventName]): string | undefined {
   if (payload && typeof payload === 'object' && 'sessionId' in payload) {
     const sid = payload.sessionId;
@@ -98,12 +99,14 @@ export function createSseHandler(
       'tool-call': onAny('tool-call'),
       'cost-update': onAny('cost-update'),
       'anti-pattern': onAny('anti-pattern'),
+      'retry-alert': onAny('retry-alert'),
       'context-update': onAny('context-update'),
       alert: onAny('alert'),
     } as const;
     bus.onWithSeq('tool-call', handlers['tool-call']);
     bus.onWithSeq('cost-update', handlers['cost-update']);
     bus.onWithSeq('anti-pattern', handlers['anti-pattern']);
+    bus.onWithSeq('retry-alert', handlers['retry-alert']);
     bus.onWithSeq('context-update', handlers['context-update']);
     bus.onWithSeq('alert', handlers['alert']);
 
@@ -125,6 +128,7 @@ export function createSseHandler(
       bus.offWithSeq('tool-call', handlers['tool-call']);
       bus.offWithSeq('cost-update', handlers['cost-update']);
       bus.offWithSeq('anti-pattern', handlers['anti-pattern']);
+      bus.offWithSeq('retry-alert', handlers['retry-alert']);
       bus.offWithSeq('context-update', handlers['context-update']);
       bus.offWithSeq('alert', handlers['alert']);
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1982,7 +1982,23 @@ async function main(): Promise<void> {
         contextWindowTracker.recordToolCall(rawRecord);
         contextTracker.recordToolCall(rawRecord);
         latencyTracker.recordToolCall(rawRecord);
-        retryDetector.recordToolCall(rawRecord);
+        const thrashingAlert = retryDetector.recordToolCall(rawRecord);
+        if (thrashingAlert) {
+          capturedNrIngest?.ingestRetryAlert(thrashingAlert, {
+            platform: typeof rawRecord.platform === 'string' ? rawRecord.platform : undefined,
+          });
+          liveBus.emit('retry-alert', {
+            // alert.sessionId (not sessionTraceId) — see RetryDetector's
+            // session-grouping comment: in --local mode this process's own
+            // RetryDetector drains every session's buffer, so only the
+            // alert's own sessionId can be trusted to name the offending one.
+            sessionId: thrashingAlert.sessionId ?? undefined,
+            toolName: thrashingAlert.toolName,
+            occurrences: thrashingAlert.occurrences,
+            tokensWasted: thrashingAlert.tokensWastedEstimate,
+            ts: thrashingAlert.timestamp,
+          });
+        }
         qualityProxyTracker.recordToolCall(rawRecord);
         const turnId = turnTracker.recordToolCall(rawRecord);
         const turnNumber = turnTracker.getCurrentTurnNumber();

--- a/src/metrics/retry-detector.test.ts
+++ b/src/metrics/retry-detector.test.ts
@@ -99,6 +99,62 @@ describe('RetryDetector', () => {
     expect(result!.similarity).toBeGreaterThanOrEqual(0.8);
   });
 
+  it('tags the alert with the sessionId of the offending calls', () => {
+    const detector = new RetryDetector();
+
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }));
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }));
+    const result = detector.recordToolCall(
+      makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.sessionId).toBe('sess-a');
+  });
+
+  it('does not blend two different sessions failing on the same tool into one alert', () => {
+    // Simulates the --local aggregator process, which drains every session's
+    // buffer into one stream: two unrelated sessions each failing Bash twice
+    // must not look like one session failing it four times.
+    const detector = new RetryDetector();
+
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }));
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-b', toolName: 'Bash', success: false }));
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }));
+    const result = detector.recordToolCall(
+      makeRecord({ sessionId: 'sess-b', toolName: 'Bash', success: false }),
+    );
+
+    // Window is [a, b, a, b] — 2 occurrences per session, below the default
+    // threshold of 3, so neither session's calls should fire on their own.
+    expect(result).toBeNull();
+    expect(detector.getMetrics().totalAlertsEmitted).toBe(0);
+  });
+
+  it('attributes each session correctly when both cross the threshold', () => {
+    const detector = new RetryDetector({ windowSize: 6 });
+
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }));
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-b', toolName: 'Bash', success: false }));
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }));
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-b', toolName: 'Bash', success: false }));
+    const aThird = detector.recordToolCall(
+      makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }),
+    );
+
+    expect(aThird).not.toBeNull();
+    expect(aThird!.sessionId).toBe('sess-a');
+    expect(aThird!.occurrences).toBe(3);
+
+    const bThird = detector.recordToolCall(
+      makeRecord({ sessionId: 'sess-b', toolName: 'Bash', success: false }),
+    );
+
+    expect(bThird).not.toBeNull();
+    expect(bThird!.sessionId).toBe('sess-b');
+    expect(bThird!.occurrences).toBe(3);
+  });
+
   it('does not alert when tools are different', () => {
     const detector = new RetryDetector();
 
@@ -351,6 +407,63 @@ describe('RetryDetector', () => {
     expect(metrics.alerts).toHaveLength(0);
     expect(metrics.totalTokensWasted).toBe(0);
     expect(metrics.totalAlertsEmitted).toBe(0);
+  });
+
+  it('tracks a running bySession breakdown incrementally, keyed by session id', () => {
+    const detector = new RetryDetector();
+    // Session A: one thrashing episode (3 failed Bash calls).
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }));
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }));
+    detector.recordToolCall(makeRecord({ sessionId: 'sess-a', toolName: 'Bash', success: false }));
+    // Sessionless calls (undefined sessionId) roll up under 'unknown': one thrashing episode.
+    detector.recordToolCall(makeRecord({ sessionId: undefined, toolName: 'Read', success: false }));
+    detector.recordToolCall(makeRecord({ sessionId: undefined, toolName: 'Read', success: false }));
+    detector.recordToolCall(makeRecord({ sessionId: undefined, toolName: 'Read', success: false }));
+
+    const metrics = detector.getMetrics();
+    expect(metrics.totalAlertsEmitted).toBe(2);
+    expect(Object.keys(metrics.bySession).sort()).toEqual(['sess-a', 'unknown']);
+    expect(metrics.bySession['sess-a']?.alertCount).toBe(1);
+    expect(metrics.bySession['unknown']?.alertCount).toBe(1);
+  });
+
+  it('caps the alerts buffer at 200 while totalAlertsEmitted keeps counting past it', () => {
+    const detector = new RetryDetector({ windowSize: 3, minOccurrences: 3 });
+    // Every call from the 3rd onward re-fires a distinct alert: the sliding
+    // 3-window's own call-id set changes on every push (ids are random per
+    // makeRecord call), so the dedupe key never repeats. 203 calls -> 201
+    // alerts fired, well past the 200 cap — this also exercises firedKeys'
+    // own FIFO eviction under heavy load without needing a direct accessor:
+    // a bug there (e.g. an off-by-one that lets an evicted key block a
+    // legitimate re-fire, or double-counts) would surface as a wrong
+    // totalAlertsEmitted below.
+    const CALLS = 203;
+    for (let i = 0; i < CALLS; i++) {
+      detector.recordToolCall(makeRecord({ toolName: 'Bash', success: false }));
+    }
+
+    const metrics = detector.getMetrics();
+    expect(metrics.totalAlertsEmitted).toBe(CALLS - 2);
+    expect(metrics.alerts).toHaveLength(200);
+    expect(metrics.alerts.length).toBeLessThan(metrics.totalAlertsEmitted);
+  });
+
+  it('evicts the least-recently-touched session once bySession exceeds its 50-session cap', () => {
+    const detector = new RetryDetector({ windowSize: 3, minOccurrences: 3 });
+    // One thrashing episode per session, sessions 0..50 (51 distinct
+    // sessions) — session 0 should be evicted once session 50 pushes the
+    // map past its cap.
+    for (let i = 0; i <= 50; i++) {
+      const sessionId = `sess-${i}`;
+      detector.recordToolCall(makeRecord({ sessionId, toolName: 'Bash', success: false }));
+      detector.recordToolCall(makeRecord({ sessionId, toolName: 'Bash', success: false }));
+      detector.recordToolCall(makeRecord({ sessionId, toolName: 'Bash', success: false }));
+    }
+
+    const metrics = detector.getMetrics();
+    expect(Object.keys(metrics.bySession)).toHaveLength(50);
+    expect(metrics.bySession['sess-0']).toBeUndefined();
+    expect(metrics.bySession['sess-50']).toBeDefined();
   });
 
   it('respects custom window size', () => {

--- a/src/metrics/retry-detector.ts
+++ b/src/metrics/retry-detector.ts
@@ -26,12 +26,24 @@ export interface ThrashingAlert {
   readonly similarity: number;
   readonly tokensWastedEstimate: number;
   readonly timestamp: number;
+  /**
+   * The Claude Code session that produced the flagged calls. `null` when the
+   * underlying ToolCallRecords carry no session id (legacy/proxy-originated
+   * records) — callers should treat that as "unattributed", not "session A".
+   */
+  readonly sessionId: string | null;
+}
+
+export interface RetrySessionBreakdown {
+  readonly tokensWasted: number;
+  readonly alertCount: number;
 }
 
 export interface RetryDetectorMetrics {
   readonly alerts: readonly ThrashingAlert[];
   readonly totalTokensWasted: number;
   readonly totalAlertsEmitted: number;
+  readonly bySession: Readonly<Record<string, RetrySessionBreakdown>>;
 }
 
 export interface RetryDetectorOptions {
@@ -53,6 +65,23 @@ const DEFAULT_SIMILARITY_THRESHOLD = 0.8;
 // recordEstimatedTokens). Only used here to estimate wasted tokens for
 // reporting, not for billing, so the approximation is acceptable.
 const BYTES_PER_TOKEN_ESTIMATE = 4;
+// Bounds memory for a long-running --local process — mirrors
+// TurnCostAttributor's MAX_TURNS bound for the same failure mode.
+const MAX_ALERTS = 200;
+// Mirrors ContextTrackerRegistry/TurnCostAttributor's session-churn bound so
+// this map doesn't grow unboundedly as distinct session ids accumulate over
+// a long-running process's lifetime.
+const DEFAULT_MAX_SESSIONS = 50;
+// firedKeys grows by one entry per uniquely-fired alert group and is never
+// touched again after insertion (unlike bySession, which re-touches an
+// existing key on every repeat alert) — a FIFO cap mirroring MAX_ALERTS is
+// enough to bound it for the same long-running-process failure mode.
+const MAX_FIRED_KEYS = MAX_ALERTS;
+// Single owner of this sentinel — api-handler.ts's retryAlertsBySession()
+// used to own this convention locally; it now reads the pre-aggregated
+// bySession map this class maintains, so this is the one place that decides
+// how a sessionless alert rolls up.
+const UNKNOWN_SESSION_KEY = 'unknown';
 
 // ---------------------------------------------------------------------------
 // Levenshtein similarity
@@ -111,6 +140,8 @@ export class RetryDetector implements Resettable {
   private readonly recentCalls: ToolCallRecord[] = [];
   private readonly alerts: ThrashingAlert[] = [];
   private totalTokensWasted = 0;
+  private totalAlertsEmitted = 0;
+  private readonly bySession = new Map<string, RetrySessionBreakdown>();
   // Track which tool+window combos already fired to avoid spamming
   private readonly firedKeys = new Set<string>();
 
@@ -136,13 +167,14 @@ export class RetryDetector implements Resettable {
     return {
       alerts: this.alerts,
       totalTokensWasted: this.totalTokensWasted,
-      totalAlertsEmitted: this.alerts.length,
+      totalAlertsEmitted: this.totalAlertsEmitted,
+      bySession: Object.fromEntries(this.bySession),
     };
   }
 
   emitMetrics(aggregator: MetricAggregator): void {
-    if (this.alerts.length > 0) {
-      aggregator.record('ai.retry.alerts_total', this.alerts.length);
+    if (this.totalAlertsEmitted > 0) {
+      aggregator.record('ai.retry.alerts_total', this.totalAlertsEmitted);
       aggregator.record('ai.retry.tokens_wasted', this.totalTokensWasted);
     }
   }
@@ -151,6 +183,8 @@ export class RetryDetector implements Resettable {
     this.recentCalls.length = 0;
     this.alerts.length = 0;
     this.totalTokensWasted = 0;
+    this.totalAlertsEmitted = 0;
+    this.bySession.clear();
     this.firedKeys.clear();
   }
 
@@ -196,6 +230,10 @@ export class RetryDetector implements Resettable {
         .join(',')}`;
       if (this.firedKeys.has(dedupeKey)) continue;
       this.firedKeys.add(dedupeKey);
+      if (this.firedKeys.size > MAX_FIRED_KEYS) {
+        const oldest = this.firedKeys.keys().next().value;
+        if (oldest !== undefined) this.firedKeys.delete(oldest);
+      }
 
       const tokensWasted = this.estimateTokensWasted(calls);
       const alert: ThrashingAlert = {
@@ -205,10 +243,16 @@ export class RetryDetector implements Resettable {
         similarity,
         tokensWastedEstimate: tokensWasted,
         timestamp: Date.now(),
+        sessionId: calls[0]!.sessionId ?? null,
       };
 
       this.alerts.push(alert);
+      if (this.alerts.length > MAX_ALERTS) {
+        this.alerts.shift();
+      }
+      this.totalAlertsEmitted++;
       this.totalTokensWasted += tokensWasted;
+      this.recordSessionBreakdown(alert.sessionId ?? UNKNOWN_SESSION_KEY, tokensWasted);
 
       logger.warn('Thrashing detected', {
         tool: toolName,
@@ -225,6 +269,27 @@ export class RetryDetector implements Resettable {
     }
 
     return null;
+  }
+
+  // Same touch-then-evict LRU shape as TurnCostAttributor's
+  // getOrCreateSession — moving a touched key to the end of the Map keeps
+  // eviction below a real LRU (evicts the least-recently-touched session,
+  // not just the least-recently-created one).
+  private recordSessionBreakdown(sessionKey: string, tokensWasted: number): void {
+    const existing = this.bySession.get(sessionKey);
+    if (existing) {
+      this.bySession.delete(sessionKey);
+      this.bySession.set(sessionKey, {
+        tokensWasted: existing.tokensWasted + tokensWasted,
+        alertCount: existing.alertCount + 1,
+      });
+      return;
+    }
+    if (this.bySession.size >= DEFAULT_MAX_SESSIONS) {
+      const oldest = this.bySession.keys().next().value;
+      if (oldest !== undefined) this.bySession.delete(oldest);
+    }
+    this.bySession.set(sessionKey, { tokensWasted, alertCount: 1 });
   }
 
   private computeGroupSimilarity(calls: ToolCallRecord[]): number {

--- a/src/transport/nr-ingest.test.ts
+++ b/src/transport/nr-ingest.test.ts
@@ -3,6 +3,7 @@ import {
   toolCallToNrEvent,
   codingTaskToNrEvent,
   antiPatternToNrEvent,
+  retryAlertToNrEvent,
   proxyToolCallToNrEvent,
   workflowRunToNrEvent,
   scriptWorkflowRunToNrEvent,
@@ -23,6 +24,7 @@ import type { ToolCallRecord } from '../storage/types.js';
 import type { ProxyToolCallRecord, ProxyRequestRecord } from '../proxy/types.js';
 import type { AiCodingTask } from '../metrics/task-detector.js';
 import type { AntiPattern } from '../metrics/anti-patterns.js';
+import type { ThrashingAlert } from '../metrics/retry-detector.js';
 import type { ContextTurnSnapshot, ToolContextContribution } from '../metrics/context-tracker.js';
 import { SessionTracker } from '../metrics/session-tracker.js';
 import { FeedbackCollector } from '../tools/workflow-tools.js';
@@ -98,6 +100,19 @@ function makePattern(overrides?: Partial<AntiPattern>): AntiPattern {
     type: 'thrashing',
     tokensWasted: 0,
     suggestion: 'Consider reviewing your approach before retrying',
+    ...overrides,
+  };
+}
+
+function makeThrashingAlert(overrides?: Partial<ThrashingAlert>): ThrashingAlert {
+  return {
+    toolName: 'Bash',
+    occurrences: 3,
+    windowSize: 5,
+    similarity: 1,
+    tokensWastedEstimate: 42,
+    timestamp: 1_700_000_000_000,
+    sessionId: 'sess-001',
     ...overrides,
   };
 }
@@ -1422,6 +1437,117 @@ describe('NrIngestManager.ingestAntiPattern()', () => {
     const types = patternEvents.map((e) => e.type);
     expect(types).toContain('thrashing');
     expect(types).toContain('re_reading');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// retryAlertToNrEvent()
+// ---------------------------------------------------------------------------
+
+describe('retryAlertToNrEvent()', () => {
+  it('serializes required fields', () => {
+    const alert = makeThrashingAlert();
+    const event = retryAlertToNrEvent(alert, {
+      developer: 'dev1',
+      appName: 'my-app',
+      sessionId: 'trace-id',
+      platform: 'claude-code',
+    });
+
+    expect(event.eventType).toBe('AiRetryAlert');
+    expect(event.tool_name).toBe('Bash');
+    expect(event.occurrences).toBe(3);
+    expect(event.window_size).toBe(5);
+    expect(event.similarity).toBe(1);
+    expect(event.tokens_wasted).toBe(42);
+    expect(event.developer).toBe('dev1');
+    expect(event.app_name).toBe('my-app');
+    expect(event.platform).toBe('claude-code');
+    expect(event.timestamp).toBe(1_700_000_000_000);
+  });
+
+  it('session_id comes from attrs.sessionId, not alert.sessionId', () => {
+    // Same single-source-of-truth convention as antiPatternToNrEvent — see
+    // "NrIngestManager.ingestRetryAlert: sessionTraceId takes precedence
+    // over alert.sessionId" below for why.
+    const alert = makeThrashingAlert({ sessionId: 'alert-own-session' });
+    const event = retryAlertToNrEvent(alert, {
+      developer: 'd',
+      appName: 'a',
+      sessionId: 'trace-id',
+    });
+
+    expect(event.session_id).toBe('trace-id');
+  });
+
+  it('omits session_id when attrs.sessionId is undefined', () => {
+    const event = retryAlertToNrEvent(makeThrashingAlert(), {
+      developer: 'd',
+      appName: 'a',
+    });
+
+    expect(event).not.toHaveProperty('session_id');
+  });
+
+  it('defaults platform to claude-code when not provided', () => {
+    const event = retryAlertToNrEvent(makeThrashingAlert(), {
+      developer: 'd',
+      appName: 'a',
+    });
+
+    expect(event.platform).toBe('claude-code');
+  });
+
+  it('includes team/project/org attribution when provided', () => {
+    const event = retryAlertToNrEvent(makeThrashingAlert(), {
+      developer: 'd',
+      appName: 'a',
+      teamId: 'team-1',
+      projectId: 'proj-1',
+      orgId: 'org-1',
+    });
+
+    expect(event.team_id).toBe('team-1');
+    expect(event.project_id).toBe('proj-1');
+    expect(event.org_id).toBe('org-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NrIngestManager.ingestRetryAlert()
+// ---------------------------------------------------------------------------
+
+describe('NrIngestManager.ingestRetryAlert()', () => {
+  it('queues an AiRetryAlert event that is flushed on stop()', async () => {
+    const manager = new NrIngestManager(makeIngestOptions());
+
+    manager.ingestRetryAlert(makeThrashingAlert(), { platform: 'claude-code' });
+    manager.start();
+    await manager.stop();
+
+    const sentEvents = (mockSendEvents.mock.calls[0] as unknown[])[0] as Array<
+      Record<string, unknown>
+    >;
+    const retryEvent = sentEvents.find((e) => e.eventType === 'AiRetryAlert');
+    expect(retryEvent).toBeDefined();
+    expect(retryEvent!.tool_name).toBe('Bash');
+  });
+
+  it('sessionTraceId takes precedence over alert.sessionId', async () => {
+    const manager = new NrIngestManager({
+      ...makeIngestOptions(),
+      sessionTraceId: 'the-trace-id',
+    });
+
+    manager.ingestRetryAlert(makeThrashingAlert({ sessionId: 'a-different-session' }));
+    manager.start();
+    await manager.stop();
+
+    const sentEvents = (mockSendEvents.mock.calls[0] as unknown[])[0] as Array<
+      Record<string, unknown>
+    >;
+    const retryEvent = sentEvents.find((e) => e.eventType === 'AiRetryAlert');
+    expect(retryEvent?.session_id).toBe('the-trace-id');
   });
 });
 

--- a/src/transport/nr-ingest.ts
+++ b/src/transport/nr-ingest.ts
@@ -28,6 +28,7 @@ import type { ProxyToolCallRecord, ProxyRequestRecord } from '../proxy/types.js'
 import type { AiCodingTask } from '../metrics/task-detector.js';
 import type { WorkflowRunMetrics } from '../metrics/workflow-run-tracker.js';
 import type { AntiPattern } from '../metrics/anti-patterns.js';
+import type { ThrashingAlert } from '../metrics/retry-detector.js';
 import type { SessionTracker } from '../metrics/session-tracker.js';
 import type { CostTracker } from '../metrics/cost-tracker.js';
 import type { EfficiencyScorer } from '../metrics/efficiency-score.js';
@@ -748,6 +749,50 @@ export function antiPatternToNrEvent(
   return event;
 }
 
+/**
+ * Convert a ThrashingAlert into a flat NR event object.
+ *
+ * session_id comes from `attrs.sessionId` (the ingesting process's resolved
+ * sessionTraceId) — the same single-source-of-truth convention every other
+ * ingest*() method uses (see ingestAntiPattern, ingestToolCall). This is
+ * deliberately NOT `alert.sessionId`: that field exists for in-process
+ * attribution (the --local dashboard's per-session breakdown, which drains
+ * every session's buffer into one RetryDetector) and is a different concern
+ * from "which process is reporting this event to NR".
+ */
+export function retryAlertToNrEvent(
+  alert: ThrashingAlert,
+  attrs: {
+    developer: string;
+    appName: string;
+    sessionId?: string;
+    platform?: string;
+    teamId?: string | null;
+    projectId?: string | null;
+    orgId?: string | null;
+  },
+): NrEventData {
+  const event: NrEventData = {
+    eventType: 'AiRetryAlert',
+    timestamp: alert.timestamp,
+    tool_name: alert.toolName,
+    occurrences: alert.occurrences,
+    window_size: alert.windowSize,
+    similarity: alert.similarity,
+    tokens_wasted: alert.tokensWastedEstimate,
+    developer: attrs.developer,
+    app_name: attrs.appName,
+    platform: attrs.platform ?? 'claude-code',
+  };
+
+  if (attrs.teamId) event.team_id = attrs.teamId;
+  if (attrs.projectId) event.project_id = attrs.projectId;
+  if (attrs.orgId) event.org_id = attrs.orgId;
+  if (attrs.sessionId != null) event.session_id = attrs.sessionId;
+
+  return event;
+}
+
 // ---------------------------------------------------------------------------
 // Retry classification
 // ---------------------------------------------------------------------------
@@ -1168,6 +1213,19 @@ export class NrIngestManager {
       projectId: this.projectId,
       orgId: this.orgId,
       detectedAt: context.detectedAt,
+    });
+    this.scheduler.addEvent(event);
+  }
+
+  ingestRetryAlert(alert: ThrashingAlert, context: { platform?: string } = {}): void {
+    const event = retryAlertToNrEvent(alert, {
+      developer: this.developer,
+      appName: this.appName,
+      sessionId: this.sessionTraceId,
+      platform: context.platform,
+      teamId: this.teamId,
+      projectId: this.projectId,
+      orgId: this.orgId,
     });
     this.scheduler.addEvent(event);
   }

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -322,6 +322,14 @@ export interface ComputeWasteResponse {
     readonly tokens_wasted: number;
     readonly instances: number;
   }>;
+  // Attributes retry_tokens_wasted back to the session(s) that caused it —
+  // anti-pattern waste has no per-session attribution yet, so this only ever
+  // covers the retry portion. Sorted descending by tokens_wasted.
+  readonly by_session: ReadonlyArray<{
+    readonly session_id: string;
+    readonly tokens_wasted: number;
+    readonly alert_count: number;
+  }>;
   readonly status: 'clean' | 'moderate' | 'needs_attention';
 }
 

--- a/src/web/hooks/useLiveEvents.test.tsx
+++ b/src/web/hooks/useLiveEvents.test.tsx
@@ -45,6 +45,7 @@ describe('useLiveEvents', () => {
       recentToolCalls: [],
       cost: null,
       antiPatterns: [],
+      retryAlerts: [],
       firingAlerts: new Map(),
       dismissedAlerts: new Set(),
     });
@@ -115,6 +116,20 @@ describe('useLiveEvents', () => {
       });
     });
     expect(useLiveStore.getState().antiPatterns).toHaveLength(1);
+  });
+
+  it('routes retry-alert to pushRetryAlert', () => {
+    renderHook(() => useLiveEvents());
+    act(() => {
+      FakeEventSource.instances[0].emit('retry-alert', {
+        sessionId: 'sess-A',
+        toolName: 'Bash',
+        occurrences: 3,
+        tokensWasted: 42,
+      });
+    });
+    expect(useLiveStore.getState().retryAlerts).toHaveLength(1);
+    expect(useLiveStore.getState().retryAlerts[0].tokensWasted).toBe(42);
   });
 
   describe('REST hydration of anti-patterns', () => {

--- a/src/web/hooks/useLiveEvents.ts
+++ b/src/web/hooks/useLiveEvents.ts
@@ -93,6 +93,7 @@ export function useLiveEvents(url: string = '/sse'): void {
       es.addEventListener('tool-call', onToolCall as EventListener);
       es.addEventListener('cost-update', onCost as EventListener);
       es.addEventListener('anti-pattern', onAnti as EventListener);
+      es.addEventListener('retry-alert', onRetryAlert as EventListener);
       es.addEventListener('alert', onAlert as EventListener);
       es.addEventListener('context-update', onContext as EventListener);
       es.addEventListener('heartbeat', onHeartbeat as EventListener);
@@ -119,6 +120,13 @@ export function useLiveEvents(url: string = '/sse'): void {
     const onAnti = (e: MessageEvent): void => {
       try {
         useLiveStore.getState().pushAntiPattern(JSON.parse(e.data));
+      } catch {
+        /* ignore malformed */
+      }
+    };
+    const onRetryAlert = (e: MessageEvent): void => {
+      try {
+        useLiveStore.getState().pushRetryAlert(JSON.parse(e.data));
       } catch {
         /* ignore malformed */
       }
@@ -174,6 +182,7 @@ export function useLiveEvents(url: string = '/sse'): void {
         es.removeEventListener('tool-call', onToolCall as EventListener);
         es.removeEventListener('cost-update', onCost as EventListener);
         es.removeEventListener('anti-pattern', onAnti as EventListener);
+        es.removeEventListener('retry-alert', onRetryAlert as EventListener);
         es.removeEventListener('alert', onAlert as EventListener);
         es.removeEventListener('context-update', onContext as EventListener);
         es.removeEventListener('heartbeat', onHeartbeat as EventListener);

--- a/src/web/store/liveStore.test.ts
+++ b/src/web/store/liveStore.test.ts
@@ -27,6 +27,7 @@ describe('liveStore', () => {
       recentToolCalls: [],
       cost: null,
       antiPatterns: [],
+      retryAlerts: [],
       firingAlerts: new Map(),
       dismissedAlerts: new Set(),
       activeSessionId: null,
@@ -74,6 +75,16 @@ describe('liveStore', () => {
     const s = useLiveStore.getState();
     expect(s.antiPatterns.length).toBe(10);
     expect(s.antiPatterns[0].target).toBe('f5.ts');
+  });
+
+  it('pushRetryAlert appends and caps to last 10', () => {
+    const push = useLiveStore.getState().pushRetryAlert;
+    for (let i = 0; i < 15; i++) {
+      push({ toolName: 'Bash', occurrences: 3, tokensWasted: i });
+    }
+    const s = useLiveStore.getState();
+    expect(s.retryAlerts.length).toBe(10);
+    expect(s.retryAlerts[0].tokensWasted).toBe(5);
   });
 });
 
@@ -212,6 +223,7 @@ describe('liveStore — setActiveSession', () => {
       recentToolCalls: [],
       cost: null,
       antiPatterns: [],
+      retryAlerts: [],
       firingAlerts: new Map(),
       dismissedAlerts: new Set(),
       activeSessionId: null,
@@ -227,17 +239,21 @@ describe('liveStore — setActiveSession', () => {
     expect(useLiveStore.getState().activeSessionId).toBe('sess-A');
   });
 
-  it('clears tool calls and anti-patterns from non-matching sessions on switch', () => {
-    const { pushToolCall, pushAntiPattern, setActiveSession } = useLiveStore.getState();
+  it('clears tool calls, anti-patterns, and retry alerts from non-matching sessions on switch', () => {
+    const { pushToolCall, pushAntiPattern, pushRetryAlert, setActiveSession } =
+      useLiveStore.getState();
     pushToolCall({ id: 'a', sessionId: 'sess-A', tool: 'Read', durationMs: 1, costUsd: 0, ts: 1 });
     pushToolCall({ id: 'b', sessionId: 'sess-B', tool: 'Read', durationMs: 1, costUsd: 0, ts: 2 });
     pushAntiPattern({ sessionId: 'sess-A', type: 'thrashing', target: 'a.ts', count: 1 });
     pushAntiPattern({ sessionId: 'sess-B', type: 'rereading', target: 'b.ts', count: 2 });
+    pushRetryAlert({ sessionId: 'sess-A', toolName: 'Bash', occurrences: 3, tokensWasted: 10 });
+    pushRetryAlert({ sessionId: 'sess-B', toolName: 'Read', occurrences: 4, tokensWasted: 20 });
 
     setActiveSession('sess-A');
     const s = useLiveStore.getState();
     expect(s.recentToolCalls.map((t) => t.id)).toEqual(['a']);
     expect(s.antiPatterns.map((a) => a.target)).toEqual(['a.ts']);
+    expect(s.retryAlerts.map((a) => a.tokensWasted)).toEqual([10]);
   });
 
   it('clears cost from a non-matching session on switch', () => {

--- a/src/web/store/liveStore.ts
+++ b/src/web/store/liveStore.ts
@@ -30,6 +30,13 @@ export interface AntiPatternEvent {
   readonly count: number;
 }
 
+export interface RetryAlertEvent {
+  readonly sessionId?: string;
+  readonly toolName: string;
+  readonly occurrences: number;
+  readonly tokensWasted: number;
+}
+
 // Mirror of the AlertEvent shape from src/dashboard/live-event-bus.ts, minus
 // its optional `sessionId` — alerts aren't session-scoped client-side (every
 // firing alert is shown regardless of which session triggered it). Kept
@@ -93,6 +100,7 @@ interface LiveState {
   readonly recentToolCalls: ToolCallEvent[];
   readonly cost: CostUpdateEvent | null;
   readonly antiPatterns: AntiPatternEvent[];
+  readonly retryAlerts: RetryAlertEvent[];
   readonly contextBySession: Map<string, ContextUpdateEvent>;
   readonly firingAlerts: Map<string, AlertEvent>;
   readonly dismissedAlerts: Set<string>;
@@ -111,6 +119,7 @@ interface LiveState {
   pushToolCall(e: ToolCallEvent): void;
   setCost(c: CostUpdateEvent): void;
   pushAntiPattern(e: AntiPatternEvent): void;
+  pushRetryAlert(e: RetryAlertEvent): void;
   setContext(c: ContextUpdateEvent): void;
   addOrUpdateAlert(e: AlertEvent): void;
   clearAlert(id: string): void;
@@ -135,6 +144,7 @@ interface LiveState {
 
 const RECENT_CAP = 20;
 const ANTI_CAP = 10;
+const RETRY_CAP = 10;
 
 const WORKFLOW_CAP = 50;
 
@@ -143,6 +153,7 @@ export const useLiveStore = create<LiveState>((set) => ({
   recentToolCalls: [],
   cost: null,
   antiPatterns: [],
+  retryAlerts: [],
   contextBySession: new Map(),
   firingAlerts: new Map(),
   dismissedAlerts: new Set(),
@@ -171,6 +182,7 @@ export const useLiveStore = create<LiveState>((set) => ({
         activeSessionId: id,
         recentToolCalls: s.recentToolCalls.filter((t) => matchOrUnknown(t.sessionId)),
         antiPatterns: s.antiPatterns.filter((a) => matchOrUnknown(a.sessionId)),
+        retryAlerts: s.retryAlerts.filter((a) => matchOrUnknown(a.sessionId)),
         cost: s.cost && matchOrUnknown(s.cost.sessionId) ? s.cost : null,
       };
     }),
@@ -203,6 +215,12 @@ export const useLiveStore = create<LiveState>((set) => ({
     set((s) => {
       const next = [...s.antiPatterns, e];
       return { antiPatterns: next.length > ANTI_CAP ? next.slice(next.length - ANTI_CAP) : next };
+    }),
+
+  pushRetryAlert: (e) =>
+    set((s) => {
+      const next = [...s.retryAlerts, e];
+      return { retryAlerts: next.length > RETRY_CAP ? next.slice(next.length - RETRY_CAP) : next };
     }),
 
   addOrUpdateAlert: (e) =>

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -1778,6 +1778,7 @@ describe('Today view — Compute Waste panel', () => {
       recentToolCalls: [],
       cost: { sessionTotalUsd: 1, todayTotalUsd: 1, forecastEodUsd: null },
       antiPatterns: [],
+      retryAlerts: [],
       firingAlerts: new Map(),
       dismissedAlerts: new Set(),
     });
@@ -1865,6 +1866,67 @@ describe('Today view — Compute Waste panel', () => {
     renderToday();
     expect(await screen.findByText(/retry: ~200/)).toBeInTheDocument();
     expect(screen.getByText(/anti-pattern: ~400/)).toBeInTheDocument();
+  });
+
+  it('shows the top contributing session when by_session is present', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/compute-waste')) {
+        return new Response(
+          JSON.stringify({
+            total_tokens_wasted: 900,
+            retry_tokens_wasted: 900,
+            anti_pattern_tokens_wasted: 0,
+            breakdown: [],
+            by_session: [{ session_id: 'abcdef1234567890', tokens_wasted: 900, alert_count: 3 }],
+            status: 'moderate',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    renderToday();
+    // liveSessions resolves to [] under the generic mock above, so
+    // sessionPillLabel falls back to the truncated session id.
+    expect(await screen.findByText(/top session: abcdef12/)).toBeInTheDocument();
+  });
+
+  it('shows the most recent retry alert live, ahead of the next REST poll', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.includes('/api/compute-waste')) {
+        return new Response(
+          JSON.stringify({
+            total_tokens_wasted: 300,
+            retry_tokens_wasted: 300,
+            anti_pattern_tokens_wasted: 0,
+            breakdown: [],
+            status: 'moderate',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+    useLiveStore.setState({
+      retryAlerts: [{ sessionId: 'sess-a', toolName: 'Bash', occurrences: 4, tokensWasted: 300 }],
+    });
+
+    renderToday();
+    await screen.findByText(/~300 wasted tokens/);
+    expect(screen.getByText('Bash')).toBeInTheDocument();
+    expect(screen.getByText(/retried 4×/)).toBeInTheDocument();
+    // liveSessions resolves to [] under the generic mock above, so
+    // sessionPillLabel falls back to the raw session id (already ≤8 chars).
+    expect(screen.getByText(/Session: sess-a/)).toBeInTheDocument();
   });
 });
 

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -127,6 +127,11 @@ interface ComputeWasteApiResponse {
     readonly tokens_wasted: number;
     readonly instances: number;
   }>;
+  readonly by_session?: ReadonlyArray<{
+    readonly session_id: string;
+    readonly tokens_wasted: number;
+    readonly alert_count: number;
+  }>;
   readonly status: 'clean' | 'moderate' | 'needs_attention';
 }
 
@@ -585,7 +590,7 @@ export function Today(): JSX.Element {
             <ApiFailurePanel />
             <ToolSelectionPanel />
             <LatencyPanel aggregate={aggregate} />
-            <ComputeWastePanel />
+            <ComputeWastePanel liveSessions={liveSessions ?? []} />
             <ModelUsagePanel />
             <CacheHealthPanel aggregate={aggregate} />
             <div className="col-span-3">
@@ -1113,14 +1118,22 @@ function CacheHealthPanel({
   );
 }
 
-function ComputeWastePanel(): JSX.Element | null {
+function ComputeWastePanel({
+  liveSessions,
+}: {
+  liveSessions: LiveSessionEntry[];
+}): JSX.Element | null {
   const { data, isPending } = useQuery<ComputeWasteApiResponse>({
     queryKey: qk.computeWaste,
     queryFn: fetchComputeWaste as () => Promise<ComputeWasteApiResponse>,
     retry: false,
   });
+  const retryAlerts = useLiveStore((s) => s.retryAlerts);
 
   if (isPending || !data || typeof data.total_tokens_wasted !== 'number') return null;
+
+  const latestRetryAlert = retryAlerts[retryAlerts.length - 1] ?? null;
+  const topSession = data.by_session?.[0] ?? null;
 
   const statusColor =
     data.status === 'clean'
@@ -1156,10 +1169,29 @@ function ComputeWastePanel(): JSX.Element | null {
         retry: ~{data.retry_tokens_wasted.toLocaleString()} · anti-pattern: ~
         {data.anti_pattern_tokens_wasted.toLocaleString()}
       </div>
+      {topSession !== null && (
+        <div className="text-[10px] text-ink-subtle/70 mt-0.5">
+          top session: {sessionPillLabel(topSession.session_id, liveSessions)} (~
+          {topSession.tokens_wasted.toLocaleString()})
+        </div>
+      )}
       {topOffender !== null && (
         <div className="text-[10px] font-medium text-accent-amber mb-1">
           {topOffender.type.replace(/_/g, ' ')} · ~{topOffender.tokens_wasted.toLocaleString()}{' '}
           tokens
+        </div>
+      )}
+      {latestRetryAlert !== null && (
+        <div className="text-[10px] mb-1">
+          <Pill tone="warning" size="sm" className="mr-1">
+            {latestRetryAlert.toolName}
+          </Pill>
+          <span className="text-ink-muted">retried {latestRetryAlert.occurrences}× </span>
+          {latestRetryAlert.sessionId && (
+            <Pill tone="neutral" size="sm" className="ml-1">
+              Session: {sessionPillLabel(latestRetryAlert.sessionId, liveSessions)}
+            </Pill>
+          )}
         </div>
       )}
       <div className="text-[10px] text-ink-subtle/70 leading-snug">


### PR DESCRIPTION
## Summary
- `RetryDetector`'s `ThrashingAlert` carried no `sessionId`, so the `--local` dashboard's Compute Waste card (whose single `RetryDetector` instance drains every session's buffer) could report a large wasted-token number with no way to tell which session caused it.
- `RetryDetector` tags each `ThrashingAlert` with the session that produced it. `/api/compute-waste` and `/api/retry-alerts` now include a `by_session` breakdown, and the Compute Waste card shows the top contributing session.
- The alert is wired into NR ingestion (new `AiRetryAlert` event) and the live "Today" feed (new `retry-alert` SSE event), and now renders live in the Compute Waste card ahead of the next REST poll.
- `RetryDetector`'s internal buffers (alert list, per-session breakdown, dedupe tracking) are bounded for a long-running `--local` process.
- No version bump — stays at `1.18.4` (already claimed on `main` by the still-Unreleased Homebrew tap work this stacks on top of).

Includes fixes by @adjohn: bounding `RetryDetector`'s alert/session buffers, and wiring the live retry-alert UI into the Compute Waste card.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (177/178 suites, 6028 tests)
- [x] `npm run lint` passes (0 errors/warnings)
- [x] `npm run format:check` passes