### PR TITLE
Fix #496: Fail closed on licenseKey without explicit mode; default local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-08-31
+
+### Fixed
+
+- **Configs with New Relic credentials but no explicit `mode` now fail to start with a clear error instead of silently sending telemetry.** The config loader previously defaulted to `cloud` whenever a license key was present without an explicit `mode`, contradicting the project's local-first, offline-by-default default; it now requires an explicit `mode` in that case, and defaults to `local` when no credentials are configured. `preflight doctor` also reports the resolved telemetry mode and where it came from.
+
 ## [1.18.6] - 2026-09-01
 
 ### Fixed

--- a/example.config.js
+++ b/example.config.js
@@ -192,15 +192,16 @@ export default {
   //
   // `mode` controls what destinations receive your AI-coding telemetry:
   //
-  //   'cloud' — (default) ship every event to New Relic. Existing behaviour.
+  //   'cloud' — ship every event to New Relic. Existing behaviour.
   //             Requires `licenseKey` and `accountId`.
-  //   'local' — keep all data on your machine. The MCP server boots an
+  //   'local' — (default) keep all data on your machine. The MCP server boots an
   //             embedded HTTP dashboard at http://127.0.0.1:7777 and does
   //             NOT send anything to NR. `licenseKey` is optional.
   //   'both'  — do both. Useful as a transition aid.
   //
   // Env: NR_AI_MODE
-  // Default: "cloud"
+  // Default: "local" — a licenseKey with no explicit mode is rejected at
+  // startup (opt-in export), not silently treated as cloud.
   // mode: 'cloud',
   //
   // dashboard: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.18.6",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.18.6",
+      "version": "1.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.18.6",
+  "version": "1.19.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2034,6 +2034,14 @@ describe('validateConfigFile()', () => {
 });
 
 describe('homelab config fields', () => {
+  beforeEach(() => {
+    // The shared beforeEach above forces NR_AI_MODE='cloud' to preserve older
+    // fixtures that predate mode becoming fail-closed. Every test here sets
+    // an explicit file mode ('local') instead — env wins over file, so it
+    // must be cleared for the file value to take effect as these tests intend.
+    delete process.env.NR_AI_MODE;
+  });
+
   it('defaults homelabServerUrl and homelabToken to null', () => {
     const configPath = writeConfigFile({ mode: 'local' });
     const config = loadMcpConfig({ config: configPath });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -45,6 +45,10 @@ beforeEach(() => {
   delete process.env.NEW_RELIC_AI_ORG_ID;
   delete process.env.NEW_RELIC_API_KEY;
   delete process.env.NR_AI_MODE;
+  // Most fixtures below set credentials without asserting on mode; an explicit
+  // 'cloud' here keeps them exercising that behavior as before mode became
+  // fail-closed. Tests of mode resolution itself override or delete this.
+  process.env.NR_AI_MODE = 'cloud';
   delete process.env.NR_AI_DASHBOARD_PORT;
   delete process.env.NR_AI_DASHBOARD_HOST;
   delete process.env.NR_AI_DASHBOARD_OPEN;
@@ -1248,12 +1252,11 @@ describe('developer sanitization via loadMcpConfig()', () => {
 });
 
 describe('mode field', () => {
-  it("defaults to 'cloud' when unset", () => {
-    process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
-    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+  it("defaults to 'local' when unset and no credentials are configured", () => {
+    delete process.env.NR_AI_MODE;
     const configPath = writeConfigFile({});
     const config = loadMcpConfig({ config: configPath });
-    expect(config.mode).toBe('cloud');
+    expect(config.mode).toBe('local');
   });
 
   it('reads mode from NR_AI_MODE env var', () => {
@@ -1275,6 +1278,7 @@ describe('mode field', () => {
   });
 
   it('file value wins when env var unset', () => {
+    delete process.env.NR_AI_MODE;
     process.env.NEW_RELIC_LICENSE_KEY = 'test-key';
     process.env.NEW_RELIC_ACCOUNT_ID = '12345';
     const configPath = writeConfigFile({ mode: 'both' });
@@ -1350,6 +1354,37 @@ describe('licenseKey gating', () => {
     expect(() => loadMcpConfig({ config: configPath })).toThrow(
       /Config file validation failed.*mode.*Invalid option: expected one of "cloud"\|"local"\|"both"/,
     );
+  });
+});
+
+describe('mode fail-closed: licenseKey without explicit mode', () => {
+  it('throws when licenseKey is in the config file and mode is unset', () => {
+    delete process.env.NR_AI_MODE;
+    const configPath = writeConfigFile({ licenseKey: 'file-key-123' });
+    expect(() => loadMcpConfig({ config: configPath })).toThrow(/no explicit mode/);
+  });
+
+  it('throws when NEW_RELIC_LICENSE_KEY env is set and mode is unset', () => {
+    delete process.env.NR_AI_MODE;
+    process.env.NEW_RELIC_LICENSE_KEY = 'env-key-1234567890';
+    const configPath = writeConfigFile({});
+    expect(() => loadMcpConfig({ config: configPath })).toThrow(/no explicit mode/);
+  });
+
+  it("still resolves 'cloud' when the file sets mode explicitly alongside licenseKey", () => {
+    delete process.env.NR_AI_MODE;
+    process.env.NEW_RELIC_ACCOUNT_ID = '12345';
+    const configPath = writeConfigFile({ mode: 'cloud', licenseKey: 'file-key-123' });
+    const config = loadMcpConfig({ config: configPath });
+    expect(config.mode).toBe('cloud');
+  });
+
+  it("resolves 'local' without throwing when NR_AI_MODE=local and licenseKey is present", () => {
+    process.env.NR_AI_MODE = 'local';
+    process.env.NEW_RELIC_LICENSE_KEY = 'env-key-1234567890';
+    const configPath = writeConfigFile({});
+    const config = loadMcpConfig({ config: configPath });
+    expect(config.mode).toBe('local');
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -610,6 +610,13 @@ export function loadMcpConfig(cliOptions?: Partial<CliOptions>): Readonly<McpSer
     }
   }
 
+  // --- licenseKey: CLI has no flag for this, so env > file ---
+  // Hoisted ahead of mode resolution: an ambiguous licenseKey-without-mode
+  // config must fail closed instead of silently defaulting to 'cloud'.
+  const licenseKeyRaw =
+    process.env.NEW_RELIC_LICENSE_KEY ??
+    (typeof file.licenseKey === 'string' ? file.licenseKey : undefined);
+
   // --- Resolve mode early so we can gate licenseKey/accountId requirements ---
   // File mode is already validated by the zod schema in loadConfigFile.
   const isValidMode = (v: string | undefined): v is Mode =>
@@ -618,13 +625,22 @@ export function loadMcpConfig(cliOptions?: Partial<CliOptions>): Readonly<McpSer
   if (envMode !== undefined && envMode !== '' && !isValidMode(envMode)) {
     throw new Error(`Invalid NR_AI_MODE='${envMode}'. Must be one of: ${VALID_MODES.join(', ')}.`);
   }
-  const mode: Mode =
-    (isValidMode(envMode) ? envMode : undefined) ?? (file.mode as Mode | undefined) ?? 'cloud';
+  const fileMode = file.mode as Mode | undefined;
+  let mode: Mode;
+  if (isValidMode(envMode)) {
+    mode = envMode;
+  } else if (fileMode !== undefined) {
+    mode = fileMode;
+  } else if (licenseKeyRaw) {
+    // Local-first default (README): telemetry export is opt-in, so a config
+    // with credentials but no explicit mode must not silently export.
+    throw new Error(
+      'Config has a licenseKey but no explicit mode. Telemetry export is opt-in: set "mode": "cloud" (or "both") in the config file, set NR_AI_MODE, or remove the credentials for local-only use. Previous versions implicitly defaulted to cloud.',
+    );
+  } else {
+    mode = 'local';
+  }
 
-  // --- licenseKey: CLI has no flag for this, so env > file ---
-  const licenseKeyRaw =
-    process.env.NEW_RELIC_LICENSE_KEY ??
-    (typeof file.licenseKey === 'string' ? file.licenseKey : undefined);
   if (mode !== 'local' && !licenseKeyRaw) {
     throw new Error(
       `Missing required configuration: licenseKey (mode='${mode}'). ` +

--- a/src/install/diagnostics.test.ts
+++ b/src/install/diagnostics.test.ts
@@ -40,6 +40,7 @@ jest.mock('../config.js', () => ({
     errors: [],
     warnings: [],
   })),
+  loadMcpConfig: jest.fn(() => ({ mode: 'local' })),
   DEFAULT_STORAGE_PATH: '/test-home/.newrelic-preflight',
 }));
 
@@ -106,6 +107,7 @@ const mockedPlatform = nodeOs.platform as jest.Mock;
 const mockedGetDaemonStatus = schedule.getDashboardDaemonStatus as jest.Mock;
 const mockedFindExecutableNodeDir = schedule.findExecutableNodeDir as jest.Mock;
 const mockedValidateConfig = config.validateConfigFile as jest.Mock;
+const mockedLoadMcpConfig = config.loadMcpConfig as jest.Mock;
 const mockedDetectSettingsPath = installHelper.detectSettingsPath as jest.Mock;
 const mockedIsWsl = platform.isWsl as jest.Mock;
 
@@ -136,6 +138,7 @@ describe('runDiagnostics', () => {
       errors: [],
       warnings: [],
     });
+    mockedLoadMcpConfig.mockReturnValue({ mode: 'local' });
     mockedDetectSettingsPath.mockReturnValue('/test-home/.claude/settings.json');
     mockedIsWsl.mockReturnValue(false);
     mockFetch.mockImplementation(async () => {
@@ -199,6 +202,57 @@ describe('runDiagnostics', () => {
       const checks = await runDiagnostics(makeOpts());
       const c = checks.find((x) => x.check === 'Config valid')!;
       expect(c.status).toBe('ok');
+    });
+  });
+
+  describe('Check: Telemetry mode', () => {
+    it('reports the resolved mode and env as its source', async () => {
+      process.env.NR_AI_MODE = 'both';
+      mockedLoadMcpConfig.mockReturnValue({ mode: 'both' });
+      const checks = await runDiagnostics(makeOpts());
+      delete process.env.NR_AI_MODE;
+      const c = checks.find((x) => x.check === 'Telemetry mode')!;
+      expect(c.status).toBe('ok');
+      expect(c.detail).toBe("Resolved to 'both' (source: env NR_AI_MODE)");
+    });
+
+    it('reports the config file as the source when mode came from there', async () => {
+      mockedValidateConfig.mockReturnValue({
+        fileExists: true,
+        malformed: false,
+        mode: 'cloud',
+        errors: [],
+        warnings: [],
+      });
+      mockedLoadMcpConfig.mockReturnValue({ mode: 'cloud' });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Telemetry mode')!;
+      expect(c.status).toBe('ok');
+      expect(c.detail).toBe("Resolved to 'cloud' (source: config file)");
+    });
+
+    it('reports the local default as the source when neither env nor file set a mode', async () => {
+      mockedLoadMcpConfig.mockReturnValue({ mode: 'local' });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Telemetry mode')!;
+      expect(c.status).toBe('ok');
+      expect(c.detail).toBe("Resolved to 'local' (source: default (local))");
+    });
+
+    it('surfaces the fail-closed licenseKey-without-mode error as a diagnostic finding, not a crash', async () => {
+      mockedLoadMcpConfig.mockImplementation(() => {
+        throw new Error(
+          'Config has a licenseKey but no explicit mode. Telemetry export is opt-in: ' +
+            'set "mode": "cloud" (or "both") in the config file, set NR_AI_MODE, or ' +
+            'remove the credentials for local-only use. Previous versions implicitly ' +
+            'defaulted to cloud.',
+        );
+      });
+      const checks = await runDiagnostics(makeOpts());
+      const c = checks.find((x) => x.check === 'Telemetry mode')!;
+      expect(c.status).toBe('fail');
+      expect(c.detail).toContain('no explicit mode');
+      expect(c.fix).toBeTruthy();
     });
   });
 
@@ -804,9 +858,9 @@ describe('runDiagnostics', () => {
         throw new Error('registry file is corrupt');
       });
       const checks = await runDiagnostics({ configPath: '/tmp/does-not-exist.json' });
-      // All 10 checks must still be present — one throwing dependency must not
+      // All 11 checks must still be present — one throwing dependency must not
       // take down the rest of the diagnostic run.
-      expect(checks).toHaveLength(10);
+      expect(checks).toHaveLength(11);
       const check = checks.find((c) => c.check === 'Local instances');
       expect(check?.status).toBe('warn');
       expect(check?.detail).toContain('registry file is corrupt');
@@ -855,8 +909,8 @@ describe('runDiagnostics', () => {
     });
   });
 
-  it('returns exactly 10 checks on macOS', async () => {
+  it('returns exactly 11 checks on macOS', async () => {
     const checks = await runDiagnostics(makeOpts());
-    expect(checks).toHaveLength(10);
+    expect(checks).toHaveLength(11);
   });
 });

--- a/src/install/diagnostics.ts
+++ b/src/install/diagnostics.ts
@@ -132,7 +132,7 @@ function checkTelemetryMode(configPath: string, fileMode: string | undefined): D
       check: 'Telemetry mode',
       status: 'fail',
       detail: message,
-      fix: 'Fix the fields listed above, then restart.',
+      fix: 'Apply the remedy named in the message, then re-run doctor.',
     };
   }
 }

--- a/src/install/diagnostics.ts
+++ b/src/install/diagnostics.ts
@@ -128,10 +128,16 @@ function checkTelemetryMode(configPath: string, fileMode: string | undefined): D
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // loadMcpConfig can throw for reasons that have nothing to do with mode
+    // (invalid accountId, a literal "null" licenseKey, etc.) — those aren't
+    // caught by the "Config valid" check above (its Zod schema doesn't
+    // validate those runtime-only rules), so still surface them here rather
+    // than dropping them, but don't imply the mode itself is at fault.
+    const isModeError = message.includes('no explicit mode');
     return {
       check: 'Telemetry mode',
       status: 'fail',
-      detail: message,
+      detail: isModeError ? message : `Could not resolve config to determine mode: ${message}`,
       fix: 'Apply the remedy named in the message, then re-run doctor.',
     };
   }

--- a/src/install/diagnostics.ts
+++ b/src/install/diagnostics.ts
@@ -7,7 +7,7 @@ import { checkNodeVersion, MIN_SUPPORTED_NODE_MAJOR } from './node-version-check
 import { isNewerVersion, fetchLatestNpmVersion } from './npm-version-check.js';
 import { VERSION } from '../version.js';
 
-import { validateConfigFile, DEFAULT_STORAGE_PATH } from '../config.js';
+import { validateConfigFile, loadMcpConfig, DEFAULT_STORAGE_PATH } from '../config.js';
 import { getDashboardDaemonStatus, findExecutableNodeDir } from './schedule.js';
 import {
   detectSettingsPath,
@@ -35,6 +35,8 @@ type DiagnosticsContext = {
   // used verbatim as the skip detail so the message is accurate for each cause
   // (absent file, config errors, local mode, missing licenseKey).
   readonly nrSkipReason: string | null;
+  // Raw file.mode, for checkTelemetryMode's source reporting — see validateConfigFile.
+  readonly fileMode: string | undefined;
 };
 
 function checkConfigValid(
@@ -100,8 +102,39 @@ function checkConfigValid(
 
   return {
     check,
-    context: { storagePath, nrSkipReason },
+    context: { storagePath, nrSkipReason, fileMode: validation.mode },
   };
+}
+
+// Reports the mode the running server would actually resolve — via the real
+// loader, not a re-derived approximation — plus which of env/file/default
+// produced it. Also the only place a licenseKey-without-explicit-mode config
+// (loadMcpConfig's fail-closed throw, see config.ts) surfaces to `doctor`
+// instead of crashing it with a stack trace.
+function checkTelemetryMode(configPath: string, fileMode: string | undefined): DiagnosticCheck {
+  const envMode = process.env.NR_AI_MODE;
+  const source =
+    envMode !== undefined && envMode !== ''
+      ? 'env NR_AI_MODE'
+      : fileMode !== undefined
+        ? 'config file'
+        : 'default (local)';
+  try {
+    const resolved = loadMcpConfig({ config: configPath });
+    return {
+      check: 'Telemetry mode',
+      status: 'ok',
+      detail: `Resolved to '${resolved.mode}' (source: ${source})`,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      check: 'Telemetry mode',
+      status: 'fail',
+      detail: message,
+      fix: 'Fix the fields listed above, then restart.',
+    };
+  }
 }
 
 function checkDaemon(): DiagnosticCheck[] {
@@ -597,6 +630,7 @@ export async function runDiagnostics(opts?: {
 }): Promise<DiagnosticCheck[]> {
   const configPath = opts?.configPath ?? resolve(DEFAULT_STORAGE_PATH, 'config.json');
   const { check: configCheck, context } = checkConfigValid(configPath, opts?.storagePath);
+  const modeCheck = checkTelemetryMode(configPath, context.fileMode);
 
   const settingsPaths: string[] = [detectSettingsPath('user')];
   if (isWsl()) {
@@ -606,6 +640,7 @@ export async function runDiagnostics(opts?: {
 
   return [
     configCheck,
+    modeCheck,
     checkNodeVersionDiagnostic(),
     ...checkDaemon(),
     checkHooksWired(settingsPaths, opts?.platform),

--- a/src/install/setup-wizard.test.ts
+++ b/src/install/setup-wizard.test.ts
@@ -430,6 +430,38 @@ describe('buildConfig', () => {
     expect(result.accountId).toBe('new');
     expect(result.licenseKey).toBe('new-key');
   });
+
+  it('always writes an explicit mode key, even when inputs.mode is omitted', () => {
+    const result = buildConfig(
+      {},
+      {
+        accountId: '1',
+        licenseKey: 'k',
+        developer: 'd',
+        teamId: null,
+        projectId: null,
+        sessionBudgetUsd: null,
+      },
+    );
+    expect(Object.keys(result)).toContain('mode');
+    expect(result.mode).toBe('cloud');
+  });
+
+  it('writes the caller-provided mode explicitly when inputs.mode is set', () => {
+    const result = buildConfig(
+      {},
+      {
+        accountId: '1',
+        licenseKey: 'k',
+        developer: 'd',
+        teamId: null,
+        projectId: null,
+        sessionBudgetUsd: null,
+        mode: 'local',
+      },
+    );
+    expect(result.mode).toBe('local');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/install/setup-wizard.ts
+++ b/src/install/setup-wizard.ts
@@ -166,7 +166,7 @@ export function buildConfig(
   const includeNrCreds = mode !== 'local';
   return {
     ...existing,
-    ...(inputs.mode ? { mode } : {}),
+    mode,
     ...(includeNrCreds ? { accountId: inputs.accountId, licenseKey: inputs.licenseKey } : {}),
     developer: inputs.developer,
     ...(inputs.teamId ? { teamId: inputs.teamId } : {}),


### PR DESCRIPTION
Supersedes #498 (originally by @adjohn), rebased onto current `main` to resolve conflicts that couldn't be resolved on the fork branch without a force-push.

## Why a new PR

#498 was 8 commits behind `main` and had `package.json`/`package-lock.json`/`CHANGELOG.md` conflicts once a version bump was added. Rebasing/force-pushing to a contributor's fork branch overwrites their commit SHAs and can strand any local WIP they have, so this rebases via cherry-pick onto a fresh branch instead — all of @adjohn's original commits are preserved with their original authorship.

## What's here

- `bc8a714` / `7bef898` — @adjohn's two original commits from #498, cherry-picked unchanged (auto-merged cleanly, no conflicts).
- `9204297` — my follow-up from #498 review: version bump (**1.19.0**, minor — this is a deliberate breaking change per the PR description, not a patch), the CHANGELOG entry, and a clarity fix to `checkTelemetryMode` so it doesn't mislabel unrelated config errors (invalid `accountId`, literal `"null"` licenseKey) as mode problems.
- `044052e` — a new fix, found only after rebasing onto current `main`: the shared `beforeEach` in `config.test.ts` (from #498) forces `NR_AI_MODE='cloud'` to keep ~100 pre-existing fixtures exercising their original implicit-cloud behavior. That collided with the "homelab config fields" tests added to `main` after #498 forked — all of those set an explicit file `mode: 'local'` instead of credentials, and since env beats file, the global override was silently promoting them to `'cloud'` and failing on a missing licenseKey. Scoped `NR_AI_MODE` clearing to that describe block so the file mode takes effect as those tests intend.

## Original PR description (#498)

Fixes #496.

- The config loader resolved `mode` as `env ?? file ?? 'cloud'`, so any config carrying a `licenseKey` but no explicit `mode` silently exported telemetry — the opposite of the README's "Local First — Offline by default" positioning.
- Resolution is now: explicit `NR_AI_MODE` → explicit file `mode` → **fail closed** if a licenseKey is present without either (startup error naming the exact fix) → `'local'` otherwise.
- **Breaking, deliberately loud:** configs with credentials but no `mode` key now error at startup instead of silently exporting.
- `preflight doctor` gains a `Telemetry mode` check reporting the resolved mode and its source.

## Test plan

- [x] `npm run build && npm test && npm run lint` — 177/178 suites (1 pre-existing skip), 6044 tests pass, lint clean
- [x] Verified the homelab-test conflict is a real interaction bug (not a mechanical merge artifact) before fixing it
- [x] Original #498 review posted in full on the source PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
