### PR TITLE
Feat: Price Claude Fable 5.1 and Mythos 5.1 via the pricing overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.1] - 2026-09-01
+
+### Added
+
+- **Claude Fable 5.1 and Claude Mythos 5.1, released 2026-09-01, are now priced.** Sessions on `claude-fable-5-1` or `claude-mythos-5-1` previously showed $0 cost because the vendored pricing table predates them. Both use Anthropic's published $10/$50 per MTok with $12.50 5-minute cache writes and the new $0.25 cache-read rate (0.025x of input, a quarter of Fable 5's). Added through the bundled gap-fill overlay, so a later upstream table sync cannot double-price them.
+
 ## [1.19.0] - 2026-08-31
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": false,

--- a/pricing-overlay/pricing.json
+++ b/pricing-overlay/pricing.json
@@ -1,1 +1,18 @@
-{}
+{
+  "claude-fable-5-1": {
+    "inputPerMTok": 10,
+    "outputPerMTok": 50,
+    "thinkingPerMTok": 50,
+    "cacheReadPerMTok": 0.25,
+    "cacheCreationPerMTok": 12.5,
+    "contextWindow": 1000000
+  },
+  "claude-mythos-5-1": {
+    "inputPerMTok": 10,
+    "outputPerMTok": 50,
+    "thinkingPerMTok": 50,
+    "cacheReadPerMTok": 0.25,
+    "cacheCreationPerMTok": 12.5,
+    "contextWindow": 1000000
+  }
+}

--- a/src/metrics/pricing-overlay.test.ts
+++ b/src/metrics/pricing-overlay.test.ts
@@ -71,6 +71,19 @@ describe('applyPricingOverlay', () => {
     });
   });
 
+  it('prices Claude Fable 5.1 and Mythos 5.1 at their published rates, including the 0.025x cache read', () => {
+    applyPricingOverlay(null);
+    for (const model of ['claude-fable-5-1', 'claude-mythos-5-1', 'claude-fable-5-1[1m]']) {
+      expect(resolveModelPricing(model)).toMatchObject({
+        inputPerMTok: 10,
+        outputPerMTok: 50,
+        cacheReadPerMTok: 0.25,
+        cacheCreationPerMTok: 12.5,
+        contextWindow: 1_000_000,
+      });
+    }
+  });
+
   it('respects an explicit user customPricingFile instead of the bundled overlay', () => {
     // A user-supplied file that is not JSON at all — loadCustomPricing() will
     // reject it and log a warning, but the point under test is that we never


### PR DESCRIPTION
## Why

Anthropic released Claude Fable 5.1 (`claude-fable-5-1`) and Claude Mythos 5.1 (`claude-mythos-5-1`) on 2026-09-01. Neither ID resolves against the vendored table in `src/shared/pricing-data.ts`: there is no exact key, no alias, and no dated-suffix key for the reverse-prefix path to match. Every session on either model is therefore costed at $0 today. The vendored table is a snapshot this repo must not edit, and `pricing-overlay/README.md` names the bundled overlay as the place for exactly this gap.

## Scope

- `pricing-overlay/pricing.json` gains entries for `claude-fable-5-1` and `claude-mythos-5-1`.
- `src/metrics/pricing-overlay.test.ts` asserts both IDs, plus the `[1m]` context-tagged form Claude Code emits, resolve to the published rates after `applyPricingOverlay(null)`. The assertion holds whether the rate comes from the overlay or, after a future sync, from the vendored table.
- `CHANGELOG.md` and the package version move to 1.19.1.

Rates verified 2026-09-01 against [Anthropic's pricing page](https://platform.claude.com/docs/en/about-claude/pricing): $10 input, $50 output, $12.50 5-minute cache write, $0.25 cache read (0.025x of input; every other model is 0.1x), 1M context. IDs verified against the [models overview](https://platform.claude.com/docs/en/models/overview).

Out of scope: Bedrock IDs (`anthropic.claude-fable-5-1` and its geo/global variants). AWS's pricing page renders client-side and could not be verified for the new cache-read multiplier, and the table's 1.1x geo derivation is only safe when the base rates are confirmed. Mythos 5.1 is not offered on Bedrock at all.

## Tradeoffs

Overlay versus vendored table. The overlay is JSON, so the source citation lives in this PR and the commit body rather than beside the entry. In exchange, the startup collision guard in `applyGapFilledOverlay` drops these entries automatically once the upstream shared repo adds the models, so a later sync cannot double-price them.

## Blast Radius

Only cost attribution for sessions on the two new models changes, from $0 to the published rate. No other model's pricing moves. Users with their own `customPricingFile` are unaffected, since that path bypasses the overlay entirely.

## Verification

- Probe on the built `dist/` output: before the overlay both IDs return null and cost $0; after it, a workload of 1M input, 100K output, 4M cache-read, and 500K cache-write tokens costs $22.25 on Fable 5.1 against $25.25 on Fable 5, the whole difference being the cheaper cache reads.
- `npx jest` over the pricing, pricing-data, and pricing-overlay suites: 107 passed.
- `npm test` full suite: 6045 passed, 3 skipped, 1 todo. One earlier full run had a single `cost-tools.test.ts` failure that did not recur in two further full runs and passes in isolation; it builds fixtures from the live clock and is unrelated to this diff.
- `npm run build`, `npm run lint`, and `npm run format:check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsqxEVNdgLkerv95LjVVrr
