### PR TITLE
Fix #556: shorten server.json description under registry's 100-char limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.33.2] - 2026-09-03
+
+### Fixed
+
+- **The MCP Registry publish step in the Release workflow was failing on every run.** `server.json`'s `description` field was 106 characters, exceeding the registry's 100-character limit; shortened it so releases reach `registry.modelcontextprotocol.io` again.
+
 ## [1.33.1] - 2026-09-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.33.1",
+      "version": "1.33.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/newrelic-experimental/preflight/issues"
   },
-  "description": "New Relic MCP server for observing AI coding assistants (Claude Code, Cursor, Windsurf, Copilot, and more)",
+  "description": "New Relic MCP server for observing AI coding assistants (Claude Code, Cursor, Copilot, etc.)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.newrelic-experimental/preflight",
-  "description": "New Relic MCP server for observing AI coding assistants (Claude Code, Cursor, Windsurf, Copilot, and more)",
+  "description": "New Relic MCP server for observing AI coding assistants (Claude Code, Cursor, Copilot, etc.)",
   "repository": {
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.33.1",
+  "version": "1.33.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.33.1",
+      "version": "1.33.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- `registry.modelcontextprotocol.io` started enforcing a 100-character cap on `server.json`'s `description` field, so the Release workflow's "Publish to MCP Registry" step has been failing with a 422 on every run since 2026-09-02 16:29 UTC, even though `npm publish` continues to succeed.
- Shortened the description in `server.json` and `package.json` from 106 to 92 characters.
- Bumped the version to 1.33.1 (in `package.json`, `package-lock.json`, `server.json`, and `plugin/.claude-plugin/plugin.json`) so the next Release workflow run actually republishes and the registry listing catches up.
- Added a CHANGELOG entry.

Fixes #556.

## Test plan
- [x] `npm run build`
- [x] `npm test` (full suite, including the `plugin.json` version-sync test)
- [x] `npm run lint`
- [ ] After merge: trigger the Release workflow and confirm the "Publish to MCP Registry" step succeeds