### PR TITLE
fix(audit): flag git clean -f and find -delete as destructive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.40.0] - 2026-09-04
+
+### Added
+
+- **Audit records now name the subagent that made each tool call.** Tool calls from Task and Workflow subagents already reached the audit trail through hooks, but `AuditRecord` dropped the hook payload's `agent_id` and `agent_type`, so a search of `~/.newrelic-preflight/audit/*.jsonl` by agent id found nothing. The on-disk audit log, `AiAuditEvent`, `SecurityAlert`, the NR log entry, and the dashboard Audit page now carry `agent_id` and `agent_type` (`agentId` and `agentType` on disk and in the dashboard). Both are absent for calls the parent session made. (#578)
+- **A non-recursive `rm` or `unlink` now raises a `file_deletion` alert at `medium` severity.** Only recursive forms were flagged before, so `rm -f <file>` left no alert even when it deleted an untracked file. `rm -rf` and the other recursive forms stay `destructive_command` at `critical`. The rule matches `rm` in command position only, so `git rm`, `npm rm`, and `docker rm` do not match. Disable it with the new `deletionPatterns: []` option on `AuditTrailManager`. (#577)
+
+### Changed
+
+- `detectSecurityAlert` evaluates an ordered rule table and returns the highest-severity match instead of the first match in an if-chain. Verdicts for the three existing alert types are unchanged.
+
 ## [1.39.0] - 2026-09-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.41.0] - 2026-09-04
+
+### Added
+
+- **`git clean -f` and `find -delete` now raise a `destructive_command` alert at `critical`.** Both delete files with no recovery path and were flagged by nothing before. Dry-run and bare `git clean` stay unflagged.
+
 ## [1.40.0] - 2026-09-04
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -246,10 +246,11 @@ Both `AgentConfig` and `McpServerConfig` are frozen with `Object.freeze()` immed
 - **Sensitive file access** — `.env`, `.pem`, `.key`, credential and password files — severity: `high`
 - **Destructive commands** — `rm -rf`, `DROP TABLE`, pipe-to-shell patterns — severity: `critical`
 - **External network requests** — `curl`, `wget`, `nc`, `ssh` — severity: `medium`
+- **File deletion** (non-recursive rm / unlink) — severity: `medium`
 
 Records are persisted to disk in real time via `LocalStore.appendAuditLog()`, so the trail survives unclean shutdowns.
 
-Classification patterns are configurable via constructor options. The log is queryable via `getSensitiveAccessLog()` and is also sent as NR events for dashboarding.
+Classification patterns are configurable via constructor options. The log is queryable via `getSensitiveAccessLog()` and is also sent as NR events for dashboarding. Records carry `agentId` and `agentType` when a subagent (Task or Workflow tool) made the call, so subagent activity is attributable on disk, in the dashboard, and in New Relic.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -244,7 +244,7 @@ Both `AgentConfig` and `McpServerConfig` are frozen with `Object.freeze()` immed
 `AuditTrailManager` (`src/security/audit-trail.ts`) classifies every tool call and flags:
 
 - **Sensitive file access** — `.env`, `.pem`, `.key`, credential and password files — severity: `high`
-- **Destructive commands** — `rm -rf`, `DROP TABLE`, pipe-to-shell patterns — severity: `critical`
+- **Destructive commands** — `rm -rf`, `git clean -f`, `find -delete`, `DROP TABLE`, pipe-to-shell patterns — severity: `critical`
 - **External network requests** — `curl`, `wget`, `nc`, `ssh` — severity: `medium`
 - **File deletion** (non-recursive rm / unlink) — severity: `medium`
 

--- a/docs/METRICS_TABLE.md
+++ b/docs/METRICS_TABLE.md
@@ -200,7 +200,7 @@ Security alert triggers:
 - **`destructive_command`** (critical): `rm -rf` (any recursive flag combo), `git push --force` (but NOT `--force-with-lease` / `--force-if-includes`), `DROP TABLE`, pipe-to-shell, etc. Detection is the OR of the bash classifier (`record.bashDestructive`) and the regex pattern list — defense in depth, neither layer alone is authoritative.
 - **`sensitive_file`** (high): `.env`, `.pem`, `.key`, `credentials`, `secret`, `.ssh`, `.npmrc`, `.pypirc`, `password`, `token` (path-boundary anchored)
 - **`external_network`** (medium): `curl`, `wget`, `nc`, `ssh` commands. Detection is the OR of the bash classifier (`record.bashNetwork`) and the regex pattern list.
-- **`file_deletion`** (medium): `rm` or `unlink` in command position (start of line, after `;`, `&`, `|`, or `(`, optionally with `sudo`). Anchoring keeps `git rm`, `npm rm`, `docker rm`, and quoted text like `echo "rm foo"` out of scope.
+- **`file_deletion`** (medium): `rm` or `unlink` in command position (start of line, after `;`, `&`, `|`, or `(`, optionally with `sudo`), OR-ed with the bash classifier's leading token (`record.bashLeading`), which also strips env-var prefixes. Anchoring keeps `git rm`, `npm rm`, `docker rm`, and quoted text like `echo "rm foo"` out of scope. Recursive forms match too but lose to `destructive_command` by severity.
 
 Source: `src/security/audit-trail.ts` — `securityAlertToNrEvent()`
 

--- a/docs/METRICS_TABLE.md
+++ b/docs/METRICS_TABLE.md
@@ -197,7 +197,7 @@ Emitted only when a security alert is triggered (subset of audit events).
 
 Security alert triggers:
 
-- **`destructive_command`** (critical): `rm -rf` (any recursive flag combo), `git push --force` (but NOT `--force-with-lease` / `--force-if-includes`), `DROP TABLE`, pipe-to-shell, etc. Detection is the OR of the bash classifier (`record.bashDestructive`) and the regex pattern list — defense in depth, neither layer alone is authoritative.
+- **`destructive_command`** (critical): `rm -rf` (any recursive flag combo), `git push --force` (but NOT `--force-with-lease` / `--force-if-includes`), `git clean -f` (any force form), `find -delete`, `DROP TABLE`, pipe-to-shell, etc. Detection is the OR of the bash classifier (`record.bashDestructive`) and the regex pattern list — defense in depth, neither layer alone is authoritative.
 - **`sensitive_file`** (high): `.env`, `.pem`, `.key`, `credentials`, `secret`, `.ssh`, `.npmrc`, `.pypirc`, `password`, `token` (path-boundary anchored)
 - **`external_network`** (medium): `curl`, `wget`, `nc`, `ssh` commands. Detection is the OR of the bash classifier (`record.bashNetwork`) and the regex pattern list.
 - **`file_deletion`** (medium): `rm` or `unlink` in command position (start of line, after `;`, `&`, `|`, or `(`, optionally with `sudo`), OR-ed with the bash classifier's leading token (`record.bashLeading`), which also strips env-var prefixes. Anchoring keeps `git rm`, `npm rm`, `docker rm`, and quoted text like `echo "rm foo"` out of scope. Recursive forms match too but lose to `destructive_command` by severity.

--- a/docs/METRICS_TABLE.md
+++ b/docs/METRICS_TABLE.md
@@ -157,6 +157,8 @@ Emitted for every tool call as a security audit record.
 | `detail`               | string  | Human-readable description of the action                                                                               |
 | `developer`            | string  | Developer identifier                                                                                                   |
 | `session_id`           | string  | Session identifier (if available)                                                                                      |
+| `agent_id`             | string  | Claude Code subagent id from the hook payload. Absent for the parent session.                                          |
+| `agent_type`           | string  | The subagent's type as reported by the Claude Code hook payload (e.g. `"Explore"`). Absent for the parent session.     |
 | `team_id`              | string  | User-defined team label from config (e.g. `"platform-eng"`). Not your NR account ID. Omitted when `teamId` is not set. |
 | `project_id`           | string  | Project identifier (derived from git remote or configured)                                                             |
 | `repo_url`             | string  | Full git remote URL, redacted for embedded credentials (own opt-out: repoUrlEnabled)                                   |
@@ -165,7 +167,7 @@ Emitted for every tool call as a security audit record.
 | `command`              | string  | Command executed (if applicable)                                                                                       |
 | `audit.security_alert` | boolean | Whether a security alert was triggered                                                                                 |
 | `audit.severity`       | string  | Alert severity: `critical`, `high`, or `medium` (if alert)                                                             |
-| `audit.alert_type`     | string  | Alert type: `destructive_command`, `sensitive_file`, or `external_network` (if alert)                                  |
+| `audit.alert_type`     | string  | Alert type: `destructive_command`, `sensitive_file`, `external_network`, or `file_deletion` (if alert)                 |
 
 Source: `src/security/audit-trail.ts` — `auditRecordToNrEvent()`
 
@@ -179,11 +181,13 @@ Emitted only when a security alert is triggered (subset of audit events).
 | `event_version` | number | Schema version, currently `1`. See [Schema Versioning](#schema-versioning).                                            |
 | `timestamp`     | number | Unix epoch seconds                                                                                                     |
 | `severity`      | string | `critical`, `high`, or `medium`                                                                                        |
-| `alert_type`    | string | `destructive_command`, `sensitive_file`, or `external_network`                                                         |
+| `alert_type`    | string | `destructive_command`, `sensitive_file`, `external_network`, or `file_deletion`                                        |
 | `description`   | string | Human-readable alert description                                                                                       |
 | `tool`          | string | Tool that triggered the alert                                                                                          |
 | `developer`     | string | Developer identifier                                                                                                   |
 | `session_id`    | string | Session identifier (if available)                                                                                      |
+| `agent_id`      | string | Claude Code subagent id from the hook payload. Absent for the parent session.                                          |
+| `agent_type`    | string | The subagent's type as reported by the Claude Code hook payload (e.g. `"Explore"`). Absent for the parent session.     |
 | `team_id`       | string | User-defined team label from config (e.g. `"platform-eng"`). Not your NR account ID. Omitted when `teamId` is not set. |
 | `project_id`    | string | Project identifier (derived from git remote or configured)                                                             |
 | `repo_url`      | string | Full git remote URL, redacted for embedded credentials (own opt-out: repoUrlEnabled)                                   |
@@ -196,6 +200,7 @@ Security alert triggers:
 - **`destructive_command`** (critical): `rm -rf` (any recursive flag combo), `git push --force` (but NOT `--force-with-lease` / `--force-if-includes`), `DROP TABLE`, pipe-to-shell, etc. Detection is the OR of the bash classifier (`record.bashDestructive`) and the regex pattern list — defense in depth, neither layer alone is authoritative.
 - **`sensitive_file`** (high): `.env`, `.pem`, `.key`, `credentials`, `secret`, `.ssh`, `.npmrc`, `.pypirc`, `password`, `token` (path-boundary anchored)
 - **`external_network`** (medium): `curl`, `wget`, `nc`, `ssh` commands. Detection is the OR of the bash classifier (`record.bashNetwork`) and the regex pattern list.
+- **`file_deletion`** (medium): `rm` or `unlink` in command position (start of line, after `;`, `&`, `|`, or `(`, optionally with `sudo`). Anchoring keeps `git rm`, `npm rm`, `docker rm`, and quoted text like `echo "rm foo"` out of scope.
 
 Source: `src/security/audit-trail.ts` — `securityAlertToNrEvent()`
 

--- a/docs/SCORECARDS.md
+++ b/docs/SCORECARDS.md
@@ -109,17 +109,17 @@ FACET team_id SINCE 7 DAYS AGO
 
 ```nrql
 FROM SecurityAlert SELECT count(*) AS 'Security Alerts (7 days)'
-WHERE team_id IS NOT NULL
+WHERE team_id IS NOT NULL AND severity IN ('critical', 'high')
 FACET team_id, alert_type SINCE 7 DAYS AGO
 ```
 
 **Progress Levels:**
 
 - **Green** (secure): 0 alerts
-- **Yellow** (watch): 1–3 alerts (non-critical, non-destructive)
-- **Red** (action required): ≥ 1 destructive command or sensitive file alert
+- **Yellow** (watch): 1–3 `sensitive_file` alerts
+- **Red** (action required): ≥ 1 `destructive_command` alert
 
-**Rationale:** Alerts when the AI tool suite detects attempts to delete code, force-push, or access secrets. Zero is ideal; any destructive command is red. Use this scorecard to audit AI tool privileges and update your security rules if the AI is flagged for legitimate high-risk operations.
+**Rationale:** Alerts when the AI tool suite detects attempts to delete code recursively, force-push, or access secrets. Zero is ideal; any destructive command is red. The `severity` filter leaves out the `medium` tier (`external_network` for every `curl` or `wget`, `file_deletion` for every non-recursive `rm`), which is routine in most sessions and would keep every team red. Query those with `WHERE severity = 'medium' FACET alert_type` when you want the full picture. Use this scorecard to audit AI tool privileges and update your security rules if the AI is flagged for legitimate high-risk operations.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.39.0",
+      "version": "1.40.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.40.0",
+      "version": "1.41.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.39.0",
+  "version": "1.40.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.39.0",
+      "version": "1.40.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.40.0",
+  "version": "1.41.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.40.0",
+      "version": "1.41.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -1724,6 +1724,44 @@ describe('api-handler GET /api/audit', () => {
     expect(status()).toBe(503);
   });
 
+  it('carries agentId and agentType through to the DTO when present, and omits them when absent', async () => {
+    const fakeAuditLog = [
+      {
+        timestamp: 1700000000000,
+        sessionId: 'session-a',
+        action: 'BashCommand',
+        tool: 'Bash',
+        detail: 'Bash: rm -rf /tmp/x',
+        developer: 'alice',
+        agentId: 'a9f8',
+        agentType: 'workflow',
+        securityAlert: { severity: 'critical', alertType: 'destructive_command' },
+      },
+      {
+        timestamp: 1700000001000,
+        sessionId: 'session-a',
+        action: 'FileRead',
+        tool: 'Read',
+        detail: '/some/file.ts',
+        developer: 'alice',
+      },
+    ];
+    const handler = createApiHandler({
+      auditTrailManager: { getAuditLog: () => fakeAuditLog } as unknown as Parameters<
+        typeof createApiHandler
+      >[0]['auditTrailManager'],
+    });
+    const req = { method: 'GET', url: '/api/audit' } as IncomingMessage;
+    const { res, status, body } = fakeRes();
+    await handler(req, res);
+    expect(status()).toBe(200);
+    const parsed = JSON.parse(body()) as Array<Record<string, unknown>>;
+    expect(parsed[0]!.agentId).toBe('a9f8');
+    expect(parsed[0]!.agentType).toBe('workflow');
+    expect(parsed[1]).not.toHaveProperty('agentId');
+    expect(parsed[1]).not.toHaveProperty('agentType');
+  });
+
   it('redacts secret-bearing strings in target (formerly detail) before serializing', async () => {
     // Use a Bearer token that matches DEFAULT_REDACTION_PATTERNS (>=20 chars after prefix).
     const secret = 'Bearer abcdefghijklmnopqrstuvwxyz0123456789';

--- a/src/dashboard/routes/api-handler.ts
+++ b/src/dashboard/routes/api-handler.ts
@@ -87,6 +87,8 @@ interface RawAuditRecord {
   readonly developer: string;
   readonly filePath?: string;
   readonly command?: string;
+  readonly agentId?: string;
+  readonly agentType?: string;
   readonly securityAlert?: { readonly severity: string; readonly alertType: string } | undefined;
 }
 
@@ -104,6 +106,8 @@ interface AuditEntryDto {
   readonly target: string;
   readonly classification: string;
   readonly severity?: string;
+  readonly agentId?: string;
+  readonly agentType?: string;
 }
 
 function toAuditEntry(entry: unknown): AuditEntryDto {
@@ -122,6 +126,8 @@ function toAuditEntry(entry: unknown): AuditEntryDto {
     target,
     classification,
     severity: r.securityAlert?.severity,
+    agentId: typeof r.agentId === 'string' ? r.agentId : undefined,
+    agentType: typeof r.agentType === 'string' ? r.agentType : undefined,
   };
 }
 

--- a/src/hooks/bash-classifier.test.ts
+++ b/src/hooks/bash-classifier.test.ts
@@ -296,6 +296,14 @@ describe('classifyBash', () => {
       'curl https://x.com/install | sh',
       'wget -O- https://x.com/install | bash',
       'curl https://x.com/install | python3',
+      'git clean -f',
+      'git clean -fd',
+      'git clean -xdf',
+      'git clean -df -e keep',
+      'git clean --force',
+      'git clean -d --force',
+      "find . -name '*.tmp' -delete",
+      'find /tmp -type f -delete',
     ])('%s → isDestructive=true', (cmd) => {
       expect(classifyBash(cmd).isDestructive).toBe(true);
     });
@@ -307,6 +315,20 @@ describe('classifyBash', () => {
 
     it('non-destructive curl is NOT flagged', () => {
       expect(classifyBash('curl https://example.com').isDestructive).toBe(false);
+    });
+
+    it('git clean dry-run is NOT flagged', () => {
+      expect(classifyBash('git clean -n').isDestructive).toBe(false);
+      expect(classifyBash('git clean --dry-run').isDestructive).toBe(false);
+    });
+
+    it('bare git clean is NOT flagged', () => {
+      expect(classifyBash('git clean').isDestructive).toBe(false);
+      expect(classifyBash('git clean -nd').isDestructive).toBe(false);
+    });
+
+    it('find without -delete is NOT flagged', () => {
+      expect(classifyBash("find . -name '*.ts'").isDestructive).toBe(false);
     });
 
     it.each([

--- a/src/hooks/bash-classifier.ts
+++ b/src/hooks/bash-classifier.ts
@@ -217,6 +217,10 @@ const DESTRUCTIVE_PATTERNS: readonly RegExp[] = [
   // in the invocation, not just immediately after `push`.
   /\bgit\s+push\b(?=.*\s(?:--force(?!-(?:with-lease|if-includes))\b|-f\b))/i,
   /\bgit\s+reset\s+--hard\b/i,
+  // git clean only deletes with -f/--force (clean.requireForce defaults to true);
+  // -n/--dry-run and bare `git clean` are safe and stay unflagged.
+  /\bgit\s+clean\b(?=.*\s(?:-[a-zA-Z]*f[a-zA-Z]*|--force)\b)/i,
+  /\bfind\b.*\s-delete\b/i,
   /\bdd\s+if=/i,
   /\bmkfs(?:\.\w+)?\b/i,
   /\bshred\b/i,

--- a/src/security/audit-trail.test.ts
+++ b/src/security/audit-trail.test.ts
@@ -1,6 +1,7 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import {
   AuditTrailManager,
+  attachAuditAttribution,
   auditRecordToNrEvent,
   securityAlertToNrEvent,
   DEFAULT_SENSITIVE_FILE_PATTERNS,
@@ -822,6 +823,145 @@ describe('AuditTrailManager.getAuditLog() disk read-back', () => {
 
     const log = mgr.getAuditLog(5);
     expect(log).toHaveLength(5);
+  });
+});
+
+describe('attachAuditAttribution()', () => {
+  it('writes session_id, agent_id, and agent_type and skips absent values', () => {
+    const full: Record<string, string | number | boolean> = {};
+    attachAuditAttribution(full, { sessionId: 'sess-1', agentId: 'a9f8', agentType: 'workflow' });
+    expect(full).toEqual({ session_id: 'sess-1', agent_id: 'a9f8', agent_type: 'workflow' });
+
+    const bare: Record<string, string | number | boolean> = {};
+    attachAuditAttribution(bare, { sessionId: null });
+    expect(bare).toEqual({});
+  });
+});
+
+describe('AuditTrailManager subagent attribution', () => {
+  it('carries agentId and agentType from the ToolCallRecord onto the AuditRecord', () => {
+    const mgr = makeManager();
+    const audit = mgr.recordToolCall(
+      makeRecord({
+        toolName: 'Bash',
+        command: 'rm -rf /tmp/x',
+        agentId: 'a9f8',
+        agentType: 'workflow',
+      }),
+    );
+
+    expect(audit.agentId).toBe('a9f8');
+    expect(audit.agentType).toBe('workflow');
+  });
+
+  it('leaves agentId and agentType undefined when the record has neither', () => {
+    const mgr = makeManager();
+    const audit = mgr.recordToolCall(makeRecord({ toolName: 'Read', filePath: 'src/app.ts' }));
+
+    expect(audit.agentId).toBeUndefined();
+    expect(audit.agentType).toBeUndefined();
+  });
+
+  it('includes agentId and agentType in the entry persisted to disk', () => {
+    const { store, appendSpy } = makeLocalStore();
+    const mgr = makeManager({ localStore: store });
+
+    mgr.recordToolCall(
+      makeRecord({
+        toolName: 'Bash',
+        command: 'rm -rf /tmp/x',
+        agentId: 'a9f8',
+        agentType: 'workflow',
+      }),
+    );
+
+    expect(appendSpy.mock.calls[0][0]).toMatchObject({ agentId: 'a9f8', agentType: 'workflow' });
+  });
+
+  it('carries agentId and agentType through recordProxyCall', () => {
+    const mgr = makeManager();
+    const audit = mgr.recordProxyCall(makeProxyRecord({ agentId: 'a9f8', agentType: 'workflow' }));
+
+    expect(audit.agentId).toBe('a9f8');
+    expect(audit.agentType).toBe('workflow');
+  });
+
+  it('reads agentId and agentType back from a disk entry via getAuditLog()', () => {
+    const appendSpy = jest.fn();
+    const store = {
+      appendAuditLog: appendSpy,
+      peekAllAuditLogs: jest.fn(() => [
+        {
+          timestamp: 555,
+          sessionId: 'sess-other',
+          action: 'BashCommand',
+          tool: 'Bash',
+          detail: 'Bash: rm -rf /tmp/x',
+          developer: 'alice',
+          agentId: 'a9f8',
+          agentType: 'workflow',
+        },
+      ]),
+    } as unknown as LocalStore;
+    const mgr = makeManager({ localStore: store });
+
+    const [entry] = mgr.getAuditLog();
+    expect(entry?.agentId).toBe('a9f8');
+    expect(entry?.agentType).toBe('workflow');
+  });
+
+  it('leaves agentId and agentType undefined for a disk entry with neither field', () => {
+    const appendSpy = jest.fn();
+    const store = {
+      appendAuditLog: appendSpy,
+      peekAllAuditLogs: jest.fn(() => [
+        {
+          timestamp: 555,
+          sessionId: 'sess-other',
+          action: 'FileRead',
+          tool: 'Read',
+          detail: 'Read src/old.ts',
+          developer: 'alice',
+        },
+      ]),
+    } as unknown as LocalStore;
+    const mgr = makeManager({ localStore: store });
+
+    const [entry] = mgr.getAuditLog();
+    expect(entry?.agentId).toBeUndefined();
+    expect(entry?.agentType).toBeUndefined();
+  });
+
+  it('emits agent_id and agent_type on auditRecordToNrEvent when present', () => {
+    const mgr = makeManager();
+    const audit = mgr.recordToolCall(
+      makeRecord({
+        toolName: 'Read',
+        filePath: 'src/app.ts',
+        agentId: 'a9f8',
+        agentType: 'workflow',
+      }),
+    );
+    const event = auditRecordToNrEvent(audit);
+
+    expect(event.agent_id).toBe('a9f8');
+    expect(event.agent_type).toBe('workflow');
+  });
+
+  it('emits agent_id and agent_type on securityAlertToNrEvent when present', () => {
+    const mgr = makeManager();
+    const audit = mgr.recordToolCall(
+      makeRecord({
+        toolName: 'Bash',
+        command: 'rm -rf /tmp/x',
+        agentId: 'a9f8',
+        agentType: 'workflow',
+      }),
+    );
+    const event = securityAlertToNrEvent(audit);
+
+    expect(event.agent_id).toBe('a9f8');
+    expect(event.agent_type).toBe('workflow');
   });
 });
 

--- a/src/security/audit-trail.test.ts
+++ b/src/security/audit-trail.test.ts
@@ -373,6 +373,34 @@ describe('AuditTrailManager', () => {
     },
   );
 
+  it.each([
+    'git clean -f',
+    'git clean -fd',
+    'git clean -xdf',
+    'git clean -df -e keep',
+    'git clean --force',
+    'git clean -d --force',
+    "find . -name '*.tmp' -delete",
+    'find /tmp -type f -delete',
+  ])('detects "%s" as critical destructive command', (command) => {
+    const mgr = makeManager();
+    const audit = mgr.recordToolCall(makeRecord({ toolName: 'Bash', command }));
+
+    expect(audit.securityAlert).toBeDefined();
+    expect(audit.securityAlert!.severity).toBe('critical');
+    expect(audit.securityAlert!.alertType).toBe('destructive_command');
+  });
+
+  it.each(['git clean -n', 'git clean --dry-run', 'git clean', "find . -name '*.ts'"])(
+    'does not flag "%s" as destructive (safe form)',
+    (command) => {
+      const mgr = makeManager();
+      const audit = mgr.recordToolCall(makeRecord({ toolName: 'Bash', command }));
+
+      expect(audit.securityAlert?.alertType).not.toBe('destructive_command');
+    },
+  );
+
   // 6. External network request (medium)
   it('detects curl as medium external network alert', () => {
     const mgr = makeManager();

--- a/src/security/audit-trail.test.ts
+++ b/src/security/audit-trail.test.ts
@@ -181,10 +181,75 @@ describe('AuditTrailManager', () => {
     expect(audit.securityAlert!.alertType).toBe('destructive_command');
   });
 
-  it('does not flag "rm -f file.txt" as destructive (no recursive flag)', () => {
+  it('flags "rm -f file.txt" as file_deletion at medium severity (no recursive flag)', () => {
     const mgr = makeManager();
     const audit = mgr.recordToolCall(makeRecord({ toolName: 'Bash', command: 'rm -f file.txt' }));
-    expect(audit.securityAlert?.alertType).not.toBe('destructive_command');
+    expect(audit.securityAlert).toMatchObject({ severity: 'medium', alertType: 'file_deletion' });
+    expect(audit.securityAlert!.description).toMatch(/^File deletion:/);
+  });
+
+  it.each(['rm file.txt', 'sudo rm file.txt', 'cd x && rm -f y', 'unlink f'])(
+    'flags "%s" as file_deletion',
+    (command) => {
+      const mgr = makeManager();
+      const audit = mgr.recordToolCall(makeRecord({ toolName: 'Bash', command }));
+      expect(audit.securityAlert?.alertType).toBe('file_deletion');
+    },
+  );
+
+  it.each(['rm -rf /tmp/x', 'rm -r d'])(
+    'still flags "%s" as destructive_command at critical (recursive form wins over file_deletion)',
+    (command) => {
+      const mgr = makeManager();
+      const audit = mgr.recordToolCall(makeRecord({ toolName: 'Bash', command }));
+      expect(audit.securityAlert).toMatchObject({
+        severity: 'critical',
+        alertType: 'destructive_command',
+      });
+    },
+  );
+
+  it('flags "rm f && curl http://x" as external_network (tie goes to the earlier row)', () => {
+    const mgr = makeManager();
+    const audit = mgr.recordToolCall(
+      makeRecord({ toolName: 'Bash', command: 'rm f && curl http://x' }),
+    );
+    expect(audit.securityAlert?.alertType).toBe('external_network');
+  });
+
+  it.each(['npm rm lodash', 'git rm f', 'docker rm c', 'echo "rm foo"', 'npm test'])(
+    '"%s" yields no security alert',
+    (command) => {
+      const mgr = makeManager();
+      const audit = mgr.recordToolCall(makeRecord({ toolName: 'Bash', command }));
+      expect(audit.securityAlert).toBeUndefined();
+    },
+  );
+
+  it('flags an env-prefixed rm through the classifier leading token when the regex misses', () => {
+    const mgr = makeManager();
+    const audit = mgr.recordToolCall(
+      makeRecord({ toolName: 'Bash', command: 'FOO=bar rm -f f', bashLeading: 'rm' }),
+    );
+    expect(audit.securityAlert?.alertType).toBe('file_deletion');
+  });
+
+  it('does not treat a package-manager rm subcommand as a deletion via the leading token', () => {
+    const mgr = makeManager();
+    const audit = mgr.recordToolCall(
+      makeRecord({ toolName: 'Bash', command: 'npm rm lodash', bashLeading: 'npm' }),
+    );
+    expect(audit.securityAlert).toBeUndefined();
+  });
+
+  it('does not flag file deletion when deletionPatterns is explicitly disabled', () => {
+    const mgr = new AuditTrailManager({
+      developer: 'dev',
+      sessionId: 'sess-001',
+      deletionPatterns: [],
+    });
+    const audit = mgr.recordToolCall(makeRecord({ toolName: 'Bash', command: 'rm -f f' }));
+    expect(audit.securityAlert).toBeUndefined();
   });
 
   // Classifier consolidation: detectSecurityAlert is the OR of the

--- a/src/security/audit-trail.ts
+++ b/src/security/audit-trail.ts
@@ -183,59 +183,78 @@ function matchesAny(value: string, patterns: readonly RegExp[]): boolean {
   return patterns.some((p) => p.test(value));
 }
 
+type AlertSubject = 'command' | 'filePath';
+
+interface AlertRule {
+  readonly alertType: string;
+  readonly severity: AlertSeverity;
+  readonly subject: AlertSubject;
+  readonly patterns: readonly RegExp[];
+  readonly classifierHit?: (record: ToolCallRecord) => boolean;
+  readonly describe: (redacted: string) => string;
+}
+
+interface AuditPatternSet {
+  readonly sensitive: readonly RegExp[];
+  readonly destructive: readonly RegExp[];
+  readonly network: readonly RegExp[];
+}
+
+const SEVERITY_RANK: Record<AlertSeverity, number> = { critical: 3, high: 2, medium: 1 };
+
+function buildAlertRules(p: AuditPatternSet): readonly AlertRule[] {
+  return [
+    {
+      alertType: 'destructive_command',
+      severity: 'critical',
+      subject: 'command',
+      patterns: p.destructive,
+      classifierHit: (r) => r.bashDestructive === true,
+      describe: (c) => `Destructive command detected: ${c}`,
+    },
+    {
+      alertType: 'sensitive_file',
+      severity: 'high',
+      subject: 'filePath',
+      patterns: p.sensitive,
+      describe: (f) => `Sensitive file accessed: ${f}`,
+    },
+    {
+      alertType: 'external_network',
+      severity: 'medium',
+      subject: 'command',
+      patterns: p.network,
+      classifierHit: (r) => r.bashNetwork === true,
+      describe: (c) => `External network request: ${c}`,
+    },
+  ];
+}
+
 function detectSecurityAlert(
   record: ToolCallRecord,
   sensitivePatterns: readonly RegExp[],
   destructivePatterns: readonly RegExp[],
   networkPatterns: readonly RegExp[],
 ): SecurityAlert | undefined {
-  const command = record.command as string | undefined;
-  const filePath = record.filePath as string | undefined;
-  // Defense in depth: the classifier's verdict and the pattern lists are
-  // OR-ed together. Either layer flagging is enough to alert. We deliberately
-  // do NOT short-circuit on `bashDestructive === false` — the two layers can
-  // diverge (the classifier and the audit pattern list maintain independent
-  // regexes), so treating the classifier as authoritative would let a
-  // narrower classifier silently suppress a hit the audit list would have
-  // caught. Treat the classifier as additive, not authoritative, for
-  // security-critical decisions.
-  const classifierDestructive = record.bashDestructive === true;
-  const classifierNetwork = record.bashNetwork === true;
+  const rules = buildAlertRules({
+    sensitive: sensitivePatterns,
+    destructive: destructivePatterns,
+    network: networkPatterns,
+  });
 
-  // Destructive commands (critical) — check first, highest priority
-  if (command) {
-    const isDestructive = classifierDestructive || matchesAny(command, destructivePatterns);
-    if (isDestructive) {
-      return {
-        severity: 'critical',
-        alertType: 'destructive_command',
-        description: `Destructive command detected: ${redactSensitive(command)}`,
-      };
-    }
-  }
-
-  // Sensitive file access (high)
-  if (filePath && matchesAny(filePath, sensitivePatterns)) {
-    return {
-      severity: 'high',
-      alertType: 'sensitive_file',
-      description: `Sensitive file accessed: ${redactSensitive(filePath)}`,
+  let best: SecurityAlert | undefined;
+  for (const rule of rules) {
+    const value = record[rule.subject];
+    if (typeof value !== 'string' || value.length === 0) continue;
+    if (!rule.classifierHit?.(record) && !matchesAny(value, rule.patterns)) continue;
+    if (best && SEVERITY_RANK[best.severity] >= SEVERITY_RANK[rule.severity]) continue;
+    best = {
+      severity: rule.severity,
+      alertType: rule.alertType,
+      description: rule.describe(redactSensitive(value)),
     };
   }
-
-  // External network request (medium) — only for Bash commands
-  if (command) {
-    const isNetwork = classifierNetwork || matchesAny(command, networkPatterns);
-    if (isNetwork) {
-      return {
-        severity: 'medium',
-        alertType: 'external_network',
-        description: `External network request: ${redactSensitive(command)}`,
-      };
-    }
-  }
-
-  return undefined;
+  return best;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/security/audit-trail.ts
+++ b/src/security/audit-trail.ts
@@ -37,13 +37,19 @@ export interface SecurityAlert {
   readonly description: string;
 }
 
-export interface AuditRecord {
+export interface AuditAttribution {
+  readonly sessionId: string | null;
+  /** Subagent that made the call. Absent for the parent session. Same id space as AiToolCall.agent_id. */
+  readonly agentId?: string;
+  readonly agentType?: string;
+}
+
+export interface AuditRecord extends AuditAttribution {
   /** Stable per-call id, sourced from `ToolCallRecord.id`/`ProxyToolCallRecord.id` — lets
    * consumers (e.g. the Audit page's React key) distinguish two entries that otherwise
    * share the same timestamp/tool/detail. */
   readonly id: string;
   readonly timestamp: number;
-  readonly sessionId: string | null;
   readonly action: AuditAction;
   readonly tool: string;
   readonly detail: string;
@@ -106,6 +112,26 @@ export const DEFAULT_NETWORK_COMMAND_PATTERNS: RegExp[] = [
   /\bnc\b/,
   /\bssh\b/,
 ];
+
+
+const ATTRIBUTION_WIRE_KEYS: Record<keyof AuditAttribution, string> = {
+  sessionId: 'session_id',
+  agentId: 'agent_id',
+  agentType: 'agent_type',
+};
+const ATTRIBUTION_KEYS = Object.keys(ATTRIBUTION_WIRE_KEYS) as ReadonlyArray<
+  keyof AuditAttribution
+>;
+
+export function attachAuditAttribution(
+  target: Record<string, string | number | boolean>,
+  source: AuditAttribution,
+): void {
+  for (const key of ATTRIBUTION_KEYS) {
+    const value = source[key];
+    if (typeof value === 'string') target[ATTRIBUTION_WIRE_KEYS[key]] = value;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Tool name → AuditAction mapping
@@ -236,8 +262,8 @@ export function auditRecordToNrEvent(
   };
 
   attachTeamAttribution(event, attrs ?? {});
+  attachAuditAttribution(event, record);
 
-  if (record.sessionId != null) event.session_id = record.sessionId;
   if (record.filePath != null) event.file_path = redactSensitive(record.filePath);
   if (record.command != null) event.command = redactSensitive(record.command);
 
@@ -275,8 +301,8 @@ export function securityAlertToNrEvent(
   };
 
   attachTeamAttribution(event, attrs ?? {});
+  attachAuditAttribution(event, record);
 
-  if (record.sessionId != null) event.session_id = record.sessionId;
   if (record.filePath != null) event.file_path = redactSensitive(record.filePath);
   if (record.command != null) event.command = redactSensitive(record.command);
 
@@ -355,6 +381,10 @@ function auditEntryToRecord(entry: AuditEntry): AuditRecord | null {
     typeof rawSessionId === 'string' && !isSyntheticSessionId(rawSessionId) ? rawSessionId : null;
   const filePath = typeof entry.filePath === 'string' ? entry.filePath : undefined;
   const command = typeof entry.command === 'string' ? entry.command : undefined;
+  const agentId =
+    typeof entry.agentId === 'string' && entry.agentId.length > 0 ? entry.agentId : undefined;
+  const agentType =
+    typeof entry.agentType === 'string' && entry.agentType.length > 0 ? entry.agentType : undefined;
   // Disk entries written before this field was introduced have no `id`; fall
   // back to the same content fingerprint used for cross-process dedup below.
   // That fingerprint isn't guaranteed unique across two distinct legacy
@@ -382,6 +412,8 @@ function auditEntryToRecord(entry: AuditEntry): AuditRecord | null {
     id,
     timestamp,
     sessionId,
+    agentId,
+    agentType,
     action,
     tool,
     detail,
@@ -412,7 +444,6 @@ export interface AuditTrailManagerOptions {
   sensitivePatterns?: RegExp[];
   destructivePatterns?: RegExp[];
   networkPatterns?: RegExp[];
-  /** Optional local store for persisting each audit record to disk immediately. */
   localStore?: LocalStore;
 }
 
@@ -450,7 +481,15 @@ export class AuditTrailManager {
   recordToolCall(record: ToolCallRecord): AuditRecord {
     const action = classifyTool(record.toolName);
     const detail = buildDetail(record);
+    return this.commit(record, action, detail);
+  }
 
+  recordProxyCall(record: ProxyToolCallRecord): AuditRecord {
+    const detail = `McpToolCall: ${record.serverName}/${record.toolName}`;
+    return this.commit(record, 'McpToolCall', detail);
+  }
+
+  private commit(record: ToolCallRecord, action: AuditAction, detail: string): AuditRecord {
     const alert = detectSecurityAlert(
       record,
       this.sensitivePatterns,
@@ -464,6 +503,8 @@ export class AuditTrailManager {
       id: record.id,
       timestamp: record.timestamp,
       sessionId: resolveAuditSessionId(record.sessionId, this.sessionId),
+      agentId: typeof record.agentId === 'string' ? record.agentId : undefined,
+      agentType: typeof record.agentType === 'string' ? record.agentType : undefined,
       action,
       tool: record.toolName,
       detail,
@@ -481,56 +522,14 @@ export class AuditTrailManager {
       if (this.sensitiveAccessLog.length >= AuditTrailManager.MAX_ENTRIES)
         this.sensitiveAccessLog.shift();
       this.sensitiveAccessLog.push(auditRecord);
-      logger.warn('Security alert', {
+      const alertContext: Record<string, string | number | boolean> = {
         severity: alert.severity,
         alertType: alert.alertType,
         tool: record.toolName,
         detail,
-      });
-    }
-
-    this.persistToDisk(auditRecord);
-    return auditRecord;
-  }
-
-  recordProxyCall(record: ProxyToolCallRecord): AuditRecord {
-    const detail = `McpToolCall: ${record.serverName}/${record.toolName}`;
-    const filePath = record.filePath as string | undefined;
-    const command = record.command as string | undefined;
-
-    const alert = detectSecurityAlert(
-      record,
-      this.sensitivePatterns,
-      this.destructivePatterns,
-      this.networkPatterns,
-    );
-
-    const auditRecord: AuditRecord = {
-      id: record.id,
-      timestamp: record.timestamp,
-      sessionId: resolveAuditSessionId(record.sessionId, this.sessionId),
-      action: 'McpToolCall',
-      tool: record.toolName,
-      detail,
-      developer: this.developer,
-      // Same redaction policy as recordToolCall — see comment there.
-      filePath: filePath != null ? redactSensitive(filePath) : undefined,
-      command: command != null ? redactSensitive(command) : undefined,
-      securityAlert: alert,
-    };
-
-    if (this.entries.length >= AuditTrailManager.MAX_ENTRIES) this.entries.shift();
-    this.entries.push(auditRecord);
-    if (alert) {
-      if (this.sensitiveAccessLog.length >= AuditTrailManager.MAX_ENTRIES)
-        this.sensitiveAccessLog.shift();
-      this.sensitiveAccessLog.push(auditRecord);
-      logger.warn('Security alert', {
-        severity: alert.severity,
-        alertType: alert.alertType,
-        tool: record.toolName,
-        detail,
-      });
+      };
+      attachAuditAttribution(alertContext, auditRecord);
+      logger.warn('Security alert', alertContext);
     }
 
     this.persistToDisk(auditRecord);
@@ -623,6 +622,8 @@ export class AuditTrailManager {
       developer: record.developer,
       filePath: record.filePath,
       command: record.command,
+      agentId: record.agentId,
+      agentType: record.agentType,
       securityAlert: record.securityAlert
         ? { severity: record.securityAlert.severity, alertType: record.securityAlert.alertType }
         : undefined,

--- a/src/security/audit-trail.ts
+++ b/src/security/audit-trail.ts
@@ -95,6 +95,10 @@ export const DEFAULT_DESTRUCTIVE_COMMAND_PATTERNS: RegExp[] = [
   /\bgit\s+push\s+--force(?!-(?:with-lease|if-includes))\b/i,
   /\bgit\s+push\s+-f\b/i,
   /\bgit\s+reset\s+--hard\b/i,
+  // git clean only deletes with -f/--force (clean.requireForce defaults to true);
+  // -n/--dry-run and bare `git clean` are safe and stay unflagged.
+  /\bgit\s+clean\b(?=.*\s(?:-[a-zA-Z]*f[a-zA-Z]*|--force)\b)/i,
+  /\bfind\b.*\s-delete\b/i,
   /\bDROP\s+TABLE\b/i,
   /\bDROP\s+DATABASE\b/i,
   /\bDELETE\s+FROM\b/i,

--- a/src/security/audit-trail.ts
+++ b/src/security/audit-trail.ts
@@ -113,6 +113,9 @@ export const DEFAULT_NETWORK_COMMAND_PATTERNS: RegExp[] = [
   /\bssh\b/,
 ];
 
+const RM_OR_UNLINK_IN_COMMAND_POSITION = /(?:^|[;&|(])\s*(?:sudo\s+)?(?:rm|unlink)\s/m;
+
+export const DEFAULT_DELETION_COMMAND_PATTERNS: RegExp[] = [RM_OR_UNLINK_IN_COMMAND_POSITION];
 
 const ATTRIBUTION_WIRE_KEYS: Record<keyof AuditAttribution, string> = {
   sessionId: 'session_id',
@@ -198,6 +201,7 @@ interface AuditPatternSet {
   readonly sensitive: readonly RegExp[];
   readonly destructive: readonly RegExp[];
   readonly network: readonly RegExp[];
+  readonly deletion: readonly RegExp[];
 }
 
 const SEVERITY_RANK: Record<AlertSeverity, number> = { critical: 3, high: 2, medium: 1 };
@@ -227,21 +231,21 @@ function buildAlertRules(p: AuditPatternSet): readonly AlertRule[] {
       classifierHit: (r) => r.bashNetwork === true,
       describe: (c) => `External network request: ${c}`,
     },
+    {
+      alertType: 'file_deletion',
+      severity: 'medium',
+      subject: 'command',
+      patterns: p.deletion,
+      classifierHit: (r) => r.bashLeading === 'rm' || r.bashLeading === 'unlink',
+      describe: (c) => `File deletion: ${c}`,
+    },
   ];
 }
 
 function detectSecurityAlert(
   record: ToolCallRecord,
-  sensitivePatterns: readonly RegExp[],
-  destructivePatterns: readonly RegExp[],
-  networkPatterns: readonly RegExp[],
+  rules: readonly AlertRule[],
 ): SecurityAlert | undefined {
-  const rules = buildAlertRules({
-    sensitive: sensitivePatterns,
-    destructive: destructivePatterns,
-    network: networkPatterns,
-  });
-
   let best: SecurityAlert | undefined;
   for (const rule of rules) {
     const value = record[rule.subject];
@@ -463,15 +467,16 @@ export interface AuditTrailManagerOptions {
   sensitivePatterns?: RegExp[];
   destructivePatterns?: RegExp[];
   networkPatterns?: RegExp[];
+  /** Non-recursive delete detection (medium). Pass [] to disable. Defaults to DEFAULT_DELETION_COMMAND_PATTERNS. */
+  deletionPatterns?: RegExp[];
+  /** Optional local store for persisting each audit record to disk immediately. */
   localStore?: LocalStore;
 }
 
 export class AuditTrailManager {
   private readonly developer: string;
   private sessionId: string | null;
-  private readonly sensitivePatterns: readonly RegExp[];
-  private readonly destructivePatterns: readonly RegExp[];
-  private readonly networkPatterns: readonly RegExp[];
+  private readonly rules: readonly AlertRule[];
   private readonly localStore: LocalStore | null;
 
   private entries: AuditRecord[] = [];
@@ -491,9 +496,12 @@ export class AuditTrailManager {
   constructor(options: AuditTrailManagerOptions) {
     this.developer = options.developer;
     this.sessionId = options.sessionId;
-    this.sensitivePatterns = options.sensitivePatterns ?? DEFAULT_SENSITIVE_FILE_PATTERNS;
-    this.destructivePatterns = options.destructivePatterns ?? DEFAULT_DESTRUCTIVE_COMMAND_PATTERNS;
-    this.networkPatterns = options.networkPatterns ?? DEFAULT_NETWORK_COMMAND_PATTERNS;
+    this.rules = buildAlertRules({
+      sensitive: options.sensitivePatterns ?? DEFAULT_SENSITIVE_FILE_PATTERNS,
+      destructive: options.destructivePatterns ?? DEFAULT_DESTRUCTIVE_COMMAND_PATTERNS,
+      network: options.networkPatterns ?? DEFAULT_NETWORK_COMMAND_PATTERNS,
+      deletion: options.deletionPatterns ?? DEFAULT_DELETION_COMMAND_PATTERNS,
+    });
     this.localStore = options.localStore ?? null;
   }
 
@@ -509,12 +517,7 @@ export class AuditTrailManager {
   }
 
   private commit(record: ToolCallRecord, action: AuditAction, detail: string): AuditRecord {
-    const alert = detectSecurityAlert(
-      record,
-      this.sensitivePatterns,
-      this.destructivePatterns,
-      this.networkPatterns,
-    );
+    const alert = detectSecurityAlert(record, this.rules);
 
     const rawFilePath = record.filePath as string | undefined;
     const rawCommand = record.command as string | undefined;

--- a/src/transport/log-ingest.test.ts
+++ b/src/transport/log-ingest.test.ts
@@ -96,6 +96,14 @@ describe('auditRecordToLogEntry()', () => {
     expect(entry.attributes).not.toHaveProperty('session_id');
   });
 
+  it('includes agent_id and agent_type when present', () => {
+    const record = makeAuditRecord({ agentId: 'a9f8', agentType: 'workflow' });
+    const entry = auditRecordToLogEntry(record, 'my-app');
+
+    expect(entry.attributes!.agent_id).toBe('a9f8');
+    expect(entry.attributes!.agent_type).toBe('workflow');
+  });
+
   it('redacts secrets in detail, file_path, and command', () => {
     const SECRET_TOKEN = 'sk-test-deadbeef0123456789abcdef0123456789';
     const record = makeAuditRecord({

--- a/src/transport/log-ingest.ts
+++ b/src/transport/log-ingest.ts
@@ -8,6 +8,7 @@ import type { NrLogEntry, TransportOptions, TransportResult } from '../shared/in
 import { sendLogs } from '../shared/index.js';
 import { redactSensitive } from '../config.js';
 import type { AuditRecord } from '../security/audit-trail.js';
+import { attachAuditAttribution } from '../security/audit-trail.js';
 
 const logger = createLogger('log-ingest');
 
@@ -47,7 +48,7 @@ export function auditRecordToLogEntry(record: AuditRecord, appName: string): NrL
     'audit.security_alert': !!record.securityAlert,
   };
 
-  if (record.sessionId != null) attributes.session_id = record.sessionId;
+  attachAuditAttribution(attributes, record);
   // Defense-in-depth: AuditRecord is already constructed with redacted
   // filePath/command/detail (see audit-trail.ts), but apply redactSensitive
   // again here so a future caller that bypasses the AuditTrailManager

--- a/src/web/api/client.ts
+++ b/src/web/api/client.ts
@@ -475,6 +475,8 @@ export interface AuditEntry {
   readonly target: string;
   readonly classification: string;
   readonly severity?: string;
+  readonly agentId?: string;
+  readonly agentType?: string;
 }
 
 export const fetchAuditLog = (): Promise<AuditEntry[]> => getJson<AuditEntry[]>('/api/audit');

--- a/src/web/views/Audit.tsx
+++ b/src/web/views/Audit.tsx
@@ -12,6 +12,7 @@ const FILTERS = [
   { key: 'sensitive_file', label: 'Sensitive files' },
   { key: 'destructive_command', label: 'Destructive' },
   { key: 'external_network', label: 'External network' },
+  { key: 'file_deletion', label: 'File deletion' },
 ] as const;
 
 type FilterKey = (typeof FILTERS)[number]['key'];
@@ -30,6 +31,7 @@ const CLASSIFICATION_LABELS: Record<string, string> = {
   sensitive_file: 'Sensitive files',
   destructive_command: 'Destructive',
   external_network: 'External network',
+  file_deletion: 'File deletion',
   other: 'Other',
 };
 

--- a/src/web/views/Audit.tsx
+++ b/src/web/views/Audit.tsx
@@ -126,13 +126,14 @@ export function Audit(): JSX.Element {
                 <th className="text-left p-2">Tool</th>
                 <th className="text-left p-2">Target</th>
                 <th className="text-left p-2">Classification</th>
+                <th className="text-left p-2">Agent</th>
                 <th className="text-left p-2">Session</th>
               </tr>
             </thead>
             <tbody>
               {visible.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="p-3 text-ink-muted text-center">
+                  <td colSpan={6} className="p-3 text-ink-muted text-center">
                     No matching entries.
                   </td>
                 </tr>
@@ -158,6 +159,9 @@ export function Audit(): JSX.Element {
                     >
                       {CLASSIFICATION_LABELS[r.classification] ?? r.classification}
                     </Pill>
+                  </td>
+                  <td className="p-2 text-ink-subtle" title={r.agentId}>
+                    {r.agentType ?? r.agentId ?? '—'}
                   </td>
                   <td className="p-2 text-ink-subtle">
                     {r.sessionId ? (


### PR DESCRIPTION
Stacked on #581. GitHub cannot target a fork branch as the base, so this PR shows #581's four commits too. Review the top two, `Fix: Flag git clean -f and find -delete as destructive commands` and `Chore: v1.41.0`. I will rebase onto main once #581 merges.

## Why

`git clean -f` deletes untracked files, recursively with `-d`, and nothing can recover them. `find <path> -delete` removes every match. Neither appears in the audit trail's destructive patterns or the bash classifier's, so both produce no alert today. After #581 `git clean` still produces nothing, because its leading token is `git` and the new `file_deletion` rule looks for `rm`. Both delete recursively by nature, so they belong in the `critical` `destructive_command` tier next to `rm -rf` and `git reset --hard`, not in the `medium` deletion tier.

## Scope

- `src/security/audit-trail.ts` and `src/hooks/bash-classifier.ts`. Two patterns added to each destructive list: `git clean` with any force form (`-f`, `-fd`, `-xdf`, `--force`), and `find … -delete`. Bare `git clean`, `git clean -n`, and `git clean --dry-run` stay unflagged, because git refuses to delete without `-f` unless `clean.requireForce` is off.
- Tests in `src/security/audit-trail.test.ts` and `src/hooks/bash-classifier.test.ts` for every matching and non-matching form above.
- `SECURITY.md` and `docs/METRICS_TABLE.md` destructive-command bullets.
- Version 1.41.0 with a changelog section.

## Blast radius

Any Bash tool call that runs `git clean -f` or `find -delete` now emits a `critical` `SecurityAlert` and sets `bashDestructive` on the `AiToolCall` event. Both are uncommon in agent sessions and both are the kind of call the audit trail exists to record. The three existing alert types and every other pattern are unchanged.

## Verification

- The `git clean` regex was run against all twelve listed forms before the tests were written. Every force form matches, and `git clean`, `git clean -n`, `git clean --dry-run`, and `git clean -nd` do not.
- `npm test` at the tip: 184 suites, 6458 tests, green. Each of the two commits builds and passes the `audit-trail` and `bash-classifier` suites on its own.
- `npm run lint` 0 errors and 0 warnings, `npm run format:check` clean, pre-commit hooks passed on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCQPMTtMRgr4V3po8ozDUc
