### PR TITLE
Fix #603: over_delegation fires on failed/interrupted spawns, not raw count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.48.2] - 2026-09-09
+
+### Fixed
+
+- The over-delegation anti-pattern now fires only when sub-agent spawns fail or are interrupted, rather than on raw spawn count. Previously, any session with three or more successful parallel sub-agent spawns — an idiomatic pattern — was flagged and could trigger coaching recommendations and alerts discouraging it.
+
 ## [1.48.1] - 2026-09-09
 
 ### Fixed

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "newrelic-preflight",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "description": "AI coding observability for Kiro. Tracks tool calls, cost, anti-patterns, and efficiency metrics — and (optionally) ships them to New Relic.",
   "author": {
     "name": "New Relic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.48.1",
+      "version": "1.48.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.48.1",
+  "version": "1.48.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.48.1",
+      "version": "1.48.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/metrics/anti-patterns.test.ts
+++ b/src/metrics/anti-patterns.test.ts
@@ -685,6 +685,50 @@ describe('Over-delegation detection', () => {
     expect(overDelegation).toHaveLength(1);
     expect(overDelegation[0].agentCount).toBe(3);
   });
+
+  it('does NOT fire when agentInterrupted is explicitly false or a non-boolean value', () => {
+    const detector = new AntiPatternDetector();
+
+    const calls: ToolCallRecord[] = [
+      makeRecord({ toolName: 'Agent', success: true, agentInterrupted: false }),
+      makeRecord({ toolName: 'Agent', success: true, agentInterrupted: false }),
+      // A truthy-but-non-boolean value must not satisfy the strict `=== true` check.
+      makeRecord({
+        toolName: 'Agent',
+        success: true,
+        agentInterrupted: 'true' as unknown as boolean,
+      }),
+    ];
+
+    const result = detector.analyze(calls);
+    expect(result.patterns.filter((p) => p.type === 'over_delegation')).toHaveLength(0);
+  });
+
+  it('does not interfere with an unrelated pattern (thrashing) detected in the same call sequence', () => {
+    const detector = new AntiPatternDetector();
+
+    const calls: ToolCallRecord[] = [
+      // 3 thrash cycles on /a.ts
+      makeRecord({ toolName: 'Edit', filePath: '/a.ts' }),
+      makeRecord({ toolName: 'Bash', isTestCommand: true, success: false }),
+      makeRecord({ toolName: 'Edit', filePath: '/a.ts' }),
+      makeRecord({ toolName: 'Bash', isTestCommand: true, success: false }),
+      makeRecord({ toolName: 'Edit', filePath: '/a.ts' }),
+      makeRecord({ toolName: 'Bash', isTestCommand: true, success: false }),
+      // 3 interrupted (but "successful") agent spawns
+      makeRecord({ toolName: 'Agent', success: true, agentInterrupted: true }),
+      makeRecord({ toolName: 'Agent', success: true, agentInterrupted: true }),
+      makeRecord({ toolName: 'Agent', success: true, agentInterrupted: true }),
+    ];
+
+    const result = detector.analyze(calls);
+    const types = result.patterns.map((p) => p.type);
+    expect(types).toContain('thrashing');
+    expect(types).toContain('over_delegation');
+
+    const overDelegation = result.patterns.filter((p) => p.type === 'over_delegation');
+    expect(overDelegation[0].agentCount).toBe(3);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/metrics/anti-patterns.test.ts
+++ b/src/metrics/anti-patterns.test.ts
@@ -615,32 +615,75 @@ describe('Agent partitioning', () => {
 // ---------------------------------------------------------------------------
 
 describe('Over-delegation detection', () => {
-  it('detects 5 Agent calls', () => {
+  it('does NOT fire when 5 Agent calls all succeed', () => {
     const detector = new AntiPatternDetector();
 
     const calls: ToolCallRecord[] = [];
     for (let i = 0; i < 5; i++) {
-      calls.push(makeRecord({ toolName: 'Agent', agentDescription: `task-${i}` }));
+      calls.push(makeRecord({ toolName: 'Agent', agentDescription: `task-${i}`, success: true }));
     }
 
     const result = detector.analyze(calls);
     const overDelegation = result.patterns.filter((p) => p.type === 'over_delegation');
 
-    expect(overDelegation).toHaveLength(1);
-    expect(overDelegation[0].agentCount).toBe(5);
+    expect(overDelegation).toHaveLength(0);
   });
 
-  it('detects exactly 3 Agent calls (at threshold, >= comparison)', () => {
+  it('fires when exactly 3 Agent calls fail (at threshold, >= comparison)', () => {
     const detector = new AntiPatternDetector();
 
     const calls: ToolCallRecord[] = [];
     for (let i = 0; i < 3; i++) {
-      calls.push(makeRecord({ toolName: 'Agent' }));
+      calls.push(makeRecord({ toolName: 'Agent', success: false }));
     }
 
     const result = detector.analyze(calls);
     const overDelegation = result.patterns.filter((p) => p.type === 'over_delegation');
     expect(overDelegation).toHaveLength(1);
+    expect(overDelegation[0].agentCount).toBe(3);
+  });
+
+  it('fires when Agent calls are interrupted, even if success is true', () => {
+    const detector = new AntiPatternDetector();
+
+    const calls: ToolCallRecord[] = [];
+    for (let i = 0; i < 3; i++) {
+      calls.push(makeRecord({ toolName: 'Agent', success: true, agentInterrupted: true }));
+    }
+
+    const result = detector.analyze(calls);
+    const overDelegation = result.patterns.filter((p) => p.type === 'over_delegation');
+    expect(overDelegation).toHaveLength(1);
+    expect(overDelegation[0].agentCount).toBe(3);
+  });
+
+  it('does NOT fire with only 2 failed spawns (threshold-1)', () => {
+    const detector = new AntiPatternDetector();
+
+    const calls: ToolCallRecord[] = [
+      makeRecord({ toolName: 'Agent', success: false }),
+      makeRecord({ toolName: 'Agent', success: false }),
+    ];
+
+    const result = detector.analyze(calls);
+    expect(result.patterns.filter((p) => p.type === 'over_delegation')).toHaveLength(0);
+  });
+
+  it('only counts failed/interrupted spawns toward the threshold, ignoring successful ones', () => {
+    const detector = new AntiPatternDetector();
+
+    const calls: ToolCallRecord[] = [
+      makeRecord({ toolName: 'Agent', success: true }),
+      makeRecord({ toolName: 'Agent', success: true }),
+      makeRecord({ toolName: 'Agent', success: false }),
+      makeRecord({ toolName: 'Agent', success: false }),
+      makeRecord({ toolName: 'Agent', success: false }),
+    ];
+
+    const result = detector.analyze(calls);
+    const overDelegation = result.patterns.filter((p) => p.type === 'over_delegation');
+    expect(overDelegation).toHaveLength(1);
+    expect(overDelegation[0].agentCount).toBe(3);
   });
 });
 
@@ -737,11 +780,11 @@ describe('threshold boundary tests', () => {
 
   // ---- Over-delegation ----
 
-  it('over_delegation: 4 agents (first count that fires, since threshold is >3) fires with agentCount=4', () => {
+  it('over_delegation: 4 failed agents (first count that fires, since threshold is >3) fires with agentCount=4', () => {
     const detector = new AntiPatternDetector();
     const calls: ToolCallRecord[] = [];
     for (let i = 0; i < 4; i++) {
-      calls.push(makeRecord({ toolName: 'Agent', agentDescription: `task-${i}` }));
+      calls.push(makeRecord({ toolName: 'Agent', agentDescription: `task-${i}`, success: false }));
     }
     const result = detector.analyze(calls);
     const over = result.patterns.filter((p) => p.type === 'over_delegation');
@@ -847,9 +890,9 @@ describe('emitMetrics()', () => {
     const detector = new AntiPatternDetector();
 
     const calls: ToolCallRecord[] = [];
-    // Trigger over-delegation (5 agents)
+    // Trigger over-delegation (5 failed agent spawns)
     for (let i = 0; i < 5; i++) {
-      calls.push(makeRecord({ toolName: 'Agent' }));
+      calls.push(makeRecord({ toolName: 'Agent', success: false }));
     }
 
     const result = detector.analyze(calls);
@@ -929,11 +972,11 @@ describe('Edge cases', () => {
       makeRecord({ toolName: 'Edit', filePath: '/b.ts' }),
       makeRecord({ toolName: 'Edit', filePath: '/b.ts' }),
       makeRecord({ toolName: 'Edit', filePath: '/b.ts' }),
-      // Over-delegation (4 agents)
-      makeRecord({ toolName: 'Agent' }),
-      makeRecord({ toolName: 'Agent' }),
-      makeRecord({ toolName: 'Agent' }),
-      makeRecord({ toolName: 'Agent' }),
+      // Over-delegation (4 failed agent spawns)
+      makeRecord({ toolName: 'Agent', success: false }),
+      makeRecord({ toolName: 'Agent', success: false }),
+      makeRecord({ toolName: 'Agent', success: false }),
+      makeRecord({ toolName: 'Agent', success: false }),
     ];
 
     const result = detector.analyze(calls);
@@ -1024,6 +1067,22 @@ describe('Token waste annotation', () => {
     expect(patterns[0].type).toBe('re_reading');
     // calls[0] is the first (necessary) read; calls[1-3] are waste
     expect(patterns[0].tokensWasted).toBe(210 + 220 + 230); // 660
+  });
+
+  it('estimates tokensWasted for over_delegation (counts every failed spawn, not just overflow)', () => {
+    const detector = new AntiPatternDetector();
+    const calls = [
+      makeRecord({ toolName: 'Agent', success: true, inputTokens: 999, outputTokens: 999 }),
+      makeRecord({ toolName: 'Agent', success: false, inputTokens: 100, outputTokens: 50 }),
+      makeRecord({ toolName: 'Agent', success: false, inputTokens: 110, outputTokens: 60 }),
+      makeRecord({ toolName: 'Agent', success: false, inputTokens: 120, outputTokens: 70 }),
+    ];
+    const { patterns } = detector.analyze(calls);
+    const overDelegation = patterns.filter((p) => p.type === 'over_delegation');
+    expect(overDelegation).toHaveLength(1);
+    // All 3 failed spawns are wasted (unlike repeat-based patterns, there's no
+    // "first one is free" — the successful spawn's tokens must not be included.
+    expect(overDelegation[0].tokensWasted).toBe(100 + 50 + 110 + 60 + 120 + 70); // 510
   });
 
   it('getTotalAntiPatternWaste() sums tokensWasted across all patterns', () => {

--- a/src/metrics/anti-patterns.ts
+++ b/src/metrics/anti-patterns.ts
@@ -7,7 +7,7 @@
  *   2. Re-reading: reading the same file excessively
  *   3. Stuck loop: running the same Bash command repeatedly
  *   4. Blind editing: multiple edits without verification
- *   5. Over-delegation: spawning too many sub-agents
+ *   5. Over-delegation: repeated sub-agent spawns that failed or were interrupted
  *
  * `analyze(toolCalls)` is pure — it returns detected patterns for a given
  * sequence (typically one task's worth of tool calls) without depending on
@@ -363,13 +363,7 @@ export class AntiPatternDetector implements Resettable {
   // ---------------------------------------------------------------------------
 
   private detectOverDelegation(toolCalls: ToolCallRecord[]): AntiPattern[] {
-    let agentCount = 0;
-
-    for (const call of toolCalls) {
-      if (call.toolName === 'Agent') {
-        agentCount++;
-      }
-    }
+    const agentCount = toolCalls.filter((call) => this.isFailedOrInterruptedAgentCall(call)).length;
 
     if (agentCount >= this.overDelegationThreshold) {
       return [
@@ -377,12 +371,17 @@ export class AntiPatternDetector implements Resettable {
           type: 'over_delegation',
           agentCount,
           tokensWasted: 0,
-          suggestion: 'Too many sub-agents spawned — consider handling more work directly',
+          suggestion:
+            'Multiple sub-agent spawns failed or were interrupted — investigate why before retrying rather than spawning more',
         },
       ];
     }
 
     return [];
+  }
+
+  private isFailedOrInterruptedAgentCall(call: ToolCallRecord): boolean {
+    return call.toolName === 'Agent' && (call.success === false || call.agentInterrupted === true);
   }
 
   private annotateTokenWaste(patterns: AntiPattern[], toolCalls: ToolCallRecord[]): AntiPattern[] {
@@ -437,8 +436,8 @@ export class AntiPatternDetector implements Resettable {
           return { ...p, tokensWasted: tokenSum(matching.slice(this.blindEditThreshold)) };
         }
         case 'over_delegation': {
-          const matching = toolCalls.filter((r) => r.toolName === 'Agent');
-          return { ...p, tokensWasted: tokenSum(matching.slice(this.overDelegationThreshold)) };
+          const matching = toolCalls.filter((r) => this.isFailedOrInterruptedAgentCall(r));
+          return { ...p, tokensWasted: tokenSum(matching) };
         }
         default:
           return p;

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -148,7 +148,8 @@ function computeWasteRecommendationText(
     re_reading: 'Read each file once and keep relevant sections in mind.',
     thrashing: 'Read the test failure output carefully before editing again.',
     blind_editing: 'Verify changes with tests between edit batches.',
-    over_delegation: 'Handle more work directly instead of spawning sub-agents.',
+    over_delegation:
+      'Multiple sub-agent spawns failed or were interrupted — investigate why before retrying.',
   };
 
   const advice = topPatternType !== null ? (patternAdvice[topPatternType] ?? null) : null;


### PR DESCRIPTION
## Summary

- The `over_delegation` anti-pattern (`src/metrics/anti-patterns.ts`) previously fired whenever a session made 3+ `Agent` tool calls, regardless of outcome — penalizing idiomatic parallel sub-agent fan-out.
- It now fires only when that many `Agent` spawns fail (`success === false`) or are interrupted (`agentInterrupted === true`), using fields already captured on the tool call record.
- `tokensWasted` for this pattern now sums every failed/interrupted spawn's tokens (each one is fully wasted), rather than only the spawns past the threshold.
- Updated the `Today.tsx` waste-recommendation copy to match the new semantics.

Fixes #603.

## Test plan

- [x] Updated/added unit tests in `src/metrics/anti-patterns.test.ts`: all-successful spawns no longer fire; failed spawns fire at threshold; interrupted spawns fire; mixed success/failure only counts failures; tokensWasted covers all failed spawns.
- [x] `npm run build && npm test` (6687 passed) and `npm run lint` (0 errors) clean.