### PR TITLE
Fix #604: exclude speed from efficiency score when no lines changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.48.3] - 2026-09-09
+
+### Fixed
+
+- The efficiency score's speed component no longer scores zero-linesChanged tasks (investigations, reviews, delegated work) as a hard 0 — it's now excluded from the composite entirely for those tasks, renormalizing the remaining components. The speed component's own weight in the composite also dropped from 0.25 to 0.10, since a raw lines-changed-per-second ratio rewarded bulk regeneration as much as a careful, well-reasoned fix.
+
 ## [1.48.2] - 2026-09-09
 
 ### Fixed

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "newrelic-preflight",
-  "version": "1.48.2",
+  "version": "1.48.3",
   "description": "AI coding observability for Kiro. Tracks tool calls, cost, anti-patterns, and efficiency metrics — and (optionally) ships them to New Relic.",
   "author": {
     "name": "New Relic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.48.2",
+  "version": "1.48.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.48.2",
+      "version": "1.48.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.48.2",
+  "version": "1.48.3",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.48.2",
+  "version": "1.48.3",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.48.2",
+  "version": "1.48.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.48.2",
+      "version": "1.48.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/metrics/efficiency-score.test.ts
+++ b/src/metrics/efficiency-score.test.ts
@@ -281,6 +281,53 @@ describe('Zero linesChanged tasks (issue #604)', () => {
     // perfect score once speed is excluded rather than dragging it down.
     expect(result.score).toBe(1);
   });
+
+  it('renormalizes correctly when custom weights do not sum to 1', () => {
+    // correctness=0.9, autonomy=0.3, firstAttemptQuality=0.3 → sum 1.5, not 1.
+    const scorer = new EfficiencyScorer({
+      correctnessWeight: 0.9,
+      autonomyWeight: 0.3,
+      firstAttemptQualityWeight: 0.3,
+    });
+
+    const task = makeTask({
+      linesChanged: 0,
+      testsRun: 4,
+      testsPassed: 4, // correctness = 1
+      askedUserQuestions: 5,
+      toolCallCount: 10, // autonomy = 0.5
+    });
+    const antiPatterns: AntiPattern[] = [
+      { type: 'thrashing', file: '/a.ts', iterations: 3, tokensWasted: 0, suggestion: '' },
+    ];
+    // firstAttemptQuality = 1 - 3/3 = 0
+
+    const result = scorer.computeScore(task, antiPatterns);
+
+    // (1*0.9 + 0.5*0.3 + 0*0.3) / 1.5 = (0.9 + 0.15 + 0) / 1.5 = 0.7
+    expect(result.score).toBeCloseTo(0.7, 3);
+  });
+
+  it('scores 0 rather than NaN when the non-speed weights are all 0', () => {
+    const scorer = new EfficiencyScorer({
+      speedWeight: 1,
+      correctnessWeight: 0,
+      autonomyWeight: 0,
+      firstAttemptQualityWeight: 0,
+    });
+
+    const task = makeTask({
+      linesChanged: 0,
+      testsRun: 4,
+      testsPassed: 4,
+      askedUserQuestions: 0,
+      toolCallCount: 10,
+    });
+    const result = scorer.computeScore(task);
+
+    expect(result.score).toBe(0);
+    expect(Number.isNaN(result.score)).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/metrics/efficiency-score.test.ts
+++ b/src/metrics/efficiency-score.test.ts
@@ -258,6 +258,58 @@ describe('Speed normalization', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Zero-lines-changed tasks (issue #604): speed must not penalize
+// investigation/review/delegated tasks that made zero edits by design.
+// ---------------------------------------------------------------------------
+
+describe('Zero linesChanged tasks (issue #604)', () => {
+  it('excludes speed from the composite score entirely, renormalizing the rest', () => {
+    const scorer = new EfficiencyScorer();
+
+    const task = makeTask({
+      linesChanged: 0,
+      testsRun: 4,
+      testsPassed: 4,
+      askedUserQuestions: 0,
+      toolCallCount: 10,
+    });
+    const result = scorer.computeScore(task);
+
+    // The speed component still reports the raw (zero) rate for diagnostics...
+    expect(result.components.speed).toBe(0);
+    // ...but correctness=1, autonomy=1, firstAttemptQuality=1 average to a
+    // perfect score once speed is excluded rather than dragging it down.
+    expect(result.score).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Speed weight (issue #604): speed's influence on the composite score is
+// reduced from 0.25 to 0.10 so raw line-churn can no longer buy most of the
+// score on its own.
+// ---------------------------------------------------------------------------
+
+describe('Speed weight reduced (issue #604)', () => {
+  it('a fast bulk edit no longer dominates the composite score via speed alone', () => {
+    const scorer = new EfficiencyScorer();
+
+    const task = makeTask({
+      linesChanged: 400,
+      durationMs: 1_000, // 400 lines/sec, far above baseline → speed clamps to 1.0
+      testsRun: 0,
+      testsPassed: 0, // correctness defaults to 0.5
+      askedUserQuestions: 5,
+      toolCallCount: 10, // autonomy = 0.5
+    });
+    const result = scorer.computeScore(task);
+
+    expect(result.components.speed).toBe(1);
+    // 1*0.10 + 0.5*0.30 + 0.5*0.30 + 1*0.30 = 0.70
+    expect(result.score).toBeCloseTo(0.7, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Score clamping
 // ---------------------------------------------------------------------------
 

--- a/src/metrics/efficiency-score.test.ts
+++ b/src/metrics/efficiency-score.test.ts
@@ -258,11 +258,11 @@ describe('Speed normalization', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Zero-lines-changed tasks (issue #604): speed must not penalize
-// investigation/review/delegated tasks that made zero edits by design.
+// Zero-lines-changed tasks: speed must not penalize investigation/review/
+// delegated tasks that made zero edits by design.
 // ---------------------------------------------------------------------------
 
-describe('Zero linesChanged tasks (issue #604)', () => {
+describe('Zero linesChanged tasks', () => {
   it('excludes speed from the composite score entirely, renormalizing the rest', () => {
     const scorer = new EfficiencyScorer();
 
@@ -331,12 +331,12 @@ describe('Zero linesChanged tasks (issue #604)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Speed weight (issue #604): speed's influence on the composite score is
-// reduced from 0.25 to 0.10 so raw line-churn can no longer buy most of the
-// score on its own.
+// Speed weight: speed's influence on the composite score is reduced from
+// 0.25 to 0.10 so raw line-churn can no longer buy most of the score on
+// its own.
 // ---------------------------------------------------------------------------
 
-describe('Speed weight reduced (issue #604)', () => {
+describe('Speed weight reduced', () => {
   it('a fast bulk edit no longer dominates the composite score via speed alone', () => {
     const scorer = new EfficiencyScorer();
 

--- a/src/metrics/efficiency-score.ts
+++ b/src/metrics/efficiency-score.ts
@@ -7,6 +7,12 @@
  *   3. Autonomy:             1 - (userQuestions / toolCalls)
  *   4. First-attempt quality: 1 - (thrashIterations / 3), floored at 0
  *
+ * Speed carries a deliberately small default weight (0.10 vs. 0.30 for the
+ * other three) — a raw lines/duration ratio rewards bulk regeneration as much
+ * as a careful fix, and zero-linesChanged tasks (investigation, review,
+ * delegated work) exclude speed from the composite entirely rather than
+ * scoring 0 on it, renormalizing across the remaining components instead.
+ *
  * Final score = weighted average, clamped to [0, 1].
  */
 
@@ -58,10 +64,10 @@ export interface EfficiencyScoreSeed {
 // Defaults
 // ---------------------------------------------------------------------------
 
-const DEFAULT_SPEED_WEIGHT = 0.25;
-const DEFAULT_CORRECTNESS_WEIGHT = 0.25;
-const DEFAULT_AUTONOMY_WEIGHT = 0.25;
-const DEFAULT_FIRST_ATTEMPT_QUALITY_WEIGHT = 0.25;
+const DEFAULT_SPEED_WEIGHT = 0.1;
+const DEFAULT_CORRECTNESS_WEIGHT = 0.3;
+const DEFAULT_AUTONOMY_WEIGHT = 0.3;
+const DEFAULT_FIRST_ATTEMPT_QUALITY_WEIGHT = 0.3;
 const DEFAULT_SPEED_BASELINE_LPS = 1; // 1 line per second = perfect speed
 
 const MAX_SCORES = 1_000;
@@ -107,13 +113,7 @@ export class EfficiencyScorer implements Resettable {
    */
   computeScore(task: AiCodingTask, antiPatterns?: AntiPattern[]): EfficiencyScore {
     const components = this.computeComponents(task, antiPatterns);
-    const raw =
-      components.speed * this.speedWeight +
-      components.correctness * this.correctnessWeight +
-      components.autonomy * this.autonomyWeight +
-      components.firstAttemptQuality * this.firstAttemptQualityWeight;
-
-    const score = clamp(Math.round(raw * 1000) / 1000, 0, 1);
+    const score = this.computeWeightedScore(components, task);
 
     const result: EfficiencyScore = {
       score,
@@ -205,13 +205,7 @@ export class EfficiencyScorer implements Resettable {
   updateScore(task: AiCodingTask, antiPatterns?: AntiPattern[]): EfficiencyScore {
     const idx = this.scores.findIndex((s) => s.taskId === task.taskId);
     const components = this.computeComponents(task, antiPatterns);
-    const raw =
-      components.speed * this.speedWeight +
-      components.correctness * this.correctnessWeight +
-      components.autonomy * this.autonomyWeight +
-      components.firstAttemptQuality * this.firstAttemptQualityWeight;
-
-    const score = clamp(Math.round(raw * 1000) / 1000, 0, 1);
+    const score = this.computeWeightedScore(components, task);
 
     const result: EfficiencyScore = {
       score,
@@ -275,6 +269,33 @@ export class EfficiencyScorer implements Resettable {
       autonomy: this.computeAutonomy(task),
       firstAttemptQuality: this.computeFirstAttemptQuality(antiPatterns),
     };
+  }
+
+  /**
+   * Weighted average of the four components, clamped to [0, 1]. When zero
+   * lines changed, speed is excluded entirely rather than scored as 0 —
+   * investigation/review/delegated tasks make no edits by design, so the
+   * remaining weights are renormalized to sum to 1 on their own.
+   */
+  private computeWeightedScore(components: EfficiencyScoreComponents, task: AiCodingTask): number {
+    if (task.linesChanged === 0) {
+      const remainingWeight =
+        this.correctnessWeight + this.autonomyWeight + this.firstAttemptQualityWeight;
+      if (remainingWeight <= 0) return 0;
+      const raw =
+        (components.correctness * this.correctnessWeight +
+          components.autonomy * this.autonomyWeight +
+          components.firstAttemptQuality * this.firstAttemptQualityWeight) /
+        remainingWeight;
+      return clamp(Math.round(raw * 1000) / 1000, 0, 1);
+    }
+
+    const raw =
+      components.speed * this.speedWeight +
+      components.correctness * this.correctnessWeight +
+      components.autonomy * this.autonomyWeight +
+      components.firstAttemptQuality * this.firstAttemptQualityWeight;
+    return clamp(Math.round(raw * 1000) / 1000, 0, 1);
   }
 
   /**


### PR DESCRIPTION
## Summary
- The efficiency score's speed component scored a hard `0` for tasks with zero `linesChanged` (investigations, reviews, delegated exploration), capping their composite score even when everything else went well. Those tasks now exclude speed from the composite entirely, renormalizing across correctness/autonomy/firstAttemptQuality.
- Speed's default weight in the composite drops from `0.25` to `0.10` (the freed-up `0.15` split evenly across the other three, now `0.30` each), since a raw lines-changed-per-second ratio otherwise let a fast bulk regeneration outscore a slow, careful, precise fix.

Fixes #604

## Test plan
- [x] Added two new test cases in `src/metrics/efficiency-score.test.ts` reproducing the issue (watched them fail before the fix, per TDD)
- [x] `npm run build`
- [x] `npm test` (full suite, 6691 passed)
- [x] `npm run lint` (0 errors/warnings)
- [x] Version bump (`1.48.2` → `1.48.3`) across all 5 manifest files + `CHANGELOG.md`