### PR TITLE
Fix #608: precise correction detection, drop fabricated impact estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.48.5] - 2026-09-09
+
+### Fixed
+
+- Correction detection now uses a small set of targeted phrase patterns instead of a single blunt first-word regex, and the unmeasured "15-25% session duration" impact estimate on the high correction rate recommendation has been removed. Previously, ordinary task instructions and refinements — "Revert the last commit", "Stop the dev server and restart it", "Actually, let's also add tests", "no rush" — were miscounted as corrections, while genuine corrections that didn't start with a trigger word — "That approach won't work because...", "You missed the null case", "This is the third time" — were missed entirely.
+
 ## [1.48.4] - 2026-09-09
 
 ### Fixed

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "newrelic-preflight",
-  "version": "1.48.4",
+  "version": "1.48.5",
   "description": "AI coding observability for Kiro. Tracks tool calls, cost, anti-patterns, and efficiency metrics — and (optionally) ships them to New Relic.",
   "author": {
     "name": "New Relic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.48.4",
+  "version": "1.48.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.48.4",
+      "version": "1.48.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.48.4",
+  "version": "1.48.5",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.48.4",
+  "version": "1.48.5",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.48.4",
+  "version": "1.48.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.48.4",
+      "version": "1.48.5",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/metrics/prompt-feedback.ts
+++ b/src/metrics/prompt-feedback.ts
@@ -51,7 +51,7 @@ export interface PromptRecommendation {
   readonly category: string;
   readonly message: string;
   readonly evidence: string;
-  readonly estimatedImpact: string;
+  readonly estimatedImpact?: string;
   readonly priority: 'high' | 'medium' | 'low';
 }
 
@@ -242,7 +242,6 @@ export class PromptFeedbackEngine {
         message:
           'Consider providing more context in initial prompts — your correction rate is high compared to team average',
         evidence: `Your correction rate is ${correctionPct}%, vs team average ${teamCorrectionPct}%`,
-        estimatedImpact: 'Fewer corrections could reduce session duration by 15-25%',
         priority: 'high',
       });
     }

--- a/src/metrics/transcript-message-tracker.test.ts
+++ b/src/metrics/transcript-message-tracker.test.ts
@@ -145,6 +145,12 @@ describe('TranscriptMessageTracker', () => {
     ["  no, that's not right"],
     ['Stop. I did not approve that.'],
     ["That's wrong, please redo it."],
+    ["Incorrect, that's not what I asked for."],
+    ["Actually, that's not right — try again."],
+    ['Undo that.'],
+    ["That approach won't work because there's a race condition."],
+    ['You missed the null case.'],
+    ['This is the third time — read the file first.'],
   ])('detects a correction for %j', (text) => {
     writeLines([userLine(text)]);
     const tracker = new TranscriptMessageTracker();
@@ -153,8 +159,15 @@ describe('TranscriptMessageTracker', () => {
     expect(tracker.getMetrics().userCorrections).toBe(1);
   });
 
-  it('does not count an ordinary message as a correction', () => {
-    writeLines([userLine('please add a new endpoint')]);
+  it.each([
+    ['please add a new endpoint'],
+    ["Actually, let's also add tests"],
+    ['Revert the last commit'],
+    ['Stop the dev server and restart it'],
+    ['no rush, whenever you get to it'],
+    ['Undo the last commit in git history'],
+  ])('does not count %j as a correction', (text) => {
+    writeLines([userLine(text)]);
     const tracker = new TranscriptMessageTracker();
     tracker.observeTranscriptPath(transcriptPath);
     tracker.refresh();

--- a/src/metrics/transcript-message-tracker.ts
+++ b/src/metrics/transcript-message-tracker.ts
@@ -32,8 +32,44 @@ const SYNTHETIC_TEXT_PREFIXES = [
   'Another Claude session sent a message:',
 ];
 
-const CORRECTION_RE =
-  /^(no|nope|not\b|stop|don't|wrong|incorrect|actually|that's not|that's wrong|undo|revert)\b/i;
+/** "actually" alone is a refinement filler ("actually, let's also add tests"), not a rejection signal. */
+const OPTIONAL_ACTUALLY = '(?:actually,?\\s+)?';
+
+/** Leading "no"/"nope", guarded against reassurance phrases that aren't corrections. */
+const LEADING_NO_RE = new RegExp(
+  `^${OPTIONAL_ACTUALLY}(no|nope)\\b(?!\\s*(rush|worries|problem|prob\\b|biggie|need))`,
+  'i',
+);
+
+/** "wrong"/"incorrect" leading a message are rarely anything but a rejection. */
+const BARE_REJECTION_RE = /^(wrong|incorrect)\b/i;
+
+/** Explicit rejection of the assistant's last output, optionally softened by "actually". */
+const EXPLICIT_REJECTION_RE = new RegExp(
+  `^${OPTIONAL_ACTUALLY}(that'?s|this is) (not|wrong|incorrect)\\b`,
+  'i',
+);
+
+/** A trigger word immediately followed by punctuation reads as an interjection, not a task instruction ("Stop the dev server" has no punctuation there). */
+const LEADING_INTERJECTION_RE = /^(stop|wait|no|nope|undo|revert)[.,!]/i;
+
+/** Undo verbs only count as a correction when they target the assistant's own action ("undo that"), not a concrete noun ("revert the last commit", "stop the dev server"). */
+const TARGETED_UNDO_RE = /^(stop|undo|revert|don'?t)\b[^.!?]{0,20}\b(that|it|this)\b/i;
+
+/** Correction phrasing that doesn't require a trigger word at the start of the message. */
+const EMBEDDED_CORRECTION_RE =
+  /\b(won'?t work|you (missed|forgot|broke)|that'?s (not (right|correct|what)|wrong|incorrect)|not what (i|you)'?d? (meant|asked|wanted|said)|this is the (\d+|second|third|fourth|fifth|\w+th) time)\b/i;
+
+function isCorrectionMessage(text: string): boolean {
+  return (
+    LEADING_NO_RE.test(text) ||
+    BARE_REJECTION_RE.test(text) ||
+    EXPLICIT_REJECTION_RE.test(text) ||
+    LEADING_INTERJECTION_RE.test(text) ||
+    TARGETED_UNDO_RE.test(text) ||
+    EMBEDDED_CORRECTION_RE.test(text)
+  );
+}
 
 /** A content block carrying a `text` field — narrows before reading `.text`. */
 function hasStringText(block: unknown): block is { text: string } {
@@ -185,7 +221,7 @@ export class TranscriptMessageTracker {
       const text = classifyUserEntry(entry);
       if (text !== null) {
         this.userMessages++;
-        if (CORRECTION_RE.test(text.trim())) {
+        if (isCorrectionMessage(text.trim())) {
           this.userCorrections++;
         }
       }


### PR DESCRIPTION
## Summary

- Replaces the single anchored `CORRECTION_RE` regex in `transcript-message-tracker.ts` — which matched task instructions/refinements ("Revert the last commit", "Stop the dev server and restart it", "Actually, let's also add tests", "no rush") and missed genuine corrections without a leading trigger word ("That approach won't work because...", "You missed the null case", "This is the third time") — with a small set of targeted patterns: guarded leading rejection words, punctuation-gated interjections, a targeted-undo check requiring the verb to reference the assistant's own action rather than a concrete noun, and embedded phrase detection for corrections that don't lead with a trigger word.
- Drops the fabricated `estimatedImpact: 'Fewer corrections could reduce session duration by 15-25%'` string from the high-correction-rate recommendation in `prompt-feedback.ts` — that number wasn't measured anywhere in the codebase. `PromptRecommendation.estimatedImpact` is now optional; downstream consumers (`recommendation-engine.ts`, `History.tsx`) already handle an absent value.
- Version bump 1.48.4 → 1.48.5 (Fixed → PATCH) across the 5 version files, plus CHANGELOG entry.

Fixes #608

## Test plan

- [x] Added test cases in `transcript-message-tracker.test.ts` covering every false positive/negative example from the issue
- [x] `npm run build && npm test` passes (6709 passed)
- [x] `npm run lint` — 0 errors/warnings
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)