### PR TITLE
Fix #605: normalize tool selection score penalty by session size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.50.2] - 2026-09-10
+
+### Fixed
+
+- **The tool selection score's penalty for redundant reads/failures/unused outputs is now actually normalized by session size**, matching what its own code comment already claimed: a session with more than 15 tool calls is no longer punished as harshly as a shorter one for the same absolute number of violations. Previously the penalty was purely absolute, so a busy day (or a session with lots of parallel/forked subagent activity) could score noticeably worse than a quiet one with an identical defect rate. Sessions of 15 calls or fewer score exactly as they did before this change.
+
 ## [1.50.1] - 2026-09-10
 
 ### Fixed

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -444,6 +444,6 @@ A single failure followed by a success does not count. The streak resets only on
 
 **How to avoid:** Prefer targeted reads over reading whole files you only need to skim once. This penalty is rare in practice — a single Read has to exceed ~20,000 bytes (a genuinely large file) and never lead to an edit of that same file.
 
-### Score floor
+### Normalization and score floor
 
-Even with many penalties the score won't drop below 0.3, so the metric is intended to track trends over time, not penalize individual sessions heavily.
+Penalties are normalized against session size before being applied, one-sided: sessions of 15 calls or fewer apply the raw penalty as-is, while sessions above 15 calls have the raw penalty total scaled down by `15 / totalCalls`, so the same absolute number of violations counts for much less in a 1000-call session. This keeps busy sessions (e.g. many parallel subagent calls) from scoring worse than a short session with an identical defect rate, without the reverse effect of making short sessions score worse than before. After normalization, the score still won't drop below 0.3, so the metric is intended to track trends over time, not penalize individual sessions heavily.

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "description": "AI coding observability for Kiro. Tracks tool calls, cost, anti-patterns, and efficiency metrics — and (optionally) ships them to New Relic.",
   "author": {
     "name": "New Relic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.50.1",
+      "version": "1.50.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.50.1",
+  "version": "1.50.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.50.1",
+      "version": "1.50.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/dashboard/routes/api-handler.test.ts
+++ b/src/dashboard/routes/api-handler.test.ts
@@ -5573,6 +5573,9 @@ describe('api-handler GET /api/tool-selection-score', () => {
     expect(parsed.totalCalls).toBe(3);
     expect(parsed.redundantReadCount).toBe(1);
     expect(parsed.penalizedCalls).toBe(1);
+    // 3 calls is below the 15-call reference session size, so normalization
+    // is a no-op here (it only dilutes penalties in sessions ABOVE the
+    // reference size — see tool-selection-scorer.ts's normalizePenalty()).
     expect(parsed.score).toBe(0.97); // 1 - (1 * DEFAULT_REDUNDANT_READ_PENALTY of 0.03)
   });
 
@@ -5684,7 +5687,8 @@ describe('api-handler GET /api/tool-selection-score', () => {
     const parsed = JSON.parse(body());
     // Combining {score:1, totalCalls:0, ...} (live, empty) with the persisted
     // summary above: repeatedFailureCount=3 * DEFAULT_REPEATED_FAILURE_PENALTY
-    // of 0.08 = 0.24 raw penalty -> score = 1 - 0.24 = 0.76.
+    // of 0.08 = 0.24 raw penalty. 5 calls is below the 15-call reference
+    // session size, so normalization is a no-op -> score = 1 - 0.24 = 0.76.
     expect(parsed.totalCalls).toBe(5);
     expect(parsed.penalizedCalls).toBe(3);
     expect(parsed.repeatedFailureCount).toBe(3);

--- a/src/metrics/tool-selection-scorer.test.ts
+++ b/src/metrics/tool-selection-scorer.test.ts
@@ -211,16 +211,84 @@ describe('ToolSelectionScorer', () => {
   it('score has a floor at 0.3 even for terrible sessions', () => {
     const scorer = new ToolSelectionScorer();
     const calls: ToolCallRecord[] = [];
-    // Many redundant reads + repeated failures. Total penalty is capped at 0.7.
-    for (let i = 0; i < 31; i++) {
-      calls.push(makeRecord({ toolName: 'Read', filePath: '/same.ts' }));
-    }
-    for (let i = 0; i < 10; i++) {
+    // 15 consecutive Bash failures (14 penalized) in a 15-call session — at
+    // exactly the reference size, normalization is a no-op, so this is the
+    // same absolute-penalty math as before the #605 fix: 14 * 0.08 = 1.12,
+    // capped at 0.7.
+    for (let i = 0; i < 15; i++) {
       calls.push(makeRecord({ toolName: 'Bash', success: false }));
     }
 
     const metrics = scorer.scoreSession(calls);
     expect(metrics.score).toBe(0.3);
+  });
+
+  it('normalizes penalty by session size: same defect count punishes a large session far less than a small one', () => {
+    const scorer = new ToolSelectionScorer();
+    const buildSession = (totalCalls: number): ToolCallRecord[] => {
+      const calls: ToolCallRecord[] = [];
+      // 12 reads of the same file -> first 2 free, 10 penalized redundant reads.
+      for (let i = 0; i < 12; i++) {
+        calls.push(makeRecord({ toolName: 'Read', filePath: '/a.ts' }));
+      }
+      // Pad with unrelated successful Bash calls to reach the target session size.
+      while (calls.length < totalCalls) {
+        calls.push(makeRecord({ toolName: 'Bash', command: 'echo ok' }));
+      }
+      return calls;
+    };
+
+    const small = scorer.scoreSession(buildSession(15));
+    const large = scorer.scoreSession(buildSession(1000));
+
+    expect(small.redundantReadCount).toBe(10);
+    expect(large.redundantReadCount).toBe(10);
+    // 15 calls is the reference session size, so behavior there is unchanged
+    // from the pre-normalization absolute penalty (10 * 0.03 = 0.3 -> 0.7).
+    expect(small.score).toBe(0.7);
+    // The same 10 redundant reads in a 1000-call session should barely register.
+    expect(large.score).toBeGreaterThan(0.99);
+  });
+
+  it('does not amplify penalty for sessions below the reference size', () => {
+    const scorer = new ToolSelectionScorer();
+    // 4-call session, 2 penalized redundant reads (0.03 each = 0.06 raw).
+    // Below the 15-call reference size, so this must score exactly as the
+    // raw penalty implies (0.94) — NOT scaled up to (0.06/4)*15=0.225,
+    // which would punish small sessions harder than before, the same
+    // unfairness #605 was filed about, just in the opposite direction.
+    const calls = [
+      makeRecord({ toolName: 'Read', filePath: '/a.ts' }),
+      makeRecord({ toolName: 'Read', filePath: '/a.ts' }),
+      makeRecord({ toolName: 'Read', filePath: '/a.ts' }),
+      makeRecord({ toolName: 'Read', filePath: '/a.ts' }),
+    ];
+
+    const metrics = scorer.scoreSession(calls);
+    expect(metrics.score).toBe(0.94);
+  });
+
+  it('supports a custom referenceSessionSize', () => {
+    const buildSession = (totalCalls: number): ToolCallRecord[] => {
+      const calls: ToolCallRecord[] = [];
+      for (let i = 0; i < 12; i++) {
+        calls.push(makeRecord({ toolName: 'Read', filePath: '/a.ts' }));
+      }
+      while (calls.length < totalCalls) {
+        calls.push(makeRecord({ toolName: 'Bash', command: 'echo ok' }));
+      }
+      return calls;
+    };
+    const calls = buildSession(200);
+
+    const defaultScore = new ToolSelectionScorer().scoreSession(calls).score;
+    const largerReferenceScore = new ToolSelectionScorer({
+      referenceSessionSize: 100,
+    }).scoreSession(calls).score;
+
+    // A larger referenceSessionSize dilutes less at the same totalCalls, so
+    // the resulting score should be lower (more penalty applied).
+    expect(largerReferenceScore).toBeLessThan(defaultScore);
   });
 
   it('penalizes large output not followed by any referencing call', () => {
@@ -440,5 +508,24 @@ describe('ToolSelectionScorer.combineSummaries', () => {
     expect(combined.unusedOutputCount).toBe(direct.unusedOutputCount);
     expect(combined.penalties).toEqual([]);
     expect(combined.worstOffenders).toEqual([]);
+  });
+
+  it('scores a busy day with many calls far better than a quiet day with the same defect count', () => {
+    const scorer = new ToolSelectionScorer();
+    const quietDay = {
+      score: 0,
+      totalCalls: 20,
+      penalizedCalls: 10,
+      redundantReadCount: 10,
+      repeatedFailureCount: 0,
+      unusedOutputCount: 0,
+    };
+    const busyDay = { ...quietDay, totalCalls: 2000 };
+
+    const quiet = scorer.combineSummaries([quietDay]);
+    const busy = scorer.combineSummaries([busyDay]);
+
+    expect(quiet.score).toBeLessThan(busy.score);
+    expect(busy.score).toBeGreaterThan(0.99);
   });
 });

--- a/src/metrics/tool-selection-scorer.ts
+++ b/src/metrics/tool-selection-scorer.ts
@@ -58,6 +58,7 @@ export interface ToolSelectionScorerOptions {
   readonly unusedOutputPenalty?: number;
   readonly unusedOutputSizeThreshold?: number;
   readonly worstOffenderCount?: number;
+  readonly referenceSessionSize?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -69,6 +70,12 @@ const DEFAULT_REPEATED_FAILURE_PENALTY = 0.08;
 const DEFAULT_UNUSED_OUTPUT_PENALTY = 0.04;
 const DEFAULT_UNUSED_OUTPUT_SIZE_THRESHOLD = 20000;
 const DEFAULT_WORST_OFFENDER_COUNT = 10;
+// Session size (in tool calls) at or below which normalization is a no-op;
+// above it, penalties are diluted in proportion to size — see
+// normalizePenalty(). Chosen to match the illustrative example this
+// normalization is designed to fix (a 15-call session with 10 redundant
+// reads applies the raw, pre-normalization penalty unchanged).
+const DEFAULT_REFERENCE_SESSION_SIZE = 15;
 
 // Tools whose output is terminal — they perform an action and their output is
 // a confirmation or result, not raw data to be consumed by later tool calls.
@@ -118,6 +125,7 @@ export class ToolSelectionScorer {
   private readonly unusedOutputPenalty: number;
   private readonly unusedOutputSizeThreshold: number;
   private readonly worstOffenderCount: number;
+  private readonly referenceSessionSize: number;
 
   constructor(options?: ToolSelectionScorerOptions) {
     this.redundantReadPenalty = options?.redundantReadPenalty ?? DEFAULT_REDUNDANT_READ_PENALTY;
@@ -127,6 +135,29 @@ export class ToolSelectionScorer {
     this.unusedOutputSizeThreshold =
       options?.unusedOutputSizeThreshold ?? DEFAULT_UNUSED_OUTPUT_SIZE_THRESHOLD;
     this.worstOffenderCount = options?.worstOffenderCount ?? DEFAULT_WORST_OFFENDER_COUNT;
+    this.referenceSessionSize = options?.referenceSessionSize ?? DEFAULT_REFERENCE_SESSION_SIZE;
+  }
+
+  /**
+   * Normalizes a raw summed penalty by session size, one-sided: sessions AT
+   * OR BELOW `referenceSessionSize` calls apply the raw penalty as-is
+   * (identical to the pre-normalization absolute penalty), while sessions
+   * ABOVE it get the penalty diluted in proportion to size — a 1000-call
+   * session with 10 redundant reads is punished far less than a 15-call
+   * session with the same 10 redundant reads. This is deliberately one-sided
+   * (`Math.min(1, referenceSessionSize / totalCalls)`, never > 1): the
+   * problem being fixed is large/busy sessions scoring worse than small ones
+   * for an identical defect count, not small sessions scoring better — a
+   * two-sided scale would fix the former by introducing the same unfairness
+   * in the other direction (amplifying penalties for small sessions instead
+   * of leaving them untouched). The result is still capped at 0.7 (floor of
+   * 0.3) so even a session dense with violations relative to its own size
+   * isn't scored as a total failure.
+   */
+  private normalizePenalty(rawPenalty: number, totalCalls: number): number {
+    if (totalCalls <= 0) return 0;
+    const scale = Math.min(1, this.referenceSessionSize / totalCalls);
+    return Math.min(rawPenalty * scale, 0.7);
   }
 
   scoreSession(toolCalls: readonly ToolCallRecord[]): ToolSelectionMetrics {
@@ -157,11 +188,7 @@ export class ToolSelectionScorer {
     penalties.push(...this.findUnusedOutputs(toolCalls));
 
     const rawPenalty = penalties.reduce((sum, p) => sum + p.penaltyScore, 0);
-    // Normalize: cap penalty contribution relative to session size so that a
-    // 1000-call session with 10 redundant reads isn't unfairly punished the
-    // same as a 15-call session with 10 redundant reads. Effective penalty is
-    // at most 70% (floor of 0.3 ensures even bad sessions aren't demoralizingly low).
-    const totalPenalty = Math.min(rawPenalty, 0.7);
+    const totalPenalty = this.normalizePenalty(rawPenalty, toolCalls.length);
     const score = Math.max(0, Math.round((1 - totalPenalty) * 1000) / 1000);
 
     const worstOffenders = [...penalties]
@@ -219,7 +246,7 @@ export class ToolSelectionScorer {
       redundantReadCount * this.redundantReadPenalty +
       repeatedFailureCount * this.repeatedFailurePenalty +
       unusedOutputCount * this.unusedOutputPenalty;
-    const totalPenalty = Math.min(rawPenalty, 0.7);
+    const totalPenalty = this.normalizePenalty(rawPenalty, totalCalls);
     const score = Math.max(0, Math.round((1 - totalPenalty) * 1000) / 1000);
 
     return {


### PR DESCRIPTION
Fixes #605

## Summary

- `ToolSelectionScorer`'s redundant-read/repeated-failure/unused-output penalty had a comment claiming it was "normalized... relative to session size," but the code just did `Math.min(rawPenalty, 0.7)` — `totalCalls` was computed but never used. A 1000-call session and a 15-call session with the same 10 redundant reads scored identically, which is exactly the unfairness the comment claimed didn't happen.
- Implemented real, one-sided normalization: sessions of 15 calls or fewer (the reference size, matching the original comment's own example) score exactly as before; sessions above 15 calls have the raw penalty diluted by `referenceSessionSize / totalCalls`, still capped at 0.7 (floor 0.3). Applied identically in both `scoreSession()` and `combineSummaries()` via a shared private `normalizePenalty()`.
- The normalization is deliberately one-sided rather than a straight `(rawPenalty / totalCalls) * referenceSize` scale — an earlier draft of this fix used the two-sided version and it amplified penalties for sessions under 15 calls (e.g. a 2-call session with 2 failures dropped from 0.92 to 0.40), introducing the same unfairness this issue was filed about, just in the opposite direction. `Math.min(1, referenceSessionSize / totalCalls)` only ever dilutes, never amplifies.
- Updated `docs/ADVANCED.md`'s scoring explanation to match, and bumped the version (Fix → PATCH) across the 5 manifest files + CHANGELOG per repo convention.

## Test plan

- [x] New unit tests in `tool-selection-scorer.test.ts`: reproduces the issue's exact 15-call-vs-1000-call scenario, confirms no amplification below the reference size, confirms a custom `referenceSessionSize` option takes effect, and a `combineSummaries`-level test matching the issue's "busy day vs. quiet day" framing directly.
- [x] Re-derived (not just adjusted) the two hardcoded score expectations in `api-handler.test.ts` and the scorer's own "floor at 0.3" test that depended on the old absolute-penalty math.
- [x] `npm run build`, `npm run lint`, `npm run format:check` all clean.
- [x] `npm test` — 200/201 suites, 6848 tests passing (1 pre-existing unrelated skip).
- [x] Independent code review pass (fresh subagent, no shared context) caught the two-sided amplification bug described above before this was pushed; fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)