### PR TITLE
Docs: Name every supported platform in README and guard the lists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ preflight/
     security/      # Audit trail + SSRF helpers
     tracing/       # OTel span lifecycle
     transport/     # NR ingest manager + log ingest
-    platforms/     # 9 platform adapters — 8 named (Claude Code, Cursor, Windsurf, Copilot, Zed, Continue.dev, Amazon Q, Amazon Kiro) + 1 generic MCP fallback
+    platforms/     # one adapter per supported platform (see docs/ADAPTERS.md) + generic MCP fallback
     digest/        # Slack digest formatter and sender
     install/       # preflight install / setup CLI
     alerts/        # Alert TS types (JSON files live in alerts/ at repo root)

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Restart your AI tool — hooks and the MCP server load at session start. Every t
 
 ## Works With
 
-**Claude Code** • **Cursor** • **Windsurf** • **GitHub Copilot** • **Zed** • **Continue.dev** • **Amazon Q Developer** • **Amazon Kiro**
+**Claude Code** • **Amazon Kiro** • **Amazon Q Developer CLI** • **Factory Droid** • **OpenAI Codex** • **opencode** • **Kilo Code** • **Pi** • **GitHub Copilot** • **GitHub Copilot SDK** • **GitHub Copilot app** • **Google Gemini CLI** • **Cursor** • **Windsurf** • **Google Antigravity** • **Zed** • **Continue.dev** • **Cline**
 
-Coverage isn't uniform — some platforms capture every built-in tool call, others (Zed, Continue.dev) only see calls routed to Preflight's own MCP tools. See [ADAPTERS.md](docs/ADAPTERS.md) for what each platform can and can't observe, and per-platform setup steps.
+Coverage isn't uniform — some platforms capture every built-in tool call, others (Zed, Continue.dev, Cline) only see calls routed to Preflight's own MCP tools. See [ADAPTERS.md](docs/ADAPTERS.md) for what each platform can and can't observe, and per-platform setup steps.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -60,7 +60,7 @@ Restart your AI tool after editing the config.
 
 **Cause:** This is expected — **Claude Desktop is not a supported platform for automatic observability.** Preflight's automatic capture relies on a hook/callback mechanism (`PreToolUse`/`PostToolUse`) that fires on every built-in tool call. Claude Desktop can load Preflight as an MCP server, but it has no such hook mechanism — see [ADAPTERS.md](https://newrelic-experimental.github.io/preflight/adapters/) for how visibility tiers work across platforms. Without hooks, none of Desktop's built-in tool calls are ever reported to Preflight, so there's nothing for the dashboard to show.
 
-**Fix:** none — this is a platform limitation, not a bug. Use one of the platforms listed under [Works With](../README.md#works-with) (Claude Code, Cursor, Windsurf, GitHub Copilot, Zed, Continue.dev, Amazon Q Developer, Amazon Kiro) for automatic capture.
+**Fix:** none — this is a platform limitation, not a bug. Use one of the platforms listed under [Works With](../README.md#works-with) for automatic capture.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/newrelic-experimental/preflight/issues"
   },
-  "description": "New Relic MCP server for observing AI coding assistants (Claude Code, Cursor, Copilot, etc.)",
+  "description": "New Relic MCP server for observing AI coding assistants (Claude Code, Cursor, Windsurf, Copilot, Codex, and more)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -54,5 +54,5 @@ See the [Advanced Configuration](/preflight/advanced/) page for alerts, OTLP exp
 ## Requirements
 
 - **Node.js v22 or higher**
-- **An AI coding tool** (Claude Code recommended for deepest integration)
+- **An AI coding tool** — see [Platform Adapters](/preflight/adapters/) for every supported tool; Claude Code has the deepest integration
 - **New Relic account** — only for `cloud`/`both` mode

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -2,7 +2,7 @@ name: newrelic-preflight
 description: >-
   AI coding observability for Claude Code. Tracks tool calls, cost,
   anti-patterns, and efficiency metrics — and ships them to New Relic.
-  Works across Claude Code, Cursor, Windsurf, and 6 other platforms.
+  Works across Claude Code, Cursor, Windsurf, Codex, Copilot, and more.
 
 startCommand:
   type: stdio

--- a/test/platform-docs.test.ts
+++ b/test/platform-docs.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createDefaultRegistry } from '../src/platforms/platform-registry.js';
+
+const repoRoot = resolve(__dirname, '..');
+
+const adaptersContent = readFileSync(resolve(repoRoot, 'docs/ADAPTERS.md'), 'utf-8');
+const readmeContent = readFileSync(resolve(repoRoot, 'README.md'), 'utf-8');
+const landingContent = readFileSync(resolve(repoRoot, 'site/src/landing.ts'), 'utf-8');
+
+interface PlatformSection {
+  readonly displayName: string;
+  readonly platformName: string;
+}
+
+function parsePlatformSections(): PlatformSection[] {
+  return Array.from(adaptersContent.matchAll(/^## (.+?)\s*\(`([^`]+)`\)$/gm), (m) => ({
+    displayName: m[1],
+    platformName: m[2],
+  }));
+}
+
+function slug(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9 -]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+describe('Platform documentation consistency', () => {
+  const platformSections = parsePlatformSections();
+  const registry = createDefaultRegistry();
+  const registeredAdapters = registry.getRegistered();
+
+  it('every registered adapter has a section in ADAPTERS.md', () => {
+    const registeredNames = new Set(registeredAdapters.map((a) => a.platformName));
+    const docNames = new Set(platformSections.map((s) => s.platformName));
+
+    expect(registeredNames).toEqual(docNames);
+  });
+
+  it('README Works With section lists all named platforms', () => {
+    const namedPlatforms = platformSections.filter((s) => s.platformName !== 'generic-mcp');
+
+    const worksWithSection =
+      readmeContent.match(/## Works With\n\n(.+?)\n\n(?:---|\n##)/s)?.[1] || '';
+
+    const displayNames = namedPlatforms.map((s) => s.displayName);
+
+    for (const displayName of displayNames) {
+      expect(worksWithSection).toContain(displayName);
+    }
+  });
+
+  it('every anchor in landing.ts matches a platform and all platforms are represented', () => {
+    const anchors = new Set(
+      Array.from(landingContent.matchAll(/anchor:\s*'([^']+)'/g), (m) => m[1]),
+    );
+
+    const expectedAnchors = new Set(
+      platformSections.map((s) => slug(`${s.displayName} ${s.platformName}`)),
+    );
+
+    expect(anchors).toEqual(expectedAnchors);
+  });
+});


### PR DESCRIPTION
Fixes #646

## Why

Preflight has shipped an OpenAI Codex adapter since v1.10.0, but the README "Works With" line still named the original eight platforms. Codex, Droid, Gemini CLI, Cline, opencode, Kilo Code, Pi, Antigravity, and the two extra Copilot adapters were invisible to anyone who reads the README or the npm page. Four other hand-maintained lists repeated the same stale eight. Nothing tied those lists to the adapter registry, so the drift went unnoticed.

## Scope

- `README.md`: the Works With line now names all 18 platform adapters with the display names ADAPTERS.md uses, and the MCP-only caveat adds Cline.
- `docs/TROUBLESHOOTING.md`: the Claude Desktop entry links to Works With instead of repeating a platform list.
- `CONTRIBUTING.md`: the `platforms/` tree comment points at ADAPTERS.md instead of counting adapters.
- `smithery.yaml` and `package.json`: the descriptions name Codex.
- `site/src/content/docs/getting-started.mdx`: the requirements entry links to the Platform Adapters page.
- `test/platform-docs.test.ts` (new): asserts the registry, the ADAPTERS.md headings, the README Works With line, and the landing page anchors in `site/src/landing.ts` all name the same platforms.

Out of scope: the landing page and `site/public/start.md` already named Codex and are unchanged.

## Tradeoffs

The display names live in ADAPTERS.md headings, not on the adapter classes. The test parses those headings rather than adding a `displayName` field to `PlatformAdapter`, which would touch all 18 adapters for a docs fix. That field is the right follow-up if the site table is ever generated from code.

## Blast Radius

Docs, two package descriptions, and one new test. No runtime code changes. The test fails CI whenever a new adapter is registered without an ADAPTERS.md section, a README entry, or a landing page anchor.

## Verification

- `npx jest test/platform-docs.test.ts`: 3 passed.
- Mutation check: removing `**OpenAI Codex**` from the README fails the Works With test; renaming the Codex anchor in `landing.ts` fails the anchor test. Both restored.
- `npm test`: full suite green.
- `npm run lint`: 0 errors, 0 warnings. `prettier --check` clean on every touched file.
- `astro build` in `site/`: succeeds, and the built Getting Started page contains the new Platform Adapters link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1qcXsqNsQWEevdqT2i7zt
