### PR TITLE
Add pull_request CI workflow (build, test, lint, drift checks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,17 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # The suite has an implicit, undocumented dependency on running under
+  # America/New_York (several date/bucket tests construct fixtures from
+  # local-midnight helpers without pinning TZ themselves) — it has only
+  # ever been run on developer machines defaulting to that zone. GitHub
+  # Actions runners default to UTC, which breaks those tests. Pin to the
+  # zone the suite actually assumes rather than debugging each test's
+  # local-time math; the individual tests remain non-portable and are a
+  # separate follow-up.
+  TZ: America/New_York
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -34,11 +45,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test
-        run: npm test
-
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm test
 
       - name: Check docs/code inventory drift
         run: npm run check:docs-inventory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+# Runs the checks a contributor is expected to run locally before opening a
+# PR (per CLAUDE.md: `npm run build && npm test`), plus lint and the two
+# drift-checker scripts that otherwise never run automatically:
+# check-docs-inventory.ts (docs/code drift) and check-bundle-size.ts (SPA
+# bundle budget, mirrors verify:plugin-hook's already-enforced pattern in
+# release.yml).
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Check docs/code inventory drift
+        run: npm run check:docs-inventory
+
+      - name: Check SPA bundle size
+        run: npm run check:bundle-size


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`, triggered on `pull_request` — previously no workflow in this repo ran on PRs at all; the checks visible on PRs (CodeQL, CLA) come from GitHub-managed apps, not a workflow here.
- Runs `npm run lint`, `npm test`, `npm run build`, plus two existing drift-checker scripts that currently never run automatically anywhere in CI:
  - `check-docs-inventory.ts` — flags emitted event types/metrics undocumented in `docs/METRICS_TABLE.md`/`PRIVACY.md` (or documented ones with no matching code)
  - `check-bundle-size.ts` — fails if the SPA bundle exceeds its 400KB gzip budget, same pattern already enforced for `verify:plugin-hook` in `release.yml`
- `concurrency` cancels superseded runs on the same PR/ref.

## Test plan
- [x] Verified locally against current `main`: `npm run build`, `npm test` (6844 passed), `npm run lint`, `npm run check:docs-inventory`, and `npm run check:bundle-size` all pass clean
- [x] Validated workflow YAML syntax with `js-yaml`
- [ ] Confirm the workflow itself runs green once this PR is opened (self-validating — it will check itself)

Closes #643
