### PR TITLE
Fix #621: separator-agnostic alerts.rulesPath containment check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **On Windows, `alerts.rulesPath` validation rejected every path — including the default one — because the containment check hardcoded `/` as the path separator, and `path.resolve()` returns backslash-separated paths on Windows.** This logged a spurious warning on every server start (`preflight doctor` included) and silently discarded any custom `alerts.rulesPath` set via config file or `NR_AI_ALERTS_RULES_PATH`, reverting it to the default. The check now uses `path.relative()` + `path.isAbsolute()`, which is separator-agnostic — the same fix applied to `static-handler.ts` for the identical bug class in #24.
+- **On Windows, `alerts.rulesPath` validation rejected every path — including the default one — because the containment check hardcoded `/` as the path separator, and `path.resolve()` returns backslash-separated paths on Windows.** This logged a spurious warning on every server start (`preflight doctor` included) and silently discarded any custom `alerts.rulesPath` set via config file or `NR_AI_ALERTS_RULES_PATH`, reverting it to the default. The check now uses `path.relative()` + `path.isAbsolute()`, which is separator-agnostic — the same fix already applied to `static-handler.ts` for the identical bug class.
 
 ## [1.50.3] - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.50.2] - 2026-09-10
+
+### Fixed
+
+- **On Windows, `alerts.rulesPath` validation rejected every path — including the default one — because the containment check hardcoded `/` as the path separator, and `path.resolve()` returns backslash-separated paths on Windows.** This logged a spurious warning on every server start (`preflight doctor` included) and silently discarded any custom `alerts.rulesPath` set via config file or `NR_AI_ALERTS_RULES_PATH`, reverting it to the default. The check now uses `path.relative()` + `path.isAbsolute()`, which is separator-agnostic — the same fix applied to `static-handler.ts` for the identical bug class in #24.
+
 ## [1.50.1] - 2026-09-10
 
 ### Fixed

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "description": "AI coding observability for Kiro. Tracks tool calls, cost, anti-patterns, and efficiency metrics — and (optionally) ships them to New Relic.",
   "author": {
     "name": "New Relic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.50.1",
+      "version": "1.50.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.50.1",
+  "version": "1.50.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.50.1",
+      "version": "1.50.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { resolve, relative, isAbsolute } from 'node:path';
 import { homedir } from 'node:os';
 import { z } from 'zod';
 import { createLogger } from './shared/index.js';
@@ -517,10 +517,12 @@ function validateRulesPath(rawPath: string, storagePath: string): string {
   }
   const resolved = resolve(rawPath);
   const storageResolved = resolve(storagePath);
-  // Match prefix only on full path segments to avoid `/foo/bar` matching
-  // `/foo/barbaz`.
-  const prefix = storageResolved.endsWith('/') ? storageResolved : storageResolved + '/';
-  if (resolved !== storageResolved && !resolved.startsWith(prefix)) {
+  // path.relative() + isAbsolute() is separator-agnostic (see static-handler.ts,
+  // fixed for the same bug class in #24) — a hand-rolled prefix check hardcodes
+  // '/' and silently fails every containment check on Windows, where resolve()
+  // returns backslash-separated paths.
+  const rel = relative(storageResolved, resolved);
+  if (rel.startsWith('..') || isAbsolute(rel)) {
     logger.warn('alerts.rulesPath resolves outside storagePath — falling back to default', {
       rawPath,
       resolved,

--- a/src/config.ts
+++ b/src/config.ts
@@ -518,7 +518,7 @@ function validateRulesPath(rawPath: string, storagePath: string): string {
   const resolved = resolve(rawPath);
   const storageResolved = resolve(storagePath);
   // path.relative() + isAbsolute() is separator-agnostic (see static-handler.ts,
-  // fixed for the same bug class in #24) — a hand-rolled prefix check hardcodes
+  // fixed for the same bug class) — a hand-rolled prefix check hardcodes
   // '/' and silently fails every containment check on Windows, where resolve()
   // returns backslash-separated paths.
   const rel = relative(storageResolved, resolved);

--- a/src/config.windows-sep.test.ts
+++ b/src/config.windows-sep.test.ts
@@ -2,7 +2,7 @@ import { win32 } from 'node:path';
 
 // validateRulesPath's containment check (src/config.ts) delegates entirely to
 // path.relative()/isAbsolute() rather than hand-rolled separator matching —
-// see static-handler.windows-sep.test.ts for the identical rationale (#24).
+// see static-handler.windows-sep.test.ts for the identical rationale.
 // This pins Node's own path.win32 behavior for the exact shapes that check
 // relies on, so a future Node behavior change here would be caught rather
 // than silently relied upon.

--- a/src/config.windows-sep.test.ts
+++ b/src/config.windows-sep.test.ts
@@ -1,0 +1,32 @@
+import { win32 } from 'node:path';
+
+// validateRulesPath's containment check (src/config.ts) delegates entirely to
+// path.relative()/isAbsolute() rather than hand-rolled separator matching —
+// see static-handler.windows-sep.test.ts for the identical rationale (#24).
+// This pins Node's own path.win32 behavior for the exact shapes that check
+// relies on, so a future Node behavior change here would be caught rather
+// than silently relied upon.
+describe('path.win32 containment behavior for alerts.rulesPath (pins Node, not our code)', () => {
+  it('accepts the default rules path under storagePath', () => {
+    const storageResolved = win32.resolve('C:\\Users\\dev\\.newrelic-preflight');
+    const resolved = win32.resolve(storageResolved, 'alerts', 'rules.json');
+    const rel = win32.relative(storageResolved, resolved);
+    expect(rel.startsWith('..')).toBe(false);
+    expect(win32.isAbsolute(rel)).toBe(false);
+  });
+
+  it('accepts a custom rules path nested under storagePath', () => {
+    const storageResolved = win32.resolve('C:\\Users\\dev\\.newrelic-preflight');
+    const resolved = win32.resolve(storageResolved, 'custom', 'my-rules.json');
+    const rel = win32.relative(storageResolved, resolved);
+    expect(rel.startsWith('..')).toBe(false);
+    expect(win32.isAbsolute(rel)).toBe(false);
+  });
+
+  it('rejects a sibling directory that merely shares a prefix', () => {
+    const storageResolved = win32.resolve('C:\\Users\\dev\\.newrelic-preflight');
+    const resolved = win32.resolve('C:\\Users\\dev\\.newrelic-preflight-evil', 'rules.json');
+    const rel = win32.relative(storageResolved, resolved);
+    expect(rel.startsWith('..')).toBe(true);
+  });
+});


### PR DESCRIPTION
> Replaces #637, which was blocked by the CLA check because its single commit was authored as `Test User <test@test.local>`. Same diff, same tree (`git diff` between the two heads is empty); only the commit author changed.

## Summary

On Windows, `validateRulesPath()` in `src/config.ts` hardcoded `/` when building the containment-check prefix. Since `path.resolve()` returns backslash-separated paths on Windows, the check never matched — every `alerts.rulesPath`, including the default, was rejected and silently replaced with the fallback. This logged a spurious warning on every server start (`preflight doctor` included), and any custom path set via `alerts.rulesPath` in `config.json` or `NR_AI_ALERTS_RULES_PATH` was silently reverted to the default even when it lived inside `storagePath`.

This is the same bug class as #24 (`static-handler.ts` path containment), just in a different file, as the issue points out.

## Fix

Replaced the hand-rolled prefix match with `path.relative()` + `isAbsolute()` — the same separator-agnostic pattern already used in `static-handler.ts` for #24. This also drops the now-redundant `resolved !== storageResolved` special case, since `relative()` already returns `''` for equal paths.

## Verification

Reproduced the exact mechanism using `path.win32` (no Windows machine needed — Node's `win32`/`posix` path submodules simulate either platform's path semantics deterministically):

- **Before fix:** default Windows rules path (`C:\Users\me\.newrelic-preflight\alerts\rules.json` under storage root `C:\Users\me\.newrelic-preflight`) is rejected — reproduces the reported bug exactly.
- **After fix:** same default path is accepted, a custom nested path under storage root is accepted, and a sibling-prefix escape attempt (`...preflight-evil\rules.json`) is still correctly rejected — on both simulated Windows and native POSIX.

Added `src/config.windows-sep.test.ts`, mirroring the existing `static-handler.windows-sep.test.ts` precedent: it pins the `path.win32.relative`/`isAbsolute` primitive behavior the fix now relies on for the three relevant shapes (default path, nested custom path, sibling escape), since there's no separator-hardcoded logic of our own left to unit-test in isolation once the fix delegates entirely to those primitives — same rationale as the precedent file.

A true failing-then-passing Jest test isn't cheaply achievable here without either injecting the path module (over-engineering relative to the rest of the codebase, which doesn't do this either) or running on an actual Windows machine — this codebase's own precedent for the identical bug class settled the same way.

### Test plan

- [x] `npx tsc -b .` — clean build
- [x] `npx jest -- src/config.test.ts src/config.windows-sep.test.ts` — 263 passed (existing rulesPath tests unaffected, 3 new pinning tests pass)
- [x] `npm run lint` — 0 errors/warnings
- [x] `npm run build && npm test` — full suite, 6847 passed, 0 failed
- [x] Pre-push hook (full test suite + plugin-hook bundle verification) — passed

Fixes #621.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsNz5NEzDEPVdZRQQKtsFh
