### PR TITLE
Fix: recognize named subagent-transcript ids in AGENT_ID_RE

### DIFF
--- a/src/dashboard/subagent-timeline-store.test.ts
+++ b/src/dashboard/subagent-timeline-store.test.ts
@@ -97,6 +97,23 @@ describe('SubagentTimelineStore', () => {
     expect(result.window.endMs).toBe(agent.endMs);
   });
 
+  it('includes a named-subagent transcript (Agent tool `name` param spawn shape)', () => {
+    // Claude Code writes `agent-a<name>-<16-hex>.jsonl` for a subagent spawned
+    // with an explicit `name` param — distinct from the plain `a<16-hex>` shape
+    // used by anonymous Task spawns (AGENT_A/AGENT_B/WF_AGENT above).
+    const namedAgentId = 'aconfluence-istio-investigator-ca0143b626a86424';
+    writeFileSync(
+      join(subDir, `agent-${namedAgentId}.jsonl`),
+      assistantLine({ timestamp: '2026-06-16T12:00:00.000Z', input: 10, output: 5 }) + '\n',
+    );
+
+    const store = new SubagentTimelineStore({ projectsDir });
+    const result = store.getSubagentsForSession(SESSION);
+
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0]!.agentId).toBe(namedAgentId);
+  });
+
   it('dedups streaming-duplicate lines sharing one message.id (counts the turn once)', () => {
     // Claude Code logs one JSONL line per streaming snapshot of a single
     // assistant turn — same message.id, byte-identical per-prompt usage

--- a/src/dashboard/subagent-timeline-store.ts
+++ b/src/dashboard/subagent-timeline-store.ts
@@ -36,6 +36,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import { calculateCost, createLogger, type TokenUsage } from '../shared/index.js';
+import { AGENT_ID_RE } from '../lib/agent-id.js';
 import { findWorkflowScriptPath, WorkflowStore } from './workflow-store.js';
 import { parseWorkflowScript, type DeclaredTopology } from '../hooks/workflow-script-parser.js';
 import type {
@@ -47,13 +48,8 @@ import type {
 const logger = createLogger('subagent-timeline-store');
 
 const SESSION_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/;
-/**
- * A valid agentId is either the plain `a<16-hex>` shape (anonymous Task
- * spawn) or `a<name>-<16-hex>` (a subagent spawned with an explicit `name`
- * via `Agent({name: ...})`, addressable later via SendMessage) — `<name>`
- * may itself contain hyphens.
- */
-const AGENT_ID_RE = /^a(?:[A-Za-z0-9_-]{1,64}-)?[a-f0-9]{16}$/;
+// AGENT_ID_RE imported from ../lib/agent-id.js — see its doc comment for the
+// two valid agentId shapes.
 const WORKFLOW_RUN_ID_RE = /^wf_[A-Za-z0-9_-]{1,128}$/;
 const PROJECTS_DIR_NAME = '.claude/projects';
 

--- a/src/dashboard/subagent-timeline-store.ts
+++ b/src/dashboard/subagent-timeline-store.ts
@@ -47,7 +47,13 @@ import type {
 const logger = createLogger('subagent-timeline-store');
 
 const SESSION_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/;
-const AGENT_ID_RE = /^a[a-f0-9]{16}$/;
+/**
+ * A valid agentId is either the plain `a<16-hex>` shape (anonymous Task
+ * spawn) or `a<name>-<16-hex>` (a subagent spawned with an explicit `name`
+ * via `Agent({name: ...})`, addressable later via SendMessage) — `<name>`
+ * may itself contain hyphens.
+ */
+const AGENT_ID_RE = /^a(?:[A-Za-z0-9_-]{1,64}-)?[a-f0-9]{16}$/;
 const WORKFLOW_RUN_ID_RE = /^wf_[A-Za-z0-9_-]{1,128}$/;
 const PROJECTS_DIR_NAME = '.claude/projects';
 

--- a/src/hooks/subagent-watcher.test.ts
+++ b/src/hooks/subagent-watcher.test.ts
@@ -659,6 +659,71 @@ describe('SubagentWatcher', () => {
     expect(healthEvents).toHaveLength(1);
   });
 
+  it('discovers and processes a named subagent transcript (Agent tool `name` param)', () => {
+    // Claude Code writes `agent-a<name>-<16-hex>.jsonl` for a subagent spawned
+    // with an explicit `name` (Agent tool `name` param, addressable later via
+    // SendMessage) — distinct from the plain `agent-a<16-hex>.jsonl` shape used
+    // by anonymous Task spawns.
+    const namedAgentId = 'aconfluence-istio-investigator-ca0143b626a86424';
+    const namedFile = join(sessionDir, 'subagents', `agent-${namedAgentId}.jsonl`);
+    writeFileSync(namedFile, makeAssistantLine({ messageId: 'msg_named' }) + '\n');
+    const watcher = new SubagentWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+    watcher.poll();
+    const bufPath = join(storagePath, `buffer-${PARENT_SESSION}.jsonl`);
+    const lines = readFileSync(bufPath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+    const healthEvents = lines.filter(
+      (l) => l.mode === 'observability_health' && l.event === 'discovery_skipped',
+    );
+    expect(healthEvents).toHaveLength(0);
+    const tokenLines = lines.filter((l) => l.mode === 'subagent_token');
+    expect(tokenLines).toHaveLength(1);
+    expect(tokenLines[0]).toMatchObject({
+      mode: 'subagent_token',
+      sessionId: PARENT_SESSION,
+      agentId: namedAgentId,
+      messageId: 'msg_named',
+    });
+  });
+
+  it('discovers and processes a named subagent transcript under a workflow run dir', () => {
+    const namedAgentId = 'aconfluence-istio-investigator-ca0143b626a86424';
+    const wfDir = join(sessionDir, 'subagents', 'workflows', 'wf_abc12345-6dd');
+    mkdirSync(wfDir, { recursive: true });
+    const namedFile = join(wfDir, `agent-${namedAgentId}.jsonl`);
+    writeFileSync(namedFile, makeAssistantLine({ messageId: 'msg_named_wf' }) + '\n');
+    const watcher = new SubagentWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+    watcher.poll();
+    const bufPath = join(storagePath, `buffer-${PARENT_SESSION}.jsonl`);
+    const lines = readFileSync(bufPath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+    const healthEvents = lines.filter(
+      (l) => l.mode === 'observability_health' && l.event === 'discovery_skipped',
+    );
+    expect(healthEvents).toHaveLength(0);
+    const tokenLines = lines.filter((l) => l.mode === 'subagent_token');
+    expect(tokenLines).toHaveLength(1);
+    expect(tokenLines[0]).toMatchObject({
+      mode: 'subagent_token',
+      sessionId: PARENT_SESSION,
+      agentId: namedAgentId,
+      workflowRunId: 'wf_abc12345-6dd',
+      messageId: 'msg_named_wf',
+    });
+  });
+
   // -------------------------------------------------------------------------
   // Memory-bound regression tests (OOM fix)
   //

--- a/src/hooks/subagent-watcher.ts
+++ b/src/hooks/subagent-watcher.ts
@@ -76,7 +76,13 @@ const HEALTH_INTERVAL_MS = 60_000;
 const SCHEMA_FINGERPRINT_REEMIT_MS = 60 * 60 * 1000; // 1h
 const COST_SELF_CHECK_MS = 60 * 60 * 1000; // 1h
 const SESSION_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/;
-const AGENT_ID_RE = /^a[a-f0-9]{16}$/;
+/**
+ * A valid agentId is either the plain `a<16-hex>` shape (anonymous Task
+ * spawn) or `a<name>-<16-hex>` (a subagent spawned with an explicit `name`
+ * via `Agent({name: ...})`, addressable later via SendMessage) — `<name>`
+ * may itself contain hyphens.
+ */
+const AGENT_ID_RE = /^a(?:[A-Za-z0-9_-]{1,64}-)?[a-f0-9]{16}$/;
 const PROJECTS_DIR_NAME = '.claude/projects';
 
 // ---------------------------------------------------------------------------
@@ -267,8 +273,9 @@ export class SubagentWatcher {
   // Files that already emitted `discovery_skipped` so we don't re-emit on
   // every poll for the same too-old file.
   private readonly discoverySkippedAnnounced = new Set<string>();
-  // Files shaped like `agent-*.jsonl` whose id doesn't match AGENT_ID_RE that
-  // already emitted `discovery_skipped`, so we don't re-emit on every poll.
+  // Files shaped like `agent-*.jsonl` whose id doesn't match AGENT_ID_RE (see
+  // AGENT_ID_RE's doc comment for the two valid shapes) that already emitted
+  // `discovery_skipped`, so we don't re-emit on every poll.
   private readonly agentIdMismatchAnnounced = new Set<string>();
   private lastCostSelfCheckMs = 0;
 

--- a/src/hooks/subagent-watcher.ts
+++ b/src/hooks/subagent-watcher.ts
@@ -43,6 +43,7 @@ import { createHash } from 'node:crypto';
 import { StringDecoder } from 'node:string_decoder';
 
 import { createLogger } from '../shared/index.js';
+import { AGENT_ID_RE } from '../lib/agent-id.js';
 import type { LocalStore } from '../storage/local-store.js';
 import type { RawTranscriptEntry, RawAssistantMessage, RawUsage } from './transcript-types.js';
 
@@ -76,13 +77,8 @@ const HEALTH_INTERVAL_MS = 60_000;
 const SCHEMA_FINGERPRINT_REEMIT_MS = 60 * 60 * 1000; // 1h
 const COST_SELF_CHECK_MS = 60 * 60 * 1000; // 1h
 const SESSION_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/;
-/**
- * A valid agentId is either the plain `a<16-hex>` shape (anonymous Task
- * spawn) or `a<name>-<16-hex>` (a subagent spawned with an explicit `name`
- * via `Agent({name: ...})`, addressable later via SendMessage) — `<name>`
- * may itself contain hyphens.
- */
-const AGENT_ID_RE = /^a(?:[A-Za-z0-9_-]{1,64}-)?[a-f0-9]{16}$/;
+// AGENT_ID_RE imported from ../lib/agent-id.js — see its doc comment for the
+// two valid agentId shapes.
 const PROJECTS_DIR_NAME = '.claude/projects';
 
 // ---------------------------------------------------------------------------

--- a/src/lib/agent-id.test.ts
+++ b/src/lib/agent-id.test.ts
@@ -1,0 +1,33 @@
+import { AGENT_ID_PATTERN, AGENT_ID_RE } from './agent-id.js';
+
+describe('AGENT_ID_RE', () => {
+  it('matches the plain anonymous-spawn shape', () => {
+    expect(AGENT_ID_RE.test('a1234567890abcde0')).toBe(true);
+  });
+
+  it('matches a named-subagent shape with hyphens in the name', () => {
+    expect(AGENT_ID_RE.test('aconfluence-istio-investigator-ca0143b626a86424')).toBe(true);
+    expect(AGENT_ID_RE.test('agithub-istio-investigator-2d4a726239ab8e6c')).toBe(true);
+  });
+
+  it('rejects an id that does not start with "a"', () => {
+    expect(AGENT_ID_RE.test('not-a-valid-id')).toBe(false);
+  });
+
+  it('rejects a hex suffix shorter or longer than 16 characters', () => {
+    expect(AGENT_ID_RE.test('a1234567890abcd')).toBe(false); // 15 hex chars
+    expect(AGENT_ID_RE.test('a1234567890abcde01')).toBe(false); // 17 hex chars
+  });
+
+  it('rejects a name segment containing non-hex-suffix-terminated garbage', () => {
+    expect(AGENT_ID_RE.test('asome-name-not-ending-in-hex')).toBe(false);
+  });
+});
+
+describe('AGENT_ID_PATTERN', () => {
+  it('can be embedded, unanchored, inside a larger regex', () => {
+    const re = new RegExp(`^prefix-(${AGENT_ID_PATTERN})-suffix$`);
+    const match = re.exec('prefix-aconfluence-istio-investigator-ca0143b626a86424-suffix');
+    expect(match?.[1]).toBe('aconfluence-istio-investigator-ca0143b626a86424');
+  });
+});

--- a/src/lib/agent-id.ts
+++ b/src/lib/agent-id.ts
@@ -1,0 +1,28 @@
+/**
+ * Shape of a Claude Code subagent-transcript agent id, as it appears in
+ * `agent-<agentId>.jsonl` filenames under
+ * `~/.claude/projects/<slug>/<sessionId>/subagents/`.
+ *
+ * A valid agentId is either:
+ *  - `a<16-hex>` — an anonymous `Task`/`Agent` spawn, or
+ *  - `a<name>-<16-hex>` — a subagent spawned with an explicit `name` (the
+ *    `Agent` tool's `name` param, addressable later via SendMessage);
+ *    `<name>` may itself contain hyphens.
+ *
+ * `subagent-watcher.ts` (transcript discovery/tailing), `subagent-timeline-
+ * store.ts` (dashboard's independent re-parse for the timeline panel and
+ * cost self-check), and `local-store.ts` (`SUBAGENT_CURSOR_RE`, cursor-file
+ * GC) all need to agree on this shape — they describe one external contract
+ * (Claude Code's own naming scheme), not three independently-tailored
+ * validation rules, so the pattern lives here once rather than being
+ * hand-copied into each.
+ *
+ * Exported as a source string (not a compiled RegExp) because callers embed
+ * it differently: `AGENT_ID_RE` below anchors it standalone, while
+ * `local-store.ts` interpolates it, unanchored, as one capture group inside
+ * a larger cursor-filename pattern.
+ */
+export const AGENT_ID_PATTERN = 'a(?:[A-Za-z0-9_-]{1,64}-)?[a-f0-9]{16}';
+
+/** Anchored form of {@link AGENT_ID_PATTERN}, for validating a standalone agentId string. */
+export const AGENT_ID_RE = new RegExp(`^${AGENT_ID_PATTERN}$`);

--- a/src/storage/local-store.test.ts
+++ b/src/storage/local-store.test.ts
@@ -1238,6 +1238,39 @@ describe('LocalStore', () => {
       expect(existsSync(path)).toBe(false);
     });
 
+    it('deletes a dead-session subagent cursor for a named-subagent transcript (Agent tool `name` spawn) older than the discovery window', () => {
+      // Named subagents (spawned via Agent({name: ...})) produce cursor files
+      // shaped `.subagent-pos-<parentSessionId>-a<name>-<16-hex>` — the agentId
+      // segment itself contains hyphens, unlike the plain `a<16-hex>` shape.
+      mkdirSync(tmpDir, { recursive: true });
+      const namedAgentId = 'aconfluence-istio-investigator-ca0143b626a86424';
+      const path = makeCursorFile(
+        `.subagent-pos-${PARENT_SESSION}-${namedAgentId}`,
+        Date.now() - 48 * 60 * 60 * 1000,
+      );
+
+      const store = new LocalStore(tmpDir);
+      const result = store.gcWatcherCursors(new Set(), 24);
+
+      expect(result.subagentCursors).toBe(1);
+      expect(existsSync(path)).toBe(false);
+    });
+
+    it('preserves a live-session subagent cursor for a named-subagent transcript, regardless of mtime', () => {
+      mkdirSync(tmpDir, { recursive: true });
+      const namedAgentId = 'aconfluence-istio-investigator-ca0143b626a86424';
+      const path = makeCursorFile(
+        `.subagent-pos-${PARENT_SESSION}-${namedAgentId}`,
+        Date.now() - 48 * 60 * 60 * 1000,
+      );
+
+      const store = new LocalStore(tmpDir);
+      const result = store.gcWatcherCursors(new Set([PARENT_SESSION]), 24);
+
+      expect(result.subagentCursors).toBe(0);
+      expect(existsSync(path)).toBe(true);
+    });
+
     it('preserves a parent-transcript cursor whose session is live, regardless of mtime', () => {
       mkdirSync(tmpDir, { recursive: true });
       const path = makeCursorFile(

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -16,7 +16,17 @@ import type { HookEvent, AuditEntry } from './types.js';
 const logger = createLogger('local-store');
 
 const SESSION_ID_RE = /^[a-zA-Z0-9_-]{1,128}$/;
-const SUBAGENT_CURSOR_RE = /^\.subagent-pos-(.+)-(a[a-f0-9]{16})$/;
+/**
+ * Matches `.subagent-pos-<parentSessionId>-<agentId>` cursor filenames.
+ * Group 1 (parentSessionId) is pinned to the UUID shape (mirrors
+ * SubagentWatcher's SESSION_ID_RE) rather than a greedy `.+`, because group 2
+ * (agentId) can itself contain internal hyphens for a named-subagent spawn
+ * (`a<name>-<16-hex>`, via `Agent({name: ...})`) — a greedy `.+` combined with
+ * a strict `a[a-f0-9]{16}$` tail would no longer reliably separate the two
+ * groups once the agentId can contain its own hyphens.
+ */
+const SUBAGENT_CURSOR_RE =
+  /^\.subagent-pos-([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})-(a(?:[A-Za-z0-9_-]{1,64}-)?[a-f0-9]{16})$/;
 const TRANSCRIPT_CURSOR_RE = /^\.transcript-pos-(.+)$/;
 const PARENT_TRANSCRIPT_CURSOR_RE = /^\.parent-transcript-pos-(.+)$/;
 

--- a/src/storage/local-store.ts
+++ b/src/storage/local-store.ts
@@ -11,6 +11,7 @@ import {
 } from 'node:fs';
 import { resolve, sep } from 'node:path';
 import { createLogger } from '../shared/index.js';
+import { AGENT_ID_PATTERN } from '../lib/agent-id.js';
 import type { HookEvent, AuditEntry } from './types.js';
 
 const logger = createLogger('local-store');
@@ -20,13 +21,14 @@ const SESSION_ID_RE = /^[a-zA-Z0-9_-]{1,128}$/;
  * Matches `.subagent-pos-<parentSessionId>-<agentId>` cursor filenames.
  * Group 1 (parentSessionId) is pinned to the UUID shape (mirrors
  * SubagentWatcher's SESSION_ID_RE) rather than a greedy `.+`, because group 2
- * (agentId) can itself contain internal hyphens for a named-subagent spawn
- * (`a<name>-<16-hex>`, via `Agent({name: ...})`) — a greedy `.+` combined with
- * a strict `a[a-f0-9]{16}$` tail would no longer reliably separate the two
- * groups once the agentId can contain its own hyphens.
+ * (agentId, see ../lib/agent-id.js) can itself contain internal hyphens for a
+ * named-subagent spawn — a greedy `.+` paired with a strict agentId tail
+ * would no longer reliably separate the two groups once the agentId can
+ * contain its own hyphens.
  */
-const SUBAGENT_CURSOR_RE =
-  /^\.subagent-pos-([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})-(a(?:[A-Za-z0-9_-]{1,64}-)?[a-f0-9]{16})$/;
+const SUBAGENT_CURSOR_RE = new RegExp(
+  `^\\.subagent-pos-([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})-(${AGENT_ID_PATTERN})$`,
+);
 const TRANSCRIPT_CURSOR_RE = /^\.transcript-pos-(.+)$/;
 const PARENT_TRANSCRIPT_CURSOR_RE = /^\.parent-transcript-pos-(.+)$/;
 


### PR DESCRIPTION
## Summary
- Claude Code writes a named subagent's transcript as `agent-a<name>-<16-hex>.jsonl` (the `Agent` tool's `name` param — used for teammates addressable via `SendMessage`), not just the anonymous `agent-a<16-hex>.jsonl` shape.
- `AGENT_ID_RE = /^a[a-f0-9]{16}$/` only matched the anonymous shape, so `SubagentWatcher.discoverFiles()` silently skipped every named-subagent transcript, and its tokens never reached `CostTracker` — `subagentCostUsd` stayed `0` and named-agent models never appeared in a session's `modelBreakdown`, even though `agentSpawns` correctly counted them.
- Verified against a real session on disk (`istio envoy support status`): Preflight reported `estimatedCostUsd: $3.75`, `subagentCostUsd: 0`, `modelBreakdown` limited to `claude-sonnet-5` — while Claude Code's own `/usage` panel for the same session showed `claude-haiku-4-5` spend (~$1.40) from 3 named subagents. Their actual transcript files exist on disk with real haiku-4-5 usage; none of their agentIds matched the old regex.
- Same bug, weaker form, in two more spots: `subagent-timeline-store.ts` (dashboard's independent re-parse for the subagent timeline panel + `SubagentWatcher`'s cost self-check) has the identical `AGENT_ID_RE`, and `local-store.ts`'s `SUBAGENT_CURSOR_RE` (stale cursor-file GC) hand-derives the same pattern a third time — once the watcher starts writing cursor files for named agents, its old greedy-`.+` form can't parse the new filename shape either.
- Widened `AGENT_ID_RE` to `a<16-hex>` or `a<name>-<16-hex>` in all three places, then extracted the pattern into `src/lib/agent-id.ts` so the three copies (previously byte-for-byte duplicates of one external contract — Claude Code's own naming scheme) can't drift again.

## Test plan
- [x] `subagent-watcher.test.ts`: new tests confirm a named-agent transcript (ad-hoc and under a workflow run dir) is discovered/processed, not `discovery_skipped`
- [x] `subagent-timeline-store.test.ts`: new test confirms a named-agent transcript appears in `getSubagentsForSession`
- [x] `local-store.test.ts`: new tests confirm `gcWatcherCursors()` correctly deletes a stale named-agent cursor file and preserves a live one
- [x] `src/lib/agent-id.test.ts`: unit coverage for the extracted pattern (both shapes, embedded/unanchored usage)
- [x] Confirmed each new test fails against the pre-fix regex before applying the fix (see commit history: tests land before the fix)
- [x] Existing malformed-id tests (`agent-not-a-valid-id.jsonl`) still correctly rejected — verified explicitly, not just assumed
- [x] `npm run build && npm test && npm run lint` all clean (6859 tests passed, 0 errors/warnings)