### PR TITLE
Chore: v1.50.3 — bump version, sync manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.50.3] - 2026-09-10
+
+### Fixed
+
+- **The README's "Works With" list and the npm package description only named the original eight supported platforms** — Codex, Droid, Gemini CLI, Cline, opencode, Kilo Code, Pi, Antigravity, and the additional Copilot variants were shipped but invisible to anyone reading the docs or the npm listing. Both now reflect the full, current set of supported platforms, and a test now guards against the list drifting out of sync again.
+
 ## [1.50.2] - 2026-09-10
 
 ### Fixed

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.50.2",
+  "version": "1.50.3",
   "description": "AI coding observability for Kiro. Tracks tool calls, cost, anti-patterns, and efficiency metrics — and (optionally) ships them to New Relic.",
   "author": {
     "name": "New Relic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.50.2",
+  "version": "1.50.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.50.2",
+      "version": "1.50.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.50.2",
+  "version": "1.50.3",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.50.2",
+  "version": "1.50.3",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.50.2",
+  "version": "1.50.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.50.2",
+      "version": "1.50.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- #638 merged with an updated npm package `description` (now naming Windsurf and Codex instead of a truncated "etc." list, matching the README's now-complete "Works With" list) but shipped without a version bump or CHANGELOG entry.
- Catches that up: bumps `package.json`, `package-lock.json`, `server.json`, `plugin/.claude-plugin/plugin.json`, and `kiro-power/plugin.json` to `1.50.3`, and adds the missing CHANGELOG entry.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes: 201 suites, 6851 tests
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] All 5 version-tracking files consistent at `1.50.3`