### PR TITLE
Test: Freeze the clock in the end-of-day forecast anchoring test

### DIFF
--- a/src/tools/cost-tools.test.ts
+++ b/src/tools/cost-tools.test.ts
@@ -441,6 +441,20 @@ describe('handleGetBudgetStatus()', () => {
 
 describe('handleGetCostForecast()', () => {
   it('anchors the end-of-day forecast to getCostForDay()/getFirstActivityMsForDay(), not the full session spend', () => {
+    // Freeze the clock. The handler and the `expected` computation below each
+    // read Date.now() independently, and today's day-bucket anchor is only
+    // milliseconds old here, so the projected rate is dailySpend / (a few ms):
+    // even single-digit ms of drift between the two reads moves a five-figure
+    // end-of-day forecast past toBeCloseTo(…, 2). Seen failing on CI runners.
+    jest.useFakeTimers({ now: Date.now() });
+    try {
+      runAnchoredForecastCase();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  function runAnchoredForecastCase(): void {
     const tracker = new CostTracker();
 
     // Backdated (but within the 48h late-arrival window) so it inflates the
@@ -491,7 +505,7 @@ describe('handleGetCostForecast()', () => {
     // `body` given the huge backdated "yesterday" spend above.
     expect(body.forecastEndOfDayUsd).toBeCloseTo(expected.forecastEndOfDayUsd ?? 0, 2);
     expect(sessionTotalCostUsd).toBeGreaterThan(tracker.getCostForDay(todayKey));
-  });
+  }
 
   it('omits resumeContext when no sessionResumeTracker is passed', () => {
     const tracker = new CostTracker();


### PR DESCRIPTION
Fixes #652

## Summary

- `cost-tools.test.ts` › `handleGetCostForecast() › anchors the end-of-day forecast…` is timing-fragile: it computes its expected value with a second `Date.now()` read a few milliseconds after the handler's own read. Inside the test, today's day-bucket anchor is only milliseconds old, so the projected rate is `dailySpend / (a few ms)` and single-digit ms of drift moves a five-figure end-of-day forecast past `toBeCloseTo(…, 2)`.
- It failed on CI for #642 with `Expected: 52576.062 / Received: 52576.068` (difference 0.006 vs tolerance 0.005) while passing locally; the same suite passed on the next run. #638 hit one unexplained CI failure earlier today that fits the same pattern.
- Fix: wrap the case in `jest.useFakeTimers({ now: Date.now() })` with `useRealTimers()` in a `finally`, so the tracker, the handler, and the expected computation all see one instant. No production code changes. Test-only, no version bump.

## Test plan

- [x] `npx jest src/tools/cost-tools.test.ts`: 31 passed
- [x] `npx eslint` and `prettier --check` on the file: clean
- [x] Full suite via pre-push hook: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsNz5NEzDEPVdZRQQKtsFh