### PR TITLE
Refactor: unify duplicated subagent-transcript line parsing (#602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.50.6] - 2026-09-11
+
+### Changed
+
+- **The subagent-transcript token-usage watcher and the dashboard's subagent timeline no longer each re-implement their own JSONL line parser.** Both now share one parsing module for extracting an assistant turn's model, token usage, and schema-drift fingerprints from a transcript line. Each pipeline keeps its own existing acceptance policy (which fields are required) and output shape unchanged. No behavior change.
+
 ## [1.50.5] - 2026-09-11
 
 ### Fixed

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.50.5",
+  "version": "1.50.6",
   "description": "AI coding observability for Kiro. Tracks tool calls, cost, anti-patterns, and efficiency metrics — and (optionally) ships them to New Relic.",
   "author": {
     "name": "New Relic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.50.5",
+  "version": "1.50.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.50.5",
+      "version": "1.50.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.50.5",
+  "version": "1.50.6",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.50.5",
+  "version": "1.50.6",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.50.5",
+  "version": "1.50.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.50.5",
+      "version": "1.50.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/dashboard/subagent-timeline-store.test.ts
+++ b/src/dashboard/subagent-timeline-store.test.ts
@@ -272,6 +272,52 @@ describe('SubagentTimelineStore', () => {
     expect(result.agents[0]!.totalTokens).toBe(10 + 5 + 20 + 5);
   });
 
+  it('rejects a line with no timestamp field (no Date.now() fallback, unlike SubagentWatcher)', () => {
+    const lineWithNoTimestamp = JSON.stringify({
+      type: 'assistant',
+      uuid: 'u-no-ts',
+      message: {
+        id: 'msg-no-ts',
+        model: KNOWN_MODEL,
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    });
+    writeFileSync(
+      join(subDir, `agent-${AGENT_A}.jsonl`),
+      [
+        assistantLine({ timestamp: '2026-06-16T12:00:00.000Z', input: 20, output: 5 }),
+        lineWithNoTimestamp,
+      ].join('\n') + '\n',
+    );
+
+    const store = new SubagentTimelineStore({ projectsDir });
+    const result = store.getSubagentsForSession(SESSION);
+    expect(result.agents).toHaveLength(1);
+    // Only the line WITH a timestamp counts; the other is silently rejected.
+    expect(result.agents[0]!.turnCount).toBe(1);
+    expect(result.agents[0]!.totalTokens).toBe(20 + 5);
+  });
+
+  it('accepts a line with no model field, defaulting to "" (unlike SubagentWatcher, which rejects)', () => {
+    const lineWithNoModel = JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-06-16T12:00:00.000Z',
+      uuid: 'u-no-model',
+      message: {
+        id: 'msg-no-model',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    });
+    writeFileSync(join(subDir, `agent-${AGENT_A}.jsonl`), lineWithNoModel + '\n');
+
+    const store = new SubagentTimelineStore({ projectsDir });
+    const result = store.getSubagentsForSession(SESSION);
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0]!.turnCount).toBe(1);
+    expect(result.agents[0]!.model).toBe('');
+    expect(result.agents[0]!.totalTokens).toBe(10 + 5);
+  });
+
   it('skips files larger than the 64 MiB cap', () => {
     // Construct a >64 MiB file cheaply: one valid line, then pad with a giant
     // run of newlines so the byte size crosses the cap without huge memory.

--- a/src/dashboard/subagent-timeline-store.ts
+++ b/src/dashboard/subagent-timeline-store.ts
@@ -37,13 +37,10 @@ import { join } from 'node:path';
 
 import { calculateCost, createLogger, type TokenUsage } from '../shared/index.js';
 import { AGENT_ID_RE } from '../lib/agent-id.js';
+import { parseAssistantTurnLine } from '../lib/subagent-transcript-parser.js';
 import { findWorkflowScriptPath, WorkflowStore } from './workflow-store.js';
 import { parseWorkflowScript, type DeclaredTopology } from '../hooks/workflow-script-parser.js';
-import type {
-  RawTranscriptEntry,
-  RawAssistantMessage,
-  RawUsage,
-} from '../hooks/transcript-types.js';
+import type { RawTranscriptEntry, RawAssistantMessage } from '../hooks/transcript-types.js';
 
 const logger = createLogger('subagent-timeline-store');
 
@@ -907,21 +904,10 @@ interface AssistantTurn {
  * malformed or not an assistant turn with usage. Never throws.
  */
 function parseAssistantTurn(line: string): AssistantTurn | null {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(line);
-  } catch {
-    return null;
-  }
-  if (!parsed || typeof parsed !== 'object') return null;
-  const obj = parsed as RawTranscriptEntry;
-  if (obj.type !== 'assistant') return null;
+  const { fields } = parseAssistantTurnLine(line);
+  if (!fields) return null;
 
-  const message = obj.message;
-  if (!message || typeof message !== 'object') return null;
-  const m = message as RawAssistantMessage;
-
-  const model = typeof m.model === 'string' ? m.model : '';
+  const model = fields.model ?? '';
   // `<synthetic>` turns carry no real usage and no priceable model.
   if (model === '<synthetic>') return null;
 
@@ -931,30 +917,21 @@ function parseAssistantTurn(line: string): AssistantTurn | null {
   // snapshots can be deduped in parseTranscript — mirroring the cost path's
   // `${agentId}|${messageId}` dedup in event-processor.ts. Lines without an id
   // are skipped, exactly as the CostTracker feed (SubagentWatcher) skips them.
-  const messageId = typeof m.id === 'string' ? m.id : '';
+  const messageId = fields.messageId ?? '';
   if (messageId.length === 0) return null;
 
-  const usage = m.usage;
-  if (!usage || typeof usage !== 'object') return null;
-  const u = usage as RawUsage;
-
-  const tsRaw = typeof obj.timestamp === 'string' ? obj.timestamp : null;
-  const timestampMs = tsRaw ? Date.parse(tsRaw) : NaN;
+  const timestampMs = fields.rawTimestamp ? Date.parse(fields.rawTimestamp) : NaN;
   if (!Number.isFinite(timestampMs)) return null;
 
   return {
     messageId,
     timestampMs,
     model,
-    inputTokens: num(u.input_tokens),
-    outputTokens: num(u.output_tokens),
-    cacheReadTokens: num(u.cache_read_input_tokens),
-    cacheCreationTokens: num(u.cache_creation_input_tokens),
+    inputTokens: fields.inputTokens,
+    outputTokens: fields.outputTokens,
+    cacheReadTokens: fields.cacheReadTokens,
+    cacheCreationTokens: fields.cacheCreationTokens,
   };
-}
-
-function num(v: unknown): number {
-  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : 0;
 }
 
 /**

--- a/src/hooks/subagent-watcher.test.ts
+++ b/src/hooks/subagent-watcher.test.ts
@@ -391,6 +391,68 @@ describe('SubagentWatcher', () => {
     expect(tokenLines).toHaveLength(0);
   });
 
+  it('accepts a line with no timestamp field, defaulting to Date.now()', () => {
+    const before = Date.now();
+    const line = JSON.stringify({
+      type: 'assistant',
+      agentId: AGENT_ID,
+      uuid: 'u',
+      sessionId: PARENT_SESSION,
+      message: {
+        id: 'msg_no_ts',
+        model: 'claude-opus-4-7',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    });
+    writeFileSync(agentJsonl, line + '\n');
+    const watcher = new SubagentWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+    watcher.poll();
+    const after = Date.now();
+    const buf = readFileSync(join(storagePath, `buffer-${PARENT_SESSION}.jsonl`), 'utf-8');
+    const tokenLines = buf
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
+      .filter((l) => l.mode === 'subagent_token');
+    expect(tokenLines).toHaveLength(1);
+    expect(tokenLines[0].timestamp).toBeGreaterThanOrEqual(before);
+    expect(tokenLines[0].timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it('rejects a line with no model field (does not emit)', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      agentId: AGENT_ID,
+      uuid: 'u',
+      timestamp: '2026-06-15T12:00:00.000Z',
+      sessionId: PARENT_SESSION,
+      message: {
+        id: 'msg_no_model',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    });
+    writeFileSync(agentJsonl, line + '\n');
+    const watcher = new SubagentWatcher({
+      storagePath,
+      projectsDir,
+      parentSessionId: PARENT_SESSION,
+    });
+    watcher.poll();
+    const bufPath = join(storagePath, `buffer-${PARENT_SESSION}.jsonl`);
+    const tokenLines = !existsSync(bufPath)
+      ? []
+      : readFileSync(bufPath, 'utf-8')
+          .split('\n')
+          .filter(Boolean)
+          .map((l) => JSON.parse(l))
+          .filter((l) => l.mode === 'subagent_token');
+    expect(tokenLines).toHaveLength(0);
+  });
+
   it('extracts reasoning_tokens from output_tokens_details', () => {
     writeFileSync(agentJsonl, makeAssistantLine({ messageId: 'msg_r', reasoning: 750 }) + '\n');
     const watcher = new SubagentWatcher({

--- a/src/hooks/subagent-watcher.ts
+++ b/src/hooks/subagent-watcher.ts
@@ -39,13 +39,12 @@ import {
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { createHash } from 'node:crypto';
 import { StringDecoder } from 'node:string_decoder';
 
 import { createLogger } from '../shared/index.js';
 import { AGENT_ID_RE } from '../lib/agent-id.js';
+import { parseAssistantTurnLine } from '../lib/subagent-transcript-parser.js';
 import type { LocalStore } from '../storage/local-store.js';
-import type { RawTranscriptEntry, RawAssistantMessage, RawUsage } from './transcript-types.js';
 
 const logger = createLogger('subagent-watcher');
 
@@ -751,59 +750,34 @@ export class SubagentWatcher {
    * with usage. Sets parseErrors counter on JSON parse failures.
    */
   private tryParseLine(line: string, _file: DiscoveredFile): ParsedAssistantTurn | null {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
+    const { fields, invalidJson } = parseAssistantTurnLine(line);
+    if (invalidJson) {
       this.parseErrors += 1;
       return null;
     }
-    if (!parsed || typeof parsed !== 'object') return null;
-    const obj = parsed as RawTranscriptEntry;
-    if (obj.type !== 'assistant') return null;
-    const message = obj.message;
-    if (!message || typeof message !== 'object') return null;
-    const m = message as RawAssistantMessage;
-    const model = typeof m.model === 'string' ? m.model : null;
+    if (!fields) return null;
+
+    const model = fields.model;
     if (!model || model === '<synthetic>') return null;
-    const messageId = typeof m.id === 'string' ? m.id : null;
+    const messageId = fields.messageId;
     if (!messageId) return null;
-    const usage = m.usage;
-    if (!usage || typeof usage !== 'object') return null;
-    const u = usage as RawUsage;
 
-    const turnUuid = typeof obj.uuid === 'string' ? obj.uuid : '';
-    const tsRaw = typeof obj.timestamp === 'string' ? obj.timestamp : null;
-    const timestampMs = tsRaw ? Date.parse(tsRaw) : Date.now();
+    const timestampMs = fields.rawTimestamp ? Date.parse(fields.rawTimestamp) : Date.now();
     if (!Number.isFinite(timestampMs)) return null;
-
-    const inputTokens = num(u.input_tokens);
-    const outputTokens = num(u.output_tokens);
-    const cacheReadTokens = num(u.cache_read_input_tokens);
-    const cacheCreationTokens = num(u.cache_creation_input_tokens);
-    let reasoningTokens = 0;
-    const otd = u.output_tokens_details;
-    if (otd && typeof otd === 'object') {
-      reasoningTokens = num(otd.reasoning_tokens);
-    }
-    const stopReason = typeof m.stop_reason === 'string' ? m.stop_reason : null;
-
-    const usageKeysFingerprint = computeUsageKeysFingerprint(u);
-    const contentBlockTypesFingerprint = computeContentBlockTypesFingerprint(m.content);
 
     return {
       timestampMs,
       messageId,
-      turnUuid,
+      turnUuid: fields.turnUuid,
       model,
-      inputTokens,
-      outputTokens,
-      cacheReadTokens,
-      cacheCreationTokens,
-      reasoningTokens,
-      stopReason,
-      usageKeysFingerprint,
-      contentBlockTypesFingerprint,
+      inputTokens: fields.inputTokens,
+      outputTokens: fields.outputTokens,
+      cacheReadTokens: fields.cacheReadTokens,
+      cacheCreationTokens: fields.cacheCreationTokens,
+      reasoningTokens: fields.reasoningTokens,
+      stopReason: fields.stopReason,
+      usageKeysFingerprint: fields.usageKeysFingerprint,
+      contentBlockTypesFingerprint: fields.contentBlockTypesFingerprint,
     };
   }
 
@@ -1009,44 +983,6 @@ export class SubagentWatcher {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function num(v: unknown): number {
-  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : 0;
-}
-
-function computeUsageKeysFingerprint(usage: Record<string, unknown>): string {
-  const keys: string[] = [];
-  for (const k of Object.keys(usage).sort()) keys.push(k);
-  // Include child keys of `output_tokens_details` so reasoning-token drift
-  // produces a distinct fingerprint without inflating the dimension space.
-  const otd = usage.output_tokens_details;
-  if (otd && typeof otd === 'object') {
-    for (const k of Object.keys(otd as Record<string, unknown>).sort()) {
-      keys.push(`output_tokens_details.${k}`);
-    }
-  }
-  return shortHash(keys.join('|'));
-}
-
-function computeContentBlockTypesFingerprint(content: unknown): string {
-  if (!Array.isArray(content)) return shortHash('');
-  const set = new Set<string>();
-  for (const block of content) {
-    if (
-      block &&
-      typeof block === 'object' &&
-      typeof (block as { type?: unknown }).type === 'string'
-    ) {
-      set.add(String((block as { type: string }).type));
-    }
-  }
-  const sorted = Array.from(set).sort();
-  return shortHash(sorted.join('|'));
-}
-
-function shortHash(input: string): string {
-  return createHash('sha1').update(input).digest('hex').slice(0, 16);
-}
 
 /**
  * Stable cursor file path computation, exported for tests that want to

--- a/src/lib/subagent-transcript-parser.test.ts
+++ b/src/lib/subagent-transcript-parser.test.ts
@@ -162,6 +162,36 @@ describe('parseAssistantTurnLine', () => {
     expect(a).not.toBe(b);
   });
 
+  it('produces a different usageKeysFingerprint when an output_tokens_details child key changes', () => {
+    const withReasoning = JSON.stringify({
+      type: 'assistant',
+      uuid: 'u',
+      timestamp: '2026-06-15T12:00:00.000Z',
+      message: {
+        id: 'msg_otd',
+        model: 'claude-opus-4-7',
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+          output_tokens_details: { reasoning_tokens: 5 },
+        },
+      },
+    });
+    const withoutReasoning = JSON.stringify({
+      type: 'assistant',
+      uuid: 'u',
+      timestamp: '2026-06-15T12:00:00.000Z',
+      message: {
+        id: 'msg_otd2',
+        model: 'claude-opus-4-7',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    });
+    const a = parseAssistantTurnLine(withReasoning).fields?.usageKeysFingerprint;
+    const b = parseAssistantTurnLine(withoutReasoning).fields?.usageKeysFingerprint;
+    expect(a).not.toBe(b);
+  });
+
   it('produces different contentBlockTypesFingerprints for different content-block shapes', () => {
     const a = parseAssistantTurnLine(makeLine({})).fields?.contentBlockTypesFingerprint;
     const line2 = JSON.stringify({

--- a/src/lib/subagent-transcript-parser.test.ts
+++ b/src/lib/subagent-transcript-parser.test.ts
@@ -1,0 +1,195 @@
+import { parseAssistantTurnLine, num } from './subagent-transcript-parser.js';
+
+function makeLine(overrides: {
+  type?: string;
+  uuid?: string;
+  timestamp?: string | null;
+  message?: Record<string, unknown> | null;
+}): string {
+  const base = {
+    type: 'assistant',
+    uuid: 'turn-uuid-1',
+    timestamp: '2026-06-15T12:00:00.000Z',
+    message: {
+      id: 'msg_1',
+      model: 'claude-opus-4-7',
+      stop_reason: 'end_turn',
+      content: [{ type: 'text' }],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 1000,
+        cache_creation_input_tokens: 200,
+      },
+    },
+    ...overrides,
+  };
+  if (overrides.timestamp === null) delete (base as Record<string, unknown>).timestamp;
+  if (overrides.message === null) delete (base as Record<string, unknown>).message;
+  return JSON.stringify(base);
+}
+
+describe('parseAssistantTurnLine', () => {
+  it('extracts all fields from a well-formed assistant turn with usage', () => {
+    const { fields, invalidJson } = parseAssistantTurnLine(makeLine({}));
+    expect(invalidJson).toBe(false);
+    expect(fields).toEqual({
+      messageId: 'msg_1',
+      model: 'claude-opus-4-7',
+      turnUuid: 'turn-uuid-1',
+      rawTimestamp: '2026-06-15T12:00:00.000Z',
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 1000,
+      cacheCreationTokens: 200,
+      reasoningTokens: 0,
+      stopReason: 'end_turn',
+      usageKeysFingerprint: expect.any(String),
+      contentBlockTypesFingerprint: expect.any(String),
+    });
+  });
+
+  it('extracts reasoning_tokens from output_tokens_details', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      uuid: 'u',
+      timestamp: '2026-06-15T12:00:00.000Z',
+      message: {
+        id: 'msg_r',
+        model: 'claude-opus-4-7',
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+          output_tokens_details: { reasoning_tokens: 750 },
+        },
+      },
+    });
+    const { fields } = parseAssistantTurnLine(line);
+    expect(fields?.reasoningTokens).toBe(750);
+  });
+
+  it('flags invalidJson on malformed JSON, without throwing', () => {
+    const result = parseAssistantTurnLine('NOT_VALID_JSON{{{');
+    expect(result.invalidJson).toBe(true);
+    expect(result.fields).toBeNull();
+  });
+
+  it('returns fields:null, invalidJson:false for a non-assistant type', () => {
+    const line = JSON.stringify({ type: 'user', message: { id: 'x' } });
+    const result = parseAssistantTurnLine(line);
+    expect(result.fields).toBeNull();
+    expect(result.invalidJson).toBe(false);
+  });
+
+  it('returns fields:null for a missing message object', () => {
+    const line = JSON.stringify({ type: 'assistant' });
+    const result = parseAssistantTurnLine(line);
+    expect(result.fields).toBeNull();
+    expect(result.invalidJson).toBe(false);
+  });
+
+  it('returns fields:null for a missing/non-object usage', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { id: 'msg_1', model: 'claude-opus-4-7' },
+    });
+    const result = parseAssistantTurnLine(line);
+    expect(result.fields).toBeNull();
+  });
+
+  it('passes through model:null (not rejected) when model is missing', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { id: 'msg_1', usage: { input_tokens: 1, output_tokens: 1 } },
+    });
+    const { fields } = parseAssistantTurnLine(line);
+    expect(fields?.model).toBeNull();
+  });
+
+  it('passes through model:"<synthetic>" unfiltered (caller decides whether to reject)', () => {
+    const line = makeLine({
+      message: {
+        id: 'msg_1',
+        model: '<synthetic>',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    });
+    const { fields } = parseAssistantTurnLine(line);
+    expect(fields?.model).toBe('<synthetic>');
+  });
+
+  it('passes through messageId:null (not rejected) when message.id is missing', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { model: 'claude-opus-4-7', usage: { input_tokens: 1, output_tokens: 1 } },
+    });
+    const { fields } = parseAssistantTurnLine(line);
+    expect(fields?.messageId).toBeNull();
+  });
+
+  it('passes through rawTimestamp:null (not rejected) when timestamp is missing', () => {
+    const line = makeLine({ timestamp: null });
+    const { fields } = parseAssistantTurnLine(line);
+    expect(fields?.rawTimestamp).toBeNull();
+  });
+
+  it('defaults turnUuid to "" when uuid is missing', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_1',
+        model: 'claude-opus-4-7',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    });
+    const { fields } = parseAssistantTurnLine(line);
+    expect(fields?.turnUuid).toBe('');
+  });
+
+  it('produces different usageKeysFingerprints for different usage-key shapes', () => {
+    const a = parseAssistantTurnLine(makeLine({})).fields?.usageKeysFingerprint;
+    const line2 = JSON.stringify({
+      type: 'assistant',
+      uuid: 'u',
+      timestamp: '2026-06-15T12:00:00.000Z',
+      message: {
+        id: 'msg_2',
+        model: 'claude-opus-4-7',
+        usage: { input_tokens: 1, output_tokens: 1, brand_new_key: 5 },
+      },
+    });
+    const b = parseAssistantTurnLine(line2).fields?.usageKeysFingerprint;
+    expect(a).not.toBe(b);
+  });
+
+  it('produces different contentBlockTypesFingerprints for different content-block shapes', () => {
+    const a = parseAssistantTurnLine(makeLine({})).fields?.contentBlockTypesFingerprint;
+    const line2 = JSON.stringify({
+      type: 'assistant',
+      uuid: 'u',
+      timestamp: '2026-06-15T12:00:00.000Z',
+      message: {
+        id: 'msg_2',
+        model: 'claude-opus-4-7',
+        content: [{ type: 'tool_use' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    });
+    const b = parseAssistantTurnLine(line2).fields?.contentBlockTypesFingerprint;
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('num', () => {
+  it('returns 0 for non-numbers, NaN, and negatives', () => {
+    expect(num(undefined)).toBe(0);
+    expect(num('5')).toBe(0);
+    expect(num(NaN)).toBe(0);
+    expect(num(-1)).toBe(0);
+  });
+
+  it('returns the value for a finite non-negative number', () => {
+    expect(num(42)).toBe(42);
+    expect(num(0)).toBe(0);
+  });
+});

--- a/src/lib/subagent-transcript-parser.ts
+++ b/src/lib/subagent-transcript-parser.ts
@@ -1,0 +1,135 @@
+import { createHash } from 'node:crypto';
+
+import type {
+  RawTranscriptEntry,
+  RawAssistantMessage,
+  RawUsage,
+} from '../hooks/transcript-types.js';
+
+/**
+ * Field-level result of parsing one JSONL transcript line as an assistant
+ * turn with token usage. Deliberately does not reject on missing
+ * model/messageId/timestamp — `SubagentWatcher` and `SubagentTimelineStore`
+ * apply slightly different acceptance policies for those (see each call
+ * site), so this module only does the parsing genuinely identical between
+ * them: JSON validity, type/shape checks, numeric field extraction, and the
+ * two schema-drift fingerprints.
+ */
+export interface ParsedAssistantTurnFields {
+  readonly messageId: string | null;
+  readonly model: string | null;
+  readonly turnUuid: string;
+  readonly rawTimestamp: string | null;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheCreationTokens: number;
+  readonly reasoningTokens: number;
+  readonly stopReason: string | null;
+  readonly usageKeysFingerprint: string;
+  readonly contentBlockTypesFingerprint: string;
+}
+
+export interface ParseAssistantTurnLineResult {
+  /**
+   * null when the line is not a usable assistant-turn-with-usage line: wrong
+   * `type`, missing/non-object `message`, or missing/non-object
+   * `message.usage`.
+   */
+  readonly fields: ParsedAssistantTurnFields | null;
+  /** true only when `JSON.parse` itself threw on this line. */
+  readonly invalidJson: boolean;
+}
+
+export function parseAssistantTurnLine(line: string): ParseAssistantTurnLineResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return { fields: null, invalidJson: true };
+  }
+  if (!parsed || typeof parsed !== 'object') return { fields: null, invalidJson: false };
+  const obj = parsed as RawTranscriptEntry;
+  if (obj.type !== 'assistant') return { fields: null, invalidJson: false };
+
+  const message = obj.message;
+  if (!message || typeof message !== 'object') return { fields: null, invalidJson: false };
+  const m = message as RawAssistantMessage;
+
+  const usage = m.usage;
+  if (!usage || typeof usage !== 'object') return { fields: null, invalidJson: false };
+  const u = usage as RawUsage;
+
+  const model = typeof m.model === 'string' ? m.model : null;
+  const messageId = typeof m.id === 'string' ? m.id : null;
+  const turnUuid = typeof obj.uuid === 'string' ? obj.uuid : '';
+  const rawTimestamp = typeof obj.timestamp === 'string' ? obj.timestamp : null;
+  const stopReason = typeof m.stop_reason === 'string' ? m.stop_reason : null;
+
+  const inputTokens = num(u.input_tokens);
+  const outputTokens = num(u.output_tokens);
+  const cacheReadTokens = num(u.cache_read_input_tokens);
+  const cacheCreationTokens = num(u.cache_creation_input_tokens);
+  let reasoningTokens = 0;
+  const otd = u.output_tokens_details;
+  if (otd && typeof otd === 'object') {
+    reasoningTokens = num(otd.reasoning_tokens);
+  }
+
+  const usageKeysFingerprint = computeUsageKeysFingerprint(u);
+  const contentBlockTypesFingerprint = computeContentBlockTypesFingerprint(m.content);
+
+  return {
+    fields: {
+      messageId,
+      model,
+      turnUuid,
+      rawTimestamp,
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheCreationTokens,
+      reasoningTokens,
+      stopReason,
+      usageKeysFingerprint,
+      contentBlockTypesFingerprint,
+    },
+    invalidJson: false,
+  };
+}
+
+export function num(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : 0;
+}
+
+function computeUsageKeysFingerprint(usage: Record<string, unknown>): string {
+  const keys: string[] = [];
+  for (const k of Object.keys(usage).sort()) keys.push(k);
+  const otd = usage.output_tokens_details;
+  if (otd && typeof otd === 'object') {
+    for (const k of Object.keys(otd as Record<string, unknown>).sort()) {
+      keys.push(`output_tokens_details.${k}`);
+    }
+  }
+  return shortHash(keys.join('|'));
+}
+
+function computeContentBlockTypesFingerprint(content: unknown): string {
+  if (!Array.isArray(content)) return shortHash('');
+  const set = new Set<string>();
+  for (const block of content) {
+    if (
+      block &&
+      typeof block === 'object' &&
+      typeof (block as { type?: unknown }).type === 'string'
+    ) {
+      set.add(String((block as { type: string }).type));
+    }
+  }
+  const sorted = Array.from(set).sort();
+  return shortHash(sorted.join('|'));
+}
+
+function shortHash(input: string): string {
+  return createHash('sha1').update(input).digest('hex').slice(0, 16);
+}

--- a/src/lib/subagent-transcript-parser.ts
+++ b/src/lib/subagent-transcript-parser.ts
@@ -105,6 +105,8 @@ export function num(v: unknown): number {
 function computeUsageKeysFingerprint(usage: Record<string, unknown>): string {
   const keys: string[] = [];
   for (const k of Object.keys(usage).sort()) keys.push(k);
+  // Include child keys of `output_tokens_details` so reasoning-token drift
+  // produces a distinct fingerprint without inflating the dimension space.
   const otd = usage.output_tokens_details;
   if (otd && typeof otd === 'object') {
     for (const k of Object.keys(otd as Record<string, unknown>).sort()) {


### PR DESCRIPTION
## Summary

Issue #602 identified three disjoint pipelines that each independently answer "which agent did this tool call." This PR addresses the two that turned out to actually duplicate logic:

- `SubagentWatcher` (streaming token-usage attribution) and `SubagentTimelineStore` (dashboard's on-demand timeline) each independently re-implemented "parse one JSONL transcript line into an assistant turn with token usage" — near-identical field extraction plus a byte-for-byte-identical `num()` helper.
- Extracted that logic into a new shared module, `src/lib/subagent-transcript-parser.ts`. Both pipelines now call it, each still applying its own (deliberately different) acceptance policy on top: `SubagentWatcher` rejects a missing model/messageId and defaults a missing timestamp to `Date.now()`; `SubagentTimelineStore` accepts a missing model (defaults to `''`) but rejects a missing timestamp with no fallback. Neither pipeline's output shape or public behavior changed.

**Scope correction vs. the original design spec:** the spec assumed the shared module would also need to cover `SubagentTimelineStore`'s tool_use/tool_result extraction (`parseToolCalls`/`parseTurnBlocks`). Reading the actual code showed that extraction has no counterpart in `SubagentWatcher` — it isn't duplicated, so it stayed untouched. The shared module covers only the assistant-turn/usage parsing, which is the actual duplication named in #602.

**Pipeline 1** (`ToolCallRecord.agentId`/`agentType`, the hook-payload path) is intentionally not touched here — see the follow-up issues below.

Also includes a version bump (1.50.5 → 1.50.6) and CHANGELOG entry per repo convention.

## Process notes

- Built via superpowers brainstorming → design spec → implementation plan → subagent-driven-development (3 code tasks, each implemented and reviewed independently; final whole-branch review on Opus).
- The final whole-branch review found 1 Important gap (no characterization tests pinned the two pipelines' divergent accept-policies) and fixed it in one fix wave (4 new tests). One residual Minor was parked rather than spent on a disallowed second fix wave: a 5th test I specified in the fix brief (meant to cover the `output_tokens_details` child-key fingerprint branch in `computeUsageKeysFingerprint`) doesn't actually isolate that branch — it compares a usage object *with* `output_tokens_details` against one *without* it, so the fingerprints differ from the top-level key-set change alone, not from the child-key descent logic it claims to test. Real gap, low blast-radius (schema-drift detection would just under-fire for one narrow input shape), flagged here rather than fixed unreviewed.

## Follow-up issues filed alongside this PR

- Comment on/close #554 with the empirical finding from this work's research phase (filename-side agentId format confirmed; no real hook-payload `agent_id` value found anywhere in this installation's transcripts to compare against it).
- New issue: `ToolCallRecord.agentId`/`agentType` hook field appears to never populate in practice — investigate when/whether it actually fires.
- New issue: add parent/child relationship + spawn/interrupt state to the shared model, once a real consumer needs it.
- New issue: a third near-identical unmigrated parser exists at `ParentTranscriptWatcher.tryParseLine` (surfaced by the final review, legitimately out of this spec's original scope).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — full suite green (204/205 suites, 1 pre-existing known-flaky suite unrelated to this change; 6885 tests passing)
- [x] `npm run lint` — 0 errors/warnings
- [x] Pre-push hook (full suite + plugin-hook bundle check) passed
- [x] Each of the 3 code tasks independently reviewed clean; final whole-branch review "Ready to merge: With fixes" — fix wave applied, one non-load-bearing residual parked (see above)

🤖 Generated with subagent-driven-development (Claude Code)