### PR TITLE
Fix #305: Drop --local watcher banner, gate opt-out banner on spend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.50.6] - 2026-09-11
+
+### Fixed
+
+- **The Today view no longer shows the "this dashboard process isn't running its own subagent watcher" banner on `--local` dashboards.** Every default install runs the dashboard as a `--local` daemon that by design never runs that watcher, so the banner appeared on every visit, and the `NR_AI_WATCHER_MODE=local` instruction it gave cannot reach a launchd daemon (the plist carries only `PATH`). Watcher state remains visible on the Settings page.
+- **The remaining `NR_AI_ENABLE_SUBAGENT_WATCHER=0` banner now hides when today's aggregate shows any subagent spend, instead of when it shows any subagent turns.** The turn count only counts Workflow-tool script runs, so it read 0 on any day whose subagents were ordinary Task/Agent-tool spawns, and the banner could claim subagents were excluded directly above a KPI showing their spend.
+
 ## [1.50.5] - 2026-09-11
 
 ### Fixed

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -250,7 +250,7 @@ If `NEW_RELIC_LICENSE_KEY`, `NEW_RELIC_ACCOUNT_ID`, or `NEW_RELIC_API_KEY` are s
 
 ## Running `--local` Standalone (No `--stdio` Session)
 
-The subagent/workflow transcript watchers only auto-start under `--stdio` by default (`NR_AI_WATCHER_MODE=stdio`) — a `--local` dashboard process doesn't run its own copy, since a `--stdio` session normally already covers the same data, scoped to itself, and the Today view's spend figures already aggregate every session's _persisted_ totals regardless of which process is currently serving the dashboard. If `watcherActive` is `false` for this reason, the dashboard shows a banner explaining it (distinct from the `NR_AI_ENABLE_SUBAGENT_WATCHER=0` banner, which is an explicit opt-out rather than this mode default).
+The subagent/workflow transcript watchers only auto-start under `--stdio` by default (`NR_AI_WATCHER_MODE=stdio`) — a `--local` dashboard process doesn't run its own copy, since a `--stdio` session normally already covers the same data, scoped to itself, and the Today view's spend figures already aggregate every session's _persisted_ totals regardless of which process is currently serving the dashboard. When `watcherActive` is `false` for this reason, the Settings page's watcher health shows it as inactive and the Today view shows no banner; the Today view only warns when `NR_AI_ENABLE_SUBAGENT_WATCHER=0` is set explicitly and there is no subagent spend recorded for the day.
 
 | Setting                         | What it does                                                                                             | Default  |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------- | -------- |

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.50.5",
+  "version": "1.50.6",
   "description": "AI coding observability for Kiro. Tracks tool calls, cost, anti-patterns, and efficiency metrics — and (optionally) ships them to New Relic.",
   "author": {
     "name": "New Relic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.50.5",
+  "version": "1.50.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/preflight",
-      "version": "1.50.5",
+      "version": "1.50.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/preflight",
-  "version": "1.50.5",
+  "version": "1.50.6",
   "mcpName": "io.github.newrelic-experimental/preflight",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-preflight",
   "displayName": "Preflight",
-  "version": "1.50.5",
+  "version": "1.50.6",
   "description": "Observability for AI coding assistants — tool-call capture, cost tracking, and efficiency scoring, powered by New Relic.",
   "author": {
     "name": "New Relic",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/newrelic-experimental/preflight",
     "source": "github"
   },
-  "version": "1.50.5",
+  "version": "1.50.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@newrelic/preflight",
-      "version": "1.50.5",
+      "version": "1.50.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/web/views/Today.test.tsx
+++ b/src/web/views/Today.test.tsx
@@ -725,11 +725,12 @@ describe('Today view', () => {
     expect(await screen.findByText(/subagent cost tracking is disabled/i)).toBeInTheDocument();
   });
 
-  it('shows a mode-mismatch banner (not the env-var message) when watcherDisabledReason is mode_mismatch', async () => {
-    // This is the --local dashboard daemon's default state: the watcher only
-    // auto-starts in --stdio mode, so watcherActive is false here by design,
-    // NOT because NR_AI_ENABLE_SUBAGENT_WATCHER is set to 0. Telling the user
-    // to unset a variable that was never set would be actively misleading.
+  it('shows no watcher banner at all when watcherDisabledReason is mode_mismatch', async () => {
+    // A --local dashboard daemon never runs its own subagent watcher, so this
+    // is its steady state on every default install. The Today spend figures
+    // already aggregate every session's persisted subagent cost, and the
+    // env var the old banner told users to set does not reach a launchd
+    // daemon. Nothing here is actionable, so nothing renders.
     stubObservabilityHealth({
       watcherActive: false,
       watcherDisabledByLock: false,
@@ -737,16 +738,19 @@ describe('Today view', () => {
     });
 
     renderToday();
-    expect(await screen.findByText(/subagent activity from other sessions/i)).toBeInTheDocument();
+    await expect(
+      screen.findByText(/subagent activity from other sessions/i, {}, { timeout: 300 }),
+    ).rejects.toThrow();
     expect(screen.queryByText(/subagent cost tracking is disabled/i)).toBeNull();
     expect(screen.queryByText(/NR_AI_ENABLE_SUBAGENT_WATCHER=0/)).toBeNull();
   });
 
-  it('does not show the watcher-disabled banner when the cross-session aggregate reports nonzero subagent turns, even though the live SSE turn count is 0', async () => {
-    // The live-only subagentStats.turns stays 0 in this test (no SSE frames
-    // are ever pushed for it) while the polled aggregate endpoint — the same
-    // one the "subagent spend" KPI above these banners already falls back
-    // to — reports turns for today. The gate must agree with that KPI.
+  it('does not show the watcher-disabled banner when the cross-session aggregate reports nonzero subagent spend, even though its turn count is 0', async () => {
+    // aggregate.subagentTurnCount only counts Workflow-tool script runs, so it
+    // reads 0 on any day where the subagents were ordinary Task/Agent-tool
+    // spawns, while aggregate.subagentUsd is summed from every persisted
+    // session's subagentCostUsd and is correct for both kinds. The banner
+    // must gate on the figure the KPI beside it trusts.
     globalThis.fetch = vi.fn(async (input) => {
       const url = String(input);
       if (url.includes('/api/observability-health')) {
@@ -760,7 +764,7 @@ describe('Today view', () => {
         );
       }
       if (url.includes('/api/sessions/today/aggregate')) {
-        return new Response(JSON.stringify({ subagentTurnCount: 5 }), {
+        return new Response(JSON.stringify({ subagentUsd: 5.5, subagentTurnCount: 0 }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         });
@@ -772,7 +776,7 @@ describe('Today view', () => {
     }) as typeof fetch;
 
     renderToday();
-    await screen.findByText('5 turns');
+    await screen.findAllByText('$5.50');
     expect(screen.queryByText(/subagent cost tracking is disabled/i)).toBeNull();
     expect(screen.queryByText(/subagent activity from other sessions/i)).toBeNull();
   });

--- a/src/web/views/Today.tsx
+++ b/src/web/views/Today.tsx
@@ -439,25 +439,13 @@ export function Today(): JSX.Element {
       ) : (
         <>
           {healthApi?.watcherActive === false &&
-            subagentTurns === 0 &&
+            subagentUsd === 0 &&
             healthApi?.watcherDisabledReason !== 'mode_mismatch' && (
               <div className="rounded-lg border border-border-subtle bg-surface-5 px-4 py-3 text-sm text-ink-muted mb-4">
                 Subagent cost tracking is disabled (
                 <code className="font-mono text-xs">NR_AI_ENABLE_SUBAGENT_WATCHER=0</code>), so
                 spend shown here excludes subagents. Unset that variable (it is on by default) and
                 restart to see full spend.
-              </div>
-            )}
-          {healthApi?.watcherActive === false &&
-            subagentTurns === 0 &&
-            healthApi?.watcherDisabledReason === 'mode_mismatch' && (
-              <div className="rounded-lg border border-border-subtle bg-surface-5 px-4 py-3 text-sm text-ink-muted mb-4">
-                This dashboard process isn&rsquo;t running its own subagent watcher — expected for a
-                background <code className="font-mono text-xs">--local</code> dashboard (the watcher
-                only auto-starts in <code className="font-mono text-xs">--stdio</code> mode). Spend
-                shown here still includes subagent activity from other sessions, read from their
-                persisted totals. To track subagents live from this process too, set{' '}
-                <code className="font-mono text-xs">NR_AI_WATCHER_MODE=local</code> and restart.
               </div>
             )}
           <AnimatedCard index={0} className="mb-4">


### PR DESCRIPTION
Related to #305

## Why

Every default install runs the dashboard as a `--local` launchd daemon. That process never runs the subagent watcher by design, so the Today view showed the "this dashboard process isn't running its own subagent watcher" banner on every visit. The banner told users to set `NR_AI_WATCHER_MODE=local` and restart, but the plist written by `installDashboardDaemon` carries only `PATH`, so a shell export never reaches the daemon. The state is expected, already visible on Settings, and not actionable from the banner, so the banner goes.

The surviving `NR_AI_ENABLE_SUBAGENT_WATCHER=0` banner hid itself only when the day's aggregate subagent turn count was nonzero. That count sums `agent_count` over `WorkflowStore.listRuns()`, which only sees Workflow-tool script runs. On any day whose subagents were Task or Agent-tool spawns it read 0, so the banner could claim subagents were excluded directly above a KPI showing their spend. It now gates on the aggregate subagent spend, which is summed from every persisted session's `subagentCostUsd`.

## Scope

- `src/web/views/Today.tsx`. Delete the `mode_mismatch` banner branch. Change the `env_var` banner guard from `subagentTurns === 0` to `subagentUsd === 0`.
- `src/web/views/Today.test.tsx`. Replace the mode_mismatch banner test with a timed negative. Replace the turn-count guard test with a spend-with-zero-turns case that matches what a real `--local` daemon returns.
- `docs/ADVANCED.md`. Update the standalone `--local` section to say where watcher state is shown now.
- Version 1.50.6 in `package.json`, `package-lock.json`, `server.json`, `kiro-power/plugin.json`, `plugin/.claude-plugin/plugin.json`, and a CHANGELOG entry.

Out of scope: running the watcher in `--local` by default, which is the real fix for #305 and needs the local rollup to persist subagent cost first. Tracked in #659.

## Blast Radius

Two render conditions in one view. The health endpoint, its `watcherDisabledReason` type, and the Settings watcher card are unchanged. A dashboard served by an older build is unaffected. The only visible change is that `--local` dashboards lose a banner and `NR_AI_ENABLE_SUBAGENT_WATCHER=0` users with subagent spend on disk lose a false one.

## Verification

- Reproduced on the live daemon on this machine before the change. `GET /api/observability-health` returned `watcherActive: false, watcherDisabledReason: "mode_mismatch"`, and `GET /api/sessions/today/aggregate` returned `subagentUsd: 5.355, subagentTurnCount: 0`. That pair renders the banner and the contradiction on the unpatched build.
- Both new tests fail on the first commit and pass on the second. `npx vitest run src/web/views/Today.test.tsx`: 76 of 76 pass after the fix.
- `npm run build` clean. `npm run lint` clean with 0 warnings. `npx prettier --check` clean on the touched files. `npx jest src/version.test.ts` passes on the bump.
- Not done: the running launchd daemon was not restarted onto this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPRNQwBL9JicnWtbHEFS1T

